### PR TITLE
fix(worker): report terminal path failures (#1330)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2703,6 +2703,26 @@ export async function executeClaimed(
   // auditor needs, so it must not be attached to the success path alone.
   // Null until admission runs, and null for every confined run.
   let filesystemConfinementReceipt = null;
+  const recorder = traceRecorder(db, { runId, attempt });
+  const recordTerminalError = (operation, err) => {
+    const message = err?.message ?? String(err);
+    console.error(
+      `[worker] terminal ${operation} failed for run ${runId} attempt ${attempt}: ${message}`,
+    );
+    // `lifecycle` is the nearest supported trace kind to a terminal error.
+    try {
+      recorder("lifecycle", {
+        terminalError: true,
+        operation,
+        runId,
+        attempt,
+        message,
+      });
+    } catch {
+      // A terminal error must still be reported when trace storage is down.
+    }
+    return message;
+  };
 
   const refuseTerminal = (
     reasonCode,
@@ -3363,7 +3383,6 @@ export async function executeClaimed(
     // Real wall-clock per event — NOT the claim-time `now`. Trace timestamps
     // are the one place frozen time defeats the feature: "what is the agent
     // doing right now" needs to say when each step actually happened.
-    const recorder = traceRecorder(db, { runId, attempt });
     const onTrace = (kind, payload) => {
       try {
         recorder(kind, payload);
@@ -3475,6 +3494,7 @@ export async function executeClaimed(
       const terminalState = db
         .query(`SELECT state FROM runs WHERE run_id = ?`)
         .get(runId)?.state;
+      let unclaimError;
       if (mayMutateClaimedTicket()) {
         try {
           unclaimTicketFn({
@@ -3483,8 +3503,8 @@ export async function executeClaimed(
             why: terminalState === "FAILED" ? "force_failed" : "cancelled",
             log: null,
           });
-        } catch {
-          /* intentionally ignored */
+        } catch (err) {
+          unclaimError = recordTerminalError("unclaimTicket", err);
         }
       }
       cleanupWorkspace();
@@ -3514,14 +3534,20 @@ export async function executeClaimed(
               currentNow,
               attemptUsage,
             );
-          } catch {
-            // ignore
+          } catch (err) {
+            return {
+              finishError: recordTerminalError("finishAttempt", err),
+            };
           }
         }
         return { ok: true };
       });
       if (res?.fenced) return { fenced: true };
-      return { cancelled: true };
+      return {
+        cancelled: true,
+        ...(unclaimError ? { unclaimError } : {}),
+        ...(res?.finishError ? { finishError: res.finishError } : {}),
+      };
     }
 
     const { exitCode, timedOut, policyDenials = [] } = outcome ?? {};
@@ -4190,10 +4216,11 @@ export async function executeClaimed(
               : "adapter_error";
     const journalReason = `${reasonCode}: ${err?.message ?? String(err)}`;
     let res;
+    let terminalError;
     try {
       res = failTerminal("FAILED", journalReason, reasonCode);
-    } catch {
-      // if failTerminal could not transition, continue
+    } catch (err) {
+      terminalError = recordTerminalError("failTerminal", err);
     }
     cleanupWorkspace({ retainWorkspace: retain });
     if (res?.fenced) return { fenced: true };
@@ -4203,6 +4230,7 @@ export async function executeClaimed(
       terminalState: "FAILED",
       reasonCode,
       error: err?.message,
+      ...(terminalError ? { terminalError } : {}),
     };
   } finally {
     stopCancellationMonitor();

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2703,7 +2703,22 @@ export async function executeClaimed(
   // auditor needs, so it must not be attached to the success path alone.
   // Null until admission runs, and null for every confined run.
   let filesystemConfinementReceipt = null;
-  const recorder = traceRecorder(db, { runId, attempt });
+  // The recorder is built before the main `try` so terminal-error reporting
+  // can use it; its construction prepares a statement and must therefore
+  // never throw out of executeClaimed (§14: trace failures stay invisible to
+  // the attempt). Fall back to a no-op recorder with the same call surface.
+  const recorder = (() => {
+    try {
+      return traceRecorder(db, { runId, attempt });
+    } catch (err) {
+      console.error(
+        `[worker] trace recorder unavailable for run ${runId} attempt ${attempt}: ${err?.message ?? String(err)}`,
+      );
+      const noop = () => {};
+      noop.stats = () => ({ recorded: 0, dropped: 0 });
+      return noop;
+    }
+  })();
   const recordTerminalError = (operation, err) => {
     const message = err?.message ?? String(err);
     console.error(

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1198,6 +1198,31 @@ describe("worker", () => {
     expect(summary.reasonCode).toBe("contract_violation");
   });
 
+  test("a trace recorder that cannot be prepared degrades to a no-op instead of throwing out of executeClaimed (#1330)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    linkEvent(db, spec.runId);
+    db.exec(`DROP TABLE attempt_trace`);
+    const err = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const summary = await runOnce(
+        db,
+        registry,
+        adapters,
+        opts({ artifactStore: freshRoot() }),
+      );
+      expect(summary.terminalState).toBe("COMPLETED");
+      expect(runState(db, spec.runId)).toBe("COMPLETED");
+      expect(
+        err.mock.calls.some((c) =>
+          String(c[0]).includes("trace recorder unavailable"),
+        ),
+      ).toBe(true);
+    } finally {
+      err.mockRestore();
+    }
+  });
+
   test("no-result: FAILED/contract_violation", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ input: { repos: ["no-result"] } }));

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2718,6 +2718,70 @@ describe("worker", () => {
     ).toEqual([{ reason_code: "adapter_error" }, { reason_code: "ok" }]);
   });
 
+  test("adapter failure logs and traces a failTerminal failure", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "throwing" }));
+    const originalQuery = db.query.bind(db);
+    const failingDb = new Proxy(db, {
+      get(target, property) {
+        if (property === "query") {
+          return (sql) => {
+            if (String(sql).includes("UPDATE attempts SET terminal_state")) {
+              throw new Error("finish attempt write failed");
+            }
+            return originalQuery(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const loud = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => loud.push(args.join(" "));
+    let summary;
+    try {
+      summary = await runOnce(
+        failingDb,
+        registry,
+        {
+          throwing: {
+            async execute() {
+              throw new Error("adapter exploded");
+            },
+          },
+        },
+        opts(),
+      );
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "adapter_error",
+      terminalError: "finish attempt write failed",
+    });
+    expect(loud.join("\n")).toContain(
+      `terminal failTerminal failed for run ${spec.runId} attempt 1: finish attempt write failed`,
+    );
+    expect(
+      db
+        .query(
+          `SELECT kind, payload_json FROM attempt_trace WHERE run_id = ? ORDER BY seq`,
+        )
+        .all(spec.runId)
+        .map((row) => ({ kind: row.kind, ...JSON.parse(row.payload_json) })),
+    ).toContainEqual({
+      kind: "lifecycle",
+      terminalError: true,
+      operation: "failTerminal",
+      runId: spec.runId,
+      attempt: 1,
+      message: "finish attempt write failed",
+    });
+  });
+
   test("SandboxUnsupportedError is fatal and never requeues", async () => {
     const db = openDb(":memory:");
     const unsupportedAdapter = {
@@ -3303,6 +3367,88 @@ describe("worker", () => {
         totalTokens: 11,
       }),
     );
+  });
+
+  test("cancelled attempt reports and traces a finishAttempt failure", async () => {
+    const db = openDb(":memory:");
+    let signalAdapterStarted;
+    const adapterStarted = new Promise((resolve) => {
+      signalAdapterStarted = resolve;
+    });
+    const longRunningAdapter = {
+      execute: ({ abortSignal }) =>
+        new Promise((resolve) => {
+          abortSignal?.addEventListener("abort", () =>
+            resolve({ exitCode: null, timedOut: false }),
+          );
+          signalAdapterStarted();
+        }),
+    };
+    const spec = queueRun(
+      db,
+      makeSpec({ adapter: "long", timeoutSeconds: 30 }),
+    );
+    const originalQuery = db.query.bind(db);
+    const failingDb = new Proxy(db, {
+      get(target, property) {
+        if (property === "query") {
+          return (sql) => {
+            if (String(sql).includes("UPDATE attempts SET terminal_state")) {
+              throw new Error("cancel finish write failed");
+            }
+            return originalQuery(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === "function" ? value.bind(target) : value;
+      },
+    });
+    const loud = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => loud.push(args.join(" "));
+    let summary;
+    try {
+      const claim = claimNext(db, opts());
+      const execution = executeClaimed(
+        failingDb,
+        registry,
+        { long: longRunningAdapter },
+        claim,
+        opts(),
+      );
+      await adapterStarted;
+      cancelRun(db, spec.runId, {
+        actor: "operator",
+        policyVersion: "test",
+        now: T0,
+      });
+      summary = await execution;
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(summary).toEqual({
+      cancelled: true,
+      finishError: "cancel finish write failed",
+    });
+    expect(loud.join("\n")).toContain(
+      `terminal finishAttempt failed for run ${spec.runId} attempt 1: cancel finish write failed`,
+    );
+    expect(
+      db
+        .query(
+          `SELECT kind, payload_json FROM attempt_trace WHERE run_id = ? ORDER BY seq`,
+        )
+        .all(spec.runId)
+        .map((row) => ({ kind: row.kind, ...JSON.parse(row.payload_json) })),
+    ).toContainEqual({
+      kind: "lifecycle",
+      terminalError: true,
+      operation: "finishAttempt",
+      runId: spec.runId,
+      attempt: 1,
+      message: "cancel finish write failed",
+    });
   });
 
   test("forceFailRun preserves the LEASED → RUNNING → FAILED journal path", () => {
@@ -5937,6 +6083,89 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         why: "force_failed",
       }),
     ]);
+  });
+
+  test("force-fail reports and traces an unclaim failure", async () => {
+    const db = openDb(":memory:");
+    const lockDir = tmpDir("evrt-force-fail-unclaim-locks-");
+    const leaseDir = tmpDir("evrt-force-fail-unclaim-leases-");
+    let signalAdapterStarted;
+    const adapterStarted = new Promise((resolve) => {
+      signalAdapterStarted = resolve;
+    });
+    const sleepingAdapter = {
+      execute: ({ abortSignal }) =>
+        new Promise((resolve) => {
+          abortSignal?.addEventListener("abort", () =>
+            resolve({ exitCode: null, timedOut: false }),
+          );
+          signalAdapterStarted();
+        }),
+    };
+    const spec = queueRun(
+      db,
+      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-955" } }),
+    );
+    const o = opts({
+      dispatch: {
+        locksDir: lockDir,
+        leasesDir: leaseDir,
+        fetchTicket: () => readyDispatchTicket("WM-955"),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        claimTicket: () => ({ ok: true }),
+        unclaimTicket: () => {
+          throw new Error("tracker unclaim failed");
+        },
+      },
+    });
+    const loud = [];
+    const originalConsoleError = console.error;
+    console.error = (...args) => loud.push(args.join(" "));
+    let summary;
+    try {
+      const claim = claimNext(db, o);
+      const execution = executeClaimed(
+        db,
+        registry,
+        { fake: sleepingAdapter },
+        claim,
+        o,
+      );
+      await adapterStarted;
+      forceFailRun(db, spec.runId, {
+        actor: "operator",
+        reason: "operator_force_fail",
+        policyVersion: "test",
+        now: T0,
+      });
+      summary = await execution;
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    expect(summary).toEqual({
+      cancelled: true,
+      unclaimError: "tracker unclaim failed",
+    });
+    expect(loud.join("\n")).toContain(
+      `terminal unclaimTicket failed for run ${spec.runId} attempt 1: tracker unclaim failed`,
+    );
+    expect(
+      db
+        .query(
+          `SELECT kind, payload_json FROM attempt_trace WHERE run_id = ? ORDER BY seq`,
+        )
+        .all(spec.runId)
+        .map((row) => ({ kind: row.kind, ...JSON.parse(row.payload_json) })),
+    ).toContainEqual({
+      kind: "lifecycle",
+      terminalError: true,
+      operation: "unclaimTicket",
+      runId: spec.runId,
+      attempt: 1,
+      message: "tracker unclaim failed",
+    });
   });
 
   // WM-718: at handoff (PR_OPEN) a red repo verify is the handoff gate


### PR DESCRIPTION
Fixes watt-mind/factory#1330

Review terminal-path error observability and retry signals before merging.

## Validation

| Check                | Command                                                                                             | Result  | Notes                              |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000`                                      | pass    | 163 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1890 pass, 10 skipped, generated clean |
| UX critique          | factory-ux-critic                                                                                   | skipped | no user-facing backend surface     |

UX critique: skipped


## Post-review

- Review verdict: MERGE with one nit, addressed in a140e83c: `traceRecorder(db, {runId, attempt})` is now constructed inside a try/catch at `executeClaimed` entry; a prepare failure logs and falls back to a no-op recorder with the same call surface (`recorder(kind, payload)`, `recorder.stats()`), so it can no longer throw out of `executeClaimed`. Covered by a new worker test that drops `attempt_trace` before `runOnce` and asserts the run still COMPLETES.
- Merged `origin/develop` (no conflicts). Verified: `bun test event-runtime/lib` (1900 pass), `bun build/emit.mjs --check`, `format:check`, `bun run check` all green.
