### PR TITLE
polish(emit): split githubSlug into remote-URL and configured-slug helpers (#1318)

### DIFF
--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -409,13 +409,19 @@ const agents = corePack.agents;
 // So the floor is SPLICED into each repo's AGENTS.md between its markers.
 // Marker-delimited rather than whole-file so a repo keeps its own content, and
 // idempotent so running it twice is a no-op.
-/** Return the canonical GitHub owner/repository slug from a Git remote URL. */
+/**
+ * Return the canonical GitHub owner/repository slug from a Git remote URL.
+ * Accepts every transport git itself does for github.com — scp-style SSH,
+ * ssh:// (with an optional port), git://, and http(s):// with an optional
+ * userinfo — because the transport does not change which repository the
+ * checkout represents. Anything that is not a github.com URL is null.
+ */
 export function remoteGithubSlug(remote) {
   if (typeof remote !== "string") return null;
   const match = remote
     .trim()
     .match(
-      /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https?:\/\/github\.com\/)([^/\s]+)\/([^\/#?\s]+)\/?$/i,
+      /^(?:git@github\.com:|(?:git\+)?(?:ssh|git|https?):\/\/(?:[^@/\s]+@)?github\.com(?::\d+)?\/)([^/\s]+)\/([^/#?\s]+)\/?$/i,
     );
   if (!match) return null;
   const repository = match[2].replace(/\.git$/i, "");
@@ -430,7 +436,7 @@ export function configuredGithubSlug(value) {
   if (typeof value !== "string") return null;
   const remote = remoteGithubSlug(value);
   if (remote) return remote;
-  const match = value.trim().match(/^([^/\s]+)\/([^\/#?\s]+)$/);
+  const match = value.trim().match(/^([^/\s]+)\/([^/#?\s]+)$/);
   if (!match) return null;
   const repository = match[2].replace(/\.git$/i, "");
   return repository ? `${match[1]}/${repository}`.toLowerCase() : null;
@@ -450,11 +456,24 @@ function originGithubSlug(root) {
 }
 
 /**
- * Resolve each configured checkout without letting a matching origin override
- * a usable explicit path. A missing/unresolvable path may be the running
- * worktree, which is why only that case falls back to its GitHub slug.
+ * Resolve each configured checkout.
+ *
+ * Read-only (`--check`): a usable explicit path wins over a matching origin,
+ * so the configured checkout's floor status stays visible even when this tree
+ * is a worktree of the same repository. Only a missing/unresolvable path falls
+ * back to the GitHub slug, which is the worktree shape the fallback exists for.
+ *
+ * Writing (`--sync-floor`, `preferRunning`): a repo whose origin matches this
+ * tree resolves to this tree, whatever its configured path says. Writes must
+ * land in the checkout that is running — never in the operator's live checkout
+ * from a worktree, which is the file that serve is reading at the time.
  */
-export function resolveFloorCheckouts({ runningRoot, runningGithub, repos }) {
+export function resolveFloorCheckouts({
+  runningRoot,
+  runningGithub,
+  repos,
+  preferRunning = false,
+}) {
   return repos.map((repo) => {
     const repoPath = String(repo.path).replace(/^~/, homedir());
     let configuredRoot = null;
@@ -466,11 +485,13 @@ export function resolveFloorCheckouts({ runningRoot, runningGithub, repos }) {
         configuredRoot = null;
       }
     }
+    const slugMatches = Boolean(
+      runningGithub &&
+      configuredGithubSlug(String(repo.github ?? "")) === runningGithub,
+    );
     const isRunningRepo =
       configuredRoot === runningRoot ||
-      (!configuredRoot &&
-        runningGithub &&
-        configuredGithubSlug(String(repo.github ?? "")) === runningGithub);
+      (slugMatches && (preferRunning || !configuredRoot));
     return {
       ...repo,
       checkoutPath: isRunningRepo ? runningRoot : repoPath,
@@ -480,7 +501,7 @@ export function resolveFloorCheckouts({ runningRoot, runningGithub, repos }) {
 }
 
 /** [{name, path, state}] — state is ok | stale | missing | no-checkout. */
-function floorStatus() {
+function floorStatus({ preferRunning = false } = {}) {
   const cfg = Bun.YAML.parse(
     readFileSync(resolveConfigPath("repos", { root: ROOT }), "utf8"),
   );
@@ -490,6 +511,7 @@ function floorStatus() {
     runningRoot,
     runningGithub,
     repos: cfg.repos ?? [],
+    preferRunning,
   }).map(({ checkoutPath, ...repo }) => {
     const agentsFile = path.join(checkoutPath, "AGENTS.md");
     if (!existsSync(checkoutPath))
@@ -509,7 +531,9 @@ function floorStatus() {
 
 if (process.argv.includes("--sync-floor")) {
   console.log("\nsyncing the floor into each configured repo's AGENTS.md:");
-  for (const r of floorStatus()) {
+  // Writes target the running checkout for this repository, never the
+  // configured (live) checkout of a worktree's origin.
+  for (const r of floorStatus({ preferRunning: true })) {
     if (r.state === "no-checkout") {
       console.log(`  skip     ${r.name} — no checkout at ${r.path}`);
       continue;

--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -412,9 +412,11 @@ const agents = corePack.agents;
 /** Return the canonical GitHub owner/repository slug from a Git remote URL. */
 export function remoteGithubSlug(remote) {
   if (typeof remote !== "string") return null;
-  const match = remote.trim().match(
-    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https?:\/\/github\.com\/)([^/\s]+)\/([^\/#?\s]+)\/?$/i,
-  );
+  const match = remote
+    .trim()
+    .match(
+      /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https?:\/\/github\.com\/)([^/\s]+)\/([^\/#?\s]+)\/?$/i,
+    );
   if (!match) return null;
   const repository = match[2].replace(/\.git$/i, "");
   return repository ? `${match[1]}/${repository}`.toLowerCase() : null;

--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -41,6 +41,7 @@ import {
   lstatSync,
   unlinkSync,
   realpathSync,
+  statSync,
 } from "node:fs";
 import { execFileSync } from "node:child_process";
 import { homedir } from "node:os";
@@ -408,21 +409,34 @@ const agents = corePack.agents;
 // So the floor is SPLICED into each repo's AGENTS.md between its markers.
 // Marker-delimited rather than whole-file so a repo keeps its own content, and
 // idempotent so running it twice is a no-op.
+/** Return the canonical GitHub owner/repository slug from a Git remote URL. */
+export function remoteGithubSlug(remote) {
+  if (typeof remote !== "string") return null;
+  const match = remote.trim().match(
+    /^(?:git@github\.com:|ssh:\/\/git@github\.com\/|https?:\/\/github\.com\/)([^/\s]+)\/([^\/#?\s]+)\/?$/i,
+  );
+  if (!match) return null;
+  const repository = match[2].replace(/\.git$/i, "");
+  return repository ? `${match[1]}/${repository}`.toLowerCase() : null;
+}
+
 /**
- * Return the canonical GitHub owner/repository slug for a remote URL.
- * SSH and HTTPS remotes are both accepted because the checkout's transport
- * does not change which repository it represents.
+ * Return the canonical GitHub slug from a configured `github:` value.
+ * Config accepts either its usual bare owner/repository slug or a full URL.
  */
-function githubSlug(remote) {
-  const value = remote.trim();
-  const match = value.match(/github\.com[/:]([^/]+\/[^/#]+?)(?:\.git)?$/i);
-  if (!match && /^[^/]+\/[^/#]+$/.test(value)) return value.toLowerCase();
-  return match?.[1]?.toLowerCase() ?? null;
+export function configuredGithubSlug(value) {
+  if (typeof value !== "string") return null;
+  const remote = remoteGithubSlug(value);
+  if (remote) return remote;
+  const match = value.trim().match(/^([^/\s]+)\/([^\/#?\s]+)$/);
+  if (!match) return null;
+  const repository = match[2].replace(/\.git$/i, "");
+  return repository ? `${match[1]}/${repository}`.toLowerCase() : null;
 }
 
 function originGithubSlug(root) {
   try {
-    return githubSlug(
+    return remoteGithubSlug(
       execFileSync("git", ["-C", root, "remote", "get-url", "origin"], {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "ignore"],
@@ -433,6 +447,36 @@ function originGithubSlug(root) {
   }
 }
 
+/**
+ * Resolve each configured checkout without letting a matching origin override
+ * a usable explicit path. A missing/unresolvable path may be the running
+ * worktree, which is why only that case falls back to its GitHub slug.
+ */
+export function resolveFloorCheckouts({ runningRoot, runningGithub, repos }) {
+  return repos.map((repo) => {
+    const repoPath = String(repo.path).replace(/^~/, homedir());
+    let configuredRoot = null;
+    if (existsSync(repoPath)) {
+      try {
+        const resolved = realpathSync(repoPath);
+        if (statSync(resolved).isDirectory()) configuredRoot = resolved;
+      } catch {
+        configuredRoot = null;
+      }
+    }
+    const isRunningRepo =
+      configuredRoot === runningRoot ||
+      (!configuredRoot &&
+        runningGithub &&
+        configuredGithubSlug(String(repo.github ?? "")) === runningGithub);
+    return {
+      ...repo,
+      checkoutPath: isRunningRepo ? runningRoot : repoPath,
+      isRunningRepo,
+    };
+  });
+}
+
 /** [{name, path, state}] — state is ok | stale | missing | no-checkout. */
 function floorStatus() {
   const cfg = Bun.YAML.parse(
@@ -440,25 +484,11 @@ function floorStatus() {
   );
   const runningRoot = realpathSync(ROOT);
   const runningGithub = originGithubSlug(ROOT);
-  return (cfg.repos ?? []).map((repo) => {
-    const repoPath = String(repo.path).replace(/^~/, homedir());
-    // The configured path can name the operator's checkout, but a worktree
-    // often has the same origin while living elsewhere. Inspect this tree for
-    // the matching path or GitHub slug; only sibling repos use their config
-    // path so their floor status remains visible too.
-    let configuredRoot = null;
-    if (existsSync(repoPath)) {
-      try {
-        configuredRoot = realpathSync(repoPath);
-      } catch {
-        configuredRoot = null;
-      }
-    }
-    const isRunningRepo =
-      configuredRoot === runningRoot ||
-      (runningGithub &&
-        githubSlug(String(repo.github ?? "")) === runningGithub);
-    const checkoutPath = isRunningRepo ? ROOT : repoPath;
+  return resolveFloorCheckouts({
+    runningRoot,
+    runningGithub,
+    repos: cfg.repos ?? [],
+  }).map(({ checkoutPath, ...repo }) => {
     const agentsFile = path.join(checkoutPath, "AGENTS.md");
     if (!existsSync(checkoutPath))
       return { ...repo, agents: agentsFile, state: "no-checkout" };

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -39,7 +39,9 @@ test("GitHub slug helpers distinguish remotes from configured values", () => {
   expect(configuredGithubSlug("HTTPS://GITHUB.COM/Owner/Repository.git")).toBe(
     "owner/repository",
   );
-  expect(configuredGithubSlug("https://gitlab.com/Owner/Repository")).toBeNull();
+  expect(
+    configuredGithubSlug("https://gitlab.com/Owner/Repository"),
+  ).toBeNull();
 });
 
 test("floor checkout resolution prefers real paths before matching a slug", () => {
@@ -57,7 +59,11 @@ test("floor checkout resolution prefers real paths before matching a slug", () =
       runningGithub: "watt-mind/factory",
       repos,
     });
-    expect(resolved.map((repo) => repo.isRunningRepo)).toEqual([false, true, true]);
+    expect(resolved.map((repo) => repo.isRunningRepo)).toEqual([
+      false,
+      true,
+      true,
+    ]);
     expect(resolved[0].checkoutPath).toBe(siblingRoot);
     expect(resolved[1].checkoutPath).toBe(realpathSync(runningRoot));
     expect(resolved[2].checkoutPath).toBe(realpathSync(runningRoot));

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -130,14 +130,20 @@ function makeEmitFixture() {
   const fixture = mkdtempSync(path.join(tmpdir(), "emit-fixture-"));
   // The emit import graph reaches across event-runtime/, orchestrator/,
   // tools/ and more, so copy the checkout rather than curate a file list.
-  // Skipped: the git dir (the fixture gets its own), node_modules (linked
-  // below), and the operator-local configs — the fixture writes its own.
+  // Skipped: the git dir (the fixture gets its own), every node_modules at
+  // any depth (the root one is linked below; nested ones are not imported by
+  // emit), operator-local trees that live inside a checkout (.claude/ and
+  // .worktrees/ hold agent worktrees that run to hundreds of MB and filled
+  // the sandbox tmpfs with ENOSPC), and the operator-local configs — the
+  // fixture writes its own.
   cpSync(ROOT, fixture, {
     recursive: true,
     filter: (source) => {
       const relative = path.relative(ROOT, source);
-      const top = relative.split(path.sep)[0];
-      if (top === ".git" || top === "node_modules") return false;
+      const segments = relative.split(path.sep);
+      if (segments.includes("node_modules") || segments[0] === ".git")
+        return false;
+      if (/^\.(claude|worktrees|factory)$/.test(segments[0])) return false;
       return !(
         path.dirname(relative) === "config" &&
         /^(repos|policy|schedule)\.yaml$/.test(path.basename(relative))

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -5,6 +5,7 @@ import {
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  realpathSync,
   rmSync,
   symlinkSync,
   writeFileSync,
@@ -12,9 +13,59 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { spliceFloor } from "../lib/floor.mjs";
+import {
+  configuredGithubSlug,
+  remoteGithubSlug,
+  resolveFloorCheckouts,
+} from "./emit.mjs";
 
 const ROOT = path.resolve(import.meta.dir, "..");
 const hadLocalReposConfig = existsSync(path.join(ROOT, "config", "repos.yaml"));
+
+test("GitHub slug helpers distinguish remotes from configured values", () => {
+  expect(remoteGithubSlug("git@github.com:Owner/Repository.git")).toBe(
+    "owner/repository",
+  );
+  expect(remoteGithubSlug("https://github.com/Owner/Repository")).toBe(
+    "owner/repository",
+  );
+  expect(remoteGithubSlug("https://github.com/Owner/Repository.git")).toBe(
+    "owner/repository",
+  );
+  expect(remoteGithubSlug("Owner/Repository")).toBeNull();
+  expect(remoteGithubSlug("https://gitlab.com/Owner/Repository")).toBeNull();
+
+  expect(configuredGithubSlug("Owner/Repository")).toBe("owner/repository");
+  expect(configuredGithubSlug("HTTPS://GITHUB.COM/Owner/Repository.git")).toBe(
+    "owner/repository",
+  );
+  expect(configuredGithubSlug("https://gitlab.com/Owner/Repository")).toBeNull();
+});
+
+test("floor checkout resolution prefers real paths before matching a slug", () => {
+  const runningRoot = mkdtempSync(path.join(tmpdir(), "emit-running-"));
+  const siblingRoot = mkdtempSync(path.join(tmpdir(), "emit-sibling-"));
+  const missingRoot = path.join(tmpdir(), "emit-missing-checkout");
+  try {
+    const repos = [
+      { name: "sibling", path: siblingRoot, github: "watt-mind/factory" },
+      { name: "missing", path: missingRoot, github: "watt-mind/factory" },
+      { name: "running", path: runningRoot, github: "watt-mind/factory" },
+    ];
+    const resolved = resolveFloorCheckouts({
+      runningRoot: realpathSync(runningRoot),
+      runningGithub: "watt-mind/factory",
+      repos,
+    });
+    expect(resolved.map((repo) => repo.isRunningRepo)).toEqual([false, true, true]);
+    expect(resolved[0].checkoutPath).toBe(siblingRoot);
+    expect(resolved[1].checkoutPath).toBe(realpathSync(runningRoot));
+    expect(resolved[2].checkoutPath).toBe(realpathSync(runningRoot));
+  } finally {
+    rmSync(runningRoot, { recursive: true, force: true });
+    rmSync(siblingRoot, { recursive: true, force: true });
+  }
+});
 
 test("emit purges orphaned commands, skills, and prompts from every output tree", () => {
   const orphaned = [
@@ -93,18 +144,17 @@ function makeEmitFixture() {
   return fixture;
 }
 
-test("floor check uses the running checkout for its matching repo", () => {
+test("floor check uses the running checkout when its configured path is missing", () => {
   const fixture = makeEmitFixture();
-  const staleFactory = mkdtempSync(path.join(tmpdir(), "emit-floor-factory-"));
   const staleSibling = mkdtempSync(path.join(tmpdir(), "emit-floor-sibling-"));
   const staleAgents =
     "<!-- FACTORY:FLOOR:BEGIN -->\nstale floor\n<!-- FACTORY:FLOOR:END -->\n";
 
   try {
     // The fixture is a current checkout of this repo (its AGENTS.md carries the
-    // floor emit just generated) whose origin names watt-mind/factory, while
-    // config points `factory` at a stale directory elsewhere — the worktree
-    // shape the slug match exists for. The sibling keeps its configured path.
+    // floor emit just generated) whose origin names watt-mind/factory. Its
+    // configured path is absent, which is the worktree shape the slug fallback
+    // supports. The sibling keeps its configured path.
     writeFileSync(
       path.join(fixture, "AGENTS.md"),
       spliceFloor(
@@ -119,11 +169,10 @@ test("floor check uses the running checkout for its matching repo", () => {
       const git = Bun.spawnSync({ cmd: ["git", ...args], cwd: fixture });
       expect(git.exitCode).toBe(0);
     }
-    writeFileSync(path.join(staleFactory, "AGENTS.md"), staleAgents);
     writeFileSync(path.join(staleSibling, "AGENTS.md"), staleAgents);
     writeFileSync(
       path.join(fixture, "config", "repos.yaml"),
-      `repos:\n  - name: factory\n    path: ${staleFactory}\n    github: watt-mind/factory\n  - name: sibling\n    path: ${staleSibling}\n    github: watt-mind/other-repo\n`,
+      `repos:\n  - name: factory\n    path: ${path.join(fixture, "missing-factory")}\n    github: watt-mind/factory\n  - name: sibling\n    path: ${staleSibling}\n    github: watt-mind/other-repo\n`,
     );
 
     const result = Bun.spawnSync({
@@ -150,7 +199,6 @@ test("floor check uses the running checkout for its matching repo", () => {
     );
   } finally {
     rmSync(fixture, { recursive: true, force: true });
-    rmSync(staleFactory, { recursive: true, force: true });
     rmSync(staleSibling, { recursive: true, force: true });
   }
 });

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -22,19 +22,34 @@ import {
 const ROOT = path.resolve(import.meta.dir, "..");
 const hadLocalReposConfig = existsSync(path.join(ROOT, "config", "repos.yaml"));
 
-test("GitHub slug helpers distinguish remotes from configured values", () => {
-  expect(remoteGithubSlug("git@github.com:Owner/Repository.git")).toBe(
-    "owner/repository",
-  );
-  expect(remoteGithubSlug("https://github.com/Owner/Repository")).toBe(
-    "owner/repository",
-  );
-  expect(remoteGithubSlug("https://github.com/Owner/Repository.git")).toBe(
-    "owner/repository",
-  );
-  expect(remoteGithubSlug("Owner/Repository")).toBeNull();
-  expect(remoteGithubSlug("https://gitlab.com/Owner/Repository")).toBeNull();
+test.each([
+  ["git@github.com:Owner/Repository.git", "owner/repository"],
+  ["https://github.com/Owner/Repository", "owner/repository"],
+  ["https://github.com/Owner/Repository.git", "owner/repository"],
+  ["https://github.com/Owner/Repository/", "owner/repository"],
+  ["http://github.com/Owner/Repository", "owner/repository"],
+  ["https://user@github.com/Owner/Repository", "owner/repository"],
+  ["https://user:token@github.com/Owner/Repository.git", "owner/repository"],
+  ["git://github.com/Owner/Repository", "owner/repository"],
+  ["git://github.com/Owner/Repository.git", "owner/repository"],
+  ["ssh://git@github.com/Owner/Repository.git", "owner/repository"],
+  ["ssh://git@github.com:22/Owner/Repository", "owner/repository"],
+  ["git+ssh://git@github.com/Owner/Repository.git", "owner/repository"],
+  ["  git@github.com:Owner/Repository.git\n", "owner/repository"],
+  ["Owner/Repository", null],
+  ["https://gitlab.com/Owner/Repository", null],
+  ["https://github.com/Owner", null],
+  ["https://github.com/Owner/Repository/extra", null],
+  ["https://github.com/Owner/.git", null],
+  ["https://notgithub.com/Owner/Repository", null],
+  ["https://github.com.evil.example/Owner/Repository", null],
+  ["", null],
+  [undefined, null],
+])("remoteGithubSlug(%j) -> %j", (remote, slug) => {
+  expect(remoteGithubSlug(remote)).toBe(slug);
+});
 
+test("GitHub slug helpers distinguish remotes from configured values", () => {
   expect(configuredGithubSlug("Owner/Repository")).toBe("owner/repository");
   expect(configuredGithubSlug("HTTPS://GITHUB.COM/Owner/Repository.git")).toBe(
     "owner/repository",
@@ -67,9 +82,72 @@ test("floor checkout resolution prefers real paths before matching a slug", () =
     expect(resolved[0].checkoutPath).toBe(siblingRoot);
     expect(resolved[1].checkoutPath).toBe(realpathSync(runningRoot));
     expect(resolved[2].checkoutPath).toBe(realpathSync(runningRoot));
+
+    // Writing (--sync-floor) never targets another checkout of this
+    // repository: a matching origin resolves to the running tree even when the
+    // configured path is a usable directory elsewhere.
+    const writing = resolveFloorCheckouts({
+      runningRoot: realpathSync(runningRoot),
+      runningGithub: "watt-mind/factory",
+      repos,
+      preferRunning: true,
+    });
+    expect(writing.map((repo) => repo.isRunningRepo)).toEqual([
+      true,
+      true,
+      true,
+    ]);
+    expect(writing.map((repo) => repo.checkoutPath)).toEqual([
+      realpathSync(runningRoot),
+      realpathSync(runningRoot),
+      realpathSync(runningRoot),
+    ]);
+    // A sibling of a different repository keeps its own path in both modes.
+    const other = { name: "other", path: siblingRoot, github: "acme/other" };
+    for (const preferRunning of [false, true]) {
+      const [resolvedOther] = resolveFloorCheckouts({
+        runningRoot: realpathSync(runningRoot),
+        runningGithub: "watt-mind/factory",
+        repos: [other],
+        preferRunning,
+      });
+      expect(resolvedOther.isRunningRepo).toBe(false);
+      expect(resolvedOther.checkoutPath).toBe(siblingRoot);
+    }
   } finally {
     rmSync(runningRoot, { recursive: true, force: true });
     rmSync(siblingRoot, { recursive: true, force: true });
+  }
+});
+
+test("floor checkout resolution is a boolean without a running remote", () => {
+  const runningRoot = mkdtempSync(path.join(tmpdir(), "emit-running-"));
+  try {
+    const repos = [
+      {
+        name: "missing",
+        path: path.join(tmpdir(), "emit-missing-checkout"),
+        github: "watt-mind/factory",
+      },
+      { name: "running", path: runningRoot, github: "watt-mind/factory" },
+    ];
+    for (const runningGithub of [null, undefined, ""]) {
+      for (const preferRunning of [false, true]) {
+        const resolved = resolveFloorCheckouts({
+          runningRoot: realpathSync(runningRoot),
+          runningGithub,
+          repos,
+          preferRunning,
+        });
+        expect(resolved.map((repo) => repo.isRunningRepo)).toEqual([
+          false,
+          true,
+        ]);
+        expect(resolved[0].checkoutPath).toBe(repos[0].path);
+      }
+    }
+  } finally {
+    rmSync(runningRoot, { recursive: true, force: true });
   }
 });
 
@@ -212,5 +290,63 @@ test("floor check uses the running checkout when its configured path is missing"
   } finally {
     rmSync(fixture, { recursive: true, force: true });
     rmSync(staleSibling, { recursive: true, force: true });
+  }
+});
+
+test("sync-floor writes the running checkout, never the configured one", () => {
+  const fixture = makeEmitFixture();
+  const configured = mkdtempSync(path.join(tmpdir(), "emit-floor-live-"));
+  const staleAgents =
+    "# Live checkout\n\n<!-- FACTORY:FLOOR:BEGIN -->\nstale floor\n<!-- FACTORY:FLOOR:END -->\n";
+
+  try {
+    // The fixture is a worktree-shaped checkout of this repo whose CONFIGURED
+    // path is a different, usable checkout (the operator's live tree) with a
+    // stale floor. Both carry a stale floor; only the running one may change.
+    writeFileSync(path.join(fixture, "AGENTS.md"), staleAgents);
+    writeFileSync(path.join(configured, "AGENTS.md"), staleAgents);
+    for (const args of [
+      ["init", "-q"],
+      ["remote", "add", "origin", "https://github.com/watt-mind/factory.git"],
+    ]) {
+      const git = Bun.spawnSync({ cmd: ["git", ...args], cwd: fixture });
+      expect(git.exitCode).toBe(0);
+    }
+    writeFileSync(
+      path.join(fixture, "config", "repos.yaml"),
+      `repos:\n  - name: factory\n    path: ${configured}\n    github: watt-mind/factory\n`,
+    );
+
+    const result = Bun.spawnSync({
+      cmd: ["bun", "build/emit.mjs", "--sync-floor"],
+      cwd: fixture,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    // Only the example-config fallback warning is expected (see above).
+    const stderrLines = result.stderr
+      .toString()
+      .split("\n")
+      .filter((line) => line && !/config\/.*\.yaml is missing/.test(line));
+    expect(stderrLines).toEqual([]);
+    expect(result.exitCode).toBe(0);
+    const output = result.stdout.toString();
+    expect(output).toContain("updated  factory");
+
+    // The running checkout received the floor; the configured one is untouched.
+    const fixtureAgents = readFileSync(path.join(fixture, "AGENTS.md"), "utf8");
+    expect(fixtureAgents).not.toBe(staleAgents);
+    expect(fixtureAgents).not.toContain("stale floor");
+    expect(readFileSync(path.join(configured, "AGENTS.md"), "utf8")).toBe(
+      staleAgents,
+    );
+    // Nothing above touched this checkout.
+    expect(existsSync(path.join(ROOT, "config", "repos.yaml"))).toBe(
+      hadLocalReposConfig,
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+    rmSync(configured, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1318

Split `githubSlug` into two exported helpers — `remoteGithubSlug` (git remote URL → lowercase `owner/repo` or `null`) and `configuredGithubSlug` (bare slug or URL from `repos.yaml` `github:` → same canonical form or `null`). `originGithubSlug` uses the remote helper; `floorStatus` delegates to a pure `resolveFloorCheckouts({ runningRoot, runningGithub, repos })` which only falls back to slug matching when the configured `path` does not exist or is not a directory, so a same-slug entry with an existing different path keeps its own checkout.

Also hardens the `--check` fixture in `build/emit.test.mjs`: the original dispatch run (`run_42104dac`) failed handoff verification with `ENOSPC` because the fixture copied the whole checkout — nested `node_modules` and `.claude/` agent worktrees (~850 MB) — into the sandbox tmpfs. The copy now skips `node_modules` at any depth and operator-local worktree dirs.

## Handoff
- Verification: `bun test build/emit.test.mjs --timeout 20000` — pass, 4 tests, 0 failures, 30 expect() calls
- Repo verify: `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` — pass (1887 pass, 10 skip, 0 fail; 94 generated files match; Prettier clean)
- UX critique: skipped — internal build tooling, no user-facing surface
- Files: 2 changed, all within Owned Paths (`build/emit.mjs`, `build/emit.test.mjs`)
- Risks: none known; single-entry floor-status behaviour unchanged

## Post-review

Addressed the FIX verdict:
- `remoteGithubSlug`/`configuredGithubSlug`: dropped the useless `\/` escapes (eslint no-useless-escape).
- `--sync-floor` no longer writes another checkout: `resolveFloorCheckouts({ preferRunning })` routes a repo whose origin matches the running tree to the running root for writes; `--check` keeps consulting the configured path read-only. New test runs `--sync-floor` from a fixture whose configured path is a separate stale checkout and asserts only the fixture AGENTS.md changes.
- `remoteGithubSlug` accepts `https://user@github.com/o/r`, `git://github.com/o/r`, `ssh://git@github.com:22/o/r`, `git+ssh://` (table-driven cases); `isRunningRepo` is always a boolean.