### PR TITLE
perf(db): index hot proposal and event lookups

### DIFF
--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -472,6 +472,20 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 16,
+    name: "proposal_and_event_lookup_indexes",
+    up(db) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_proposals_run_id
+          ON proposals (run_id, created_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_proposals_event
+          ON proposals (event_source, event_id);
+        CREATE INDEX IF NOT EXISTS idx_events_correlation
+          ON events (correlation_id);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -185,9 +185,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
   });
 
   test("tier escalation handoffs reach schema 15 from a fresh and from a v14 database", () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(15);
+    expect(CURRENT_SCHEMA_VERSION).toBeGreaterThanOrEqual(15);
     const fresh = openDb(freshFile());
-    expect(getSchemaVersion(fresh)).toBe(15);
+    expect(getSchemaVersion(fresh)).toBe(CURRENT_SCHEMA_VERSION);
     fresh.close();
 
     // #1230 (#1197) owns migration 14 and lands first; a database already at
@@ -197,9 +197,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrateDb(at14, { targetVersion: 13 });
     at14.exec("PRAGMA user_version = 14;");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(15);
+    expect(getSchemaVersion(at14)).toBe(CURRENT_SCHEMA_VERSION);
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(15);
+    expect(getSchemaVersion(at14)).toBe(CURRENT_SCHEMA_VERSION);
     expect(
       at14
         .query(
@@ -227,6 +227,53 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       ]),
     );
     db.close();
+  });
+
+  test("hot proposal and inbox lookup indexes upgrade an existing database", () => {
+    const file = freshFile();
+    const db = new Database(file);
+    migrateDb(db, { targetVersion: CURRENT_SCHEMA_VERSION - 1 });
+    db.close();
+
+    const migrated = openDb(file);
+    const plans = [
+      [
+        "metrics latest proposal",
+        `SELECT p2.rowid FROM proposals p2
+         WHERE p2.run_id = 'run-1'
+         ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1`,
+        "idx_proposals_run_id",
+      ],
+      [
+        "event proposal",
+        `SELECT p2.rowid FROM proposals p2
+         WHERE p2.event_source = 'github' AND p2.event_id = 'event-1'
+         ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1`,
+        "idx_proposals_event",
+      ],
+      [
+        "inbox correlation",
+        `SELECT p.id FROM events e
+         JOIN proposals p
+           ON p.event_source = e.source AND p.event_id = e.event_id
+         WHERE e.correlation_id = 'inbox-1'
+         ORDER BY p.created_at DESC, p.rowid DESC LIMIT 1`,
+        "idx_events_correlation",
+      ],
+    ];
+
+    for (const [name, sql, index] of plans) {
+      const detail = migrated
+        .query(`EXPLAIN QUERY PLAN ${sql}`)
+        .all()
+        .map((row) => row.detail)
+        .join("\n");
+      expect(detail, name).toMatch(
+        new RegExp(`USING (?:COVERING )?INDEX ${index}`),
+      );
+      expect(detail, name).not.toMatch(/SCAN (?:p2|p|e)\b/);
+    }
+    migrated.close();
   });
 
   test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {


### PR DESCRIPTION
Fixes #1327

Apply lookup indexes to existing runtime databases so metrics, events, and inbox correlation reads avoid table scans.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/db.test.mjs event-runtime/lib/metrics.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/inbox.test.mjs --timeout 20000` | pass    | 100 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1888 pass, 0 failures  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped




## Post-review

- Merged `origin/develop`; PR #1325 already owns migration **16** (`inbox_proposal_id`), so the lookup-index migration is renumbered to **17** and `CURRENT_SCHEMA_VERSION` is now 17.
- `db.test.mjs`: exact pins restored (`toBe(17)`), the upgrade test now migrates to an explicit `targetVersion: 16` and asserts the 16→17 hop plus idempotent re-run; the v15→17 inbox backfill case is kept.
- Verified against a copy of the live `runtime.db`: `user_version` ends at 17 and `idx_inbox_items_proposal_id`, `idx_events_correlation`, `idx_proposals_run_id`, `idx_proposals_event` all exist.
