### PR TITLE
fix(worker): align stalled lease exhaustion reasons

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4198,10 +4198,13 @@ export function releaseStalledWorkerLease(
     }
 
     const spec = JSON.parse(run.spec_json);
-    const failureReason = typedFailureReason("lease_expired");
     db.query(
       `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = ?`,
     ).run(iso(currentNow - 1), heldRunId, run.attempts);
+    const decision = retryDecision(db, heldRunId, spec, "lease_expired", {
+      includeCurrentFailure: true,
+    });
+    const failureReason = terminalFailureReason(decision, "lease_expired");
     if (run.state === "VERIFYING") {
       transition(db, {
         runId: heldRunId,
@@ -4221,7 +4224,6 @@ export function releaseStalledWorkerLease(
       "lease_expired",
       currentNow,
     );
-    const decision = retryDecision(db, heldRunId, spec, "lease_expired");
     if (decision.retry) {
       transition(db, {
         runId: heldRunId,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3120,9 +3120,7 @@ describe("worker", () => {
       [releasedDb, releasedSpec],
       [reapedDb, reapedSpec],
     ]) {
-      db.query(`UPDATE runs SET attempts = 1 WHERE run_id = ?`).run(
-        spec.runId,
-      );
+      db.query(`UPDATE runs SET attempts = 1 WHERE run_id = ?`).run(spec.runId);
       db.query(
         `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
          VALUES (?, ?, ?, ?, ?, ?)`,
@@ -3140,15 +3138,17 @@ describe("worker", () => {
       );
     }
 
-    const releasedClaim = claimNext(
-      releasedDb,
-      opts({ owner: "w-release" }),
-    );
+    const releasedClaim = claimNext(releasedDb, opts({ owner: "w-release" }));
     const reapedClaim = claimNext(reapedDb, opts({ owner: "reaper" }));
     expect(releasedClaim.attempt).toBe(2);
     expect(reapedClaim.attempt).toBe(2);
     const afterExpiry = T0 + (releasedSpec.timeoutSeconds + 120) * 1000 + 1;
-    insertStalledWorker(releasedDb, "w-release", releasedSpec.runId, afterExpiry);
+    insertStalledWorker(
+      releasedDb,
+      "w-release",
+      releasedSpec.runId,
+      afterExpiry,
+    );
 
     expect(
       releaseStalledWorkerLease(
@@ -3182,21 +3182,26 @@ describe("worker", () => {
     const reapedDb = openDb(":memory:");
     const releasedSpec = queueRun(
       releasedDb,
-      makeSpec({ runId: "run_stalled_release_retry", maxEnvironmentRetries: 1 }),
+      makeSpec({
+        runId: "run_stalled_release_retry",
+        maxEnvironmentRetries: 1,
+      }),
     );
     const reapedSpec = queueRun(
       reapedDb,
       makeSpec({ runId: "run_stalled_reap_retry", maxEnvironmentRetries: 1 }),
     );
-    const releasedClaim = claimNext(
-      releasedDb,
-      opts({ owner: "w-release" }),
-    );
+    const releasedClaim = claimNext(releasedDb, opts({ owner: "w-release" }));
     const reapedClaim = claimNext(reapedDb, opts({ owner: "reaper" }));
     expect(releasedClaim.attempt).toBe(1);
     expect(reapedClaim.attempt).toBe(1);
     const afterExpiry = T0 + (releasedSpec.timeoutSeconds + 120) * 1000 + 1;
-    insertStalledWorker(releasedDb, "w-release", releasedSpec.runId, afterExpiry);
+    insertStalledWorker(
+      releasedDb,
+      "w-release",
+      releasedSpec.runId,
+      afterExpiry,
+    );
 
     expect(
       releaseStalledWorkerLease(

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -210,6 +210,24 @@ function opts(extra = {}) {
   };
 }
 
+function insertStalledWorker(db, workerId, runId, now) {
+  const staleAt = now - 90_001;
+  db.query(
+    `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    workerId,
+    "test-host",
+    1,
+    "{}",
+    "fake",
+    new Date(now).toISOString(),
+    new Date(staleAt).toISOString(),
+    "busy",
+    runId,
+  );
+}
+
 describe("worker", () => {
   test("materialized harness entries record hashes for every copied file", () => {
     const factoryRoot = tmpDir("evrt-harness-source-");
@@ -3025,6 +3043,129 @@ describe("worker", () => {
         )
         .get(spec.runId, claim.attempt),
     ).toEqual({ terminal_state: "FAILED", reason_code: "lease_expired" });
+  });
+
+  test("stalled-worker release matches reaper at the environment retry ceiling", () => {
+    const releasedDb = openDb(":memory:");
+    const reapedDb = openDb(":memory:");
+    const releasedSpec = queueRun(
+      releasedDb,
+      makeSpec({
+        runId: "run_stalled_release_ceiling",
+        maxAttempts: 5,
+        maxEnvironmentRetries: 0,
+      }),
+    );
+    const reapedSpec = queueRun(
+      reapedDb,
+      makeSpec({
+        runId: "run_stalled_reap_ceiling",
+        maxAttempts: 5,
+        maxEnvironmentRetries: 0,
+      }),
+    );
+
+    for (const [db, spec] of [
+      [releasedDb, releasedSpec],
+      [reapedDb, reapedSpec],
+    ]) {
+      db.query(`UPDATE runs SET attempts = 1 WHERE run_id = ?`).run(
+        spec.runId,
+      );
+      db.query(
+        `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
+         VALUES (?, ?, ?, ?, ?, ?)`,
+      ).run(
+        spec.runId,
+        1,
+        1,
+        new Date(T0 - 1).toISOString(),
+        "FAILED",
+        "lease_expired",
+      );
+      db.query(`INSERT INTO counters (name, value) VALUES (?, ?)`).run(
+        "fencing",
+        1,
+      );
+    }
+
+    const releasedClaim = claimNext(
+      releasedDb,
+      opts({ owner: "w-release" }),
+    );
+    const reapedClaim = claimNext(reapedDb, opts({ owner: "reaper" }));
+    expect(releasedClaim.attempt).toBe(2);
+    expect(reapedClaim.attempt).toBe(2);
+    const afterExpiry = T0 + (releasedSpec.timeoutSeconds + 120) * 1000 + 1;
+    insertStalledWorker(releasedDb, "w-release", releasedSpec.runId, afterExpiry);
+
+    expect(
+      releaseStalledWorkerLease(
+        releasedDb,
+        { workerId: "w-release", runId: releasedSpec.runId },
+        { now: afterExpiry, policyVersion: "test" },
+      ),
+    ).toEqual({ released: true, runId: releasedSpec.runId });
+    expect(
+      reapExpiredLeases(reapedDb, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
+
+    expect(runState(releasedDb, releasedSpec.runId)).toBe("FAILED");
+    expect(runState(reapedDb, reapedSpec.runId)).toBe("FAILED");
+    expect(
+      lifecycleOf(releasedDb, releasedSpec.runId)
+        .slice(-2)
+        .map(({ to_state, reason }) => ({ to_state, reason })),
+    ).toEqual(
+      lifecycleOf(reapedDb, reapedSpec.runId)
+        .slice(-2)
+        .map(({ to_state, reason }) => ({ to_state, reason })),
+    );
+    expect(lifecycleOf(releasedDb, releasedSpec.runId).at(-1).reason).toBe(
+      "failure:environment:lease_expired; environment_retry_budget_exhausted",
+    );
+  });
+
+  test("stalled-worker release matches reaper below the environment retry ceiling", () => {
+    const releasedDb = openDb(":memory:");
+    const reapedDb = openDb(":memory:");
+    const releasedSpec = queueRun(
+      releasedDb,
+      makeSpec({ runId: "run_stalled_release_retry", maxEnvironmentRetries: 1 }),
+    );
+    const reapedSpec = queueRun(
+      reapedDb,
+      makeSpec({ runId: "run_stalled_reap_retry", maxEnvironmentRetries: 1 }),
+    );
+    const releasedClaim = claimNext(
+      releasedDb,
+      opts({ owner: "w-release" }),
+    );
+    const reapedClaim = claimNext(reapedDb, opts({ owner: "reaper" }));
+    expect(releasedClaim.attempt).toBe(1);
+    expect(reapedClaim.attempt).toBe(1);
+    const afterExpiry = T0 + (releasedSpec.timeoutSeconds + 120) * 1000 + 1;
+    insertStalledWorker(releasedDb, "w-release", releasedSpec.runId, afterExpiry);
+
+    expect(
+      releaseStalledWorkerLease(
+        releasedDb,
+        { workerId: "w-release", runId: releasedSpec.runId },
+        { now: afterExpiry, policyVersion: "test" },
+      ),
+    ).toEqual({ released: true, runId: releasedSpec.runId });
+    expect(
+      reapExpiredLeases(reapedDb, { now: afterExpiry, policyVersion: "test" }),
+    ).toBe(1);
+
+    expect(runState(releasedDb, releasedSpec.runId)).toBe("QUEUED");
+    expect(runState(reapedDb, reapedSpec.runId)).toBe("QUEUED");
+    expect(lifecycleOf(releasedDb, releasedSpec.runId).at(-1).reason).toBe(
+      "retry:environment",
+    );
+    expect(lifecycleOf(reapedDb, reapedSpec.runId).at(-1).reason).toBe(
+      "retry:environment",
+    );
   });
 
   test("cancelRun on a RUNNING attempt aborts adapter immediately and records attempt (OPS-417)", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1287

Aligns stalled-worker lease expiry exhaustion reasons with the reaper behavior and adds parity coverage.

## Validation

| Check                | Command                                                       | Result | Notes                              |
| -------------------- | ------------------------------------------------------------- | ------ | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000 && bun run check` | pass   | 157 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass   | 1870 pass, 10 skipped, 0 failures |
| UX critique          | factory-ux-critic                                             | not run | backend-only change                |

UX critique: skipped
## Handoff

- Release note: `releaseStalledWorkerLease` now spends the environment retry budget one attempt earlier, aligned with the reaper.
