### PR TITLE
fix(owned-paths): fail closed registry digest policy

### DIFF
--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -139,7 +139,11 @@ function ownedPathsClosureCheck(description = "", repo, manifestCache) {
 }
 
 /** Convert closure errors into an issue-level guard message without aborting a scan. */
-export function ownedPathsClosureGuard(description = "", repo, manifestCache = new Map()) {
+export function ownedPathsClosureGuard(
+  description = "",
+  repo,
+  manifestCache = new Map(),
+) {
   try {
     return ownedPathsClosureCheck(description, repo, manifestCache);
   } catch (err) {

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -138,6 +138,20 @@ function ownedPathsClosureCheck(description = "", repo, manifestCache) {
   return { messages, gaps };
 }
 
+/** Convert closure errors into an issue-level guard message without aborting a scan. */
+export function ownedPathsClosureGuard(description = "", repo, manifestCache = new Map()) {
+  try {
+    return ownedPathsClosureCheck(description, repo, manifestCache);
+  } catch (err) {
+    return {
+      messages: [
+        `Owned Paths Closure: ${err.code ? `${err.code}: ` : ""}${err.message || String(err)}`,
+      ],
+      gaps: [],
+    };
+  }
+}
+
 export async function fetchReadyIssues(repo) {
   return loadControlPlane().listDispatchable({
     team: repo.team,
@@ -210,18 +224,13 @@ export async function main(argv = process.argv.slice(2)) {
     const bad = issues
       .map((issue) => {
         const gapNames = [...templateGaps(issue.description ?? "")];
-        try {
-          const closure = ownedPathsClosureCheck(
-            issue.description ?? "",
-            repo,
-            closureRequirements,
-          );
-          gapNames.push(...closure.messages);
-          return { issue, gaps: gapNames };
-        } catch (err) {
-          gapNames.push(`Owned Paths Closure: ${err.message || String(err)}`);
-          return { issue, gaps: gapNames };
-        }
+        const closure = ownedPathsClosureGuard(
+          issue.description ?? "",
+          repo,
+          closureRequirements,
+        );
+        gapNames.push(...closure.messages);
+        return { issue, gaps: gapNames };
       })
       .filter((r) => r.gaps.length);
 

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -11,7 +11,7 @@
  * genuine catch (CLNT-871/872's shape) and the false positives that got cut.
  */
 import { test, expect } from "bun:test";
-import { templateGaps } from "./label-guard.mjs";
+import { ownedPathsClosureGuard, templateGaps } from "./label-guard.mjs";
 
 const FULL_SPEC = `## Problem & Context
 
@@ -31,6 +31,16 @@ Something is broken and it matters.
 
 test("a real §5 spec passes with no gaps", () => {
   expect(templateGaps(FULL_SPEC)).toEqual([]);
+});
+
+test("a malformed registry digest policy is rendered as a guard message", () => {
+  const result = ownedPathsClosureGuard("", {
+    name: "factory",
+    ownedPathsPolicy: { registryDigest: { inputs: [] } },
+  });
+  expect(result.gaps).toEqual([]);
+  expect(result.messages).toHaveLength(1);
+  expect(result.messages[0]).toContain("invalid_owned_paths_policy");
 });
 
 test("the 4-section Frappe support-ticket template fails on both mechanical gaps (CLNT-871/872)", () => {

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -375,8 +375,14 @@ function segmentsMayOverlap(a, b) {
   const suffixA = literalSuffix(a);
   const suffixB = literalSuffix(b);
   return (
-    (!prefixA || !prefixB || prefixA.startsWith(prefixB) || prefixB.startsWith(prefixA)) &&
-    (!suffixA || !suffixB || suffixA.endsWith(suffixB) || suffixB.endsWith(suffixA))
+    (!prefixA ||
+      !prefixB ||
+      prefixA.startsWith(prefixB) ||
+      prefixB.startsWith(prefixA)) &&
+    (!suffixA ||
+      !suffixB ||
+      suffixA.endsWith(suffixB) ||
+      suffixB.endsWith(suffixA))
   );
 }
 
@@ -399,7 +405,8 @@ function registryGlobOverlaps(owned, input) {
     if (memo.has(key)) return memo.get(key);
     let result;
     if (i === a.length || j === b.length) {
-      result = (i === a.length && b.slice(j).every((segment) => segment === "**")) ||
+      result =
+        (i === a.length && b.slice(j).every((segment) => segment === "**")) ||
         (j === b.length && a.slice(i).every((segment) => segment === "**"));
     } else if (a[i] === "**") {
       result = intersects(i + 1, j) || intersects(i, j + 1);

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -212,6 +212,15 @@ export class OwnedPathsPatternError extends Error {
   }
 }
 
+/** A closure policy was supplied by a caller but does not have a safe shape. */
+export class OwnedPathsPolicyError extends Error {
+  constructor(reason) {
+    super(`invalid Owned Paths policy registryDigest: ${reason}`);
+    this.name = "OwnedPathsPolicyError";
+    this.code = "invalid_owned_paths_policy";
+  }
+}
+
 function compileBraceAlternation(glob, start) {
   const alternatives = [];
   let index = start;
@@ -343,29 +352,95 @@ export function globsOverlap(a, b) {
   }
 }
 
+const hasGlobSyntax = (segment) => /[*?{]/.test(segment);
+
 /**
- * The literal directory portion shared by all paths matched by a glob.
- * A concrete input file's directory is used rather than the file itself.
+ * Whether two one-segment globs could name the same segment. This is
+ * deliberately conservative for two wildcarded segments, but preserves their
+ * literal prefixes/suffixes so `foo*` and `bar*` do not become an anchor.
  */
-function globDirectoryPrefix(glob) {
-  const segments = glob.split("/");
-  const wildcard = segments.findIndex((segment) => /[*?{]/.test(segment));
-  const directories = segments.slice(0, wildcard === -1 ? -1 : wildcard);
-  return directories.length ? `${directories.join("/")}/` : "";
+function segmentsMayOverlap(a, b) {
+  if (a === b) return true;
+  if (!hasGlobSyntax(a)) return globToRegExp(b).test(a);
+  if (!hasGlobSyntax(b)) return globToRegExp(a).test(b);
+  if (a.includes("{") || b.includes("{")) return true;
+
+  const literalPrefix = (segment) => segment.slice(0, segment.search(/[*?]/));
+  const literalSuffix = (segment) => {
+    const index = Math.max(segment.lastIndexOf("*"), segment.lastIndexOf("?"));
+    return segment.slice(index + 1);
+  };
+  const prefixA = literalPrefix(a);
+  const prefixB = literalPrefix(b);
+  const suffixA = literalSuffix(a);
+  const suffixB = literalSuffix(b);
+  return (
+    (!prefixA || !prefixB || prefixA.startsWith(prefixB) || prefixB.startsWith(prefixA)) &&
+    (!suffixA || !suffixB || suffixA.endsWith(suffixB) || suffixB.endsWith(suffixA))
+  );
+}
+
+/**
+ * Segment-aware intersection for registry inputs. Unlike generic Owned Paths
+ * collision detection, this must not let a leading `**` make unrelated input
+ * directories look like anchors.
+ */
+function registryGlobOverlaps(owned, input) {
+  // Validate the whole patterns first so malformed Owned Paths retain the
+  // generic fail-closed behavior below.
+  globToRegExp(owned);
+  globToRegExp(input);
+  const a = owned.replace(/^\.\//, "").split("/");
+  const b = input.replace(/^\.\//, "").split("/");
+  const memo = new Map();
+
+  const intersects = (i, j) => {
+    const key = `${i}:${j}`;
+    if (memo.has(key)) return memo.get(key);
+    let result;
+    if (i === a.length || j === b.length) {
+      result = (i === a.length && b.slice(j).every((segment) => segment === "**")) ||
+        (j === b.length && a.slice(i).every((segment) => segment === "**"));
+    } else if (a[i] === "**") {
+      result = intersects(i + 1, j) || intersects(i, j + 1);
+    } else if (b[j] === "**") {
+      result = intersects(i, j + 1) || intersects(i + 1, j);
+    } else {
+      result = segmentsMayOverlap(a[i], b[j]) && intersects(i + 1, j + 1);
+    }
+    memo.set(key, result);
+    return result;
+  };
+
+  return intersects(0, 0);
 }
 
 /**
  * Registry inputs are deliberately stricter than generic Owned Paths overlap.
- * A leading wildcard can reach every directory, but must name an input's
- * directory before it can opt a ticket into the registry-digest closure.
+ * A leading wildcard can reach every directory, but must retain a literal
+ * segment anchor before it can opt a ticket into the registry-digest closure.
  */
 function registryInputOverlaps(owned, input) {
-  const firstSegment = owned.split("/", 1)[0] ?? "";
-  if (/[*?{]/.test(firstSegment)) {
-    const inputDirectory = globDirectoryPrefix(input);
-    if (!inputDirectory || !owned.includes(inputDirectory)) return false;
+  try {
+    const ownedSegments = owned.replace(/^\.\//, "").split("/");
+    const inputSegments = input.replace(/^\.\//, "").split("/");
+    // A leading wildcard alone is too broad to opt into a non-root registry
+    // input (for example, `**/*.json`). It must carry at least one literal
+    // path segment as an anchor; root-level files are their own anchor.
+    if (
+      hasGlobSyntax(ownedSegments[0] ?? "") &&
+      (ownedSegments[0] === "**" || inputSegments.length > 1) &&
+      !ownedSegments
+        .slice(1)
+        .some((segment) => segment !== "**" && !hasGlobSyntax(segment))
+    ) {
+      return false;
+    }
+    return registryGlobOverlaps(owned, input);
+  } catch (error) {
+    if (error instanceof OwnedPathsPatternError) return true;
+    throw error;
   }
-  return globsOverlap(owned, input);
 }
 
 /** Do two tickets' Owned Paths sets intersect? */
@@ -571,6 +646,29 @@ export function ownedPathsClosureGaps({
   pinManifestRequirements = [],
 } = {}) {
   const own = Array.isArray(ownedPaths) ? ownedPaths : [];
+  const rawRegistryDigest = ownedPathsPolicy?.registryDigest;
+  let registryDigest = null;
+  if (rawRegistryDigest !== undefined && rawRegistryDigest !== null) {
+    if (
+      typeof rawRegistryDigest !== "object" ||
+      Array.isArray(rawRegistryDigest) ||
+      !Array.isArray(rawRegistryDigest.inputs) ||
+      rawRegistryDigest.inputs.length === 0 ||
+      !rawRegistryDigest.inputs.every(
+        (input) => typeof input === "string" && input.trim(),
+      ) ||
+      typeof rawRegistryDigest.baseline !== "string" ||
+      !rawRegistryDigest.baseline.trim()
+    ) {
+      throw new OwnedPathsPolicyError(
+        "registryDigest must be { inputs: non-empty string[], baseline: non-empty string }",
+      );
+    }
+    registryDigest = {
+      inputs: rawRegistryDigest.inputs.map((input) => input.trim()),
+      baseline: rawRegistryDigest.baseline.trim(),
+    };
+  }
   const policy = {
     direct: Array.isArray(ownedPathsPolicy?.direct)
       ? ownedPathsPolicy.direct
@@ -578,12 +676,7 @@ export function ownedPathsClosureGaps({
     pinManifests: Array.isArray(ownedPathsPolicy?.pinManifests)
       ? ownedPathsPolicy.pinManifests
       : [],
-    registryDigest:
-      ownedPathsPolicy?.registryDigest &&
-      Array.isArray(ownedPathsPolicy.registryDigest.inputs) &&
-      typeof ownedPathsPolicy.registryDigest.baseline === "string"
-        ? ownedPathsPolicy.registryDigest
-        : null,
+    registryDigest,
   };
 
   const gaps = [];

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -332,7 +332,10 @@ test("a present malformed registry digest policy fails closed", () => {
     }
   }
 
-  expectEqual(ownedPathsClosureGaps({ ownedPaths: [], ownedPathsPolicy: {} }), []);
+  expectEqual(
+    ownedPathsClosureGaps({ ownedPaths: [], ownedPathsPolicy: {} }),
+    [],
+  );
   expectEqual(
     ownedPathsClosureGaps({
       ownedPaths: [],
@@ -430,7 +433,12 @@ test("registry input overlap respects path segments and root-level inputs", () =
   const gap = (owned) =>
     ownedPathsClosureGaps({ ownedPaths: [owned], ownedPathsPolicy: policy });
 
-  for (const owned of ["**/agents/*.md", "pins.json", "*.json", "**/pins.json"]) {
+  for (const owned of [
+    "**/agents/*.md",
+    "pins.json",
+    "*.json",
+    "**/pins.json",
+  ]) {
     expectEqual(gap(owned), [
       {
         rule: "registry-digest",

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -21,6 +21,7 @@ import {
   globsOverlap,
   isMatchEverythingGlob,
   OwnedPathsPatternError,
+  OwnedPathsPolicyError,
   pathsCollide,
   nextDispatchable,
   readPinManifestRequirements,
@@ -304,6 +305,43 @@ test("registry inputs require owning the zero-pack digest baseline when configur
   ]);
 });
 
+test("a present malformed registry digest policy fails closed", () => {
+  const malformedPolicies = [
+    { registryDigest: { inputs: ["event-runtime/agents/**"] } },
+    {
+      registryDigest: {
+        inputs: "event-runtime/agents/**",
+        baseline: REGISTRY_DIGEST_BASELINE_PATH,
+      },
+    },
+    {
+      registryDigest: {
+        inputs: [],
+        baseline: REGISTRY_DIGEST_BASELINE_PATH,
+      },
+    },
+  ];
+
+  for (const ownedPathsPolicy of malformedPolicies) {
+    try {
+      ownedPathsClosureGaps({ ownedPaths: [], ownedPathsPolicy });
+      throw new Error("expected malformed registry digest policy to throw");
+    } catch (error) {
+      expect(error).toBeInstanceOf(OwnedPathsPolicyError);
+      expect(error.code).toBe("invalid_owned_paths_policy");
+    }
+  }
+
+  expectEqual(ownedPathsClosureGaps({ ownedPaths: [], ownedPathsPolicy: {} }), []);
+  expectEqual(
+    ownedPathsClosureGaps({
+      ownedPaths: [],
+      ownedPathsPolicy: { registryDigest: null },
+    }),
+    [],
+  );
+});
+
 test("each registry data input requires the digest baseline, but unrelated paths do not", () => {
   for (const input of [
     "event-runtime/event-types.json",
@@ -375,6 +413,36 @@ test("registry digest closure is opt-in and ignores unanchored wildcards", () =>
       },
     ],
   );
+});
+
+test("registry input overlap respects path segments and root-level inputs", () => {
+  const policy = {
+    registryDigest: {
+      inputs: [
+        "event-runtime/agents/*.md",
+        "lib/foobar/*.json",
+        "pins.json",
+        "event-types.json",
+      ],
+      baseline: REGISTRY_DIGEST_BASELINE_PATH,
+    },
+  };
+  const gap = (owned) =>
+    ownedPathsClosureGaps({ ownedPaths: [owned], ownedPathsPolicy: policy });
+
+  for (const owned of ["**/agents/*.md", "pins.json", "*.json", "**/pins.json"]) {
+    expectEqual(gap(owned), [
+      {
+        rule: "registry-digest",
+        requiredPath: REGISTRY_DIGEST_BASELINE_PATH,
+        requiredBy: owned,
+      },
+    ]);
+  }
+  expectEqual(gap("**/subagents/*.md"), []);
+  expectEqual(gap("**/lib/foo*"), []);
+  expectEqual(gap("**/*.json"), []);
+  expectEqual(gap("event-runtime/**"), []);
 });
 
 test("pin manifests require owning generated output manifests", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1295

Review the fail-closed registry-digest policy and segment-aware closure matching.

## Validation

| Check                | Command                                                                          | Result  | Notes                          |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test orchestrator/owned-paths.test.mjs orchestrator/label-guard.test.mjs --timeout 20000 && bun run check` | pass    | 55 tests, 0 failures; check ok |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`       | pass    | 1875 pass, 10 skipped          |
| UX critique          | factory-ux-critic                                                                | skipped | no user-facing surface          |

UX critique: skipped — backend guard logic; no user-facing surface

## Post-review

- Review verdict FIX (mechanical): `Full verification` failed at `Formatting check (prettier)` on the PR's own lines. Ran prettier on the 4 owned files only (`orchestrator/owned-paths.mjs`, `orchestrator/label-guard.mjs`, `orchestrator/owned-paths.test.mjs`), merged `origin/develop`; `format:check`, `owned-paths.test.mjs` (42 pass), `event-runtime/lib` tests (1890 pass), `emit --check`, `bun run check` all green locally. Commit `style(owned-paths): prettier (#1295)`.
