### PR TITLE
perf(inbox): materialize proposal IDs

### DIFF
--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -472,6 +472,27 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 16,
+    name: "inbox_proposal_id",
+    up(db) {
+      const columns = new Set(
+        db
+          .query(`PRAGMA table_info(inbox_items)`)
+          .all()
+          .map((row) => row.name),
+      );
+      if (!columns.has("proposal_id")) {
+        db.exec(`ALTER TABLE inbox_items ADD COLUMN proposal_id TEXT;`);
+      }
+      db.exec(`
+        UPDATE inbox_items
+           SET proposal_id = json_extract(refs_json, '$.proposalId');
+        CREATE INDEX IF NOT EXISTS idx_inbox_items_proposal_id
+          ON inbox_items (proposal_id);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -184,10 +184,10 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrated.close();
   });
 
-  test("tier escalation handoffs reach schema 15 from a fresh and from a v14 database", () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(15);
+  test("tier escalation handoffs and inbox proposal IDs reach schema 16 from a fresh and from a v14 database", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(16);
     const fresh = openDb(freshFile());
-    expect(getSchemaVersion(fresh)).toBe(15);
+    expect(getSchemaVersion(fresh)).toBe(16);
     fresh.close();
 
     // #1230 (#1197) owns migration 14 and lands first; a database already at
@@ -197,9 +197,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrateDb(at14, { targetVersion: 13 });
     at14.exec("PRAGMA user_version = 14;");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(15);
+    expect(getSchemaVersion(at14)).toBe(16);
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(15);
+    expect(getSchemaVersion(at14)).toBe(16);
     expect(
       at14
         .query(
@@ -208,6 +208,44 @@ describe("schema migration runner and assertions (OPS-415)", () => {
         .get()?.name,
     ).toBe("tier_escalations");
     at14.close();
+  });
+
+  test("inbox proposal ID migration backfills populated v15 rows and indexes the column", () => {
+    const db = new Database(freshFile());
+    migrateDb(db, { targetVersion: 15 });
+    db.query(
+      `INSERT INTO inbox_items (id, kind, title, refs_json, source, created_at)
+       VALUES (?, 'decision_needed', ?, ?, 'cli', '2026-08-30T00:00:00.000Z')`,
+    ).run("with-proposal", "with proposal", '{"proposalId":"proposal-1"}');
+    db.query(
+      `INSERT INTO inbox_items (id, kind, title, refs_json, source, created_at)
+       VALUES (?, 'BLOCKED', ?, ?, 'cli', '2026-08-30T00:00:00.000Z')`,
+    ).run("without-proposal", "without proposal", '{"repo":"factory"}');
+
+    migrateDb(db);
+
+    expect(CURRENT_SCHEMA_VERSION).toBe(16);
+    expect(getSchemaVersion(db)).toBe(16);
+    expect(
+      db
+        .query(
+          `SELECT id, proposal_id FROM inbox_items
+           WHERE id IN ('with-proposal', 'without-proposal') ORDER BY id`,
+        )
+        .all(),
+    ).toEqual([
+      { id: "with-proposal", proposal_id: "proposal-1" },
+      { id: "without-proposal", proposal_id: null },
+    ]);
+    expect(
+      db
+        .query(
+          `SELECT sql FROM sqlite_master
+           WHERE type = 'index' AND name = 'idx_inbox_items_proposal_id'`,
+        )
+        .get()?.sql,
+    ).toContain("inbox_items (proposal_id)");
+    db.close();
   });
 
   test("tier escalation handoffs migrate with unique root and continuation ownership", () => {
@@ -312,6 +350,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       "dedupe_key",
       "resolved_reason",
       "waiters_json",
+      "proposal_id",
     ]);
     upgraded.close();
   });
@@ -334,7 +373,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       .query("PRAGMA table_info(inbox_items)")
       .all()
       .map((row) => row.name);
-    expect(columns.slice(-7)).toEqual([
+    expect(columns.slice(-8)).toEqual([
       "decision_json",
       "response_json",
       "decided_at",
@@ -342,6 +381,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       "dedupe_key",
       "resolved_reason",
       "waiters_json",
+      "proposal_id",
     ]);
     expect(
       upgraded.query("SELECT title FROM inbox_items WHERE id = 'legacy'").get()

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -322,7 +322,7 @@ export function itemView(row) {
 function inboxExpiredPredicate(item = "i") {
   return `(${item}.kind = 'proposal_expired' OR EXISTS (
     SELECT 1 FROM proposals p
-     WHERE p.id = json_extract(${item}.refs_json, '$.proposalId')
+     WHERE p.id = ${item}.proposal_id
        AND p.status = 'open'
        AND p.ttl_seconds > 0
        AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
@@ -434,8 +434,8 @@ export function createInboxItem(
       db.query(
         `INSERT INTO inbox_items
            (id, kind, severity, title, body, refs_json, source, created_at,
-            delivery_json, decision_json, dedupe_key, waiters_json)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?, '[]')`,
+            proposal_id, delivery_json, decision_json, dedupe_key, waiters_json)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, '{}', ?, ?, '[]')`,
       ).run(
         id,
         kind,
@@ -445,6 +445,7 @@ export function createInboxItem(
         JSON.stringify(refs),
         source,
         createdAt,
+        refs.proposalId ?? null,
         decision === null ? null : JSON.stringify(decision),
         dedupeKey,
       );
@@ -558,12 +559,13 @@ function retargetInboxDecision(db, id, answer, proposalId, { now }) {
       : row.title;
   db.query(
     `UPDATE inbox_items
-     SET refs_json = ?, decision_json = ?, dedupe_key = ?, delivery_json = ?,
+     SET refs_json = ?, proposal_id = ?, decision_json = ?, dedupe_key = ?, delivery_json = ?,
          title = ?,
          response_json = NULL, decided_at = NULL, decided_by = NULL
      WHERE id = ?`,
   ).run(
     JSON.stringify(nextRefs),
+    proposalId,
     JSON.stringify(request),
     retargetedDedupeKey(db, row, previousProposalId, proposalId),
     JSON.stringify({
@@ -1079,9 +1081,9 @@ function bindProposalToItem(db, id, proposalId) {
      SET refs_json = json_set(
        CASE WHEN json_valid(refs_json) THEN refs_json ELSE '{}' END,
        '$.proposalId', ?
-     )
+     ), proposal_id = ?
      WHERE id = ? AND resolved_at IS NULL`,
-  ).run(proposalId, id);
+  ).run(proposalId, proposalId, id);
   return getInboxItem(db, id);
 }
 

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -701,6 +701,90 @@ describe("human inbox ledger (WM-285)", () => {
     });
   });
 
