### PR TITLE
polish(presentation): normalize blank link labels and unify inspect rendering

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -2,7 +2,7 @@
 /** Event-runtime CLI argument routing and command dispatch. */
 import path from "node:path";
 import { COMMANDS } from "./cli/commands.mjs";
-import { inspect as inspectCommand } from "./cli/inspect.mjs";
+import { renderInspect } from "./cli/inspect.mjs";
 import { withClient } from "./cli/shared.mjs";
 import { USAGE as BASE_USAGE } from "./cli/usage.mjs";
 import { backfillResultArtifacts } from "./lib/artifacts.mjs";
@@ -380,7 +380,7 @@ export async function inspectWithPresentation(args) {
         // presentation is optional garnish, so it must not make inspect pay
         // for a second GET /runs/:id.
         detail = await client.run(args[0]);
-        await inspectCommand({ ...client, run: async () => detail }, args[0]);
+        await renderInspect(detail, client);
       });
     }
   } finally {

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { COMMAND_NAMES } from "./cli/commands.mjs";
+import { renderInspect } from "./cli/inspect.mjs";
 import { CLI, freePort, runCli } from "./cli/test-helpers.mjs";
 
 const EXPECTED_COMMANDS = [
@@ -142,5 +143,69 @@ describe("cli routing", () => {
     }
 
     expect(runRequests).toBe(1);
+  });
+
+  test("inspect without presentation matches the shared detail renderer", async () => {
+    const detail = {
+      run: {
+        runId: "run-1301",
+        state: "COMPLETED",
+        attempts: 1,
+        created_at: "2026-01-01T00:00:00.000Z",
+        updated_at: "2026-01-01T00:01:00.000Z",
+        spec: {
+          agent: "worker",
+          adapter: "fake",
+          outputContract: "factory.agent-result/v1",
+          maxAttempts: 1,
+        },
+      },
+      workspace: "/tmp/run-1301",
+      lifecycle: [],
+      result: { terminalState: "COMPLETED" },
+    };
+    const lines = [];
+    const originalLog = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await renderInspect(detail, {});
+    } finally {
+      console.log = originalLog;
+    }
+
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        if (new URL(request.url).pathname === "/runs/run-1301")
+          return Response.json(detail);
+        return new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const child = Bun.spawn(["bun", CLI, "inspect", "run-1301"], {
+        env: {
+          ...process.env,
+          FACTORY_EVENT_PORT: String(server.port),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stdout] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+      ]);
+      expect(status).toBe(0);
+      expect(stdout.trimEnd().split("\n")).toEqual(
+        lines.flatMap((line) => line.split("\n")),
+      );
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("inspect without a run ID reports usage", () => {
+    const result = runCli(["inspect"]);
+    expect(result.status).not.toBe(0);
+    expect(result.all).toContain("usage: inspect <run-id>");
   });
 });

--- a/event-runtime/cli/inspect.mjs
+++ b/event-runtime/cli/inspect.mjs
@@ -20,7 +20,11 @@ async function viewFor(client, agentRef) {
 }
 
 export async function inspect(client, runId) {
-  const view = await client.run(runId);
+  return renderInspect(await client.run(runId), client);
+}
+
+/** Render one already-fetched run detail for every inspect entry point. */
+export async function renderInspect(view, client) {
   const { run } = view;
   console.log(`run        ${run.runId}`);
   console.log(

--- a/event-runtime/lib/presentation-text.mjs
+++ b/event-runtime/lib/presentation-text.mjs
@@ -113,7 +113,11 @@ function renderBlock(block, width) {
             item[candidate] !== undefined && item[candidate] !== null,
         );
         const target = key ? text(item[key]) : "—";
-        return `${item.label ?? target} <${target}>`;
+        const label =
+          typeof item.label === "string" && item.label.trim()
+            ? item.label
+            : target;
+        return `${label} <${target}>`;
       });
     default:
       return [];

--- a/event-runtime/lib/presentation-text.test.mjs
+++ b/event-runtime/lib/presentation-text.test.mjs
@@ -79,12 +79,14 @@ Repo <https://github.com/watt-mind/factory>`);
             items: [
               { url: "https://example.test/runs/1" },
               { issue: "WM-1289" },
+              { label: "", url: "https://example.test/runs/2" },
+              { label: "  \t", url: "https://example.test/runs/3" },
             ],
           },
         ],
       }),
     ).toBe(
-      "https://example.test/runs/1 <https://example.test/runs/1>\nWM-1289 <WM-1289>",
+      "https://example.test/runs/1 <https://example.test/runs/1>\nWM-1289 <WM-1289>\nhttps://example.test/runs/2 <https://example.test/runs/2>\nhttps://example.test/runs/3 <https://example.test/runs/3>",
     );
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1301

Review the shared inspect renderer and blank-label fallback coverage.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/presentation-text.test.mjs event-runtime/cli.test.mjs --timeout 20000 && bun run check` | pass | 10 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1875 passed, 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped