### PR TITLE
fix(event-runtime): tolerate corrupt model-tier config rows

### DIFF
--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -283,7 +283,10 @@ export function configView({
   extensions = loadedExtensions(),
 } = {}) {
   const policy = readYaml(resolveConfigPath("policy", { root }));
-  const policyModels = modelTierConfigViewTolerant(db, loadModelTierMap({ root }));
+  const policyModels = modelTierConfigViewTolerant(
+    db,
+    loadModelTierMap({ root }),
+  );
   const schedule = readYaml(resolveConfigPath("schedule", { root }));
   const nodesFile = nodesConfigPath(root);
   const loadedAt = registryLoadedAt ?? new Date(now).toISOString();

--- a/event-runtime/lib/api-config.mjs
+++ b/event-runtime/lib/api-config.mjs
@@ -6,7 +6,7 @@ import { loadedExtensions, maskExtensionSecrets } from "./extensions.mjs";
 import { reposView } from "./repos.mjs";
 import { loadNodesConfig, nodesConfigPath } from "./workers-remote.mjs";
 import { loadModelTierMap } from "./registry.mjs";
-import { modelTierConfigView } from "./runtime-overrides.mjs";
+import { modelTierConfigViewTolerant } from "./runtime-overrides.mjs";
 
 const POLICY_KEYS = [
   "packs",
@@ -283,7 +283,7 @@ export function configView({
   extensions = loadedExtensions(),
 } = {}) {
   const policy = readYaml(resolveConfigPath("policy", { root }));
-  const policyModels = modelTierConfigView(db, loadModelTierMap({ root }));
+  const policyModels = modelTierConfigViewTolerant(db, loadModelTierMap({ root }));
   const schedule = readYaml(resolveConfigPath("schedule", { root }));
   const nodesFile = nodesConfigPath(root);
   const loadedAt = registryLoadedAt ?? new Date(now).toISOString();

--- a/event-runtime/lib/api-config.test.mjs
+++ b/event-runtime/lib/api-config.test.mjs
@@ -229,6 +229,45 @@ describe("GET /config view", () => {
     db.close();
   });
 
+  test("keeps the config inventory available when a model-tier cell is corrupt", async () => {
+    const { server, port, db, close } = await makeServer({
+      configRoot: fixtureRoot(),
+    });
+    putOverride(db, {
+      kind: KIND_MODEL_TIER_CELL,
+      key: "pi:strong",
+      patch: { model: "runtime-strong" },
+      actor: "operator",
+    });
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      KIND_MODEL_TIER_CELL,
+      "pi:standard",
+      JSON.stringify({ model: "" }),
+      new Date(0).toISOString(),
+      "test",
+    );
+    try {
+      const response = await fetch(`http://127.0.0.1:${port}/config`);
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      const section = body.sections.find((item) => item.id === "policy-models");
+      expect(section.modelTierConfig.runtime.pi.strong).toBe("runtime-strong");
+      expect(section.modelTierConfig.problems).toEqual([
+        {
+          key: "pi:standard",
+          error: expect.stringContaining("model must be a non-empty string"),
+        },
+      ]);
+      expect(body.sections.map((item) => item.id)).toContain("registry");
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
   test("uses explicit allow-lists and publishes node env keys, never values", () => {
     const view = configView({
       root: fixtureRoot(),

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -1,5 +1,10 @@
 /** Agent and repository registry endpoints. */
-import { getArtifactView, loadModelTierMap, resolveModel } from "./registry.mjs";
+import {
+  RegistryError,
+  getArtifactView,
+  loadModelTierMap,
+  resolveModel,
+} from "./registry.mjs";
 import {
   RepoError,
   reposRoot,
@@ -118,6 +123,12 @@ export function agentsView(registry, { overrides = emptyOverrides() } = {}) {
 function sendOverlayError(send, err) {
   if (err instanceof OverlayError)
     return send(err.status, { error: err.message });
+  // The tracked model map is reread from disk per request; a corrupt
+  // policy.yaml is an operator-fixable 500, not an uncaught handler throw.
+  if (err instanceof RegistryError)
+    return send(500, {
+      error: `tracked policy.yaml is unreadable: ${err.message}`,
+    });
   throw err;
 }
 

--- a/event-runtime/lib/api-registry.mjs
+++ b/event-runtime/lib/api-registry.mjs
@@ -1,6 +1,11 @@
 /** Agent and repository registry endpoints. */
-import { getArtifactView, resolveModel } from "./registry.mjs";
-import { RepoError, resolvePromotionTarget, reposView } from "./repos.mjs";
+import { getArtifactView, loadModelTierMap, resolveModel } from "./registry.mjs";
+import {
+  RepoError,
+  reposRoot,
+  resolvePromotionTarget,
+  reposView,
+} from "./repos.mjs";
 import {
   KIND_AGENT,
   KIND_EVENT_TYPE,
@@ -136,11 +141,12 @@ export async function handleRegistryApiRoute({
     return send(200, agentsView(registry, { overrides }));
   }
 
-  const trackedModelTiers =
-    registry.trackedModelTiers ?? registry.modelTiers ?? {};
-
   if (route === "GET /overrides/config") {
     try {
+      // The tracked map is hot-reloadable policy input. The registry keeps its
+      // startup snapshot for execution, while both configuration endpoints
+      // read this disk source so their operator-facing views cannot drift.
+      const trackedModelTiers = loadModelTierMap({ root: reposRoot() });
       return send(200, modelTierConfigView(db, trackedModelTiers));
     } catch (err) {
       return sendOverlayError(send, err);
@@ -152,6 +158,7 @@ export async function handleRegistryApiRoute({
   );
   if (modelCellPath && (req.method === "PUT" || req.method === "DELETE")) {
     try {
+      const trackedModelTiers = loadModelTierMap({ root: reposRoot() });
       let adapter;
       let tier;
       try {

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -563,10 +563,7 @@ describe("runtime overlay API (WM-887)", () => {
     const root = tmpDir("evrt-api-model-map-");
     mkdirSync(path.join(root, "config"), { recursive: true });
     const policy = path.join(root, "config", "policy.yaml");
-    writeFileSync(
-      policy,
-      "models:\n  pi:\n    standard: disk-model-before\n",
-    );
+    writeFileSync(policy, "models:\n  pi:\n    standard: disk-model-before\n");
     const previousRoot = process.env.FACTORY_REPOS_ROOT;
     process.env.FACTORY_REPOS_ROOT = root;
     const { server, port, close } = await makeServer({
@@ -574,11 +571,10 @@ describe("runtime overlay API (WM-887)", () => {
       repos: () => new Map(),
     });
     try {
-      writeFileSync(
-        policy,
-        "models:\n  pi:\n    standard: disk-model-after\n",
-      );
-      const config = await (await fetch(`http://127.0.0.1:${port}/config`)).json();
+      writeFileSync(policy, "models:\n  pi:\n    standard: disk-model-after\n");
+      const config = await (
+        await fetch(`http://127.0.0.1:${port}/config`)
+      ).json();
       const overrides = await (
         await fetch(`http://127.0.0.1:${port}/overrides/config`)
       ).json();
@@ -608,9 +604,7 @@ describe("runtime overlay API (WM-887)", () => {
       "test",
     );
     try {
-      const response = await fetch(
-        `http://127.0.0.1:${port}/overrides/config`,
-      );
+      const response = await fetch(`http://127.0.0.1:${port}/overrides/config`);
       expect(response.status).toBe(500);
       expect((await response.json()).error).toContain(
         "delete or correct this runtime_overrides row",
@@ -618,6 +612,44 @@ describe("runtime overlay API (WM-887)", () => {
     } finally {
       close();
       server.close();
+    }
+  });
+
+  test("GET /overrides/config maps a corrupt tracked policy.yaml to a 500 with a clear message", async () => {
+    const root = tmpDir("evrt-api-corrupt-policy-");
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const policy = path.join(root, "config", "policy.yaml");
+    writeFileSync(policy, "models:\n  pi:\n    standard: ok\n");
+    const previousRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    const { server, port, close } = await makeServer({
+      configRoot: root,
+      repos: () => new Map(),
+    });
+    try {
+      writeFileSync(policy, "models:\n  pi:\n    turbo: not-a-tier\n");
+      const response = await fetch(`http://127.0.0.1:${port}/overrides/config`);
+      expect(response.status).toBe(500);
+      const { error } = await response.json();
+      expect(error).toContain("tracked policy.yaml is unreadable");
+      expect(error).toContain("models.pi.turbo is not a tier");
+      const cell = await fetch(
+        `http://127.0.0.1:${port}/overrides/config/models/pi/standard`,
+        {
+          method: "PUT",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ model: "x" }),
+        },
+      );
+      expect(cell.status).toBe(500);
+      expect((await cell.json()).error).toContain(
+        "models.pi.turbo is not a tier",
+      );
+    } finally {
+      close();
+      server.close();
+      if (previousRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previousRoot;
     }
   });
 

--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -40,6 +40,7 @@ import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 import { agentsView, handleRegistryApiRoute } from "./api-registry.mjs";
 import {
   KIND_EVENT_TYPE,
+  KIND_MODEL_TIER_CELL,
   listOverrideJournal,
   putOverride,
 } from "./runtime-overrides.mjs";
@@ -552,6 +553,68 @@ describe("runtime overlay API (WM-887)", () => {
         effectiveModel: before,
         restartRequired: true,
       });
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
+  test("GET /config and GET /overrides/config reread the same tracked map", async () => {
+    const root = tmpDir("evrt-api-model-map-");
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    const policy = path.join(root, "config", "policy.yaml");
+    writeFileSync(
+      policy,
+      "models:\n  pi:\n    standard: disk-model-before\n",
+    );
+    const previousRoot = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    const { server, port, close } = await makeServer({
+      configRoot: root,
+      repos: () => new Map(),
+    });
+    try {
+      writeFileSync(
+        policy,
+        "models:\n  pi:\n    standard: disk-model-after\n",
+      );
+      const config = await (await fetch(`http://127.0.0.1:${port}/config`)).json();
+      const overrides = await (
+        await fetch(`http://127.0.0.1:${port}/overrides/config`)
+      ).json();
+      expect(
+        config.sections.find((item) => item.id === "policy-models")
+          .modelTierConfig.tracked.pi.standard,
+      ).toBe("disk-model-after");
+      expect(overrides.tracked.pi.standard).toBe("disk-model-after");
+    } finally {
+      close();
+      server.close();
+      if (previousRoot === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previousRoot;
+    }
+  });
+
+  test("GET /overrides/config keeps strict corrupt-row behavior", async () => {
+    const { server, port, db, close } = await makeServer();
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      KIND_MODEL_TIER_CELL,
+      "pi:standard",
+      JSON.stringify({ model: "" }),
+      new Date(0).toISOString(),
+      "test",
+    );
+    try {
+      const response = await fetch(
+        `http://127.0.0.1:${port}/overrides/config`,
+      );
+      expect(response.status).toBe(500);
+      expect((await response.json()).error).toContain(
+        "delete or correct this runtime_overrides row",
+      );
     } finally {
       close();
       server.close();

--- a/event-runtime/lib/runtime-overrides.mjs
+++ b/event-runtime/lib/runtime-overrides.mjs
@@ -113,40 +113,69 @@ export function validateModelTierCellPatch(adapter, tier, patch) {
 }
 
 /** Read and validate only independently stored policy model cells. */
-export function runtimeModelTierCells(db) {
-  if (!db) return {};
-  const rows = db
+function readModelTierCell(row) {
+  const { adapter, tier } = parseModelTierCellKey(row.key);
+  let parsed;
+  try {
+    parsed = JSON.parse(row.patch_json);
+  } catch (err) {
+    throw new OverlayError(
+      500,
+      `invalid stored ${KIND_MODEL_TIER_CELL} row ${JSON.stringify(row.key)}: patch_json is not JSON (${err.message}); delete or correct this runtime_overrides row`,
+    );
+  }
+  let patch;
+  try {
+    patch = validateModelTierCellPatch(adapter, tier, parsed);
+  } catch (err) {
+    if (err instanceof OverlayError) {
+      throw new OverlayError(
+        500,
+        `invalid stored ${KIND_MODEL_TIER_CELL} row ${JSON.stringify(row.key)}: ${err.message}; delete or correct this runtime_overrides row`,
+      );
+    }
+    throw err;
+  }
+  return { adapter, tier, model: patch.model };
+}
+
+function modelTierCellRows(db) {
+  if (!db) return [];
+  return db
     .query(
       `SELECT key, patch_json FROM runtime_overrides WHERE kind = ? ORDER BY key`,
     )
     .all(KIND_MODEL_TIER_CELL);
+}
+
+function addModelTierCell(runtime, { adapter, tier, model }) {
+  runtime[adapter] = { ...(runtime[adapter] ?? {}), [tier]: model };
+}
+
+export function runtimeModelTierCells(db) {
   const runtime = {};
-  for (const row of rows) {
-    const { adapter, tier } = parseModelTierCellKey(row.key);
-    let parsed;
-    try {
-      parsed = JSON.parse(row.patch_json);
-    } catch (err) {
-      throw new OverlayError(
-        500,
-        `invalid stored ${KIND_MODEL_TIER_CELL} row ${JSON.stringify(row.key)}: patch_json is not JSON (${err.message}); delete or correct this runtime_overrides row`,
-      );
-    }
-    let patch;
-    try {
-      patch = validateModelTierCellPatch(adapter, tier, parsed);
-    } catch (err) {
-      if (err instanceof OverlayError) {
-        throw new OverlayError(
-          500,
-          `invalid stored ${KIND_MODEL_TIER_CELL} row ${JSON.stringify(row.key)}: ${err.message}; delete or correct this runtime_overrides row`,
-        );
-      }
-      throw err;
-    }
-    runtime[adapter] = { ...(runtime[adapter] ?? {}), [tier]: patch.model };
+  for (const row of modelTierCellRows(db)) {
+    addModelTierCell(runtime, readModelTierCell(row));
   }
   return runtime;
+}
+
+/**
+ * Read the model-tier cells for a read-only overview. Unlike the strict
+ * reader, one malformed persisted row is reported and does not hide valid
+ * cells or the rest of the configuration inventory.
+ */
+export function runtimeModelTierCellsTolerant(db) {
+  const runtime = {};
+  const problems = [];
+  for (const row of modelTierCellRows(db)) {
+    try {
+      addModelTierCell(runtime, readModelTierCell(row));
+    } catch (err) {
+      problems.push({ key: row.key, error: err.message });
+    }
+  }
+  return { cells: runtime, problems };
 }
 
 /** Compose stored cells over tracked policy; used before registry startup. */
@@ -167,6 +196,10 @@ export function applyModelTierCellOverrides(db, tracked) {
 /** Focused, secret-free policy model projection for API and Settings. */
 export function modelTierConfigView(db, tracked) {
   const runtime = runtimeModelTierCells(db);
+  return modelTierConfigViewFromRuntime(tracked, runtime);
+}
+
+function modelTierConfigViewFromRuntime(tracked, runtime) {
   const effective = composeModelTierMap(tracked, runtime);
   const adapters = [...MODEL_ADAPTERS];
   return {
@@ -182,6 +215,12 @@ export function modelTierConfigView(db, tracked) {
       adapters.map((adapter) => [adapter, { ...(effective[adapter] ?? {}) }]),
     ),
   };
+}
+
+/** Read-only configuration view that preserves valid cells alongside problems. */
+export function modelTierConfigViewTolerant(db, tracked) {
+  const { cells: runtime, problems } = runtimeModelTierCellsTolerant(db);
+  return { ...modelTierConfigViewFromRuntime(tracked, runtime), problems };
 }
 
 export function modelTierCellResult(db, tracked, adapter, tier, extra = {}) {

--- a/event-runtime/lib/runtime-overrides.test.mjs
+++ b/event-runtime/lib/runtime-overrides.test.mjs
@@ -20,8 +20,10 @@ import {
   mergeAgentPatch,
   modelTierCellKey,
   modelTierConfigView,
+  modelTierConfigViewTolerant,
   plannedDef,
   putOverride,
+  runtimeModelTierCellsTolerant,
   validateAgentPatch,
   validateEventTypePatch,
   validateModelTierCellPatch,
@@ -394,6 +396,39 @@ describe("policy model-tier cell overrides (gh-859)", () => {
     );
     expect(() => applyModelTierCellOverrides(db, tracked)).toThrow(
       /invalid stored modelTierCell row.*unknown model adapter.*delete or correct/,
+    );
+    db.close();
+  });
+
+  test("tolerant model-tier reads report malformed rows and retain valid cells", () => {
+    const db = openDb(":memory:");
+    putOverride(db, {
+      kind: KIND_MODEL_TIER_CELL,
+      key: "pi:strong",
+      patch: { model: "runtime-strong" },
+    });
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      KIND_MODEL_TIER_CELL,
+      "pi:standard",
+      JSON.stringify({ model: "runtime-standard", extra: true }),
+      new Date(0).toISOString(),
+      "test",
+    );
+
+    expect(runtimeModelTierCellsTolerant(db)).toEqual({
+      cells: { pi: { strong: "runtime-strong" } },
+      problems: [
+        {
+          key: "pi:standard",
+          error: expect.stringContaining("accepts exactly one field: model"),
+        },
+      ],
+    });
+    expect(modelTierConfigViewTolerant(db, tracked).effective.pi.strong).toBe(
+      "runtime-strong",
     );
     db.close();
   });


### PR DESCRIPTION
Fixes watt-mind/factory#1283

Config overviews now tolerate malformed override rows and share hot-reloaded policy model data.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-config.test.mjs event-runtime/lib/runtime-overrides.test.mjs event-runtime/lib/api-registry.test.mjs --timeout 20000 && bun run check` | pass    | 53 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass    | 1,876 tests, 0 failures; 10 skipped |
| UX critique          | factory-ux-critic                | not run | backend-only change; no user-facing surface |

UX critique: skipped — backend-only change; no user-facing surface

## Post-review

Review verdict FIX, addressed in 999d352a:

- `GET /overrides/config` and the model-cell PUT/DELETE reread `policy.yaml` per request via `loadModelTierMap()`, which throws `RegistryError`; `sendOverlayError` rethrew it, so a corrupt tracked file became an uncaught handler throw. `sendOverlayError` now maps `RegistryError` to a 500 with `tracked policy.yaml is unreadable: <reason>`.
- New test: corrupt tracked `policy.yaml` → 500 with a clear message on both the read and the cell-write route.
- Prettier applied to `api-config.mjs`, `api-registry.mjs`, `api-registry.test.mjs`; `bun run format:check` clean.
- Merged `origin/develop` (was 2 behind).
- Re-verified: `bun test --timeout 20000 event-runtime/lib/api-config.test.mjs event-runtime/lib/api-registry.test.mjs event-runtime/lib/registry.test.mjs` → 92 pass, 0 fail; `bun run check` exit 0.

## Handoff

Ready for landing: review findings addressed, develop merged, verification re-run green. Squash-merge on green `Full verification`.