+  test("inbox expiry lookups use the proposals primary-key index", () => {
+    const db = openDb(":memory:");
+    const expiredAt = new Date(Date.now() - 61_000).toISOString();
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES ('expired-proposal', 'test', 'evt', 'run', 'open', ?, 60)`,
+    ).run(expiredAt);
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "expired by proposal",
+        refs: { proposalId: "expired-proposal" },
+      },
+      { id: "expired-proposal-item" },
+    );
+
+    const expiryPredicate = `(i.kind = 'proposal_expired' OR EXISTS (
+      SELECT 1 FROM proposals p
+       WHERE p.id = i.proposal_id
+         AND p.status = 'open'
+         AND p.ttl_seconds > 0
+         AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
+    ))`;
+    const planFor = (sql) =>
+      db
+        .query(`EXPLAIN QUERY PLAN ${sql}`)
+        .all()
+        .map((row) => row.detail)
+        .join(" ");
+    const listPlan = planFor(`
+      SELECT i.*, i.rowid AS list_rowid, ${expiryPredicate} AS expired
+      FROM inbox_items i
+      WHERE 1 = 1
+      ORDER BY i.created_at DESC, i.rowid DESC
+      LIMIT 101
+    `);
+    const countsPlan = planFor(`
+      SELECT SUM(CASE WHEN i.resolved_at IS NULL AND i.acked_at IS NULL
+                           AND NOT ${expiryPredicate}
+                      THEN 1 ELSE 0 END) AS open
+      FROM inbox_items i
+    `);
+
+    for (const plan of [listPlan, countsPlan]) {
+      expect(plan).toContain(
+        "SEARCH p USING INDEX sqlite_autoindex_proposals_1 (id=?)",
+      );
+      expect(plan).not.toContain("SCAN p");
+    }
+    db.close();
+  });
+
+  test("inbox counts complete within 200ms for 10k inbox rows and proposals", () => {
+    const db = openDb(":memory:");
+    const createdAt = new Date().toISOString();
+    const insertProposal = db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, 'run', 'open', ?, 3600)`,
+    );
+    const insertInbox = db.query(
+      `INSERT INTO inbox_items
+         (id, kind, severity, title, refs_json, proposal_id, source, created_at)
+       VALUES (?, 'decision_needed', 'normal', 'inbox item', ?, ?, 'cli', ?)`,
+    );
+    db.transaction(() => {
+      for (let i = 0; i < 10_000; i += 1) {
+        const proposalId = `proposal-${i}`;
+        insertProposal.run(proposalId, `event-${i}`, createdAt);
+        insertInbox.run(
+          `inbox-${i}`,
+          JSON.stringify({ proposalId }),
+          proposalId,
+          createdAt,
+        );
+      }
+    })();
+
+    const started = performance.now();
+    expect(inboxCounts(db).open).toBe(10_000);
+    expect(performance.now() - started).toBeLessThan(200);
+    db.close();
+  });
+
   test("runtime-owned referents auto-resolve after leaving their waiting state", () => {
     const db = openDb(":memory:");
     insertProposal(db, { id: "prop-1" });


### PR DESCRIPTION
Fixes watt-mind/factory#1307

Review migration 16 backfill and indexed proposal-ID expiry lookups.

## Validation

| Check                | Command                                                                                             | Result  | Notes                         |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/db.test.mjs event-runtime/lib/api-inbox.test.mjs --timeout 20000 && bun run check` | pass    | 69 tests, 0 failures; check ok |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1887 pass, 10 skipped; clean  |
| UX critique          | `factory-ux-critic`                                                                                 | not run | no user-facing surface        |

UX critique: skipped