### PR TITLE
perf(merge): queue trailing webhook scan

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1718,14 +1718,72 @@ function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
   return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
 }
 
+const WEBHOOK_MERGE_SCAN_ALREADY_LIVE = "webhook_merge_scan_already_live";
+const EXECUTING_MERGE_SCAN_STATES = new Set(["LEASED", "RUNNING", "VERIFYING"]);
+
+function hasQueuedWebhookMergeScan(db, runId) {
+  return Boolean(
+    db
+      .query(
+        `SELECT 1
+         FROM proposals
+         WHERE run_id = ?
+           AND decision = 'noop'
+           AND reason = ?
+         LIMIT 1`,
+      )
+      .get(runId, WEBHOOK_MERGE_SCAN_ALREADY_LIVE),
+  );
+}
+
+/**
+ * Re-admit the single webhook delivery retained behind each finished merge
+ * scan. The retained noop proposal is the durable queue marker: later burst
+ * deliveries have no proposal, so they cannot create extra trailing scans.
+ */
+function reAdmitQueuedWebhookMergeScans(db) {
+  const queued = db
+    .query(
+      `SELECT e.source, e.event_id
+       FROM events e
+       JOIN proposals p
+         ON p.event_source = e.source AND p.event_id = e.event_id
+       JOIN runs r ON r.run_id = p.run_id
+       WHERE e.source = 'github'
+         AND e.type = 'factory.merge.requested'
+         AND e.status = 'noop'
+         AND p.decision = 'noop'
+         AND p.reason = ?
+         AND r.state IN ('COMPLETED', 'REFUSED', 'FAILED', 'TIMED_OUT', 'CANCELLED')
+       ORDER BY p.created_at, p.rowid`,
+    )
+    .all(WEBHOOK_MERGE_SCAN_ALREADY_LIVE);
+  for (const event of queued) {
+    db.query(
+      `UPDATE events
+       SET status = 'admitted', last_plan_error = NULL
+       WHERE source = ? AND event_id = ? AND status = 'noop'`,
+    ).run(event.source, event.event_id);
+  }
+}
+
 /**
  * GitHub sends a delivery for each CI state change. Unlike an operator or
  * schedule request, those deliveries do not each deserve an auditable
- * proposal: one live repo-wide merge scan will read the current GitHub state
- * when it runs. Mark later deliveries as consumed without creating the noisy
- * noop proposals that otherwise flood the merge lane.
+ * proposal: a PROPOSED, APPROVED, or QUEUED scan will read current GitHub
+ * state when it executes, so later deliveries stay pure noops. Once the scan
+ * is LEASED, RUNNING, or VERIFYING, retain exactly one delivery as a
+ * TTL-backed noop proposal; planAdmittedEvents re-admits it after that scan
+ * reaches a terminal state. Further deliveries remain proposal-free noops.
  */
