### PR TITLE
fix(inbox): centralize expiry projection

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -301,6 +301,7 @@ export function itemView(row) {
     refs: parseObject(row.refs_json),
     source: row.source,
     createdAt: row.created_at,
+    expired: row.expired === 1,
     ackedAt: row.acked_at ?? null,
     resolvedAt: row.resolved_at ?? null,
     resolvedBy: row.resolved_by ?? null,
@@ -317,8 +318,26 @@ export function itemView(row) {
   };
 }
 
+/** Shared by inbox projections and the open-count query. */
+function inboxExpiredPredicate(item = "i") {
+  return `(${item}.kind = 'proposal_expired' OR EXISTS (
+    SELECT 1 FROM proposals p
+     WHERE p.id = json_extract(${item}.refs_json, '$.proposalId')
+       AND p.status = 'open'
+       AND p.ttl_seconds > 0
+       AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
+  ))`;
+}
+
 export function getInboxItem(db, id) {
-  return itemView(db.query("SELECT * FROM inbox_items WHERE id = ?").get(id));
+  return itemView(
+    db
+      .query(
+        `SELECT i.*, ${inboxExpiredPredicate("i")} AS expired
+         FROM inbox_items i WHERE i.id = ?`,
+      )
+      .get(id),
+  );
 }
 
 function supersedeInboxDecision(db, row, { title, body, refs, decision }) {
@@ -885,9 +904,10 @@ export function listInboxPage(
     : [limit + 1];
   const rows = db
     .query(
-      `SELECT *, rowid AS list_rowid FROM inbox_items
+      `SELECT i.*, i.rowid AS list_rowid, ${inboxExpiredPredicate("i")} AS expired
+       FROM inbox_items i
        WHERE ${where}${cursor}
-       ORDER BY created_at DESC, rowid DESC
+       ORDER BY i.created_at DESC, i.rowid DESC
        LIMIT ?`,
     )
     .all(...params);
@@ -1008,19 +1028,14 @@ export function resolveInboxItem(
 }
 
 export function inboxCounts(db) {
-  // The expiry predicate below must agree with `isExpiredInboxItem` in
-  // event-runtime/web/src/views/Inbox.tsx (badge vs. Open tab count).
+  // Use the same expiry predicate projected by `listInboxItems` and
+  // `getInboxItem`, so the badge and the Open tab count agree.
   const totals = db
     .query(
       `SELECT
        SUM(CASE WHEN i.resolved_at IS NULL AND i.acked_at IS NULL
-                      AND NOT (i.kind = 'proposal_expired' OR EXISTS (
-                        SELECT 1 FROM proposals p
-                         WHERE p.id = json_extract(i.refs_json, '$.proposalId')
-                           AND p.status = 'open'
-                           AND p.ttl_seconds > 0
-                           AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
-                      )) THEN 1 ELSE 0 END) AS open,
+                      AND NOT ${inboxExpiredPredicate("i")}
+                      THEN 1 ELSE 0 END) AS open,
        SUM(CASE WHEN i.resolved_at IS NULL AND i.acked_at IS NOT NULL THEN 1 ELSE 0 END) AS acked
      FROM inbox_items i`,
     )

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -641,13 +641,18 @@ describe("human inbox ledger (WM-285)", () => {
     });
   });
 
-  test("inbox counts omit expired open items", () => {
+  test("list items and counts share the expired-open predicate", () => {
     const db = openDb(":memory:");
     const expiredAt = new Date(Date.now() - 61_000).toISOString();
+    const liveAt = new Date().toISOString();
     db.query(
       `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
        VALUES ('expired-proposal', 'test', 'evt', 'run', 'open', ?, 60)`,
     ).run(expiredAt);
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES ('live-proposal', 'test', 'live-evt', 'run', 'open', ?, 60)`,
+    ).run(liveAt);
     createInboxItem(db, { kind: "BLOCKED", title: "active" }, { id: "active" });
     createInboxItem(
       db,
@@ -663,8 +668,37 @@ describe("human inbox ledger (WM-285)", () => {
       },
       { id: "expired-proposal-item" },
     );
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "live by proposal",
+        refs: { proposalId: "live-proposal" },
+      },
+      { id: "live-proposal-item" },
+    );
 
