### PR TITLE
verify(factory): add Prettier to the handoff gate

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -22,7 +22,7 @@ repos:
     worktree_down: bin/worktree-down.sh
     worktree_root: ~/Develop/.worktrees/factory
     max_in_flight: 20
-    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check
+    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check
     # Executables this repo's worktree script and verify command need, with the
     # semver range each must satisfy (WM-316, docs/event-runtime-repos.md §5).
     # Preflight resolves each one on the node and compares versions BEFORE a

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:daaebb160438c12c99e8f58801a228a92307d4d3ceea75cfd6ebd4445276570b",
+    "agents/dispatch.md": "sha256:8efe0ae5a9c9c19584c2e7f88d82e9b5548b8b571b2b457f446e85a841ad1516",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -16,32 +16,22 @@
     "services": ["tracker:write", "repo:write", "github:write"],
     "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
-  "limits": {
-    "timeout_seconds": 5400,
-    "attempts": 1,
-    "budget_usd": 15
-  },
+  "limits": { "timeout_seconds": 5400, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "memos": [
     {
-      "subject": {
-        "type": "ticket",
-        "id": "$.input.ticket"
-      },
+      "subject": { "type": "ticket", "id": "$.input.ticket" },
       "kinds": ["postmortem", "decision"],
       "max": 10
     },
     {
-      "subject": {
-        "type": "repo",
-        "id": "$.input.repo"
-      },
+      "subject": { "type": "repo", "id": "$.input.repo" },
       "kinds": ["decision"],
       "max": 10
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:8b9f9d8c2158935c09cf3f2936afeb7a7c5e56336f8a074d98afa9879f2242e7",
+    "agents/dispatch.md": "sha256:daaebb160438c12c99e8f58801a228a92307d4d3ceea75cfd6ebd4445276570b",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -64,9 +64,9 @@ new ticket.
    output; never weaken a test to get green. For the factory repo, the
    configured gate ends with `bun run format:check` after the unit and emit
    checks; run `bun run format` before verification when needed so Prettier
-   cannot turn a handoff green locally but red in CI. **The worker verifies the handoff
-   mechanically after you return:** it re-runs the repo's declared verify
-   command and the ticket's exact
+   cannot turn a handoff green locally but red in CI.
+   **The worker verifies the handoff mechanically after you return:** it
+   re-runs the repo's declared verify command and the ticket's exact
    `Verification Command`, runs `cd event-runtime/web && bun run build` when
    your diff touches `event-runtime/web/src/**`, and diffs
    `origin/<base>..HEAD` against the ticket's Owned Paths. A non-zero exit

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -61,7 +61,10 @@ new ticket.
    `bun test` or the repo's full suite as a PR-opening gate. The full suite is
    CI's job; duplicating it in concurrent dispatched worktrees causes
    load-induced flakes and must not prevent a PR. Never proceed past failing
-   output; never weaken a test to get green. **The worker verifies the handoff
+   output; never weaken a test to get green. For the factory repo, the
+   configured gate ends with `bun run format:check` after the unit and emit
+   checks; run `bun run format` before verification when needed so Prettier
+   cannot turn a handoff green locally but red in CI. **The worker verifies the handoff
    mechanically after you return:** it re-runs the repo's declared verify
    command and the ticket's exact
    `Verification Command`, runs `cd event-runtime/web && bun run build` when

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2629,7 +2629,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:4476b2f37992c75814f4e8896f0332242c37885c9fcf94a5b7103d44797fe854","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:64692fdaf524fb0e54e8d2156bcf9a3bfe3356c663ce6a7b83910a9043b6314e","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2629,7 +2629,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:9b9f59322454c0935cef3a83c85adf2dee84e6b1e6d5301d1b1de46267b05ea4","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:4476b2f37992c75814f4e8896f0332242c37885c9fcf94a5b7103d44797fe854","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -303,8 +303,12 @@ describe("registry", () => {
     // `result.presentation` document (Layer B pilot); triage-scan.json is
     // re-pinned. Prompt text and its pin only — no schema, contract, route,
     // capability, or model tier changed.
+    // Regenerated (#1324): dispatch.md now tells factory ticket agents that
+    // the configured handoff gate includes Prettier after the unit and emit
+    // checks; dispatch.json is re-pinned. Prompt text only — no schema,
+    // contract, route, capability, or model tier changed.
     const expected =
-      "sha256:91a5c728b78852bfe450a71eebddd87a17231e43dbe739c0b590de81cfda34ab";
+      "sha256:c4b4d2eebf6e2a69a69018c9cad13d877c8b6f487d924ee936129bdd933e4647";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -548,8 +552,11 @@ describe("registry", () => {
     // table (observed results, no PR on a fail, bounded rows, must agree with
     // the Handoff), so the prompt pin moved. Prompt text only — `pack` stays
     // non-enumerable and no enumerable key was added.
+    // Regenerated (#1324): dispatch.md includes the factory Prettier handoff
+    // check, so its prompt pin legitimately moved; `pack` remains
+    // non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:9b9f59322454c0935cef3a83c85adf2dee84e6b1e6d5301d1b1de46267b05ea4",
+      "sha256:4476b2f37992c75814f4e8896f0332242c37885c9fcf94a5b7103d44797fe854",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -308,7 +308,7 @@ describe("registry", () => {
     // checks; dispatch.json is re-pinned. Prompt text only — no schema,
     // contract, route, capability, or model tier changed.
     const expected =
-      "sha256:c4b4d2eebf6e2a69a69018c9cad13d877c8b6f487d924ee936129bdd933e4647";
+      "sha256:9478df60d64bd504a50935c322760df759dc0055dd3b781f06a0a7165f1c6172";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -556,7 +556,7 @@ describe("registry", () => {
     // check, so its prompt pin legitimately moved; `pack` remains
     // non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:4476b2f37992c75814f4e8896f0332242c37885c9fcf94a5b7103d44797fe854",
+      "sha256:64692fdaf524fb0e54e8d2156bcf9a3bfe3356c663ce6a7b83910a9043b6314e",
     );
   });
 

--- a/orchestrator/repos-config.test.mjs
+++ b/orchestrator/repos-config.test.mjs
@@ -52,11 +52,13 @@ test("factory branches are unchanged by OPS-463; verify is the fast lib-only gat
   expect(factory.base).toBe("develop");
   expect(factory.deployBranch).toBe("main");
   // The local VERIFYING gate is deliberately a strict subset of CI: unit-only
-  // event-runtime/lib (no daemons/ports/demo seed) plus the emit contract check.
+  // event-runtime/lib (no daemons/ports/demo seed) plus the emit contract check
+  // and the Prettier gate (`bun run format:check`, gh-1324) so a formatting
+  // drift cannot turn a handoff green locally but red in CI's format job.
   // The full `bun test` stays in .github/workflows/ci.yml, the real merge gate.
   // `--timeout 20000` (WM-651) lifts bun's 5 s per-test default so spawn/timing
   // tests don't go red under host load; explicit per-test timeouts still win.
   expect(factory.verify).toBe(
-    "bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check",
+    "bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check",
   );
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1324

Make the tracked factory verify gate run Prettier before handoff.

## Validation

| Check                | Command                                                                                      | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass    | 113 tests, 0 failures; emit clean      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,887 pass, 0 fail; Prettier clean     |
| UX critique          | factory-ux-critic                                                                            | not run | no user-facing surface                 |

UX critique: skipped

## Handoff

- format:check measured 27.9 s on a clean checkout (AC3, under the 60 s budget)

## Post-review

- `orchestrator/repos-config.test.mjs` now expects the factory verify string ending in `&& bun run format:check`, and the "strict subset of CI" comment explains the Prettier gate (the ticket's Owned Paths were widened to include this file).
- Re-wrapped the dispatch.md paragraph so the new Prettier sentence and `**The worker verifies the handoff…**` sit on separate lines; `dispatch.json` re-pinned via `bun event-runtime/cli.mjs update-pins`, registry/planner digest fixtures regenerated.
- Verified: `bun test orchestrator/repos-config.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/planner.test.mjs --timeout 20000` (152 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` all green.
