### PR TITLE
fix(schedules): reject invalid manual cadence

### DIFF
--- a/event-runtime/lib/api-schedules.mjs
+++ b/event-runtime/lib/api-schedules.mjs
@@ -92,8 +92,10 @@ export async function handleScheduleApiRoute({
     let cadenceSeconds;
     try {
       cadenceSeconds = parseCadence(schedule.every);
-    } catch {
-      // Cadence might have parse error in bad config.
+    } catch (err) {
+      return send(422, {
+        error: `schedule ${loop}: invalid cadence '${schedule.every}': ${err.message}`,
+      });
     }
     const isoNow = new Date(nowMs).toISOString();
     let eventId = `manual:${loop}:${isoNow}`;

--- a/event-runtime/lib/api-schedules.test.mjs
+++ b/event-runtime/lib/api-schedules.test.mjs
@@ -125,6 +125,45 @@ describe("POST /schedules/:loop/run (OPS-401)", () => {
     expect(body.decision).toBe("run");
   });
 
+  test("rejects manual fire when the configured cadence is invalid", async () => {
+    const every = "not-a-cadence";
+    const invalidCadenceRegistry = {
+      ...registry,
+      schedules: {
+        ...registry.schedules,
+        reaper: { ...registry.schedules.reaper, every },
+      },
+    };
+    const invalidCadenceServer = await makeServer({
+      registry: invalidCadenceRegistry,
+    });
+    try {
+      const schedules = await fetch(invalidCadenceServer.url("/schedules"));
+      const view = (await schedules.json()).schedules.find(
+        (schedule) => schedule.loop === "reaper",
+      );
+      const before = invalidCadenceServer.db
+        .query(`SELECT COUNT(*) AS n FROM events`)
+        .get().n;
+
+      const res = await fetch(
+        invalidCadenceServer.url("/schedules/reaper/run"),
+        { method: "POST" },
+      );
+
+      expect(res.status).toBe(422);
+      expect(await res.json()).toEqual({
+        error: `schedule reaper: invalid cadence '${every}': ${view.error}`,
+      });
+      expect(
+        invalidCadenceServer.db.query(`SELECT COUNT(*) AS n FROM events`).get()
+          .n,
+      ).toBe(before);
+    } finally {
+      invalidCadenceServer.close();
+    }
+  });
+
   test("manual merge trigger propagates selected PR numbers into the immutable event and planned input", async () => {
     // Planning commits the run before the API sends its response, so a returned
     // runId guarantees read-after-write. Keep this schedule-input test isolated


### PR DESCRIPTION
Fixes watt-mind/factory#1334

Manual schedule fires now return a clear 422 when a configured cadence is invalid.

## Validation

| Check                | Command                                                               | Result  | Notes                       |
| -------------------- | --------------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `bun test event-runtime/lib/api-schedules.test.mjs --timeout 20000` | pass    | 11 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1888 pass, 10 skipped |
| UX critique          | factory-ux-critic                                                     | not run | no user-facing surface      |

UX critique: skipped
