### PR TITLE
fix(control): retry proposal approval busy locks

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -4,7 +4,7 @@ import { artifactHead } from "./api-artifacts.mjs";
 import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 import { STALE_SCAN_MS, loadLinearSupply } from "./linear.mjs";
 import { loadRepos, RepoError } from "./repos.mjs";
-import { runUsage } from "./db.mjs";
+import { isBusyError, runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
@@ -1790,6 +1790,8 @@ export async function handleRunApiRoute({
       });
       return send(200, { rejected: true, runId: outcome.runId });
     } catch (err) {
+      if (verb === "approve" && isBusyError(err))
+        return send(503, { error: "db_busy", retryable: true });
       const status = String(err.message).startsWith("unknown proposal")
         ? 404
         : 409;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1136,17 +1136,22 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     const lock = await holdWriteLock(s.db.filename, 75);
     const startedAt = Date.now();
     const approved = await s.client.approve(waiting.id);
+    const elapsedMs = Date.now() - startedAt;
     expect(approved).toEqual({ approved: true, runId: waiting.runId });
-    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    // The lock is held for 75 ms; a lower bound proves the approval actually
+    // waited on it instead of racing past a lock that was never taken.
+    expect(elapsedMs).toBeGreaterThanOrEqual(50);
+    expect(elapsedMs).toBeLessThan(2_000);
     expect(await lock.exited).toBe(0);
     expect(await s.client.cancel(waiting.runId, "test cleanup")).toEqual({
       cancelled: true,
     });
 
     const timedOut = await planned("approve-busy-timeout");
-    s.db.exec("PRAGMA busy_timeout = 10;");
-    const timeoutLock = await holdWriteLock(s.db.filename, 75);
+    let timeoutLock;
     try {
+      s.db.exec("PRAGMA busy_timeout = 10;");
+      timeoutLock = await holdWriteLock(s.db.filename, 75);
       const err = await rejection(s.client.approve(timedOut.id));
       expect(err.status).toBe(503);
       expect(err.message).toBe("db_busy");
@@ -1154,7 +1159,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     } finally {
       s.db.exec("PRAGMA busy_timeout = 5000;");
     }
-    expect(await timeoutLock.exited).toBe(0);
+    expect(await timeoutLock?.exited).toBe(0);
   });
 
   test("reject an open proposal → run CANCELLED", async () => {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -61,6 +61,33 @@ const makeServer = async (...args) => {
   return result;
 };
 
+async function holdWriteLock(file, durationMs) {
+  const child = Bun.spawn(
+    [
+      "bun",
+      "-e",
+      `
+        import { openDb } from "./event-runtime/lib/db.mjs";
+        const db = openDb(process.argv[1]);
+        db.exec("BEGIN IMMEDIATE");
+        console.log("locked");
+        await new Promise((resolve) => setTimeout(resolve, Number(process.argv[2])));
+        db.exec("ROLLBACK");
+        db.close();
+      `,
+      file,
+      String(durationMs),
+    ],
+    { cwd: process.cwd(), stdout: "pipe", stderr: "pipe" },
+  );
+  const reader = child.stdout.getReader();
+  const { value, done } = await reader.read();
+  reader.releaseLock();
+  expect(done).toBe(false);
+  expect(new TextDecoder().decode(value)).toContain("locked");
+  return child;
+}
+
 describe("run deadline extension (WM-566)", () => {
   const start = Date.parse("2026-08-12T10:00:00Z");
   // The policy cap the extend endpoint enforces, owned by this suite rather
@@ -1102,6 +1129,32 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     const again = await rejection(s.client.approve(flowProposalId));
     expect(again.status).toBe(409);
     expect(again.message).toContain("not open");
+  });
+
+  test("approval waits for a worker write lock and returns db_busy after its timeout", async () => {
+    const waiting = await planned("approve-waits-for-lock");
+    const lock = await holdWriteLock(s.db.filename, 75);
+    const startedAt = Date.now();
+    const approved = await s.client.approve(waiting.id);
+    expect(approved).toEqual({ approved: true, runId: waiting.runId });
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(await lock.exited).toBe(0);
+    expect(await s.client.cancel(waiting.runId, "test cleanup")).toEqual({
+      cancelled: true,
+    });
+
+    const timedOut = await planned("approve-busy-timeout");
+    s.db.exec("PRAGMA busy_timeout = 10;");
+    const timeoutLock = await holdWriteLock(s.db.filename, 75);
+    try {
+      const err = await rejection(s.client.approve(timedOut.id));
+      expect(err.status).toBe(503);
+      expect(err.message).toBe("db_busy");
+      expect(err.body).toEqual({ error: "db_busy", retryable: true });
+    } finally {
+      s.db.exec("PRAGMA busy_timeout = 5000;");
+    }
+    expect(await timeoutLock.exited).toBe(0);
   });
 
   test("reject an open proposal → run CANCELLED", async () => {

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -10,7 +10,7 @@
  */
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
-import { tx } from "./db.mjs";
+import { tx, txImmediate } from "./db.mjs";
 import { newProposalId } from "./ids.mjs";
 import { runState, transition } from "./lifecycle.mjs";
 import { buildRunSpec } from "./planner.mjs";
@@ -123,7 +123,11 @@ export function approveProposal(
     reason,
   } = {},
 ) {
-  return tx(db, () => {
+  // Take the write lock before reading the proposal. A deferred transaction
+  // reads first and then fails immediately when its later write must upgrade
+  // behind a worker claim; BEGIN IMMEDIATE lets SQLite's busy_timeout wait for
+  // that short-lived claimant transaction instead.
+  return txImmediate(db, () => {
     const proposal = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!proposal) throw new Error(`unknown proposal ${id}`);
     if (proposal.status !== "open")


### PR DESCRIPTION
Fixes watt-mind/factory#1319

Review the SQLite lock retry and structured `db_busy` control response.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/db.test.mjs event-runtime/lib/proposals.test.mjs event-runtime/lib/proposals.test.mjs --timeout 20000` | pass    | 38 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1885 tests; emit and format clean  |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface             |

UX critique: skipped — backend control-path change with no user-facing surface

## Post-review

- Reviewer FIX (a): `Full verification` failed on AgentHoverCard/TicketHoverCard load flakes (run 33280752609) — rerun.
- Reviewer FIX (b): in `api-runs.test.mjs` the `PRAGMA busy_timeout = 10` is now set inside the `try` whose `finally` restores 5000, so the timeout is restored on every path; added a lower-bound assertion (`elapsedMs >= 50`) proving the approval actually waited on the held write lock (cebe1ce68d5a5472e888ae63031af15647402059).