-function coalesceWebhookMergeRequest(db, event, envelope, agentRef) {
+function coalesceWebhookMergeRequest(
+  db,
+  event,
+  envelope,
+  agentRef,
+  at,
+  ttlSeconds,
+) {
   if (
     event.source !== "github" ||
     event.type !== "factory.merge.requested" ||
@@ -1738,7 +1796,20 @@ function coalesceWebhookMergeRequest(db, event, envelope, agentRef) {
   });
   if (!blockingRun) return null;
 
-  const reason = "webhook_merge_scan_already_live";
+  const reason = WEBHOOK_MERGE_SCAN_ALREADY_LIVE;
+  if (
+    EXECUTING_MERGE_SCAN_STATES.has(blockingRun.state) &&
+    !hasQueuedWebhookMergeScan(db, blockingRun.run_id)
+  ) {
+    return noopBehindLiveRun(
+      db,
+      event,
+      blockingRun,
+      reason,
+      at,
+      ttlSeconds,
+    );
+  }
   setEventStatus(db, event, "noop", reason);
   return { decision: "noop", runId: blockingRun.run_id, reason };
 }
@@ -1997,6 +2068,8 @@ export function planEvent(
       event,
       envelope,
       mapping.agent,
+      at,
+      ttlSeconds,
     );
     if (webhookMergeCoalesced) return webhookMergeCoalesced;
 
@@ -2453,6 +2526,7 @@ export function archiveDeadLetteredEvent(
  * @returns {{ planned: number, failed: number, deadLettered: number }}
  */
 export function planAdmittedEvents(db, registry, opts = {}) {
+  reAdmitQueuedWebhookMergeScans(db);
   const rows = db
     .query(
       `SELECT source, event_id, type FROM events WHERE status = 'admitted' ORDER BY admitted_at, rowid`,

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1801,14 +1801,7 @@ function coalesceWebhookMergeRequest(
     EXECUTING_MERGE_SCAN_STATES.has(blockingRun.state) &&
     !hasQueuedWebhookMergeScan(db, blockingRun.run_id)
   ) {
-    return noopBehindLiveRun(
-      db,
-      event,
-      blockingRun,
-      reason,
-      at,
-      ttlSeconds,
-    );
+    return noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds);
   }
   setEventStatus(db, event, "noop", reason);
   return { decision: "noop", runId: blockingRun.run_id, reason };

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -347,7 +347,9 @@ describe("planEvent", () => {
     expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(3);
 
     const trailingRun = db
-      .query(`SELECT run_id FROM proposals WHERE event_id = 'check-2' AND decision = 'run'`)
+      .query(
+        `SELECT run_id FROM proposals WHERE event_id = 'check-2' AND decision = 'run'`,
+      )
       .get();
     for (const to of [
       "APPROVED",

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -269,7 +269,7 @@ describe("planEvent", () => {
     expect(event.status).toBe("noop");
   });
 
-  test("GitHub CI bursts coalesce per repo without proposals; schedule and other repos remain distinct", () => {
+  test("GitHub CI bursts retain one trailing scan only behind an executing merge scan", () => {
     const db = openDb(":memory:");
     const webhook = (eventId, repo = "factory") => ({
       eventId,
@@ -286,7 +286,36 @@ describe("planEvent", () => {
     });
     expect(first.decision).toBe("run");
 
-    for (const eventId of ["check-2", "check-3", "check-4", "check-5"]) {
+    const whileProposed = planEvent(
+      db,
+      registry,
+      admit(db, webhook("check-proposed")),
+      { now: NOW + 1000, policyVersion: "git:test" },
+    );
+    expect(whileProposed).toEqual({
+      decision: "noop",
+      runId: first.runId,
+      reason: "webhook_merge_scan_already_live",
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(1);
+
+    for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    const queued = planEvent(db, registry, admit(db, webhook("check-2")), {
+      now: NOW + 1000,
+      policyVersion: "git:test",
+    });
+    expect(queued).toMatchObject({
+      decision: "noop",
+      runId: first.runId,
+      reason: "webhook_merge_scan_already_live",
+    });
+    expect(queued.proposal.status).toBe("resolved");
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(2);
+
+    for (const eventId of ["check-3", "check-4", "check-5"]) {
       const next = planEvent(db, registry, admit(db, webhook(eventId)), {
         now: NOW + 1000,
         policyVersion: "git:test",
@@ -298,8 +327,28 @@ describe("planEvent", () => {
       });
     }
     expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
-    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(1);
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(2);
 
+    for (const to of ["VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    expect(
+      planAdmittedEvents(db, registry, {
+        now: NOW + 2000,
+        policyVersion: "git:test",
+      }),
+    ).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
+    const trailing = db
+      .query(`SELECT status FROM events WHERE event_id = 'check-2'`)
+      .get();
+    expect(trailing.status).toBe("planned");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(3);
+
+    const trailingRun = db
+      .query(`SELECT run_id FROM proposals WHERE event_id = 'check-2' AND decision = 'run'`)
+      .get();
     for (const to of [
       "APPROVED",
       "QUEUED",
@@ -308,7 +357,7 @@ describe("planEvent", () => {
       "VERIFYING",
       "COMPLETED",
     ]) {
-      transition(db, { runId: first.runId, to, actor: "test" });
+      transition(db, { runId: trailingRun.run_id, to, actor: "test" });
     }
 
     const clockRef = admit(db, {
@@ -350,7 +399,7 @@ describe("planEvent", () => {
     );
     expect(other.decision).toBe("run");
     expect(other.runId).not.toBe(first.runId);
-    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(3);
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(5);
   });
 
   test("repeat remediations with identical payload but distinct correlationId produce distinct runs (OPS-419)", () => {


### PR DESCRIPTION
Fixes #1239

Queue one trailing GitHub merge scan after an executing scan finishes.

## Validation

| Check                | Command                          | Result  | Notes                              |
| -------------------- | -------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs --timeout 20000 && bun run check` | pass    | 89 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1867 tests, 10 environment skips  |
| UX critique          | factory-ux-critic                | not run | backend planner; no user flow      |

UX critique: skipped

## Handoff

**Verification** (after `style(planner): prettier (#1239)`, on a merge of origin/develop):

```
bunx prettier --write event-runtime/lib/planner.mjs event-runtime/lib/planner.test.mjs
bun run format:check            -> All matched files use Prettier code style!
bun test event-runtime/lib/planner.test.mjs --timeout 20000 -> 89 pass, 0 fail (469 expect() calls)
bun run check                   -> exit 0
```

**UX:** n/a — backend planner change, no user-completable flow.

**File scope:** `event-runtime/lib/planner.mjs`, `event-runtime/lib/planner.test.mjs` only.

**Risks:**

- A scan that reaches PROPOSED/APPROVED/QUEUED and then ends REFUSED/CANCELLED leaves no trailing marker for deliveries coalesced during that window (waits for next webhook or 4h clock) — tracked in follow-up #1293.
