### PR TITLE
perf(api): narrow ticket journey SQL reads

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -282,74 +282,172 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     .toUpperCase();
   if (!TICKET_ID.test(ticket)) return null;
 
-  const eventRows = db
-    .query(`SELECT * FROM events ORDER BY admitted_at, rowid`)
-    .all();
-  const proposalRows = db
-    .query(`SELECT * FROM proposals ORDER BY created_at, rowid`)
-    .all();
-  const runRows = db
-    .query(`SELECT * FROM runs ORDER BY created_at, rowid`)
-    .all();
-  const resultRows = db.query(`SELECT * FROM results ORDER BY rowid`).all();
-  const resultByRun = new Map();
-  for (const row of resultRows) {
-    const result = parseObject(row.result_json);
-    if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
-    resultByRun.get(row.run_id).push(result);
-  }
-
   const events = new Set();
   const proposals = new Set();
   const runs = new Set();
-  for (const row of eventRows) {
+
+  // Keep only the small connected component for this ticket in memory. JSON
+  // LIKE is deliberately a broad SQL prefilter: objectNamesTicket below still
+  // checks the parsed, named fields so prose mentioning a ticket is excluded.
+  const ticketLike = `%${ticket}%`;
+  const eventRows = new Map();
+  const proposalRows = new Map();
+  const runRows = new Map();
+  const resultRows = new Map();
+  const eventKey = (row) => `${row.source}\0${row.event_id}`;
+  const addRows = (rows, into, key) => {
+    for (const row of rows) into.set(key(row), row);
+  };
+  const placeholders = (values) => [...values].map(() => "?").join(", ");
+
+  const addEvents = (keys) => {
+    const pairs = [...keys]
+      .filter((key) => !eventRows.has(key))
+      .map((key) => key.split("\0"));
+    if (!pairs.length) return;
+    const where = pairs.map(() => "(source = ? AND event_id = ?)").join(" OR ");
+    addRows(
+      db
+        .query(`SELECT *, rowid AS list_rowid FROM events WHERE ${where}`)
+        .all(...pairs.flat()),
+      eventRows,
+      eventKey,
+    );
+  };
+  const addRuns = (ids) => {
+    const missing = [...ids].filter((id) => !runRows.has(id));
+    if (!missing.length) return;
+    addRows(
+      db
+        .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(missing)})`)
+        .all(...missing),
+      runRows,
+      (row) => row.run_id,
+    );
+  };
+  const addResults = (ids) => {
+    const missing = [...ids].filter((id) => !resultRows.has(id));
+    if (!missing.length) return;
+    addRows(
+      db
+        .query(
+          `SELECT * FROM results WHERE run_id IN (${placeholders(missing)})`,
+        )
+        .all(...missing),
+      resultRows,
+      (row) => `${row.run_id}\0${row.attempt}`,
+    );
+  };
+  const addProposals = (eventKeys, runIds) => {
+    const clauses = [];
+    const params = [];
+    for (const key of eventKeys) {
+      const [source, id] = key.split("\0");
+      clauses.push("(event_source = ? AND event_id = ?)");
+      params.push(source, id);
+    }
+    if (runIds.size) {
+      clauses.push(`run_id IN (${placeholders(runIds)})`);
+      params.push(...runIds);
+    }
+    if (!clauses.length) return;
+    addRows(
+      db
+        .query(
+          `SELECT *, rowid AS list_rowid FROM proposals WHERE ${clauses.join(" OR ")}`,
+        )
+        .all(...params),
+      proposalRows,
+      (row) => row.id,
+    );
+  };
+
+  addRows(
+    db
+      .query(
+        `SELECT *, rowid AS list_rowid FROM events
+         WHERE UPPER(subject) = ? OR UPPER(correlation_id) = ? OR UPPER(envelope_json) LIKE ?`,
+      )
+      .all(ticket, ticket, ticketLike),
+    eventRows,
+    eventKey,
+  );
+  addRows(
+    db
+      .query(
+        `SELECT *, rowid AS list_rowid FROM proposals WHERE UPPER(spec_json) LIKE ?`,
+      )
+      .all(ticketLike),
+    proposalRows,
+    (row) => row.id,
+  );
+  addRows(
+    db
+      .query(`SELECT * FROM runs WHERE UPPER(spec_json) LIKE ?`)
+      .all(ticketLike),
+    runRows,
+    (row) => row.run_id,
+  );
+  addRows(
+    db
+      .query(`SELECT * FROM results WHERE UPPER(result_json) LIKE ?`)
+      .all(ticketLike),
+    resultRows,
+    (row) => `${row.run_id}\0${row.attempt}`,
+  );
+
+  for (const row of eventRows.values()) {
     const envelope = parseObject(row.envelope_json);
     if (
       String(row.subject ?? "").toUpperCase() === ticket ||
+      String(row.correlation_id ?? "").toUpperCase() === ticket ||
       objectNamesTicket(envelope, ticket)
     )
-      events.add(`${row.source}\0${row.event_id}`);
+      events.add(eventKey(row));
   }
-  for (const row of proposalRows) {
-    const spec = parseObject(row.spec_json);
-    if (objectNamesTicket(spec.input, ticket)) proposals.add(row.id);
+  for (const row of proposalRows.values()) {
+    if (objectNamesTicket(parseObject(row.spec_json).input, ticket))
+      proposals.add(row.id);
   }
-  for (const row of runRows) {
-    const spec = parseObject(row.spec_json);
-    const results = resultByRun.get(row.run_id) ?? [];
-    if (
-      objectNamesTicket(spec.input, ticket) ||
-      results.some((result) => objectNamesTicket(result, ticket))
-    )
+  for (const row of runRows.values()) {
+    if (objectNamesTicket(parseObject(row.spec_json).input, ticket))
+      runs.add(row.run_id);
+  }
+  for (const row of resultRows.values()) {
+    if (objectNamesTicket(parseObject(row.result_json), ticket))
       runs.add(row.run_id);
   }
 
-  // Link closure catches runs that name only their proposal/event and events
-  // whose payload names only a PR emitted by the original dispatch attempt.
-  let changed = true;
-  while (changed) {
-    changed = false;
-    for (const row of proposalRows) {
-      const eventKey = `${row.event_source}\0${row.event_id}`;
-      if (
-        proposals.has(row.id) ||
-        events.has(eventKey) ||
-        (row.run_id && runs.has(row.run_id))
-      ) {
-        if (!proposals.has(row.id)) {
+  const closeOverLinks = () => {
+    let changed = true;
+    while (changed) {
+      const before = `${events.size}/${proposals.size}/${runs.size}`;
+      addEvents(events);
+      addProposals(events, runs);
+      addRuns(runs);
+      addResults(runs);
+      for (const row of proposalRows.values()) {
+        const linkedEvent = `${row.event_source}\0${row.event_id}`;
+        if (
+          proposals.has(row.id) ||
+          events.has(linkedEvent) ||
+          (row.run_id && runs.has(row.run_id))
+        ) {
           proposals.add(row.id);
-          changed = true;
-        }
-        if (!events.has(eventKey)) {
-          events.add(eventKey);
-          changed = true;
-        }
-        if (row.run_id && !runs.has(row.run_id)) {
-          runs.add(row.run_id);
-          changed = true;
+          events.add(linkedEvent);
+          if (row.run_id) runs.add(row.run_id);
         }
       }
+      changed = before !== `${events.size}/${proposals.size}/${runs.size}`;
     }
+  };
+  closeOverLinks();
+
+  const resultByRun = new Map();
+  for (const row of resultRows.values()) {
+    const result = parseObject(row.result_json);
+    if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
+    resultByRun.get(row.run_id).push(result);
   }
 
   const prRefs = { numbers: new Set(), urls: new Set() };
@@ -358,27 +456,95 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       collectPrRefs(result, prRefs);
   }
   if (prRefs.numbers.size || prRefs.urls.size) {
-    for (const row of runRows) {
-      const spec = parseObject(row.spec_json);
-      const results = resultByRun.get(row.run_id) ?? [];
-      if (
-        hasPrRef(spec.input, prRefs) ||
-        results.some((result) => hasPrRef(result, prRefs))
-      )
+    const prLike = [...prRefs.urls, ...prRefs.numbers].map(
+      (reference) => `%${reference}%`,
+    );
+    const where = prLike.map(() => "UPPER(spec_json) LIKE ?").join(" OR ");
+    addRows(
+      db.query(`SELECT * FROM runs WHERE ${where}`).all(...prLike),
+      runRows,
+      (row) => row.run_id,
+    );
+    const resultWhere = prLike
+      .map(() => "UPPER(result_json) LIKE ?")
+      .join(" OR ");
+    addRows(
+      db.query(`SELECT * FROM results WHERE ${resultWhere}`).all(...prLike),
+      resultRows,
+      (row) => `${row.run_id}\0${row.attempt}`,
+    );
+    const eventWhere = prLike
+      .map(() => "UPPER(envelope_json) LIKE ?")
+      .join(" OR ");
+    addRows(
+      db
+        .query(`SELECT *, rowid AS list_rowid FROM events WHERE ${eventWhere}`)
+        .all(...prLike),
+      eventRows,
+      eventKey,
+    );
+    for (const row of runRows.values()) {
+      if (hasPrRef(parseObject(row.spec_json).input, prRefs))
         runs.add(row.run_id);
     }
-    for (const row of eventRows) {
-      if (hasPrRef(parseObject(row.envelope_json), prRefs))
-        events.add(`${row.source}\0${row.event_id}`);
+    for (const row of resultRows.values()) {
+      if (hasPrRef(parseObject(row.result_json), prRefs)) runs.add(row.run_id);
     }
+    for (const row of eventRows.values()) {
+      if (hasPrRef(parseObject(row.envelope_json), prRefs))
+        events.add(eventKey(row));
+    }
+    closeOverLinks();
   }
 
-  const matchedEvents = eventsView(db).events.filter((event) =>
-    events.has(`${event.source}\0${event.eventId}`),
-  );
-  const matchedProposals = proposalHistory(db).proposals.filter((proposal) =>
-    proposals.has(proposal.id),
-  );
+  const latestProposalByEvent = new Map();
+  for (const row of proposalRows.values()) {
+    const key = `${row.event_source}\0${row.event_id}`;
+    const current = latestProposalByEvent.get(key);
+    if (
+      !current ||
+      row.created_at > current.created_at ||
+      (row.created_at === current.created_at &&
+        row.list_rowid > current.list_rowid)
+    )
+      latestProposalByEvent.set(key, row);
+  }
+  const matchedEvents = [...eventRows.values()]
+    .filter((row) => events.has(eventKey(row)))
+    .sort(
+      (a, b) =>
+        b.admitted_at.localeCompare(a.admitted_at) ||
+        b.list_rowid - a.list_rowid,
+    )
+    .map((row) => {
+      const proposal = latestProposalByEvent.get(eventKey(row));
+      const envelope = parseObject(row.envelope_json);
+      return {
+        source: row.source,
+        eventId: row.event_id,
+        type: row.type,
+        subject: row.subject,
+        status: row.status,
+        occurredAt: row.occurred_at,
+        receivedAt: row.received_at,
+        correlationId: row.correlation_id,
+        causationId: row.causation_id,
+        planFailures: row.plan_failures,
+        lastPlanError: row.last_plan_error,
+        admittedAt: row.admitted_at,
+        proposalId: proposal?.id ?? null,
+        runId: proposal?.run_id ?? null,
+        envelope,
+        repos: repoNamesFromInput(envelope.payload),
+      };
+    });
+  const matchedProposals = [...proposalRows.values()]
+    .filter((row) => proposals.has(row.id))
+    .sort(
+      (a, b) =>
+        b.created_at.localeCompare(a.created_at) || b.list_rowid - a.list_rowid,
+    )
+    .map((row) => proposalView({ ...row, spec: parseObject(row.spec_json) }));
   const matchedRuns = [...runs]
     .map((runId) => runView(db, runId, options))
     .filter(Boolean)

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -281,6 +281,7 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     .trim()
     .toUpperCase();
   if (!TICKET_ID.test(ticket)) return null;
+  const nowMs = options.nowMs ?? Date.now();
 
   const events = new Set();
   const proposals = new Set();
@@ -299,67 +300,84 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     for (const row of rows) into.set(key(row), row);
   };
   const placeholders = (values) => [...values].map(() => "?").join(", ");
+  // Stay well under SQLite's bind-variable cap (999 on older builds) when a
+  // ticket's component grows large; each chunk is one bounded query.
+  const chunked = (values, size = 400) => {
+    const list = [...values];
+    const chunks = [];
+    for (let i = 0; i < list.length; i += size)
+      chunks.push(list.slice(i, i + size));
+    return chunks;
+  };
 
   const addEvents = (keys) => {
     const pairs = [...keys]
       .filter((key) => !eventRows.has(key))
       .map((key) => key.split("\0"));
-    if (!pairs.length) return;
-    const where = pairs.map(() => "(source = ? AND event_id = ?)").join(" OR ");
-    addRows(
-      db
-        .query(`SELECT *, rowid AS list_rowid FROM events WHERE ${where}`)
-        .all(...pairs.flat()),
-      eventRows,
-      eventKey,
-    );
+    for (const chunk of chunked(pairs)) {
+      const where = chunk
+        .map(() => "(source = ? AND event_id = ?)")
+        .join(" OR ");
+      addRows(
+        db
+          .query(`SELECT *, rowid AS list_rowid FROM events WHERE ${where}`)
+          .all(...chunk.flat()),
+        eventRows,
+        eventKey,
+      );
+    }
   };
   const addRuns = (ids) => {
     const missing = [...ids].filter((id) => !runRows.has(id));
-    if (!missing.length) return;
-    addRows(
-      db
-        .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(missing)})`)
-        .all(...missing),
-      runRows,
-      (row) => row.run_id,
-    );
+    for (const chunk of chunked(missing)) {
+      addRows(
+        db
+          .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(chunk)})`)
+          .all(...chunk),
+        runRows,
+        (row) => row.run_id,
+      );
+    }
   };
   const addResults = (ids) => {
     const missing = [...ids].filter((id) => !resultRows.has(id));
-    if (!missing.length) return;
-    addRows(
-      db
-        .query(
-          `SELECT * FROM results WHERE run_id IN (${placeholders(missing)})`,
-        )
-        .all(...missing),
-      resultRows,
-      (row) => `${row.run_id}\0${row.attempt}`,
-    );
+    for (const chunk of chunked(missing)) {
+      addRows(
+        db
+          .query(
+            `SELECT * FROM results WHERE run_id IN (${placeholders(chunk)})`,
+          )
+          .all(...chunk),
+        resultRows,
+        (row) => `${row.run_id}\0${row.attempt}`,
+      );
+    }
   };
   const addProposals = (eventKeys, runIds) => {
-    const clauses = [];
-    const params = [];
-    for (const key of eventKeys) {
-      const [source, id] = key.split("\0");
-      clauses.push("(event_source = ? AND event_id = ?)");
-      params.push(source, id);
+    const byKey = (row) => row.id;
+    for (const chunk of chunked(eventKeys)) {
+      const where = chunk
+        .map(() => "(event_source = ? AND event_id = ?)")
+        .join(" OR ");
+      addRows(
+        db
+          .query(`SELECT *, rowid AS list_rowid FROM proposals WHERE ${where}`)
+          .all(...chunk.flatMap((key) => key.split("\0"))),
+        proposalRows,
+        byKey,
+      );
     }
-    if (runIds.size) {
-      clauses.push(`run_id IN (${placeholders(runIds)})`);
-      params.push(...runIds);
+    for (const chunk of chunked(runIds)) {
+      addRows(
+        db
+          .query(
+            `SELECT *, rowid AS list_rowid FROM proposals WHERE run_id IN (${placeholders(chunk)})`,
+          )
+          .all(...chunk),
+        proposalRows,
+        byKey,
+      );
     }
-    if (!clauses.length) return;
-    addRows(
-      db
-        .query(
-          `SELECT *, rowid AS list_rowid FROM proposals WHERE ${clauses.join(" OR ")}`,
-        )
-        .all(...params),
-      proposalRows,
-      (row) => row.id,
-    );
   };
 
   addRows(
@@ -456,8 +474,10 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       collectPrRefs(result, prRefs);
   }
   if (prRefs.numbers.size || prRefs.urls.size) {
+    // The prefilters compare UPPER(json), so the patterns must be uppercased
+    // too; hasPrRef below still matches the parsed, exact references.
     const prLike = [...prRefs.urls, ...prRefs.numbers].map(
-      (reference) => `%${reference}%`,
+      (reference) => `%${String(reference).toUpperCase()}%`,
     );
     const where = prLike.map(() => "UPPER(spec_json) LIKE ?").join(" OR ");
     addRows(
@@ -544,7 +564,18 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       (a, b) =>
         b.created_at.localeCompare(a.created_at) || b.list_rowid - a.list_rowid,
     )
-    .map((row) => proposalView({ ...row, spec: parseObject(row.spec_json) }));
+    .map((row) => {
+      const expiresAt =
+        Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
+      return proposalView({
+        ...row,
+        expired:
+          row.status === "open" &&
+          Number.isFinite(expiresAt) &&
+          expiresAt < nowMs,
+        spec: row.spec_json ? JSON.parse(row.spec_json) : null,
+      });
+    });
   const matchedRuns = [...runs]
     .map((runId) => runView(db, runId, options))
     .filter(Boolean)

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -18,6 +18,7 @@ import {
   mergeTicketSupply,
   scanTicketSupply,
   setTicketDetailControlPlane,
+  ticketJourneyView,
   ticketIndexView,
   ticketSupplyView,
 } from "./api-runs.mjs";
@@ -619,6 +620,12 @@ describe("ticket journey join (WM-595)", () => {
           "sha256:result-merge",
           "2026-01-01T11:01:00.000Z",
         );
+      await s.client.replay(
+        envelope({
+          eventId: "pr-linked-merge",
+          payload: { pr: 595 },
+        }),
+      );
 
       const response = await fetch(s.url("/runs?ticket=WM-595"));
       expect(response.status).toBe(200);
@@ -633,6 +640,9 @@ describe("ticket journey join (WM-595)", () => {
       expect(journey.events.map((event) => event.eventId)).toContain(
         "ticket-dispatch",
       );
+      expect(journey.events.map((event) => event.eventId)).toContain(
+        "pr-linked-merge",
+      );
       expect(journey.runs.map((run) => run.run.runId)).toEqual([
         "run_ticket",
         "run_merge",
@@ -643,6 +653,69 @@ describe("ticket journey join (WM-595)", () => {
       expect((await unknown.json()).activity).toBe(false);
       const invalid = await fetch(s.url("/runs?ticket=not-a-ticket"));
       expect(invalid.status).toBe(422);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("keeps unrelated records out without issuing unrestricted table reads", async () => {
+    const s = await makeServer();
+    try {
+      await s.client.replay(
+        envelope({
+          eventId: "ticket-json-only",
+          payload: { ticket: "WM-1328" },
+        }),
+      );
+      await s.client.replay(
+        envelope({
+          eventId: "unrelated-ticket",
+          subject: "WM-999",
+          payload: { ticket: "WM-999" },
+        }),
+      );
+      const spec = (ticket) =>
+        JSON.stringify({
+          schemaVersion: "factory.run-spec/v1",
+          runId: "ignored",
+          agent: "dispatch@1",
+          input: { repo: "factory", ticket },
+        });
+      for (const [runId, ticket] of [
+        ["run-json-only", "WM-1328"],
+        ["run-unrelated", "WM-999"],
+      ]) {
+        s.db
+          .query(
+            `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+             VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+          )
+          .run(
+            runId,
+            `${runId}-key`,
+            spec(ticket),
+            `sha256:${runId}`,
+            "COMPLETED",
+            "2026-01-01T10:00:00.000Z",
+            "2026-01-01T10:01:00.000Z",
+          );
+      }
+      const guardedDb = {
+        query(sql) {
+          if (
+            /SELECT \* FROM (events|proposals|runs|results) ORDER BY/i.test(sql)
+          )
+            throw new Error(`unrestricted ticket journey query: ${sql}`);
+          return s.db.query(sql);
+        },
+      };
+      const journey = ticketJourneyView(guardedDb, "WM-1328");
+      expect(journey.events.map((event) => event.eventId)).toEqual([
+        "ticket-json-only",
+      ]);
+      expect(journey.runs.map((run) => run.run.runId)).toEqual([
+        "run-json-only",
+      ]);
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -747,6 +747,65 @@ describe("ticket journey join (WM-595)", () => {
       s.close();
     }
   });