-    expect(inboxCounts(db)).toMatchObject({ open: 1, acked: 0 });
+    const items = listInboxItems(db, { status: "all" });
+    expect(
+      items.find((item) => item.id === "expired-proposal-item"),
+    ).toMatchObject({
+      expired: true,
+    });
+    expect(getInboxItem(db, "expired-proposal-item")).toMatchObject({
+      expired: true,
+    });
+    expect(
+      items.find((item) => item.id === "live-proposal-item"),
+    ).toMatchObject({
+      expired: false,
+    });
+    expect(inboxCounts(db)).toMatchObject({
+      open: items.filter(
+        (item) =>
+          item.resolvedAt === null && item.ackedAt === null && !item.expired,
+      ).length,
+      acked: 0,
+    });
   });
 
   test("runtime-owned referents auto-resolve after leaving their waiting state", () => {

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -12,7 +12,7 @@ import type {
   EnvIdentity,
   DecisionEffect,
   DecisionResponseInput,
-  InboxItem,
+  InboxItem as BaseInboxItem,
   InboxStatus,
   JournalView,
   MetricsBreakdownView,
@@ -29,6 +29,9 @@ import type {
   TraceView,
   Worker,
 } from "./types";
+
+/** Inbox expiry is server-authoritative; it is optional for older servers. */
+export type InboxItem = BaseInboxItem & { expired?: boolean };
 
 // Same contract as lib/client.mjs: one function per endpoint, an Error with
 // `.status` on non-2xx, no status at all on connection failure.

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -12,7 +12,7 @@ import type {
   EnvIdentity,
   DecisionEffect,
   DecisionResponseInput,
-  InboxItem as BaseInboxItem,
+  InboxItem,
   InboxStatus,
   JournalView,
   MetricsBreakdownView,
@@ -31,9 +31,6 @@ import type {
   TraceView,
   Worker,
 } from "./types";
-
-/** Inbox expiry is server-authoritative; it is optional for older servers. */
-export type InboxItem = BaseInboxItem & { expired?: boolean };
 
 // Same contract as lib/client.mjs: one function per endpoint, an Error with
 // `.status` on non-2xx, no status at all on connection failure.

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -1053,6 +1053,12 @@ export interface InboxItem {
   decidedAt?: string | null;
   decidedBy?: string | null;
   dedupeKey?: string | null;
+  /**
+   * Server-authoritative expiry projection from the shared predicate in
+   * event-runtime/lib/inbox.mjs. Current servers always set it; it stays
+   * optional for pre-#1223 servers and hand-built fixtures.
+   */
+  expired?: boolean;
 }
 
 /** One recent ticket summary (GET /tickets). */

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -38,8 +38,7 @@ afterEach(() => {
 });
 
 function item(
-  overrides: Partial<InboxItem & { expired?: boolean }> &
-    Pick<InboxItem, "id" | "kind">,
+  overrides: Partial<InboxItem> & Pick<InboxItem, "id" | "kind">,
 ): InboxItem {
   return {
     severity: "normal",

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -38,7 +38,8 @@ afterEach(() => {
 });
 
 function item(
-  overrides: Partial<InboxItem> & Pick<InboxItem, "id" | "kind">,
+  overrides: Partial<InboxItem & { expired?: boolean }> &
+    Pick<InboxItem, "id" | "kind">,
 ): InboxItem {
   return {
     severity: "normal",
@@ -427,17 +428,11 @@ describe("Inbox view", () => {
         kind: "decision_needed",
         title: "Expired by proposal",
         refs: { proposalId: "expired-proposal-id" },
+        expired: true,
       }),
     ];
     api.proposals = mock(async () => ({
-      proposals: [
-        {
-          id: "expired-proposal-id",
-          status: "open",
-          created_at: new Date(Date.now() - 61_000).toISOString(),
-          ttl_seconds: 60,
-        } as Proposal,
-      ],
+      proposals: [],
     }));
 
     const { view } = renderInbox();

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -413,7 +413,7 @@ export function proposalTtlLabel(
  * event-runtime/lib/inbox.mjs, so the sidebar badge and Open tab count match.
  */
 export function isExpiredInboxItem(
-  item: InboxItem & { expired?: boolean },
+  item: InboxItem,
   proposalsById: Map<string, Proposal>,
   now: number,
 ): boolean {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -409,14 +409,17 @@ export function proposalTtlLabel(
 
 /**
  * Expired items stay available in the Open tab, but are not actionable by default.
- * Must agree with the `open` count predicate in `inboxCounts` (event-runtime/lib/inbox.mjs)
- * so the sidebar badge and the Open tab count match.
+ * The server's `expired` flag comes from the shared predicate in
+ * event-runtime/lib/inbox.mjs, so the sidebar badge and Open tab count match.
  */
 export function isExpiredInboxItem(
-  item: InboxItem,
+  item: InboxItem & { expired?: boolean },
   proposalsById: Map<string, Proposal>,
   now: number,
 ): boolean {
+  // The server uses the shared inbox SQL predicate. Older servers omit this
+  // field, so retain the proposal lookup only as a backwards-compatible fallback.
+  if (item.expired !== undefined) return item.expired;
   if (item.kind === "proposal_expired") return true;
   const proposal = item.refs.proposalId
     ? proposalsById.get(item.refs.proposalId)


### PR DESCRIPTION
Fixes watt-mind/factory#1223

Review the server-owned inbox expiry projection that keeps Open items aligned with its badge.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/api-inbox.test.mjs --timeout 20000 && (cd event-runtime/web && bun test src/views/Inbox.test.tsx && bunx tsc --noEmit) && bun run check` | pass | 79 tests, typecheck and drift check clean |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1795 pass, 10 skipped |
| UX critique | `factory-ux-critic` | pass | SHIP after 2 rounds; Inbox observed |

UX critique: required

## Handoff

- Verification (merge-stage, on origin/develop merge + 8b2880c7): `cd event-runtime/web && bunx tsc --noEmit` clean; `bun test src/views/Inbox.test.tsx` 41 pass / 0 fail; `bun test event-runtime/lib/inbox.test.mjs --timeout 20000` 33 pass / 0 fail; `bun run check` exit 0; prettier clean. Earlier full repo verify: 1795 pass / 0 fail lib, web tsc clean.
- UX verdict (from ticket/PR validation): `factory-ux-critic` SHIP after 2 rounds; Inbox observed.
- File scope: `event-runtime/lib/inbox.mjs`, `event-runtime/lib/inbox.test.mjs`, `event-runtime/web/src/api.ts`, `event-runtime/web/src/types.ts`, `event-runtime/web/src/views/Inbox.tsx`, `event-runtime/web/src/views/Inbox.test.tsx` — all within #1223 Owned Paths (`types.ts` added to the ticket at merge stage so the `expired` flag lives on the shared `InboxItem` type instead of a shadowing type in `api.ts`).
