### PR TITLE
polish(adapters): clarify Cursor child environment ownership

### DIFF
--- a/docs/event-runtime-conventions.md
+++ b/docs/event-runtime-conventions.md
@@ -217,6 +217,10 @@ subscription authentication.
 values. A non-mutating run strips them _after_ merging the caller's `env`, so a
 caller cannot smuggle mutation authority back in through the overlay.
 
+Nested Claude Code session markers (`CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT`)
+are stripped for all adapters so child processes do not inherit the operator's
+interactive session context.
+
 [WM-223](https://linear.app/watt-mind/issue/WM-223/fixevent-runtime-pi-adapter-strips-push-credentials-for-mutating-runs)
 is the incident that proves the signature matters: pi's environment helper did
 not receive `def`, so mutating dispatch runs lost the credentials needed to

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -38,8 +38,7 @@ export const PROVIDER_CREDENTIAL_ENV = [
   "MISTRAL_API_KEY",
   "DEEPSEEK_API_KEY",
   "GROQ_API_KEY",
-  // Nested-session markers, not keys: every adapter strips them so children
-  // do not inherit an interactive Claude Code session's execution context.
+  // Nested-session markers, not keys; all adapters strip them to avoid inheriting Claude Code's interactive context.
   "CLAUDECODE",
   "CLAUDE_CODE_ENTRYPOINT",
 ];

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -38,6 +38,8 @@ export const PROVIDER_CREDENTIAL_ENV = [
   "MISTRAL_API_KEY",
   "DEEPSEEK_API_KEY",
   "GROQ_API_KEY",
+  // Nested-session markers, not keys: every adapter strips them so children
+  // do not inherit an interactive Claude Code session's execution context.
   "CLAUDECODE",
   "CLAUDE_CODE_ENTRYPOINT",
 ];

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -33,7 +33,6 @@ import { FACTORY_ROOT } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import {
-  BASE_INHERITED_ENV as SHARED_BASE_INHERITED_ENV,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
@@ -129,14 +128,6 @@ export function buildCursorArgv({ prompt, model }) {
   args.push("--", prompt);
   return args;
 }
-
-export const BASE_INHERITED_ENV = [
-  ...SHARED_BASE_INHERITED_ENV,
-  // `agent -p` ignores the login session and requires this Cursor user key
-  // (WM-443). It authenticates as the account and bills the user's plan —
-  // not a provider BYOK key. Still strip CURSOR_API_ENDPOINT below.
-  "CURSOR_API_KEY",
-];
 
 /**
  * Keep untrusted model subprocesses from inheriting the worker's authority.

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -312,6 +312,7 @@ export function piExtensions(def) {
  *
  * The shared helper treats only an explicit `mutating: true` (or boolean
  * argument) as mutating, so malformed definitions fail closed everywhere.
+ * Nested Claude Code session markers are stripped by the shared helper too.
  */
 export function safeChildEnvironment(
   env = {},


### PR DESCRIPTION
Fixes watt-mind/factory#1308

Remove the dead Cursor allowlist export and document shared nested-session marker stripping without changing child environment behavior.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/cursor.test.mjs event-runtime/lib/adapters/child-env.test.mjs event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/acp.test.mjs --timeout 20000 && bun run check`    | pass    | 106 pass, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check`  | pass    | 1884 pass, 10 skipped, 0 failures |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend/docs-only change; no user-facing surface