### PR TITLE
perf(merge): re-admit deliveries after never-executed scans

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1732,19 +1732,24 @@ function queuedWebhookMergeScan(db, runId) {
            AND reason IN (?, ?)
          LIMIT 1`,
     )
-    .get(
-      runId,
-      WEBHOOK_MERGE_SCAN_ALREADY_LIVE,
-      WEBHOOK_MERGE_SCAN_PENDING,
-    );
+    .get(runId, WEBHOOK_MERGE_SCAN_ALREADY_LIVE, WEBHOOK_MERGE_SCAN_PENDING);
 }
 
-function moveQueuedWebhookMergeScan(db, proposalId, event, reason) {
+function moveQueuedWebhookMergeScan(
+  db,
+  proposalId,
+  event,
+  reason,
+  at,
+  ttlSeconds,
+) {
   db.query(
     `UPDATE proposals
-     SET event_source = ?, event_id = ?, reason = ?
+     SET event_source = ?, event_id = ?, reason = ?,
+         spec_json = NULL, spec_hash = NULL, idempotency_key = NULL,
+         created_at = ?, ttl_seconds = ?
      WHERE id = ?`,
-  ).run(event.source, event.event_id, reason, proposalId);
+  ).run(event.source, event.event_id, reason, at, ttlSeconds, proposalId);
   setEventStatus(db, event, "noop", reason);
   return db.query(`SELECT * FROM proposals WHERE id = ?`).get(proposalId);
 }
@@ -1753,6 +1758,8 @@ function moveQueuedWebhookMergeScan(db, proposalId, event, reason) {
  * Re-admit the single webhook delivery retained behind each finished merge
  * scan. A never-executed scan re-arms one coalesced delivery only when refused
  * or cancelled; an executed scan re-arms only deliveries received while running.
+ * "Never executed" is proven by the lifecycle journal (no LEASED record) rather
+ * than `runs.attempts`, which a claim-lock contention requeue resets to 0.
  */
 function reAdmitQueuedWebhookMergeScans(db) {
   const queued = db
@@ -1769,7 +1776,12 @@ function reAdmitQueuedWebhookMergeScans(db) {
          AND (
            (p.reason = ?
             AND r.state IN ('COMPLETED', 'REFUSED', 'FAILED', 'TIMED_OUT', 'CANCELLED'))
-           OR (p.reason = ? AND r.state IN ('REFUSED', 'CANCELLED'))
+           OR (p.reason = ?
+               AND r.state IN ('REFUSED', 'CANCELLED')
+               AND NOT EXISTS (
+                 SELECT 1 FROM lifecycle_events le
+                 WHERE le.run_id = r.run_id AND le.to_state = 'LEASED'
+               ))
          )
        ORDER BY p.created_at, p.rowid`,
     )
@@ -1821,7 +1833,14 @@ function coalesceWebhookMergeRequest(
     return noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds);
   }
   if (executing && marker.reason === WEBHOOK_MERGE_SCAN_PENDING) {
-    const proposal = moveQueuedWebhookMergeScan(db, marker.id, event, reason);
+    const proposal = moveQueuedWebhookMergeScan(
+      db,
+      marker.id,
+      event,
+      reason,
+      at,
+      ttlSeconds,
+    );
     return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
   }
   setEventStatus(db, event, "noop", marker.reason);

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1719,27 +1719,40 @@ function noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds) {
 }
 
 const WEBHOOK_MERGE_SCAN_ALREADY_LIVE = "webhook_merge_scan_already_live";
+const WEBHOOK_MERGE_SCAN_PENDING = "webhook_merge_scan_pending";
 const EXECUTING_MERGE_SCAN_STATES = new Set(["LEASED", "RUNNING", "VERIFYING"]);
 
