### PR TITLE
fix(cli): clarify help and normalize filters

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -424,6 +424,14 @@ export async function inspectWithPresentation(args) {
 
 export async function dispatch(argv = process.argv.slice(2)) {
   const [command, ...args] = argv;
+  if (!command) {
+    console.error(USAGE);
+    process.exit(1);
+  }
+  if (["help", "-h", "--help"].includes(command)) {
+    console.log(USAGE);
+    return;
+  }
   if (command === "init") return initCommand(args);
   if (command === "decide") return decideCommand(args);
   if (command === "inbox") return inboxCommand(args);
@@ -433,7 +441,7 @@ export async function dispatch(argv = process.argv.slice(2)) {
   if (command === "artifacts") return artifactsCommand(args);
   if (command === "inspect") return inspectWithPresentation(args);
   if (!Object.hasOwn(COMMANDS, command)) {
-    console.error(USAGE);
+    console.error(`unknown command: ${command} (try: cli.mjs help)`);
     process.exit(1);
   }
   return COMMANDS[command](args);

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import { COMMAND_NAMES } from "./cli/commands.mjs";
+import { events } from "./cli/events.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
+import { ps } from "./cli/ps.mjs";
+import { runs } from "./cli/runs.mjs";
 import { CLI, freePort, runCli, throwawayRunDir } from "./cli/test-helpers.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
@@ -75,10 +78,66 @@ describe("cli routing", () => {
     expect(parsed.adapters[0]).toHaveProperty("sandboxSupport");
   });
 
-  test("unknown command → usage text, non-zero exit", () => {
+  test("unknown command names the verb without dumping usage", () => {
     const r = runCli(["frobnicate"]);
-    expect(r.status).not.toBe(0);
-    expect(r.all).toContain("usage:");
+    expect(r.status).toBe(1);
+    expect(r.stderr.trim()).toBe(
+      "unknown command: frobnicate (try: cli.mjs help)",
+    );
+    expect(r.stdout).toBe("");
+    expect(r.stderr).not.toContain("usage:");
+  });
+
+  test("help, -h, and --help print usage to stdout and exit zero", () => {
+    for (const args of [["help"], ["-h"], ["--help"]]) {
+      const r = runCli(args);
+      expect(r.status).toBe(0);
+      expect(r.stdout).toContain("usage:");
+      expect(r.stderr).toBe("");
+    }
+  });
+
+  test("state and status filters are uppercased before client calls", async () => {
+    const calls = [];
+    const client = {
+      runs: async (state) => {
+        calls.push(["runs", state]);
+        return {
+          runs: [
+            {
+              runId: "run-1",
+              state: "RUNNING",
+              agent: "worker",
+              adapter: "fake",
+              attempts: 1,
+              maxAttempts: 1,
+              eventId: null,
+              updated_at: "now",
+            },
+          ],
+        };
+      },
+      events: async (status) => {
+        calls.push(["events", status]);
+        return { events: [] };
+      },
+    };
+    const lines = [];
+    const log = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await runs(client, "running");
+      await ps(client, "running");
+      await events(client, "queued");
+    } finally {
+      console.log = log;
+    }
+    expect(calls).toEqual([
+      ["runs", "RUNNING"],
+      ["runs", "RUNNING"],
+      ["events", "QUEUED"],
+    ]);
+    expect(lines.join("\n")).toContain("RUNNING");
   });
 
   test("registered command set is unchanged", () => {

--- a/event-runtime/cli/events.mjs
+++ b/event-runtime/cli/events.mjs
@@ -1,11 +1,10 @@
 import { pad, withClient } from "./shared.mjs";
 
 export async function events(client, statusFilter) {
-  const { events: rows } = await client.events(statusFilter);
+  const status = statusFilter?.toUpperCase();
+  const { events: rows } = await client.events(status);
   if (rows.length === 0) {
-    console.log(
-      statusFilter ? `no events with status ${statusFilter}` : "no events",
-    );
+    console.log(status ? `no events with status ${status}` : "no events");
     return;
   }
   console.log(

--- a/event-runtime/cli/ps.mjs
+++ b/event-runtime/cli/ps.mjs
@@ -1,16 +1,15 @@
 import { pad, withClient } from "./shared.mjs";
 
 export async function ps(client, stateFilter) {
-  const { runs: rows } = await client.runs();
-  const filtered = stateFilter
-    ? rows.filter((r) => r.state.toUpperCase() === stateFilter.toUpperCase())
+  const state = stateFilter?.toUpperCase();
+  const { runs: rows } = await client.runs(state);
+  const filtered = state
+    ? rows.filter((r) => r.state.toUpperCase() === state)
     : rows.filter((r) => r.state === "RUNNING" || r.state === "LEASED");
 
   if (filtered.length === 0) {
     console.log(
-      stateFilter
-        ? `no process runs with state ${stateFilter}`
-        : "no running processes",
+      state ? `no process runs with state ${state}` : "no running processes",
     );
     return;
   }

--- a/event-runtime/cli/runs.mjs
+++ b/event-runtime/cli/runs.mjs
@@ -1,9 +1,10 @@
 import { pad, withClient } from "./shared.mjs";
 
 export async function runs(client, stateFilter) {
-  const { runs: rows } = await client.runs(stateFilter);
+  const state = stateFilter?.toUpperCase();
+  const { runs: rows } = await client.runs(state);
   if (rows.length === 0) {
-    console.log(stateFilter ? `no runs with state ${stateFilter}` : "no runs");
+    console.log(state ? `no runs with state ${state}` : "no runs");
     return;
   }
   console.log(

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -5,6 +5,8 @@ export const USAGE = `event-runtime — watched event → agent runtime (docs/ev
 
 usage: bun event-runtime/cli.mjs <command>
 
+  help | -h | --help             print this usage
+
   serve [--port N] [--adapter-override fake] [--watch] [--with-worker]
                                  start the control API (loopback) and planner
                                  in the foreground. Runs NO worker unless


### PR DESCRIPTION
Fixes watt-mind/factory#1332

Make CLI help and filter behavior predictable for operators.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1887 pass, 10 skipped |
| UX critique          | factory-ux-critic                | not run | skipped: internal CLI, no browser surface |

UX critique: skipped