+
+  test("journey proposals keep TTL expiry and null spec", async () => {
+    const s = await makeServer();
+    try {
+      await s.client.replay(
+        envelope({
+          eventId: "ticket-expiry",
+          payload: { ticket: "WM-1328" },
+        }),
+      );
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, decision, spec_json, spec_hash, status, reason, created_at, ttl_seconds)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "prop-expired",
+          "linear",
+          "ticket-expiry",
+          "human_needed",
+          JSON.stringify({ input: { repo: "factory", ticket: "WM-1328" } }),
+          "sha256:prop-expired",
+          "open",
+          "needs a human",
+          "2026-01-01T10:00:00.000Z",
+          60,
+        );
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "prop-no-spec",
+          "linear",
+          "ticket-expiry",
+          "noop",
+          "open",
+          "2026-01-01T10:00:00.000Z",
+          3600,
+        );
+      const nowMs = Date.parse("2026-01-01T10:30:00.000Z");
+      const journey = ticketJourneyView(s.db, "WM-1328", { nowMs });
+      const byId = Object.fromEntries(
+        journey.proposals.map((proposal) => [proposal.id, proposal]),
+      );
+      expect(byId["prop-expired"].expired).toBe(true);
+      expect(byId["prop-expired"].status).toBe("open");
+      expect(byId["prop-no-spec"].expired).toBe(false);
+      expect(byId["prop-no-spec"].spec).toBeNull();
+      expect(
+        ticketJourneyView(s.db, "WM-1328", {
+          nowMs: Date.parse("2026-01-01T10:00:30.000Z"),
+        }).proposals.find((proposal) => proposal.id === "prop-expired").expired,
+      ).toBe(false);
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("recent-ticket index (WM-821)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1328

Ticket-journey polling now loads only the ticket’s connected event, proposal, run, and result records.

## Validation

| Check                | Command                                                                                     | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs --timeout 20000`                              | pass    | 34 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,888 tests, generated clean |
| UX critique          | factory-ux-critic                                                                           | not run | no user-facing surface        |

UX critique: skipped

## Post-review

Review verdict FIX addressed in ad3cec69:
- Journey proposals compute `expired` from `created_at`/`ttl_seconds` against `options.nowMs ?? Date.now()` (parity with `proposalHistory`); test covers an expired open proposal.
- PR-ref LIKE prefilter uppercases its patterns so `UPPER(json) LIKE` can match URL references.
- Null `spec_json` yields `spec: null` (was `{}`).
- Event/run/result/proposal id lookups are chunked (400 per query) to stay under the SQLite bind-variable cap.
