### PR TITLE
docs(cli): document ticket command and handoff

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,7 +188,7 @@ Quote glob arguments: `grep -rn "..." src --include='*.ts'`, never `--include=*.
 Mechanical factory tools run from **any cwd** via the `factory` CLI on PATH — product checkouts and worktrees do not contain `orchestrator/` or `tools/`.
 
 ```bash
-factory linear get CLNT-616
+factory ticket get CLNT-616
 factory queue --repo bj29
 factory next --repo bj29
 factory label-guard --repo bj29 --apply
@@ -198,26 +198,26 @@ Install once: `bun build/emit.mjs --link-bin` (symlinks `~/Develop/factory/bin/f
 
 ### Linear
 
-**Use `factory linear` — not the Linear MCP, and not the standalone `linear` CLI.** The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
+**Use `factory ticket` — not the Linear MCP, and not the standalone `linear` CLI.** The `linear` command is a deprecated alias. The MCP fails input validation often enough that 96 measured runs fell through to a hand-rolled GraphQL fallback; the schpet `linear` CLI fails differently (`linear issue comment CLNT-526 --body` is wrong syntax — it needs `comment add`; `linear issue query` with hand-rolled filters errors on type coercion). Both waste turns. The factory tool is in git, has the protocol's guardrails built in, and its claim verb performs the read-back that _is_ the concurrency control.
 
-You work in a worktree, not in the factory checkout. **`factory linear` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/linear.mjs"`.
+You work in a worktree, not in the factory checkout. **`factory ticket` resolves the checkout itself**; headless runs also set `$FACTORY_ROOT`. Fallback when the CLI is missing: `bun "$FACTORY_ROOT/tools/linear.mjs"`.
 
 ```bash
-factory linear get CLNT-616                              # ticket, state, labels, criteria
-factory linear claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
-factory linear comment CLNT-616 "..."                    # the heartbeat
-factory linear state CLNT-616 "In Review" --add ai:needs-review
-factory linear file --team CLNT --title "..." --body "..." --type bug
-factory linear queue --team CLNT                         # what is dispatchable
+factory ticket get CLNT-616                              # ticket, state, labels, criteria
+factory ticket claim CLNT-616 --agent claude             # assign + In Progress + labels + read-back
+factory ticket comment CLNT-616 "..."                    # the heartbeat
+factory ticket state CLNT-616 "In Review" --add ai:needs-review
+factory ticket file --team CLNT --title "..." --body "..." --type bug
+factory ticket queue --team CLNT                         # what is dispatchable
 ```
 
 `claim` **exits non-zero when another agent won the race** — that is not a retry, it means take the next ticket. For anything the verbs do not cover, `raw '<graphql>' --var k=v` beats inventing a new flag.
 
 **Attribution.** Factory runs set `$FACTORY_RUN_ID`. Linear comments and issues filed through `tools/linear.mjs` are stamped with it automatically; the one surface the tool cannot reach is GitHub, so **end every PR body with a final line `run:$FACTORY_RUN_ID`** (after `Fixes <ISSUE-ID>`). That one line is what joins the PR back to its transcript and metrics row when someone asks "which run produced this?". Unset (interactive session) — omit it.
 
-**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory linear state` or `factory linear claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
+**Labels are replaced wholesale, never merged.** Always go through `--add` / `--remove` via `factory ticket state` or `factory ticket claim`; a hand-written mutation or `linear issue update -l` that passes only the labels you want added silently replaces the entire label set, stripping `type:*`, `area:*`, `source:*`, and other existing taxonomy labels from the ticket. `type:*` has exactly eight values: `bug feature ui-ux security performance maintenance docs a11y` — `type:chore` fails. `area:*` is per-team; copy an existing ticket in the project rather than inventing one. Every new issue carries exactly one `source:*`: `source:agent` for work you discover yourself, `source:human` for a direct request, `source:sentry` / `source:client-support` for those intake paths.
 
-**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory linear file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
+**Strict order of operations for discovered work.** Discovered work filed during a merge review or ticket session cannot have its ticket ID known prior to creation. Pre-writing cross-references in summary or handoff comments before filing causes fake or broken identifiers. Follow this strict order: file follow-ups first via `factory ticket file`, collect the returned issue identifiers, and then author summary and handoff comments referencing those real IDs.
 
 ### Secrets
 

--- a/bin/factory
+++ b/bin/factory
@@ -322,6 +322,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   warm          orchestrator/warm.mjs
   tick          orchestrator/tick.mjs
   dispatch      tools/dispatch.mjs (swift event task runner: triage, status, janitor)
+  handoff       tools/handoff.mjs (remote handoff broker)
   events        event-runtime/cli.mjs (status, ps, runs, proposals, approve, reject, inject, requeue)
   pack          scaffold or validate a data-only filesystem pack
   inbox         list open human inbox items

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -12,6 +12,27 @@ import path from "node:path";
 
 const FACTORY = path.resolve(import.meta.dir, "factory");
 
+test("factory help documents every dispatcher verb", () => {
+  const source = readFileSync(FACTORY, "utf8");
+  const dispatcher = source.match(/case "\$cmd" in([\s\S]*?)\nesac/);
+  expect(dispatcher).not.toBeNull();
+
+  const verbs = [...dispatcher[1].matchAll(/^ {2}([a-z][a-z-]*)\)/gm)].map(
+    ([, verb]) => verb,
+  );
+  const result = Bun.spawnSync({
+    cmd: ["bash", FACTORY, "help"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.exitCode).toBe(0);
+  const help = result.stdout.toString();
+  for (const verb of verbs) {
+    expect(help).toMatch(new RegExp(`^  ${verb}\\s`, "m"));
+  }
+});
+
 function makeNotifier(dir) {
   const notifier = path.join(dir, "notify_stub.py");
   writeFileSync(

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -195,7 +195,7 @@ open chain-dispatch proposal re-ran `fetchTicket` + `fetchViewer` +
 `fetchInFlight` on every tick. Rate-limited outcomes are **retry-later**:
 
 - `tools/linear.mjs` records `X-RateLimit-Requests-*` (falling back to the
-  complexity headers), exposes `factory linear budget`, and exits 3 with
+  complexity headers), exposes `factory ticket budget`, and exits 3 with
   `{rateLimited:true, resetAt}` instead of a generic failure.
 - One planning pass memoizes in-flight issues by team+project for ≤60s and
   per-ticket reads for the run, so ten candidates in one repo do not issue

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -67,7 +67,7 @@ factory watchdog --once
 Alternatively, inspect individual components:
 
 - **Stack & Workers**: `curl -sf http://127.0.0.1:7381/health && bun event-runtime/cli.mjs status`
-- **Supply Queue**: `factory linear queue --team WM`
+- **Supply Queue**: `factory ticket queue --team WM`
 - **Open PRs**: `gh pr list --state open`
 - **Git Freshness**: `git status --porcelain && git rev-list --count HEAD..origin/develop`
 
@@ -75,8 +75,8 @@ Alternatively, inspect individual components:
 
 ```bash
 # Check dispatchable queue for target teams (e.g. WM, CLNT, OPS)
-factory linear queue --team WM
-factory linear queue --team CLNT
+factory ticket queue --team WM
+factory ticket queue --team CLNT
 ```
 
 - **Healthy Supply**: 10–20+ tickets in `Todo` + `ai:agent-ready` + unassigned.
@@ -169,7 +169,7 @@ Workers idle if supply dries up. Ensure a continuous pipeline of dispatchable wo
 3. **Idempotency Pin Trap**:
    - A `FAILED` or `BLOCKED` run pins its ticket's idempotency key. A duplicate `dispatch.requested` will be ignored as `noop` (`ticket_dispatch_already_live`).
    - To re-run a pinned run **of the current `policyVersion`**: `bun event-runtime/cli.mjs retry <runId> --force`. A run planned before a stack restart is pinned to the old `policyVersion` and no worker will ever claim it (`registry_stale` spin) — `cancel` it and inject fresh instead.
-   - Every terminal failure strips `ai:agent-ready` from the ticket, even for harness-side causes (WM-682); relabel with `factory linear labels <T> --add ai:agent-ready` before re-injecting.
+   - Every terminal failure strips `ai:agent-ready` from the ticket, even for harness-side causes (WM-682); relabel with `factory ticket labels <T> --add ai:agent-ready` before re-injecting.
 
 ---
 
@@ -361,14 +361,14 @@ bun event-runtime/cli.mjs inspect <runId># Full execution receipt, lifecycle & l
 bun event-runtime/cli.mjs retry <runId> --force # Force retry pinned failed run
 bun event-runtime/cli.mjs update-pins    # Regenerate agent definition hashes
 
-# --- Linear CLI (factory linear) ---
-factory linear queue --team WM           # Query dispatchable tickets
-factory linear get WM-123                # Read ticket, criteria, owned paths
-factory linear claim WM-123 --agent claude # Claim + assign + In Progress
-factory linear comment WM-123 "..."      # Post heartbeat or status
-factory linear state WM-123 "In Review" --add ai:needs-review # Advance state
-factory linear detail WM-123 "..."       # Append criteria / verification block
-factory linear file --team WM --title "..." --body "..." --type bug # File new issue
+# --- Ticket CLI (factory ticket; `linear` is a deprecated alias) ---
+factory ticket queue --team WM           # Query dispatchable tickets
+factory ticket get WM-123                # Read ticket, criteria, owned paths
+factory ticket claim WM-123 --agent claude # Claim + assign + In Progress
+factory ticket comment WM-123 "..."      # Post heartbeat or status
+factory ticket state WM-123 "In Review" --add ai:needs-review # Advance state
+factory ticket detail WM-123 "..."       # Append criteria / verification block
+factory ticket file --team WM --title "..." --body "..." --type bug # File new issue
 
 # --- CI & GitHub Checks ---
 # One-shot reads — fine inline:
@@ -391,7 +391,7 @@ gh run watch <run-id> --exit-status      # blocks until the run ends
 | **`git stash` in Worktrees**               | The stash stack (`.git/refs/stash`) is repo-global, not isolated per worktree.                                                                                                                                                   | **NEVER use `git stash` or `git rebase --autostash`** in agent worktrees. Use temporary patches or WIP commits.                                                                                                         |
 | **macOS Bash 3.2**                         | Default macOS bash lacks `mapfile` / `readarray` and modern expansions.                                                                                                                                                          | Use POSIX `while IFS= read -r line` loops in all shell scripts.                                                                                                                                                         |
 | **Prettier Scope**                         | Running prettier across whole repo reformats hundreds of `.mjs` files unnecessarily.                                                                                                                                             | Prettier is configured ONLY for `shared/**/*.md` (`bun run format:check`).                                                                                                                                              |
-| **Label Replacement**                      | Direct GraphQL label mutations replace the whole array, wiping `type:*` and `area:*`.                                                                                                                                            | Always use `--add` / `--remove` flags via `factory linear state` or `factory linear labels`.                                                                                                                            |
+| **Label Replacement**                      | Direct GraphQL label mutations replace the whole array, wiping `type:*` and `area:*`.                                                                                                                                            | Always use `--add` / `--remove` flags via `factory ticket state` or `factory ticket labels`.                                                                                                                            |
 | **Restart Orphans In-Flight Runs**         | `bin/live-stack.sh down` does not actually wait for in-flight dispatches; their leaseholder dies, the run stays `RUNNING` forever, and the `reaper` loop that would reclaim it is disabled (WM-657).                             | Restart only when no `dispatch@1` run is `RUNNING`/`LEASED`. After any restart, compare `attempts.lease_owner` against `cli.mjs workers` and `cancel` orphans — preserving+pushing any uncommitted worktree work first. |
 | **Stale Rebase Reverts Trunk**             | A fixer that rebases onto an `origin/develop` fetched minutes earlier silently drops PRs merged in between and still passes CI. Nearly reverted #582 via #583.                                                                   | Before merging any rebased PR: `git diff --stat origin/develop origin/<branch>` must show no unexplained deletions of develop-side files. Tell fixers to `git fetch` immediately before `rebase`.                       |
 | **Blocking Waits Inline**                  | A `sleep`-and-recheck loop or `gh run watch` in the session queues the operator's steering behind it for the whole wait.                                                                                                         | Loop 6 hard rule: nothing inline may block >~30s. CI waits, merges-on-green, reruns, test runs, rebases go to a subagent; the session keeps only decisions.                                                             |

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -123,7 +123,7 @@ them to native labels of the same spelling.
 API error. Every new issue carries exactly one `source:*`.
 
 **Labels are replaced wholesale, never merged.** Always go through `--add` /
-`--remove` (`factory linear state` / `claim`, or `setLabels` on the adapter).
+`--remove` (`factory ticket state` / `claim`, or `setLabels` on the adapter).
 A mutation that passes only the labels you want added silently drops every
 other label on the ticket.
 
@@ -247,7 +247,7 @@ deliverable, or an investigation with an operational finding. Do not file
 an ordinary question, a read-only lookup with no actionable finding, or an
 inconsequential edit.
 
-Search for duplicates first (`factory linear`, or the tracker's search).
+Search for duplicates first (`factory ticket`, or the tracker's search).
 Comment on the existing ticket with new evidence rather than filing a
 second issue.
 
@@ -344,18 +344,18 @@ page URL or screenshot path.
 
 ## 13. Tracker access
 
-**Use `factory linear` — not a tracker MCP, and not a standalone tracker
-CLI.** The factory tool is in git, has this protocol's guardrails built in,
+**Use `factory ticket` — not a tracker MCP, and not a standalone tracker
+CLI.** The `linear` command is a deprecated alias. The factory tool is in git, has this protocol's guardrails built in,
 and its `claim` verb performs the advisory read-back. The authoritative
 concurrency control is the per-repository dispatch lock described in §7.
 
 ```bash
-factory linear get CLNT-616
-factory linear claim CLNT-616 --agent claude
-factory linear comment CLNT-616 "..."
-factory linear state CLNT-616 "In Review" --add ai:needs-review
-factory linear file --team CLNT --title "..." --body "..." --type bug
-factory linear queue --team CLNT
+factory ticket get CLNT-616
+factory ticket claim CLNT-616 --agent claude
+factory ticket comment CLNT-616 "..."
+factory ticket state CLNT-616 "In Review" --add ai:needs-review
+factory ticket file --team CLNT --title "..." --body "..." --type bug
+factory ticket queue --team CLNT
 ```
 
 `claim` exits non-zero when another agent won the race — that is not a


### PR DESCRIPTION
Fixes watt-mind/factory#1333

Use `factory ticket` in docs and discover remote handoff in CLI help.

## Validation

| Check                | Command                                                                          | Result  | Notes                    |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test bin/factory.test.mjs --timeout 20000`                                  | pass    | 15 tests, 0 failures    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1887 pass, 0 failures   |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface  |

UX critique: skipped

Post-review: no-regex-spaces fix already on branch (c392e994); merged origin/develop (d4c981ee); eslint/tests/emit/format/check pass locally.
