### PR TITLE
fix(ci): guard empty security file list and clarify downloads

### DIFF
--- a/.github/scripts/install-pinned-tools.sh
+++ b/.github/scripts/install-pinned-tools.sh
@@ -23,7 +23,7 @@ force_install="${FORCE_INSTALL:-0}"
 custom_prefix="${INSTALL_PREFIX:-}"
 
 download() {
-  local destination="$1" url="$2"
+  local url="$1" destination="$2"
   curl "${CURL_DOWNLOAD_FLAGS[@]}" -o "$destination" "$url"
 }
 
@@ -38,7 +38,7 @@ install_bun() {
   archive="$temp_dir/bun-linux-x64.zip"
   extract_dir="$temp_dir/bun-linux-x64"
   rm -rf "$extract_dir"
-  download "$archive" "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip"
+  download "https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/bun-linux-x64.zip" "$archive"
   printf '%s  %s\n' "$BUN_SHA256" "$archive" | sha256sum -c -
   unzip -q "$archive" -d "$temp_dir"
   mkdir -p "$prefix/bin"
@@ -55,7 +55,7 @@ install_gitleaks() {
 
   archive="$temp_dir/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
   mkdir -p "$prefix/bin"
-  download "$archive" "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz"
+  download "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" "$archive"
   printf '%s  %s\n' "$GITLEAKS_SHA256" "$archive" | sha256sum -c -
   tar -xzf "$archive" -C "$prefix/bin" gitleaks
   chmod +x "$destination"
@@ -71,7 +71,7 @@ install_uv() {
   archive="$temp_dir/uv-x86_64-unknown-linux-gnu.tar.gz"
   extract_dir="$temp_dir/uv-x86_64-unknown-linux-gnu"
   rm -rf "$extract_dir"
-  download "$archive" "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz"
+  download "https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-x86_64-unknown-linux-gnu.tar.gz" "$archive"
   printf '%s  %s\n' "$UV_SHA256" "$archive" | sha256sum -c -
   tar -xzf "$archive" -C "$temp_dir"
   mkdir -p "$prefix/bin"
@@ -88,7 +88,7 @@ install_actionlint() {
 
   archive="$temp_dir/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
   mkdir -p "$prefix/bin"
-  download "$archive" "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz"
+  download "https://github.com/rhysd/actionlint/releases/download/v${ACTIONLINT_VERSION}/actionlint_${ACTIONLINT_VERSION}_linux_amd64.tar.gz" "$archive"
   printf '%s  %s\n' "$ACTIONLINT_SHA256" "$archive" | sha256sum -c -
   tar -xzf "$archive" -C "$prefix/bin" actionlint
   chmod +x "$destination"

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -35,14 +35,16 @@ jobs:
           github_changed=false
           # Fail loudly on an API error; an incomplete file list must not skip the smoke job.
           changed_files="$(gh api --paginate "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}/files" --jq '.[].filename')"
-          while IFS= read -r file; do
-            case "$file" in
-              .github/*)
-                github_changed=true
-                break
-                ;;
-            esac
-          done <<< "$changed_files"
+          if [ -n "$changed_files" ]; then
+            while IFS= read -r file; do
+              case "$file" in
+                .github/*)
+                  github_changed=true
+                  break
+                  ;;
+              esac
+            done <<< "$changed_files"
+          fi
           echo "github_changed=$github_changed" >> "$GITHUB_OUTPUT"
 
   pinned-tools-smoke:


### PR DESCRIPTION
Fixes watt-mind/factory#1300

Guard empty changed-file results and make pinned-tool downloads URL-first without changing workflow behavior.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `actionlint .github/workflows/security.yml && bash -n .github/scripts/install-pinned-tools.sh && bun run check`    | pass    | actionlint, syntax check, and generated-file check passed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`  | pass    | event-runtime/lib tests and generated-file check passed |
| Installer smoke      | `FORCE_INSTALL=1 INSTALL_PREFIX=$(mktemp -d) .github/scripts/install-pinned-tools.sh bun gitleaks uv actionlint` | pass | all four tools installed and reported versions |
| UX critique          | factory-ux-critic                | not run | no user-facing surface; CI maintenance only |

UX critique: skipped — no user-facing surface; CI maintenance only