### PR TITLE
fix(adapters): close ACP transcripts and honor runtime workspace root

### DIFF
--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -19,6 +19,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { Readable } from "node:stream";
 import {
   HARNESS_LAYOUT as CLAUDE_HARNESS_LAYOUT,
   KILL_GRACE_MS as CLAUDE_KILL_GRACE_MS,
@@ -155,7 +156,9 @@ function writeRpc(stream, obj) {
 export function createAcpRpc({ stdin, stdout, onRequest, onNotification }) {
   let nextId = 1;
   const pending = new Map();
-  const rl = createInterface({ input: stdout });
+  // A child can fail before stdio pipes are created. Keep the RPC transport
+  // inert in that case so the close/error path can settle the run normally.
+  const rl = createInterface({ input: stdout ?? Readable.from([]) });
 
   rl.on("line", (line) => {
     let msg;
@@ -471,6 +474,8 @@ export async function execute({
   resume = null,
   abortSignal,
   signal,
+  spawnProcess = spawn,
+  transcriptFactory = createWriteStream,
 }) {
   refuseSandbox("acp", def, SANDBOX_DEFERRAL_REASON);
 
@@ -492,27 +497,53 @@ export async function execute({
   const argv = [...resolved.args];
 
   return new Promise((resolve, reject) => {
-    const child = spawn(resolved.command, argv, {
-      cwd: workspaceDir,
-      env: childEnv,
-      stdio: ["pipe", "pipe", "pipe"],
-      detached: true,
-    });
-
-    child.stdin?.on("error", () => {});
-
-    const transcript = createWriteStream(
+    // Open the transcript before spawning so a spawn error cannot race past
+    // cleanup, and so every failed launch has the same lifecycle as a run
+    // whose child reached the protocol handshake.
+    const transcript = transcriptFactory(
       path.join(workspaceDir, ".transcript.json"),
     );
     transcript.on("error", () => {});
     // Child close only says its stdio handles are closed; the file stream may
     // still have buffered bytes. Register before piping so a fast child cannot
     // finish before we can observe the output flush.
+    let resolveTranscriptClosed;
     const transcriptClosed = new Promise((done) => {
-      transcript.once("finish", done);
-      transcript.once("close", done);
+      resolveTranscriptClosed = done;
+      const doneOnce = () => {
+        resolveTranscriptClosed = null;
+        done();
+      };
+      transcript.once("finish", doneOnce);
+      transcript.once("close", doneOnce);
+      transcript.once("error", doneOnce);
     });
+    const closeTranscript = () => {
+      if (!transcript.destroyed && !transcript.writableEnded) {
+        transcript.end();
+      }
+    };
+
+    let child;
+    try {
+      child = spawnProcess(resolved.command, argv, {
+        cwd: workspaceDir,
+        env: childEnv,
+        stdio: ["pipe", "pipe", "pipe"],
+        detached: true,
+      });
+    } catch (err) {
+      closeTranscript();
+      transcript.destroy();
+      resolveTranscriptClosed?.();
+      reject(err);
+      return;
+    }
+
+    child.stdin?.on("error", () => {});
+
     if (child.stdout) child.stdout.pipe(transcript);
+    else transcript.end();
 
     let stderrBuf = "";
     if (child.stderr) {
@@ -775,7 +806,9 @@ export async function execute({
       cancelPendingPermissions();
       rpc.rejectAll(new Error("ACP child closed"));
       rpc.close();
+      closeTranscript();
       transcript.destroy();
+      resolveTranscriptClosed?.();
       fn(value);
     };
 

--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -806,6 +806,10 @@ export async function execute({
       cancelPendingPermissions();
       rpc.rejectAll(new Error("ACP child closed"));
       rpc.close();
+      // end() before destroy() is intentional: it lets an already-flushed
+      // stream emit "finish" (resolving transcriptClosed through the normal
+      // path) rather than only "close"; destroy() then guarantees the fd is
+      // released even when buffered bytes are abandoned.
       closeTranscript();
       transcript.destroy();
       resolveTranscriptClosed?.();

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -1,5 +1,6 @@
 import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-acp-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   existsSync,
   readFileSync,
@@ -8,6 +9,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { PassThrough } from "node:stream";
 import * as acp from "./acp.mjs";
 import {
   AcpProtocolError,
@@ -607,6 +609,63 @@ describe("permission policy", () => {
 });
 
 describe("execute against a fake ACP agent", () => {
+  test("spawn errors destroy the transcript before rejecting", async () => {
+    const workspaceDir = ws();
+    let transcript;
+    const child = new EventEmitter();
+    child.stdin = new PassThrough();
+    child.stdout = null;
+    child.stderr = null;
+
+    const pending = execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 1000,
+      config: fakeConfig,
+      spawnProcess: () => {
+        queueMicrotask(() =>
+          child.emit("error", Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+        );
+        return child;
+      },
+      transcriptFactory: () => {
+        transcript = new PassThrough();
+        return transcript;
+      },
+    });
+
+    await expect(pending).rejects.toMatchObject({ code: "ENOENT" });
+    expect(transcript.destroyed).toBe(true);
+  });
+
+  test("a child without stdout still settles when it closes", async () => {
+    const workspaceDir = ws();
+    const child = new EventEmitter();
+    child.stdin = new PassThrough();
+    child.stdout = null;
+    child.stderr = null;
+
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 1000,
+      config: fakeConfig,
+      spawnProcess: () => {
+        queueMicrotask(() => child.emit("close", 0));
+        return child;
+      },
+      transcriptFactory: () => new PassThrough(),
+    });
+
+    expect(outcome).toEqual({
+      exitCode: 0,
+      timedOut: false,
+      policyDenials: [],
+    });
+  });
+
   test("refuses a definition without verified promptText before launching the ACP agent", async () => {
     const workspaceDir = ws();
     const recordFile = path.join(workspaceDir, "record.json");

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -625,7 +625,10 @@ describe("execute against a fake ACP agent", () => {
       config: fakeConfig,
       spawnProcess: () => {
         queueMicrotask(() =>
-          child.emit("error", Object.assign(new Error("ENOENT"), { code: "ENOENT" })),
+          child.emit(
+            "error",
+            Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+          ),
         );
         return child;
       },

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -41,7 +41,7 @@ import path from "node:path";
 import { runInSandbox } from "../sandbox/gondolin.mjs";
 import { normalizePolicy } from "../sandbox/policy.mjs";
 import { MODEL_ADAPTERS } from "../registry.mjs";
-import { FACTORY_ROOT } from "../config.mjs";
+import { FACTORY_ROOT, workspacesRoot } from "../config.mjs";
 
 /**
  * Stable refusal code shared by the planner and worker. A workspace-only
@@ -62,9 +62,9 @@ const RAW_CREDENTIAL_PATH =
   /(?:^|\/)\.(?:aws|azure|claude|config\/gcloud|config\/gh|cursor|gnupg|kube|ssh)(?:\/|$)|(?:^|\/)(?:credentials|hosts\.yml|secrets\.env)(?:\/|$)|(?:^|\/)\.worktrees(?:\/|$)/;
 
 /** The only runtime-owned subtree that a sandboxed adapter may mount from HOME. */
-export const HOME_MOUNT_ALLOWLIST = Object.freeze([
-  ".factory/event-runtime/workspaces",
-]);
+export function HOME_MOUNT_ALLOWLIST(home = homedir()) {
+  return [path.relative(home, workspacesRoot())];
+}
 
 function pathContains(parent, child) {
   const relative = path.relative(path.resolve(parent), path.resolve(child));
@@ -90,7 +90,7 @@ function unsafeHostMountReason(hostPath) {
     return "names a raw credential store or sibling worktree";
   if (
     pathContains(home, resolved) &&
-    !HOME_MOUNT_ALLOWLIST.some((prefix) =>
+    !HOME_MOUNT_ALLOWLIST(home).some((prefix) =>
       pathContains(path.join(home, prefix), resolved),
     )
   ) {

--- a/event-runtime/lib/adapters/sandboxed.mjs
+++ b/event-runtime/lib/adapters/sandboxed.mjs
@@ -61,9 +61,29 @@ const MODEL_BACKED_ADAPTER_SET = new Set(MODEL_BACKED_ADAPTERS);
 const RAW_CREDENTIAL_PATH =
   /(?:^|\/)\.(?:aws|azure|claude|config\/gcloud|config\/gh|cursor|gnupg|kube|ssh)(?:\/|$)|(?:^|\/)(?:credentials|hosts\.yml|secrets\.env)(?:\/|$)|(?:^|\/)\.worktrees(?:\/|$)/;
 
-/** The only runtime-owned subtree that a sandboxed adapter may mount from HOME. */
+/** Default workspaces subtree under the operator home when no runtime home is configured. */
+const DEFAULT_HOME_WORKSPACES = path.join(
+  ".factory",
+  "event-runtime",
+  "workspaces",
+);
+
+/**
+ * The only runtime-owned subtree that a sandboxed adapter may mount from HOME.
+ *
+ * Derived from the configured runtime home so a relocated FACTORY_EVENT_HOME
+ * keeps its workspaces mountable. `workspacesRoot()` throws under test/CI when
+ * FACTORY_EVENT_HOME is unset (config.mjs `runtimeHome`); this guard must
+ * never raise from inside an admission decision, so that case falls back to
+ * the literal default subtree relative to `home`, which keeps the check
+ * fail-closed: an undeclared runtime home admits nothing outside it.
+ */
 export function HOME_MOUNT_ALLOWLIST(home = homedir()) {
-  return [path.relative(home, workspacesRoot())];
+  try {
+    return [path.relative(home, workspacesRoot())];
+  } catch {
+    return [DEFAULT_HOME_WORKSPACES];
+  }
 }
 
 function pathContains(parent, child) {

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -465,6 +465,52 @@ describe("workspace-only model admission (#962)", () => {
     expect(child.exitCode).toBe(0);
   });
 
+  test("mount guard refuses instead of throwing when FACTORY_EVENT_HOME is unset under NODE_ENV=test", () => {
+    const operatorHome = ws();
+    const program = String.raw`
+      import { mkdirSync } from "node:fs";
+      import path from "node:path";
+      import { filesystemConfinementRefusal, HOME_MOUNT_ALLOWLIST } from "./sandboxed.mjs";
+
+      const mountRefusal = (hostPath) =>
+        filesystemConfinementRefusal("pi", {
+          ref: "confined@1",
+          mutating: false,
+          capabilities: { filesystem: "workspace-only", services: [] },
+          sandbox: {
+            provider: "gondolin",
+            mounts: { "/opt/tools": { path: hostPath, readonly: true } },
+          },
+        });
+      const home = process.env.HOME;
+      const allow = HOME_MOUNT_ALLOWLIST(home);
+      if (allow.length !== 1 || allow[0] !== path.join(".factory", "event-runtime", "workspaces")) {
+        throw new Error("allowlist did not fall back to the default subtree: " + JSON.stringify(allow));
+      }
+      const configPath = path.join(home, ".config", "sometool");
+      mkdirSync(configPath, { recursive: true });
+      const refusal = mountRefusal(configPath);
+      if (!refusal?.detail.includes("lies inside the operator home")) {
+        throw new Error("home-data mount was not refused: " + JSON.stringify(refusal));
+      }
+      const defaultWorkspace = path.join(home, ".factory", "event-runtime", "workspaces", "run-x");
+      mkdirSync(defaultWorkspace, { recursive: true });
+      if (mountRefusal(defaultWorkspace) !== null) {
+        throw new Error("default workspace subtree was refused");
+      }
+    `;
+    const env = { ...process.env, HOME: operatorHome, NODE_ENV: "test" };
+    delete env.FACTORY_EVENT_HOME;
+    const child = Bun.spawnSync({
+      cmd: [process.execPath, "--eval", program],
+      cwd: import.meta.dir,
+      env,
+      stderr: "pipe",
+    });
+    expect(child.stderr.toString()).toBe("");
+    expect(child.exitCode).toBe(0);
+  });
+
   test("non-model adapters and mutating definitions retain their existing semantics", () => {
     expect(filesystemConfinementRefusal("fake", confinedDef())).toBeNull();
     expect(

--- a/event-runtime/lib/adapters/sandboxed.test.mjs
+++ b/event-runtime/lib/adapters/sandboxed.test.mjs
@@ -11,6 +11,7 @@ import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapte
 import { describe, expect, test } from "bun:test";
 import {
   existsSync,
+  mkdirSync,
   readFileSync,
   rmSync,
   symlinkSync,
@@ -379,7 +380,7 @@ describe("workspace-only model admission (#962)", () => {
       const home = process.env.HOME;
       const configPath = path.join(home, ".config", "sometool");
       const localPath = path.join(home, ".local", "share", "x");
-      const workspacePath = path.join(home, ".factory", "event-runtime", "workspaces", "run-x");
+      const workspacePath = path.join(process.env.FACTORY_EVENT_HOME, "workspaces", "run-x");
       const rawCredentialPath = path.join(home, ".config", "gh");
       mkdirSync(configPath, { recursive: true });
       mkdirSync(localPath, { recursive: true });
@@ -401,7 +402,64 @@ describe("workspace-only model admission (#962)", () => {
     const child = Bun.spawnSync({
       cmd: [process.execPath, "--eval", program],
       cwd: import.meta.dir,
-      env: { ...process.env, HOME: home, ALIAS_ROOT: ws() },
+      env: {
+        ...process.env,
+        HOME: home,
+        FACTORY_EVENT_HOME: home,
+        ALIAS_ROOT: ws(),
+      },
+      stderr: "pipe",
+    });
+    expect(child.exitCode).toBe(0);
+  });
+
+  test("workspace allowlist follows relocated FACTORY_EVENT_HOME", () => {
+    const operatorHome = ws();
+    const runtimeHome = ws();
+    const program = String.raw`
+      import { mkdirSync } from "node:fs";
+      import path from "node:path";
+      import { filesystemConfinementRefusal } from "./sandboxed.mjs";
+
+      const mountRefusal = (hostPath) =>
+        filesystemConfinementRefusal("pi", {
+          ref: "confined@1",
+          mutating: false,
+          capabilities: { filesystem: "workspace-only", services: [] },
+          sandbox: {
+            provider: "gondolin",
+            mounts: { "/opt/tools": { path: hostPath, readonly: true } },
+          },
+        });
+      const configuredWorkspace = path.join(
+        process.env.FACTORY_EVENT_HOME,
+        "workspaces",
+        "run-x",
+      );
+      const legacyWorkspace = path.join(
+        process.env.HOME,
+        ".factory",
+        "event-runtime",
+        "workspaces",
+        "run-x",
+      );
+      mkdirSync(configuredWorkspace, { recursive: true });
+      mkdirSync(legacyWorkspace, { recursive: true });
+      if (mountRefusal(configuredWorkspace) !== null) {
+        throw new Error("relocated workspace was refused");
+      }
+      if (!mountRefusal(legacyWorkspace)?.detail.includes("lies inside the operator home")) {
+        throw new Error("legacy workspace was not refused");
+      }
+    `;
+    const child = Bun.spawnSync({
+      cmd: [process.execPath, "--eval", program],
+      cwd: import.meta.dir,
+      env: {
+        ...process.env,
+        HOME: operatorHome,
+        FACTORY_EVENT_HOME: runtimeHome,
+      },
       stderr: "pipe",
     });
     expect(child.exitCode).toBe(0);


### PR DESCRIPTION
Fixes watt-mind/factory#1285

Review ACP early-exit stream cleanup and relocated workspace mount admission.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/acp.test.mjs event-runtime/lib/adapters/sandboxed.test.mjs --timeout 20000 && bun run check`    | pass    | 58 pass, 1 skip, 0 fail |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`  | pass    | clean                  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend/infrastructure adapter maintenance; no user-facing surface

## Handoff

- Review FIX addressed in 11cef01: `HOME_MOUNT_ALLOWLIST()` wraps the `workspacesRoot()` derivation in try/catch and falls back to the literal `.factory/event-runtime/workspaces` (relative to `home`) when `runtimeHome()` throws (NODE_ENV=test/CI without FACTORY_EVENT_HOME), so `unsafeHostMountReason` always returns a refusal instead of raising inside the guard.
- New test spawns a child with NODE_ENV=test and FACTORY_EVENT_HOME cleared and asserts a `lies inside the operator home` refusal plus admission of the default workspace subtree.
- `acp.mjs` `settle`: kept `closeTranscript()` before `destroy()` with a comment explaining why (lets a flushed stream emit `finish`; destroy still guarantees fd release).
- Verified: `bun test --timeout 20000 event-runtime/lib/adapters/sandboxed.test.mjs event-runtime/lib/adapters/acp.test.mjs event-runtime/lib/worker.test.mjs` (214 pass, 1 skip), `bun run check` clean, prettier clean on touched files.