-function hasQueuedWebhookMergeScan(db, runId) {
-  return Boolean(
-    db
-      .query(
-        `SELECT 1
+function queuedWebhookMergeScan(db, runId) {
+  return db
+    .query(
+      `SELECT id, reason
          FROM proposals
          WHERE run_id = ?
            AND decision = 'noop'
-           AND reason = ?
+           AND reason IN (?, ?)
          LIMIT 1`,
-      )
-      .get(runId, WEBHOOK_MERGE_SCAN_ALREADY_LIVE),
-  );
+    )
+    .get(
+      runId,
+      WEBHOOK_MERGE_SCAN_ALREADY_LIVE,
+      WEBHOOK_MERGE_SCAN_PENDING,
+    );
+}
+
+function moveQueuedWebhookMergeScan(db, proposalId, event, reason) {
+  db.query(
+    `UPDATE proposals
+     SET event_source = ?, event_id = ?, reason = ?
+     WHERE id = ?`,
+  ).run(event.source, event.event_id, reason, proposalId);
+  setEventStatus(db, event, "noop", reason);
+  return db.query(`SELECT * FROM proposals WHERE id = ?`).get(proposalId);
 }
 
 /**
  * Re-admit the single webhook delivery retained behind each finished merge
- * scan. The retained noop proposal is the durable queue marker: later burst
- * deliveries have no proposal, so they cannot create extra trailing scans.
+ * scan. A never-executed scan re-arms one coalesced delivery only when refused
+ * or cancelled; an executed scan re-arms only deliveries received while running.
  */
 function reAdmitQueuedWebhookMergeScans(db) {
   const queued = db
@@ -1753,11 +1766,14 @@ function reAdmitQueuedWebhookMergeScans(db) {
          AND e.type = 'factory.merge.requested'
          AND e.status = 'noop'
          AND p.decision = 'noop'
-         AND p.reason = ?
-         AND r.state IN ('COMPLETED', 'REFUSED', 'FAILED', 'TIMED_OUT', 'CANCELLED')
+         AND (
+           (p.reason = ?
+            AND r.state IN ('COMPLETED', 'REFUSED', 'FAILED', 'TIMED_OUT', 'CANCELLED'))
+           OR (p.reason = ? AND r.state IN ('REFUSED', 'CANCELLED'))
+         )
        ORDER BY p.created_at, p.rowid`,
     )
-    .all(WEBHOOK_MERGE_SCAN_ALREADY_LIVE);
+    .all(WEBHOOK_MERGE_SCAN_ALREADY_LIVE, WEBHOOK_MERGE_SCAN_PENDING);
   for (const event of queued) {
     db.query(
       `UPDATE events
@@ -1771,10 +1787,10 @@ function reAdmitQueuedWebhookMergeScans(db) {
  * GitHub sends a delivery for each CI state change. Unlike an operator or
  * schedule request, those deliveries do not each deserve an auditable
  * proposal: a PROPOSED, APPROVED, or QUEUED scan will read current GitHub
- * state when it executes, so later deliveries stay pure noops. Once the scan
- * is LEASED, RUNNING, or VERIFYING, retain exactly one delivery as a
- * TTL-backed noop proposal; planAdmittedEvents re-admits it after that scan
- * reaches a terminal state. Further deliveries remain proposal-free noops.
+ * state when it executes, so later deliveries stay pure noops. Retain one
+ * pending marker before execution in case the scan is refused or cancelled;
+ * while executing, retain one delivery as the trailing-scan marker. Further
+ * deliveries remain proposal-free noops.
  */
 function coalesceWebhookMergeRequest(
   db,
@@ -1796,15 +1812,24 @@ function coalesceWebhookMergeRequest(
   });
   if (!blockingRun) return null;
 
-  const reason = WEBHOOK_MERGE_SCAN_ALREADY_LIVE;
-  if (
-    EXECUTING_MERGE_SCAN_STATES.has(blockingRun.state) &&
-    !hasQueuedWebhookMergeScan(db, blockingRun.run_id)
-  ) {
+  const executing = EXECUTING_MERGE_SCAN_STATES.has(blockingRun.state);
+  const marker = queuedWebhookMergeScan(db, blockingRun.run_id);
+  const reason = executing
+    ? WEBHOOK_MERGE_SCAN_ALREADY_LIVE
+    : WEBHOOK_MERGE_SCAN_PENDING;
+  if (!marker) {
     return noopBehindLiveRun(db, event, blockingRun, reason, at, ttlSeconds);
   }
-  setEventStatus(db, event, "noop", reason);
-  return { decision: "noop", runId: blockingRun.run_id, reason };
+  if (executing && marker.reason === WEBHOOK_MERGE_SCAN_PENDING) {
+    const proposal = moveQueuedWebhookMergeScan(db, marker.id, event, reason);
+    return { decision: "noop", proposal, runId: blockingRun.run_id, reason };
+  }
+  setEventStatus(db, event, "noop", marker.reason);
+  return {
+    decision: "noop",
+    runId: blockingRun.run_id,
+    reason: marker.reason,
+  };
 }
 
 function humanNeeded(db, event, reason, at, ttlSeconds) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -447,18 +447,13 @@ describe("planEvent", () => {
       ).toBe(1);
     };
 
-    for (const terminal of ["REFUSED", "CANCELLED"]) {
+    // A queued scan cancelled before any worker leased it never read GitHub:
+    // the retained pending delivery is re-admitted and plans a fresh scan.
+    {
       const db = openDb(":memory:");
-      const first = queueScan(db, `${terminal.toLowerCase()}-first`);
-      const suffix = terminal.toLowerCase();
-      coalesceTwoDeliveries(db, suffix, first.runId);
-
-      // A queued run has not reached a worker. REFUSED is normally emitted
-      // from VERIFYING, so model the durable terminal state directly here.
-      db.query(`UPDATE runs SET state = ? WHERE run_id = ?`).run(
-        terminal,
-        first.runId,
-      );
+      const first = queueScan(db, "cancelled-first");
+      coalesceTwoDeliveries(db, "cancelled", first.runId);
+      transition(db, { runId: first.runId, to: "CANCELLED", actor: "test" });
 
       expect(
         planAdmittedEvents(db, registry, {
@@ -470,29 +465,41 @@ describe("planEvent", () => {
       expect(
         db
           .query(`SELECT status FROM events WHERE event_id = ?`)
-          .get(`${suffix}-1`).status,
+          .get("cancelled-1").status,
       ).toBe("planned");
       expect(
         db
           .query(`SELECT status FROM events WHERE event_id = ?`)
-          .get(`${suffix}-2`).status,
+          .get("cancelled-2").status,
       ).toBe("noop");
     }
 
-    const db = openDb(":memory:");
-    const first = queueScan(db, "completed-first");
-    coalesceTwoDeliveries(db, "completed", first.runId);
-    for (const to of ["LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
-      transition(db, { runId: first.runId, to, actor: "test" });
-    }
+    // REFUSED is only reachable from VERIFYING, i.e. the scan executed and
+    // read current GitHub state; a pending marker must not re-arm a trailing
+    // scan for it. Same for the executed COMPLETED path.
+    for (const terminal of ["REFUSED", "COMPLETED"]) {
+      const db = openDb(":memory:");
+      const suffix = terminal.toLowerCase();
+      const first = queueScan(db, `${suffix}-first`);
+      coalesceTwoDeliveries(db, suffix, first.runId);
+      for (const to of ["LEASED", "RUNNING", "VERIFYING", terminal]) {
+        transition(db, { runId: first.runId, to, actor: "test" });
+      }
 
-    expect(
-      planAdmittedEvents(db, registry, {
-        now: NOW + 2000,
-        policyVersion: "git:test",
-      }),
-    ).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
-    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+      expect(
+        planAdmittedEvents(db, registry, {
+          now: NOW + 2000,
+          policyVersion: "git:test",
+        }),
+      ).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
+      for (const eventId of [`${suffix}-1`, `${suffix}-2`]) {
+        expect(
+          db.query(`SELECT status FROM events WHERE event_id = ?`).get(eventId)
+            .status,
+        ).toBe("noop");
+      }
+    }
   });
 
   test("repeat remediations with identical payload but distinct correlationId produce distinct runs (OPS-419)", () => {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -292,12 +292,13 @@ describe("planEvent", () => {
       admit(db, webhook("check-proposed")),
       { now: NOW + 1000, policyVersion: "git:test" },
     );
-    expect(whileProposed).toEqual({
+    expect(whileProposed).toMatchObject({
       decision: "noop",
       runId: first.runId,
-      reason: "webhook_merge_scan_already_live",
+      reason: "webhook_merge_scan_pending",
     });
-    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(1);
+    expect(whileProposed.proposal.status).toBe("resolved");
+    expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(2);
 
     for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING"]) {
       transition(db, { runId: first.runId, to, actor: "test" });
@@ -402,6 +403,96 @@ describe("planEvent", () => {
     expect(other.decision).toBe("run");
     expect(other.runId).not.toBe(first.runId);
     expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(5);
+  });
+
+  test("never-executed merge scans retain one webhook delivery only when refused or cancelled", () => {
+    const webhook = (eventId) => ({
+      eventId,
+      type: "factory.merge.requested",
+      source: "github",
+      subject: "factory",
+      correlationId: eventId,
+      payload: { repo: "factory" },
+    });
+    const queueScan = (db, eventId) => {
+      const first = planEvent(db, registry, admit(db, webhook(eventId)), {
+        now: NOW,
+        policyVersion: "git:test",
+      });
+      for (const to of ["APPROVED", "QUEUED"]) {
+        transition(db, { runId: first.runId, to, actor: "test" });
+      }
+      return first;
+    };
+    const coalesceTwoDeliveries = (db, suffix, runId) => {
+      for (const eventId of [`${suffix}-1`, `${suffix}-2`]) {
+        expect(
+          planEvent(db, registry, admit(db, webhook(eventId)), {
+            now: NOW + 1000,
+            policyVersion: "git:test",
+          }),
+        ).toMatchObject({
+          decision: "noop",
+          runId,
+          reason: "webhook_merge_scan_pending",
+        });
+      }
+      expect(
+        db
+          .query(
+            `SELECT COUNT(*) AS n FROM proposals
+             WHERE run_id = ? AND reason = 'webhook_merge_scan_pending'`,
+          )
+          .get(runId).n,
+      ).toBe(1);
+    };
+
+    for (const terminal of ["REFUSED", "CANCELLED"]) {
+      const db = openDb(":memory:");
+      const first = queueScan(db, `${terminal.toLowerCase()}-first`);
+      const suffix = terminal.toLowerCase();
+      coalesceTwoDeliveries(db, suffix, first.runId);
+
+      // A queued run has not reached a worker. REFUSED is normally emitted
+      // from VERIFYING, so model the durable terminal state directly here.
+      db.query(`UPDATE runs SET state = ? WHERE run_id = ?`).run(
+        terminal,
+        first.runId,
+      );
+
+      expect(
+        planAdmittedEvents(db, registry, {
+          now: NOW + 2000,
+          policyVersion: "git:test",
+        }),
+      ).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(2);
+      expect(
+        db
+          .query(`SELECT status FROM events WHERE event_id = ?`)
+          .get(`${suffix}-1`).status,
+      ).toBe("planned");
+      expect(
+        db
+          .query(`SELECT status FROM events WHERE event_id = ?`)
+          .get(`${suffix}-2`).status,
+      ).toBe("noop");
+    }
+
+    const db = openDb(":memory:");
+    const first = queueScan(db, "completed-first");
+    coalesceTwoDeliveries(db, "completed", first.runId);
+    for (const to of ["LEASED", "RUNNING", "VERIFYING", "COMPLETED"]) {
+      transition(db, { runId: first.runId, to, actor: "test" });
+    }
+
+    expect(
+      planAdmittedEvents(db, registry, {
+        now: NOW + 2000,
+        policyVersion: "git:test",
+      }),
+    ).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(1);
   });
 
   test("repeat remediations with identical payload but distinct correlationId produce distinct runs (OPS-419)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1293

Review the pending webhook marker recovery for cancelled or refused merge scans.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs --timeout 20000 && bun run check` | pass | 90 tests, 0 failures; generated tree clean |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1876 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

## Post-review

- Pending-marker re-admit is now gated on the run never having executed: `NOT EXISTS (lifecycle_events WHERE to_state = 'LEASED')`. `runs.attempts` was rejected as the witness because a claim-lock contention requeue resets it to `attempt - 1` (worker.mjs), so a leased-then-requeued-then-cancelled run would look never-executed.
- Tests drive every state through `transition()`; added QUEUED->LEASED->RUNNING->VERIFYING->REFUSED (and ->COMPLETED) with a pending marker planning zero trailing scans, kept CANCELLED-from-QUEUED re-admitting one delivery.
- `moveQueuedWebhookMergeScan` now refreshes `created_at`/`ttl_seconds` from the superseding delivery and nulls `spec_json`/`spec_hash`/`idempotency_key` (noop markers never carry a spec).
