### PR TITLE
fix(repos): fail closed on wildcard-like toolchain constraints

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -41,6 +41,8 @@ repos:
     #
     # Constraints are validated at load: a range that is not semver (`latest`,
     # a typo) is a config error rather than a gate that silently passes.
+    # The single canonical wildcard "*" means the executable must exist; any parsed version passes.
+    # Other wildcard spellings are rejected because some only look constrained.
     #
     # Keep an example's floors genuinely low. This file is a LIVE fallback when
     # config/repos.yaml is absent, so a tight floor here would make the factory

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -355,12 +355,13 @@ Both are validated at config load, and both are strict on purpose:
 - a constraint must parse as a semver range. This is not decoration:
   `Bun.semver.satisfies("1.2.3", "not a range")` returns **true**, so an
   unvalidated typo would produce a gate that silently admits every version.
-  `isToolchainConstraint` rejects it at load instead. Whitespace after an
-  operator (`>= 1.2.3`) is valid node-semver and is accepted — a false reject
-  throws inside `loadRepos` and takes down every command that reads the
-  registry, so the validator is strict about garbage and lenient about
-  spelling. Known residue: some wildcard forms (`*.2.3`, `<*`) still validate
-  while constraining nothing (#1115).
+  `isToolchainConstraint` rejects it at load instead. Accepted syntax is an
+  exact or partial numeric version, a comparator, a two-sided comparator set,
+  a valid hyphen range, or clauses joined by `||`. Whitespace after an operator
+  (`>= 1.2.3`) is accepted. The single canonical wildcard "*" means the executable must exist; any parsed version passes.
+  Other whole-range or misleading wildcard spellings (`X`, `^x`, `<*`,
+  `*.2.3`) are rejected; requiring the canonical form avoids Bun/node-semver
+  divergence and makes an always-pass declaration explicit.
 
 The contract records what the repo requires; it does not select a version
 manager or install system packages. `repo doctor` resolves each executable in

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -208,11 +208,13 @@ const TOOLCHAIN_PROBE_TIMEOUT_MS = 10_000;
 const TOOLCHAIN_EXECUTABLE = /^[A-Za-z0-9][A-Za-z0-9._+-]*$/;
 
 /**
- * One comparator of a semver range: an optional operator followed by a
- * partial version (`>=22`, `^1.2.3`, `1.x`, `*`).
+ * One constrained comparator of a semver range: an optional operator followed
+ * by a numeric or numeric-leading partial version (`>=22`, `^1.2.3`, `1.x`).
+ * The canonical whole-range wildcard (`*`) is handled separately so wildcard
+ * lookalikes cannot accidentally become always-pass constraints.
  */
 const SEMVER_COMPARATOR =
-  /^(?:[<>]=?|=|\^|~)?v?(?:\d+|[xX*])(?:\.(?:\d+|[xX*]))?(?:\.(?:\d+|[xX*]))?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
+  /^(?:[<>]=?|=|\^|~)?v?\d+(?:\.(?:\d+|[xX*]))?(?:\.(?:\d+|[xX*]))?(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$/;
 
 /**
  * Whether a string is a semver range this implementation will evaluate.
@@ -231,15 +233,34 @@ export function isToolchainConstraint(constraint) {
   // with the odd spelling.
   const trimmed = constraint.trim().replace(/([<>]=?|=|\^|~)\s+/g, "$1");
   if (!trimmed) return false;
+  // Deliberate policy: `*` means the executable must exist but any parsed
+  // version passes. It is the only accepted spelling of a whole-range
+  // wildcard; keeping it out of SEMVER_COMPARATOR rejects Bun's always-pass
+  // interpretations of `<*`, `X`, `v*`, `*.2.3`, and similar lookalikes.
+  if (trimmed === "*") return true;
   for (const clause of trimmed.split("||")) {
     const tokens = clause.trim().split(/\s+/).filter(Boolean);
     if (!tokens.length) return false;
     // `A - B` hyphen range: exactly two comparators around a lone hyphen.
     if (tokens.includes("-")) {
       if (tokens.length !== 3 || tokens[1] !== "-") return false;
+      // Hyphen endpoints are versions, not comparator expressions.
+      if (/^[<>=^~]/.test(tokens[0]) || /^[<>=^~]/.test(tokens[2])) {
+        return false;
+      }
       if (!SEMVER_COMPARATOR.test(tokens[0])) return false;
       if (!SEMVER_COMPARATOR.test(tokens[2])) return false;
       continue;
+    }
+    // Toolchain policy admits a single version/comparator or a conventional
+    // two-sided comparator set. Bare token lists and three-way sets are easy
+    // to misread and have surprising cross-engine semantics.
+    if (tokens.length > 2) return false;
+    if (
+      tokens.length === 2 &&
+      !tokens.every((token) => /^(?:[<>]=?|=|\^|~)/.test(token))
+    ) {
+      return false;
     }
     if (!tokens.every((token) => SEMVER_COMPARATOR.test(token))) return false;
   }
@@ -305,7 +326,7 @@ function normalizeToolchain(raw, repoName, file) {
     seen.add(executable);
     if (!isToolchainConstraint(rawConstraint)) {
       throw new RepoError(
-        `${file}: repo ${repoName} toolchain constraint for ${JSON.stringify(executable)} must be a semver range, got ${JSON.stringify(rawConstraint)}`,
+        `${file}: repo ${repoName} toolchain constraint for ${JSON.stringify(executable)} must be a semver range ("*" is the only canonical any-version form), got ${JSON.stringify(rawConstraint)}`,
       );
     }
     toolchain.push({ executable, constraint: rawConstraint.trim() });

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -2,6 +2,7 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-repos-tes
 import { afterAll, describe, expect, test } from "bun:test";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import path from "node:path";
+import semver from "semver";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import {
   isToolchainConstraint,
@@ -645,6 +646,70 @@ describe("toolchain: declaration parsing and validation", () => {
     expect(() => repoWith(`    toolchain:\n      bun: latest\n`)).toThrow(
       /must be a semver range/,
     );
+  });
+
+  test("only canonical * may express an always-pass whole-range wildcard", () => {
+    expect(isToolchainConstraint("*")).toBe(true);
+    expect(Bun.semver.satisfies("0.0.1", "*")).toBe(true);
+    expect(Bun.semver.satisfies("999.999.999", "*")).toBe(true);
+    expect(repoWith(`    toolchain:\n      bun: "*"\n`).toolchain).toEqual([
+      { executable: "bun", constraint: "*" },
+    ]);
+
+    const rejected = [
+      "X",
+      "X.X.X",
+      "*.*",
+      "^x",
+      "~*",
+      ">=*",
+      "<*",
+      "v*",
+      "*||*",
+      "*.2.3",
+      "x.2.3",
+    ];
+    for (const constraint of rejected) {
+      expect([constraint, isToolchainConstraint(constraint)]).toEqual([
+        constraint,
+        false,
+      ]);
+      expect(() =>
+        repoWith(`    toolchain:\n      bun: ${JSON.stringify(constraint)}\n`),
+      ).toThrow(/"\*" is the only canonical any-version form/);
+    }
+
+    // Bun treats `<*` as always-pass while node-semver treats it as
+    // always-fail. Reject it before either engine can choose the semantics.
+    for (const version of ["0.0.1", "999.999.999"]) {
+      expect(Bun.semver.satisfies(version, "<*")).toBe(true);
+      expect(semver.satisfies(version, "<*")).toBe(false);
+    }
+  });
+
+  test("ambiguous comparator lists and operator-prefixed hyphen ranges fail closed", () => {
+    for (const constraint of ["1 2 3", ">=1 >=2 >=3", ">=1.2.3 - 2.0.0"]) {
+      expect([constraint, isToolchainConstraint(constraint)]).toEqual([
+        constraint,
+        false,
+      ]);
+      expect(() =>
+        repoWith(`    toolchain:\n      bun: ${JSON.stringify(constraint)}\n`),
+      ).toThrow(/must be a semver range/);
+    }
+  });
+
+  test("the canonical wildcard's always-pass policy is documented for operators", () => {
+    const root = path.resolve(import.meta.dir, "../..");
+    for (const relative of [
+      "config/repos.example.yaml",
+      "docs/event-runtime-repos.md",
+    ]) {
+      const text = readFileSync(path.join(root, relative), "utf8");
+      expect(text).toContain(
+        'The single canonical wildcard "*" means the executable must exist; any parsed version passes.',
+      );
+    }
   });
 
   test("structural errors name the repo instead of loading a half-understood block", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1115

Review the fail-closed constraint grammar and canonical wildcard policy.

## Validation

| Check                | Command                                                                                                 | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/repos.test.mjs`                          | pass    | 60 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`       | pass    | 1890 pass, 10 skip; emit and format clean  |
| UX critique          | factory-ux-critic                                                                                       | not run | no user-facing surface                     |

UX critique: skipped — backend/config validation and docs only; no user-facing flow
