### PR TITLE
fix(gh-app-auth): schedule daemon refresh from token expiry

### DIFF
--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -314,16 +314,21 @@ export async function runDaemon({
       now,
     });
 
+  /**
+   * One refresh attempt. `ok: false` means the mint/write threw; `ok: true`
+   * with a null `expiresAt` means the token is usable but GitHub gave no
+   * parseable expiry — the two are scheduled differently below.
+   */
   const refresh = async () => {
     try {
       await resolveGhToken({ tokenFile: config.tokenFile, now, mint });
       const expiresAt = expiryMs(readTokenFile(config.tokenFile)?.expiresAt);
       log.log?.(`[gh-app-auth] installation token ready (${config.tokenFile})`);
-      return expiresAt;
+      return { ok: true, expiresAt };
     } catch (err) {
       // `err.message` is deliberately status/path-only (see mint/resolve).
       log.warn?.(`[gh-app-auth] token refresh failed: ${err?.message ?? err}`);
-      return null;
+      return { ok: false, expiresAt: null };
     }
   };
 
@@ -340,18 +345,50 @@ export async function runDaemon({
     signals.on?.("SIGTERM", stop);
     signals.on?.("SIGINT", stop);
 
-    const scheduleRefresh = async () => {
-      const expiresAt = await refresh();
-      if (stopped) return;
+    let warnedNoExpiry = false;
+    const backoff = () => {
+      const delayMs = retryDelayMs;
+      retryDelayMs = Math.min(retryDelayMs * 2, RETRY_MAX_DELAY_MS);
+      return delayMs;
+    };
 
+    // Never rejects: anything thrown outside `refresh()` is logged and the
+    // timer is still re-armed, so one bad tick cannot kill the chain.
+    const scheduleRefresh = async () => {
       let delayMs;
-      if (expiresAt == null) {
-        delayMs = retryDelayMs;
-        retryDelayMs = Math.min(retryDelayMs * 2, RETRY_MAX_DELAY_MS);
-      } else {
-        retryDelayMs = RETRY_INITIAL_DELAY_MS;
-        const refreshFromExpiry = expiresAt - now() - EXPIRY_SKEW_MS;
-        delayMs = Math.min(intervalMs, refreshFromExpiry);
+      try {
+        const { ok, expiresAt } = await refresh();
+        if (stopped) return;
+        if (!ok) {
+          delayMs = backoff();
+        } else if (expiresAt == null) {
+          // A successful mint without a usable expiry is not a failure:
+          // keep the fixed cadence (the cache treats it as stale, so the
+          // next tick re-mints) instead of hammering GitHub on backoff.
+          retryDelayMs = RETRY_INITIAL_DELAY_MS;
+          delayMs = intervalMs;
+          if (!warnedNoExpiry) {
+            warnedNoExpiry = true;
+            log.warn?.(
+              "[gh-app-auth] installation token has no usable expires_at; " +
+                `refreshing every ${Math.round(intervalMs / 1000)}s`,
+            );
+          }
+        } else {
+          retryDelayMs = RETRY_INITIAL_DELAY_MS;
+          const refreshFromExpiry = expiresAt - now() - EXPIRY_SKEW_MS;
+          delayMs = Math.min(intervalMs, refreshFromExpiry);
+        }
+      } catch (err) {
+        if (stopped) return;
+        try {
+          log.warn?.(
+            `[gh-app-auth] refresh scheduling failed: ${err?.message ?? err}`,
+          );
+        } catch {
+          // A throwing logger must not take the daemon down with it.
+        }
+        delayMs = backoff();
       }
       delayMs = Math.max(MIN_REFRESH_DELAY_MS, delayMs);
       timer = setTimeoutImpl(scheduleRefresh, delayMs);

--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -37,6 +37,11 @@ import path from "node:path";
 const EXPIRY_SKEW_MS = 5 * 60 * 1000;
 /** Daemon refresh cadence — comfortably inside the 1h token lifetime. */
 const REFRESH_INTERVAL_MS = 45 * 60 * 1000;
+/** Never spin on a malformed expiry or a clock anomaly. */
+const MIN_REFRESH_DELAY_MS = 30 * 1000;
+/** A transient mint failure should recover promptly without hammering GitHub. */
+const RETRY_INITIAL_DELAY_MS = 60 * 1000;
+const RETRY_MAX_DELAY_MS = 5 * 60 * 1000;
 /** JWTs GitHub accepts must expire within 10 min; back-date `iat` for skew. */
 const JWT_LIFETIME_S = 9 * 60;
 const JWT_BACKDATE_S = 60;
@@ -265,10 +270,12 @@ export function readCachedAppToken({
 }
 
 /**
- * The supervised refresher (`--daemon`). Mints once on startup, then every
- * ~45 min, and exits cleanly on SIGTERM/SIGINT. Reads config from env and the
- * private key from `FACTORY_GH_APP_PRIVATE_KEY_PATH`. Logs only paths and
- * expiry timestamps — never the token or the key.
+ * The supervised refresher (`--daemon`). Each successful refresh is scheduled
+ * from the cached token's expiry (up to the normal 45-minute cadence), while
+ * failures use bounded retry backoff. It exits cleanly on SIGTERM/SIGINT.
+ * Reads config from env and the private key from
+ * `FACTORY_GH_APP_PRIVATE_KEY_PATH`. Logs only paths and expiry timestamps —
+ * never the token or the key.
  *
  * @param {{
  *   env?: NodeJS.ProcessEnv,
@@ -277,6 +284,8 @@ export function readCachedAppToken({
  *   log?: { log?: Function, warn?: Function },
  *   signals?: { on?: Function },
  *   intervalMs?: number,
+ *   setTimeoutImpl?: typeof setTimeout,
+ *   clearTimeoutImpl?: typeof clearTimeout,
  * }} [args]
  */
 export async function runDaemon({
@@ -286,6 +295,8 @@ export async function runDaemon({
   log = console,
   signals = process,
   intervalMs = REFRESH_INTERVAL_MS,
+  setTimeoutImpl = setTimeout,
+  clearTimeoutImpl = clearTimeout,
 } = {}) {
   const config = readAppConfig(env);
   if (!config)
@@ -306,29 +317,48 @@ export async function runDaemon({
   const refresh = async () => {
     try {
       await resolveGhToken({ tokenFile: config.tokenFile, now, mint });
+      const expiresAt = expiryMs(readTokenFile(config.tokenFile)?.expiresAt);
       log.log?.(`[gh-app-auth] installation token ready (${config.tokenFile})`);
+      return expiresAt;
     } catch (err) {
       // `err.message` is deliberately status/path-only (see mint/resolve).
       log.warn?.(`[gh-app-auth] token refresh failed: ${err?.message ?? err}`);
+      return null;
     }
   };
 
-  await refresh();
   await new Promise((resolve) => {
     let timer = null;
     let stopped = false;
+    let retryDelayMs = RETRY_INITIAL_DELAY_MS;
     const stop = () => {
       if (stopped) return;
       stopped = true;
-      if (timer) clearInterval(timer);
+      if (timer) clearTimeoutImpl(timer);
       resolve();
     };
     signals.on?.("SIGTERM", stop);
     signals.on?.("SIGINT", stop);
-    timer = setInterval(() => {
-      refresh();
-    }, intervalMs);
-    if (typeof timer?.unref === "function") timer.unref();
+
+    const scheduleRefresh = async () => {
+      const expiresAt = await refresh();
+      if (stopped) return;
+
+      let delayMs;
+      if (expiresAt == null) {
+        delayMs = retryDelayMs;
+        retryDelayMs = Math.min(retryDelayMs * 2, RETRY_MAX_DELAY_MS);
+      } else {
+        retryDelayMs = RETRY_INITIAL_DELAY_MS;
+        const refreshFromExpiry = expiresAt - now() - EXPIRY_SKEW_MS;
+        delayMs = Math.min(intervalMs, refreshFromExpiry);
+      }
+      delayMs = Math.max(MIN_REFRESH_DELAY_MS, delayMs);
+      timer = setTimeoutImpl(scheduleRefresh, delayMs);
+      if (typeof timer?.unref === "function") timer.unref();
+    };
+
+    void scheduleRefresh();
   });
 }
 

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -17,6 +17,7 @@ import {
   mintInstallationToken,
   readCachedAppToken,
   resolveGhToken,
+  runDaemon,
 } from "./gh-app-auth.mjs";
 
 const { privateKey, publicKey } = generateKeyPairSync("rsa", {
@@ -37,6 +38,54 @@ afterAll(() => {
 
 function decodeSegment(seg) {
   return JSON.parse(Buffer.from(seg, "base64url").toString("utf8"));
+}
+
+/** A deterministic, awaitable setTimeout replacement for daemon tests. */
+function fakeTimers(startMs) {
+  let nowMs = startMs;
+  let nextId = 0;
+  const timers = new Map();
+  const setTimeoutImpl = (callback, delayMs) => {
+    const id = ++nextId;
+    timers.set(id, { callback, at: nowMs + delayMs, delayMs });
+    return id;
+  };
+  const clearTimeoutImpl = (id) => timers.delete(id);
+  const next = () =>
+    [...timers.entries()].sort(([, a], [, b]) => a.at - b.at)[0] ?? null;
+  return {
+    now: () => nowMs,
+    setTimeoutImpl,
+    clearTimeoutImpl,
+    nextDelay: () => next()?.[1].delayMs ?? null,
+    async advanceBy(ms) {
+      const target = nowMs + ms;
+      while (next()?.[1].at <= target) {
+        const [id, timer] = next();
+        timers.delete(id);
+        nowMs = timer.at;
+        await timer.callback();
+      }
+      nowMs = target;
+    },
+  };
+}
+
+function daemonSignals() {
+  const handlers = new Map();
+  return {
+    on(signal, handler) {
+      handlers.set(signal, handler);
+    },
+    stop() {
+      handlers.get("SIGTERM")?.();
+    },
+  };
+}
+
+async function flushDaemon() {
+  // A failed mint crosses several promise boundaries (resolve → mint → fetch).
+  for (let i = 0; i < 10; i += 1) await Promise.resolve();
 }
 
 describe("buildAppJwt", () => {
@@ -249,5 +298,120 @@ describe("readCachedAppToken", () => {
         now: () => Date.parse("2026-08-29T12:00:00Z"),
       }),
     ).toThrow();
+  });
+});
+
+describe("runDaemon", () => {
+  const appEnv = (dir) => ({
+    FACTORY_GH_APP_ID: "42",
+    FACTORY_GH_APP_INSTALLATION_ID: "9001",
+    FACTORY_GH_APP_PRIVATE_KEY_PATH: path.join(dir, "app-key.pem"),
+    FACTORY_GH_APP_TOKEN_FILE: path.join(dir, "gh-app-token.json"),
+  });
+
+  const daemonOptions = (env, timers, signals, fetchImpl) => ({
+    env,
+    fetchImpl,
+    now: timers.now,
+    signals,
+    log: { log() {}, warn() {} },
+    setTimeoutImpl: timers.setTimeoutImpl,
+    clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+
+  test("re-mints a cached token before its seven-minute expiry", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: new Date(start + 7 * 60 * 1000).toISOString(),
+      }),
+    );
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    let mints = 0;
+    const daemon = runDaemon(
+      daemonOptions(env, timers, signals, async () => {
+        mints += 1;
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            token: "ghs_reminted",
+            expires_at: new Date(timers.now() + 60 * 60 * 1000).toISOString(),
+          }),
+        };
+      }),
+    );
+    await flushDaemon();
+
+    // Seven minutes minus the five-minute safety skew is two minutes.
+    expect(timers.nextDelay()).toBe(2 * 60 * 1000);
+    await timers.advanceBy(2 * 60 * 1000 - 1);
+    expect(mints).toBe(0);
+    await timers.advanceBy(1);
+    expect(mints).toBe(1);
+
+    signals.stop();
+    await daemon;
+  });
+
+  test("keeps the 45-minute cadence for a fresh one-hour cached token", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: new Date(start + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    const daemon = runDaemon(
+      daemonOptions(env, timers, signals, async () => {
+        throw new Error("a fresh cache must not mint on startup");
+      }),
+    );
+    await flushDaemon();
+
+    expect(timers.nextDelay()).toBe(45 * 60 * 1000);
+    signals.stop();
+    await daemon;
+  });
+
+  test("retries failed refreshes with bounded backoff", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    let attempts = 0;
+    const daemon = runDaemon(
+      daemonOptions(env, timers, signals, async () => {
+        attempts += 1;
+        return { ok: false, status: 503, json: async () => ({}) };
+      }),
+    );
+    await flushDaemon();
+
+    expect(attempts).toBe(1);
+    expect(timers.nextDelay()).toBe(60 * 1000);
+    await timers.advanceBy(60 * 1000);
+    expect(attempts).toBe(2);
+    expect(timers.nextDelay()).toBe(2 * 60 * 1000);
+    await timers.advanceBy(2 * 60 * 1000);
+    expect(attempts).toBe(3);
+    expect(timers.nextDelay()).toBe(4 * 60 * 1000);
+
+    signals.stop();
+    await daemon;
   });
 });

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -414,4 +414,102 @@ describe("runDaemon", () => {
     signals.stop();
     await daemon;
   });
+
+  test("a successful mint without a usable expiry keeps the interval and warns once", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    const warnings = [];
+    let mints = 0;
+    const daemon = runDaemon({
+      ...daemonOptions(env, timers, signals, async () => {
+        mints += 1;
+        return {
+          ok: true,
+          status: 201,
+          // No expires_at at all on the first mint, garbage on the second.
+          json: async () =>
+            mints === 1
+              ? { token: "ghs_no_expiry" }
+              : { token: "ghs_bad_expiry", expires_at: "not-a-date" },
+        };
+      }),
+      log: {
+        log() {},
+        warn(message) {
+          warnings.push(message);
+        },
+      },
+    });
+    await flushDaemon();
+
+    // Not a failure: the fixed cadence applies, not the 60s→5m backoff.
+    expect(mints).toBe(1);
+    expect(timers.nextDelay()).toBe(45 * 60 * 1000);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain("no usable expires_at");
+    expect(warnings[0]).not.toContain("ghs_");
+
+    await timers.advanceBy(45 * 60 * 1000);
+    expect(mints).toBe(2);
+    expect(timers.nextDelay()).toBe(45 * 60 * 1000);
+    // The warning is emitted once, not on every tick.
+    expect(warnings).toHaveLength(1);
+
+    signals.stop();
+    await daemon;
+  });
+
+  test("a throw outside refresh() re-arms with backoff instead of killing the chain", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-auth-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    const warnings = [];
+    let mints = 0;
+    const daemon = runDaemon({
+      ...daemonOptions(env, timers, signals, async () => {
+        mints += 1;
+        return {
+          ok: true,
+          status: 201,
+          json: async () => ({
+            token: "ghs_no_expiry",
+            expires_at:
+              mints === 1
+                ? null
+                : new Date(timers.now() + 60 * 60 * 1000).toISOString(),
+          }),
+        };
+      }),
+      log: {
+        log() {},
+        // The no-expiry warning is raised outside refresh(); make it throw
+        // once so the scheduling body itself fails.
+        warn(message) {
+          warnings.push(message);
+          if (warnings.length === 1) throw new Error("logger exploded");
+        },
+      },
+    });
+    await flushDaemon();
+
+    expect(mints).toBe(1);
+    expect(warnings).toHaveLength(2);
+    expect(warnings[1]).toContain("refresh scheduling failed: logger exploded");
+    expect(timers.nextDelay()).toBe(60 * 1000);
+
+    // The chain survived: the next tick mints again and returns to cadence.
+    await timers.advanceBy(60 * 1000);
+    expect(mints).toBe(2);
+    expect(timers.nextDelay()).toBe(45 * 60 * 1000);
+
+    signals.stop();
+    await daemon;
+  });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1322

Review expiry-derived daemon scheduling and bounded retry behavior (authorised: inbox_23bd537e-c8b1-4b98-a58d-f64584e88b77, decided 2026-08-29T23:09:41.538Z).

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/gh-app-auth.test.mjs --timeout 20000` | pass | 14 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1887 pass, 10 skip, 0 fail; emit and format clean |
| UX critique | factory-ux-critic | not run | no user-facing backend surface |

UX critique: skipped — backend daemon scheduling has no user-facing surface

## Post-review

Folded in two review nits (83d6b555):

- A successful mint whose `expires_at` is absent/unparseable no longer falls into the failure backoff (60s→…→5m re-mints with no reason logged). `refresh()` now distinguishes "threw" from "no usable expiry"; the latter keeps the fixed `intervalMs` cadence and logs one `warn` on first occurrence. Fake-timer test added.
- `scheduleRefresh` never rejects: the scheduling body is wrapped in try/catch, logs `refresh scheduling failed`, and still re-arms the timer with backoff, so a throw outside `refresh()` cannot kill the chain. Fake-timer test added (a logger that throws once).
