### PR TITLE
fix(connectors): strip forbidden config subtrees

### DIFF
--- a/event-runtime/lib/connectors.mjs
+++ b/event-runtime/lib/connectors.mjs
@@ -301,6 +301,8 @@ export function createConnectorClient({ db, registry, extension, name }) {
  * fields come first; remaining keys matching the heuristic are moved too
  * so a schema that predates WM-920 still does not leak credentials into
  * `ctx.config`.
+ * Paths containing forbidden segments are deleted from `config` and are
+ * never copied to `secrets`.
  *
  * @param {object|null|undefined} values
  * @param {Array<{ path: string[] }>} secretFields
@@ -309,7 +311,10 @@ export function splitConfigSecrets(values, secretFields = []) {
   const config = cloneJson(values) ?? {};
   const secrets = {};
   const move = (keyPath) => {
-    if (keyPath.some((key) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key))) return;
+    if (keyPath.some((key) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key))) {
+      deleteConfigPath(config, keyPath);
+      return;
+    }
     let node = values;
     for (const key of keyPath) {
       if (
@@ -333,6 +338,7 @@ function moveHeuristic(from, secrets, path) {
   for (const [key, inner] of Object.entries(from)) {
     const next = [...path, key];
     if (next.some((segment) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(segment))) {
+      delete from[key];
       continue;
     }
     if (SECRET_KEY_HEURISTIC.test(key) && !isPlainObject(inner)) {
@@ -341,6 +347,19 @@ function moveHeuristic(from, secrets, path) {
       continue;
     }
     moveHeuristic(inner, secrets, next);
+  }
+}
+
+function deleteConfigPath(config, keyPath) {
+  let node = config;
+  for (let i = 0; i < keyPath.length; i++) {
+    const key = keyPath[i];
+    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return;
+    if (FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key)) {
+      delete node[key];
+      return;
+    }
+    node = node[key];
   }
 }
 

--- a/event-runtime/lib/connectors.mjs
+++ b/event-runtime/lib/connectors.mjs
@@ -334,7 +334,14 @@ export function splitConfigSecrets(values, secretFields = []) {
 }
 
 function moveHeuristic(from, secrets, path) {
-  if (!from || typeof from !== "object" || Array.isArray(from)) return;
+  if (!from || typeof from !== "object") return;
+  if (Array.isArray(from)) {
+    // Arrays are opaque to the secret heuristic (an index is never a
+    // secret key) but forbidden own-keys must still be stripped from any
+    // object or nested array inside them.
+    for (const element of from) stripForbiddenSegments(element);
+    return;
+  }
   for (const [key, inner] of Object.entries(from)) {
     const next = [...path, key];
     if (next.some((segment) => FORBIDDEN_CONFIG_PATH_SEGMENTS.has(segment))) {
@@ -350,11 +357,27 @@ function moveHeuristic(from, secrets, path) {
   }
 }
 
+/** Recursively delete forbidden own-keys from objects and arrays; scalars are untouched. */
+function stripForbiddenSegments(node) {
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    for (const element of node) stripForbiddenSegments(element);
+    return;
+  }
+  for (const key of Object.keys(node)) {
+    if (FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key)) {
+      delete node[key];
+      continue;
+    }
+    stripForbiddenSegments(node[key]);
+  }
+}
+
 function deleteConfigPath(config, keyPath) {
   let node = config;
   for (let i = 0; i < keyPath.length; i++) {
     const key = keyPath[i];
-    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return;
+    if (!isContainer(node) || !Object.hasOwn(node, key)) return;
     if (FORBIDDEN_CONFIG_PATH_SEGMENTS.has(key)) {
       delete node[key];
       return;
@@ -365,6 +388,11 @@ function deleteConfigPath(config, keyPath) {
 
 function isPlainObject(value) {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Plain object or array — anything a config path may traverse through. */
+function isContainer(value) {
+  return typeof value === "object" && value !== null;
 }
 
 function setAt(obj, keyPath, value) {
@@ -405,12 +433,12 @@ function deleteAt(obj, keyPath) {
   let node = obj;
   for (let i = 0; i < keyPath.length - 1; i++) {
     const key = keyPath[i];
-    if (!isPlainObject(node) || !Object.hasOwn(node, key)) return;
-    if (!isPlainObject(node[key])) return;
+    if (!isContainer(node) || !Object.hasOwn(node, key)) return;
+    if (!isContainer(node[key])) return;
     node = node[key];
   }
   const key = keyPath[keyPath.length - 1];
-  if (isPlainObject(node) && Object.hasOwn(node, key)) delete node[key];
+  if (isContainer(node) && Object.hasOwn(node, key)) delete node[key];
 }
 
 function connectorLog(log, extension, name) {

--- a/event-runtime/lib/connectors.test.mjs
+++ b/event-runtime/lib/connectors.test.mjs
@@ -168,6 +168,62 @@ describe("splitConfigSecrets", () => {
     expect({}.apiKey).toBeUndefined();
   });
 
+  test("strips forbidden keys from objects inside arrays", () => {
+    const { config, secrets } = splitConfigSecrets(
+      JSON.parse('{"items":[{"__proto__":{"x":1},"name":"a"},"scalar",7]}'),
+    );
+    expect(config).toEqual({ items: [{ name: "a" }, "scalar", 7] });
+    expect(Object.hasOwn(config.items[0], "__proto__")).toBe(false);
+    expect(secrets).toEqual({});
+    expect({}.x).toBeUndefined();
+  });
+
+  test("strips forbidden keys from objects inside nested arrays", () => {
+    const { config } = splitConfigSecrets(
+      JSON.parse(
+        '{"rows":[[{"constructor":{"y":2},"id":1}],[[{"prototype":{"z":3}}]]]}',
+      ),
+    );
+    expect(config).toEqual({ rows: [[{ id: 1 }], [[{}]]] });
+    expect(Object.hasOwn(config.rows[0][0], "constructor")).toBe(false);
+    expect(Object.hasOwn(config.rows[1][0][0], "prototype")).toBe(false);
+  });
+
+  test("deletes explicit secret paths that pass through an array element", () => {
+    const values = JSON.parse(
+      '{"items":[{"nested":{"__proto__":{"value":"x"}},"token":"t"}]}',
+    );
+    const { config, secrets } = splitConfigSecrets(values, [
+      { path: ["items", "0", "nested", "__proto__", "value"] },
+      { path: ["items", "0", "token"] },
+    ]);
+    expect(config).toEqual({ items: [{ nested: {} }] });
+    expect(Object.hasOwn(config.items[0].nested, "__proto__")).toBe(false);
+    expect(Object.hasOwn(secrets, "__proto__")).toBe(false);
+    expect(secrets).toEqual({ items: { 0: { token: "t" } } });
+    expect({}.value).toBeUndefined();
+  });
+
+  test("preserves legitimate arrays, including forbidden names as scalar elements", () => {
+    const { config, secrets } = splitConfigSecrets({
+      allowed: ["__proto__", "constructor", "prototype"],
+      items: [{ name: "a", tags: ["x", "y"] }, { name: "b" }],
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    });
+    expect(config).toEqual({
+      allowed: ["__proto__", "constructor", "prototype"],
+      items: [{ name: "a", tags: ["x", "y"] }, { name: "b" }],
+      matrix: [
+        [1, 2],
+        [3, 4],
+      ],
+    });
+    expect(secrets).toEqual({});
+  });
+
   test("does not write through an inherited intermediate object", () => {
     Object.prototype.nested = {};
     const { secrets } = splitConfigSecrets({ nested: { token: "x" } }, [

--- a/event-runtime/lib/connectors.test.mjs
+++ b/event-runtime/lib/connectors.test.mjs
@@ -121,6 +121,21 @@ describe("splitConfigSecrets", () => {
     }
   });
 
+  test("deletes forbidden heuristic subtrees from config", () => {
+    const values = JSON.parse(
+      '{"__proto__":{"token":"x"},"constructor":{"apiKey":"y"},"nested":{"prototype":{"secret":"z"}}}',
+    );
+    const { config, secrets } = splitConfigSecrets(values);
+
+    expect(config).toEqual({ nested: {} });
+    expect(Object.hasOwn(config, "__proto__")).toBe(false);
+    expect(Object.hasOwn(config, "constructor")).toBe(false);
+    expect(Object.hasOwn(secrets, "__proto__")).toBe(false);
+    expect(Object.hasOwn(secrets, "constructor")).toBe(false);
+    expect(secrets).toEqual({});
+    expect({}.token).toBeUndefined();
+  });
+
   test("does not traverse constructor.prototype config keys", () => {
     const { secrets } = splitConfigSecrets(
       JSON.parse('{"constructor":{"prototype":{"apiKey":"x"}}}'),
@@ -129,17 +144,28 @@ describe("splitConfigSecrets", () => {
     expect(Object.hasOwn(secrets, "constructor")).toBe(false);
   });
 
-  test("ignores explicit secret paths containing forbidden segments", () => {
-    const values = JSON.parse(
-      '{"nested":{"value":"x"},"constructor":{"prototype":{"apiKey":"y"}}}',
+  test("deletes forbidden nested heuristic subtrees from config", () => {
+    const { config, secrets } = splitConfigSecrets(
+      JSON.parse('{"nested":{"prototype":{"secret":"x"}}}'),
     );
-    const { secrets } = splitConfigSecrets(values, [
-      { path: ["nested", "__proto__", "value"] },
-      { path: ["constructor", "prototype", "apiKey"] },
-    ]);
-    expect(Object.prototype.token).toBeUndefined();
-    expect(Object.prototype.apiKey).toBeUndefined();
+    expect(config).toEqual({ nested: {} });
+    expect(Object.hasOwn(config.nested, "prototype")).toBe(false);
     expect(secrets).toEqual({});
+    expect({}.secret).toBeUndefined();
+  });
+
+  test("deletes explicit secret paths containing forbidden segments", () => {
+    const values = JSON.parse(
+      '{"nested":{"__proto__":{"value":"x"}},"constructor":{"apiKey":"y"}}',
+    );
+    const { config, secrets } = splitConfigSecrets(values, [
+      { path: ["nested", "__proto__", "value"] },
+      { path: ["constructor", "apiKey"] },
+    ]);
+    expect(config).toEqual({ nested: {} });
+    expect(secrets).toEqual({});
+    expect({}.value).toBeUndefined();
+    expect({}.apiKey).toBeUndefined();
   });
 
   test("does not write through an inherited intermediate object", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1237

Strip forbidden-key subtrees from connector plaintext config; authorized by inbox_c83dfd7a-093c-4621-af1d-9348e875f2df at 2026-08-29T23:24:59.345Z.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/connectors.test.mjs --timeout 20000 && bun run check`    | pass    | 19 tests, 0 failures; generated files match shared/ |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`  | pass    | 1895 pass, 10 skipped, 0 failures; formatting clean |
| UX critique          | factory-ux-critic                | not run | skipped: no user-facing surface |

UX critique: skipped — no user-facing surface

## Post-review

Reviewer gap closed in c32cb91c: `moveHeuristic` returned early on arrays and `deleteConfigPath`/`deleteAt` refused to traverse them, so a forbidden own-key inside an array element (`{"items":[{"__proto__":{"x":1}}]}`) survived on `config.items[0]`. Arrays are now walked: forbidden segments (`__proto__`, `constructor`, `prototype`) are stripped from objects and nested arrays inside them, scalars are untouched, explicit secret paths may pass through array indices. Heuristic secret moves still treat array indices as opaque (unchanged). Regression tests cover object-in-array, nested arrays, an explicit secret path through an array element, and legitimate arrays (including forbidden names as scalar elements) that must be preserved.

## Handoff

- Merged origin/develop; `bun test event-runtime/lib` 1901 pass / 0 fail, `bun build/emit.mjs --check`, `format:check`, `bun run check` all green.
- Only `event-runtime/lib/connectors.mjs` and `connectors.test.mjs` changed post-review.
- Landed autonomously under the operator's 2026-08-29 security batch pre-approval.
