### PR TITLE
perf(inbox): batch CI success candidates

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1199,24 +1199,14 @@ function completedShipProposal(db, proposalId) {
   );
 }
 
-function laterCiSuccess(db, row, refs) {
+function laterCiSuccess(row, refs, candidates) {
   const pr = prNumber(refs.pr);
   if (!refs.repo || !pr) return false;
-  const events = db
-    .query(
-      `SELECT subject, envelope_json FROM events
-       WHERE source = 'github'
-         AND type = 'factory.merge.requested'
-         AND admitted_at > ?
-       ORDER BY admitted_at, rowid`,
-    )
-    .all(row.created_at);
-  return events.some((event) => {
-    const envelope = parseObject(event.envelope_json);
-    const payload = envelope.payload;
+  return candidates.some(({ admittedAt, subject, payload }) => {
+    if (admittedAt <= row.created_at) return false;
     if (!payload || typeof payload !== "object" || Array.isArray(payload))
       return false;
-    const repo = payload.repo ?? event.subject;
+    const repo = payload.repo ?? subject;
     return (
       repo === refs.repo &&
       Array.isArray(payload.prNumbers) &&
@@ -1313,6 +1303,34 @@ export function reconcileInbox(
      ORDER BY created_at, rowid`,
     )
     .all();
+  const ciRows = rows.filter((row) => row.kind === "CI RED");
+  const earliestCiCreatedAt = ciRows.reduce(
+    (earliest, row) =>
+      earliest === null || row.created_at < earliest
+        ? row.created_at
+        : earliest,
+    null,
+  );
+  const mergeRequestedCandidates =
+    earliestCiCreatedAt === null
+      ? []
+      : db
+          .query(
+            `SELECT admitted_at, subject, envelope_json FROM events
+             WHERE source = 'github'
+               AND type = 'factory.merge.requested'
+               AND admitted_at > ?
+             ORDER BY admitted_at, rowid`,
+          )
+          .all(earliestCiCreatedAt)
+          .map((event) => {
+            const envelope = parseObject(event.envelope_json);
+            return {
+              admittedAt: event.admitted_at,
+              subject: event.subject,
+              payload: envelope.payload,
+            };
+          });
   const linearRows = [];
   for (const row of rows) {
     // Pending decisions are not skipped: once the referent stops waiting the
@@ -1334,7 +1352,8 @@ export function reconcileInbox(
           refs.proposalId = proposalId;
         }
       }
-      if (laterCiSuccess(db, row, refs)) resolvedBy = "auto:ci_green";
+      if (laterCiSuccess(row, refs, mergeRequestedCandidates))
+        resolvedBy = "auto:ci_green";
     } else if (row.kind === "RC READY") {
       if (refs.proposalId && completedShipProposal(db, refs.proposalId))
         resolvedBy = "auto:ship_completed";

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1038,7 +1038,7 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
-  test("CI success and the proposal spawned by Ship auto-resolve their matching items", async () => {
+  test("CI success reads merge requests once and resolves only its matching CI RED item", async () => {
     const db = openDb(":memory:");
     createInboxItem(
       db,
@@ -1048,6 +1048,15 @@ describe("human inbox ledger (WM-285)", () => {
         refs: { repo: "factory", pr: "PR #607" },
       },
       { id: "ci-red", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "CI RED",
+        title: "different PR stays red",
+        refs: { repo: "factory", pr: "PR #608" },
+      },
+      { id: "ci-red-other", now: 1000 },
     );
     const successAt = new Date(2000).toISOString();
     const success = {
@@ -1111,11 +1120,33 @@ describe("human inbox ledger (WM-285)", () => {
        VALUES ('ship-proposal', 'operator', 'ship-event', 'run', 'ship-run', 'approved', ?, 1800)`,
     ).run(successAt);
 
-    expect(await reconcileInbox(db, { now: 3000 })).toEqual([
+    let mergeRequestedReads = 0;
+    const instrumented = new Proxy(db, {
+      get(target, property) {
+        if (property === "query") {
+          return (sql) => {
+            if (
+              /SELECT admitted_at, subject, envelope_json FROM events\s+WHERE source = 'github'/s.test(
+                sql,
+              )
+            ) {
+              mergeRequestedReads += 1;
+            }
+            return target.query(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+
+    expect(await reconcileInbox(instrumented, { now: 3000 })).toEqual([
       { id: "ci-red", resolvedBy: "auto:ci_green" },
       { id: "rc-ready", resolvedBy: "auto:ship_completed" },
     ]);
+    expect(mergeRequestedReads).toBe(1);
     expect(getInboxItem(db, "ci-red").refs.proposalId).toBe("rerun-proposal");
+    expect(getInboxItem(db, "ci-red-other").resolvedAt).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1329

Review the shared CI-success candidate cache and its one-query regression coverage.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs --timeout 20000` | pass    | 33 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1887 pass, 0 failures  |
| UX critique          | factory-ux-critic                | not run | backend reconciliation path |

UX critique: skipped