### PR TITLE
test(cli): sandbox spawned inspect command

### DIFF
--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,12 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { COMMAND_NAMES } from "./cli/commands.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
-import {
-  CLI,
-  freePort,
-  runCli,
-  throwawayRunDir,
-} from "./cli/test-helpers.mjs";
+import { CLI, freePort, runCli, throwawayRunDir } from "./cli/test-helpers.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
 const EXPECTED_COMMANDS = [

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,7 +1,13 @@
 import { describe, expect, test } from "bun:test";
 import { COMMAND_NAMES } from "./cli/commands.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
-import { CLI, freePort, runCli } from "./cli/test-helpers.mjs";
+import {
+  CLI,
+  freePort,
+  runCli,
+  throwawayRunDir,
+} from "./cli/test-helpers.mjs";
+import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
 const EXPECTED_COMMANDS = [
   "serve",
@@ -126,7 +132,9 @@ describe("cli routing", () => {
       const child = Bun.spawn(["bun", CLI, "inspect", "run-1289"], {
         env: {
           ...process.env,
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
           FACTORY_EVENT_PORT: String(server.port),
+          FACTORY_RUN_DIR: throwawayRunDir(),
         },
         stdout: "pipe",
         stderr: "pipe",


### PR DESCRIPTION
Fixes #1315

Keeps the spawned inspect CLI test isolated from the operator runtime.

## Validation

| Check                | Command                                                  | Result  | Notes                     |
| -------------------- | -------------------------------------------------------- | ------- | ------------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000`    | pass    | 7 tests, 0 failures       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 1884 pass; emit clean |
| UX critique          | factory-ux-critic                                        | not run | internal test-only change |

UX critique: skipped


## Post-review

- Review verdict FIX (mechanical): CI `Formatting check (prettier)` failed on `event-runtime/cli.test.mjs`. Collapsed the multi-line import via `bunx prettier --write`; `format:check`, `cli.test.mjs`, and `bun run check` pass locally (f4ac9dd5).
