### PR TITLE
perf(control): bound proposal write contention

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -4,7 +4,7 @@ import { artifactHead } from "./api-artifacts.mjs";
 import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 import { STALE_SCAN_MS, loadLinearSupply } from "./linear.mjs";
 import { loadRepos, RepoError } from "./repos.mjs";
-import { isBusyError, runUsage } from "./db.mjs";
+import { isBusyError, retryBusy, runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
 import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
@@ -1766,11 +1766,13 @@ export async function handleRunApiRoute({
     const body = parseJson(await readBody(req)).value ?? {};
     try {
       if (verb === "approve") {
-        const outcome = approveProposal(db, registry, id, {
-          actor,
-          now: nowMs,
-          policyVersion,
-        });
+        const outcome = await retryBusy(db, () =>
+          approveProposal(db, registry, id, {
+            actor,
+            now: nowMs,
+            policyVersion,
+          }),
+        );
         if (outcome.approved)
           return send(200, { approved: true, runId: outcome.runId });
         return send(200, {
@@ -1782,15 +1784,17 @@ export async function handleRunApiRoute({
           ),
         });
       }
-      const outcome = rejectProposal(db, id, {
-        actor,
-        reason: body.reason,
-        now: nowMs,
-        policyVersion,
-      });
+      const outcome = await retryBusy(db, () =>
+        rejectProposal(db, id, {
+          actor,
+          reason: body.reason,
+          now: nowMs,
+          policyVersion,
+        }),
+      );
       return send(200, { rejected: true, runId: outcome.runId });
     } catch (err) {
-      if (verb === "approve" && isBusyError(err))
+      if (isBusyError(err))
         return send(503, { error: "db_busy", retryable: true });
       const status = String(err.message).startsWith("unknown proposal")
         ? 404

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1131,37 +1131,6 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(again.message).toContain("not open");
   });
 
-  test("approval waits for a worker write lock and returns db_busy after its timeout", async () => {
-    const waiting = await planned("approve-waits-for-lock");
-    const lock = await holdWriteLock(s.db.filename, 75);
-    const startedAt = Date.now();
-    const approved = await s.client.approve(waiting.id);
-    const elapsedMs = Date.now() - startedAt;
-    expect(approved).toEqual({ approved: true, runId: waiting.runId });
-    // The lock is held for 75 ms; a lower bound proves the approval actually
-    // waited on it instead of racing past a lock that was never taken.
-    expect(elapsedMs).toBeGreaterThanOrEqual(50);
-    expect(elapsedMs).toBeLessThan(2_000);
-    expect(await lock.exited).toBe(0);
-    expect(await s.client.cancel(waiting.runId, "test cleanup")).toEqual({
-      cancelled: true,
-    });
-
-    const timedOut = await planned("approve-busy-timeout");
-    let timeoutLock;
-    try {
-      s.db.exec("PRAGMA busy_timeout = 10;");
-      timeoutLock = await holdWriteLock(s.db.filename, 75);
-      const err = await rejection(s.client.approve(timedOut.id));
-      expect(err.status).toBe(503);
-      expect(err.message).toBe("db_busy");
-      expect(err.body).toEqual({ error: "db_busy", retryable: true });
-    } finally {
-      s.db.exec("PRAGMA busy_timeout = 5000;");
-    }
-    expect(await timeoutLock?.exited).toBe(0);
-  });
-
   test("reject an open proposal → run CANCELLED", async () => {
     const prop = await planned("rej-1");
     const rejected = await s.client.reject(prop.id, "not today");
@@ -1175,6 +1144,34 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     const rejectAgain = await rejection(s.client.reject(prop.id, "again"));
     expect(rejectAgain.status).toBe(409);
     expect(rejectAgain.message).toContain("not open");
+  });
+
+  test("contended approvals and rejections yield to /health and return typed db_busy", async () => {
+    const approvedProposal = await planned("approve-contention");
+    const approveLock = await holdWriteLock(s.db.filename, 400);
+    const approval = s.client.approve(approvedProposal.id);
+    await new Promise((resolve) => setImmediate(resolve));
+    const healthStartedAt = Date.now();
+    const health = await fetch(s.url("/health"));
+    expect(health.status).toBe(200);
+    expect(Date.now() - healthStartedAt).toBeLessThan(500);
+    expect(await approval).toEqual({
+      approved: true,
+      runId: approvedProposal.runId,
+    });
+    expect(await approveLock.exited).toBe(0);
+    expect(
+      await s.client.cancel(approvedProposal.runId, "test cleanup"),
+    ).toEqual({ cancelled: true });
+
+    const rejectedProposal = await planned("reject-contention");
+    const rejectLock = await holdWriteLock(s.db.filename, 6_000);
+    const startedAt = Date.now();
+    const err = await rejection(s.client.reject(rejectedProposal.id, "locked"));
+    expect(err.status).toBe(503);
+    expect(err.body).toEqual({ error: "db_busy", retryable: true });
+    expect(Date.now() - startedAt).toBeGreaterThan(4_000);
+    expect(await rejectLock.exited).toBe(0);
   });
 
   test("cancel a QUEUED run → 200; cancel again → 409; unknown run → 404", async () => {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1278,6 +1278,40 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(rejectAgain.message).toContain("not open");
   });
 
+  test("approval waits for a worker write lock and returns db_busy after its timeout", async () => {
+    const waiting = await planned("approve-waits-for-lock");
+    const lock = await holdWriteLock(s.db.filename, 75);
+    const startedAt = Date.now();
+    const approved = await s.client.approve(waiting.id);
+    const elapsedMs = Date.now() - startedAt;
+    expect(approved).toEqual({ approved: true, runId: waiting.runId });
+    // The lock is held for 75 ms; a lower bound proves the approval actually
+    // waited on it instead of racing past a lock that was never taken.
+    expect(elapsedMs).toBeGreaterThanOrEqual(50);
+    expect(elapsedMs).toBeLessThan(2_000);
+    expect(await lock.exited).toBe(0);
+    expect(await s.client.cancel(waiting.runId, "test cleanup")).toEqual({
+      cancelled: true,
+    });
+
+    // A connection deliberately tuned to fail fast keeps that contract even
+    // though approvals now retry across event-loop turns (#1349): the
+    // lowered busy_timeout bounds the whole retry budget.
+    const timedOut = await planned("approve-busy-timeout");
+    let timeoutLock;
+    try {
+      s.db.exec("PRAGMA busy_timeout = 10;");
+      timeoutLock = await holdWriteLock(s.db.filename, 75);
+      const err = await rejection(s.client.approve(timedOut.id));
+      expect(err.status).toBe(503);
+      expect(err.message).toBe("db_busy");
+      expect(err.body).toEqual({ error: "db_busy", retryable: true });
+    } finally {
+      s.db.exec("PRAGMA busy_timeout = 5000;");
+    }
+    expect(await timeoutLock?.exited).toBe(0);
+  });
+
   test("contended approvals and rejections yield to /health and return typed db_busy", async () => {
     const approvedProposal = await planned("approve-contention");
     const approveLock = await holdWriteLock(s.db.filename, 400);

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -631,8 +631,12 @@ function enableWal(db, { attempts = 20, waitMs = 50 } = {}) {
   }
 }
 
+/** Every connection's busy_timeout: plain writers block for up to this long. */
+export const DB_BUSY_TIMEOUT_MS = 5_000;
+/** One retryBusy() attempt: short, so the event loop is pinned briefly. */
 export const DB_BUSY_ATTEMPT_TIMEOUT_MS = 100;
-export const DB_BUSY_RETRY_TIMEOUT_MS = 5_000;
+/** The whole retryBusy() budget across attempts (matches the connection). */
+export const DB_BUSY_RETRY_TIMEOUT_MS = DB_BUSY_TIMEOUT_MS;
 
 export function openDb(file = dbPath()) {
   if (file !== ":memory:") mkdirSync(path.dirname(file), { recursive: true });
@@ -641,7 +645,7 @@ export function openDb(file = dbPath()) {
   // and a second process opening the database concurrently must wait for it
   // rather than failing with SQLITE_BUSY_RECOVERY. Ordering matters here —
   // observed live the moment serve and work became separate processes.
-  db.exec("PRAGMA busy_timeout = 5000;");
+  db.exec(`PRAGMA busy_timeout = ${DB_BUSY_TIMEOUT_MS};`);
   enableWal(db);
   // Set synchronous = FULL (OPS-414): under WAL mode, the default NORMAL only
   // fsyncs at checkpoint boundaries, which can lose recent committed transactions
@@ -652,10 +656,6 @@ export function openDb(file = dbPath()) {
   db.exec("PRAGMA foreign_keys = ON;");
   migrateDb(db);
   assertSchema(db);
-  // Runtime writes must fail quickly rather than pin serve's event loop behind
-  // another process's transaction. Latency-sensitive callers use retryBusy()
-  // to retry these short attempts across event-loop turns.
-  db.exec(`PRAGMA busy_timeout = ${DB_BUSY_ATTEMPT_TIMEOUT_MS};`);
   return db;
 }
 
@@ -700,8 +700,19 @@ export function isBusyError(err) {
 
 /**
  * Retry an idempotent SQLite attempt without holding the event loop for the
- * connection's normal busy timeout. The callback must contain the complete
- * transaction, so a SQLITE_BUSY rollback leaves each retry safe to repeat.
+ * connection's normal busy timeout (#1349).
+ *
+ * Each attempt runs with a short `busy_timeout` (restored afterwards), and a
+ * busy failure sleeps across event-loop turns before trying again, until the
+ * total budget is spent — the same ~5 s a plain writer would block for, but
+ * with /health and other requests served in between. The callback must be
+ * synchronous and contain the complete transaction, so a SQLITE_BUSY rollback
+ * leaves each retry safe to repeat; a thenable is rejected outright because
+ * the timeout is restored as soon as the callback returns.
+ *
+ * A connection whose `busy_timeout` was deliberately lowered below one attempt
+ * keeps its fail-fast contract: that value bounds the attempt, and there is no
+ * retry budget beyond it, so it errors after that single short wait.
  */
 export async function retryBusy(
   db,
@@ -714,13 +725,31 @@ export async function retryBusy(
     random = Math.random,
   } = {},
 ) {
+  if (typeof attempt !== "function")
+    throw new TypeError("retryBusy: attempt must be a function");
+  const connectionTimeout = Number(
+    db.query("PRAGMA busy_timeout").get()?.timeout ?? DB_BUSY_TIMEOUT_MS,
+  );
+  const attemptTimeoutMs = Math.max(
+    0,
+    Math.floor(Math.min(busyTimeoutMs, connectionTimeout)),
+  );
+  // SQLite already waits the connection's own timeout inside that single
+  // attempt, so there is nothing left to retry across turns.
+  const budgetMs = connectionTimeout < busyTimeoutMs ? 0 : timeoutMs;
   const startedAt = Date.now();
   let lastBusyError;
   for (;;) {
     const previousTimeout = db.query("PRAGMA busy_timeout").get().timeout;
-    db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.floor(busyTimeoutMs))};`);
+    db.exec(`PRAGMA busy_timeout = ${attemptTimeoutMs};`);
     try {
-      return attempt();
+      const result = attempt();
+      if (result !== null && typeof result?.then === "function") {
+        throw new TypeError(
+          "retryBusy: attempt must be synchronous (it returned a thenable); the per-attempt busy_timeout is restored as soon as it returns",
+        );
+      }
+      return result;
     } catch (err) {
       if (!isBusyError(err)) throw err;
       lastBusyError = err;
@@ -728,7 +757,7 @@ export async function retryBusy(
       db.exec(`PRAGMA busy_timeout = ${previousTimeout};`);
     }
 
-    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    const remainingMs = budgetMs - (Date.now() - startedAt);
     if (remainingMs <= 0) throw lastBusyError;
     const spread = Math.max(0, maxDelayMs - minDelayMs);
     const delayMs = Math.min(

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -631,6 +631,9 @@ function enableWal(db, { attempts = 20, waitMs = 50 } = {}) {
   }
 }
 
+export const DB_BUSY_ATTEMPT_TIMEOUT_MS = 100;
+export const DB_BUSY_RETRY_TIMEOUT_MS = 5_000;
+
 export function openDb(file = dbPath()) {
   if (file !== ":memory:") mkdirSync(path.dirname(file), { recursive: true });
   const db = new Database(file, { create: true });
@@ -649,6 +652,10 @@ export function openDb(file = dbPath()) {
   db.exec("PRAGMA foreign_keys = ON;");
   migrateDb(db);
   assertSchema(db);
+  // Runtime writes must fail quickly rather than pin serve's event loop behind
+  // another process's transaction. Latency-sensitive callers use retryBusy()
+  // to retry these short attempts across event-loop turns.
+  db.exec(`PRAGMA busy_timeout = ${DB_BUSY_ATTEMPT_TIMEOUT_MS};`);
   return db;
 }
 
@@ -689,6 +696,47 @@ export function isBusyError(err) {
   return /database is locked|database table is locked|resource temporarily unavailable|\bSQLITE_BUSY\b|\bSQLITE_LOCKED\b/i.test(
     msg,
   );
+}
+
+/**
+ * Retry an idempotent SQLite attempt without holding the event loop for the
+ * connection's normal busy timeout. The callback must contain the complete
+ * transaction, so a SQLITE_BUSY rollback leaves each retry safe to repeat.
+ */
+export async function retryBusy(
+  db,
+  attempt,
+  {
+    busyTimeoutMs = DB_BUSY_ATTEMPT_TIMEOUT_MS,
+    timeoutMs = DB_BUSY_RETRY_TIMEOUT_MS,
+    minDelayMs = 15,
+    maxDelayMs = 50,
+    random = Math.random,
+  } = {},
+) {
+  const startedAt = Date.now();
+  let lastBusyError;
+  for (;;) {
+    const previousTimeout = db.query("PRAGMA busy_timeout").get().timeout;
+    db.exec(`PRAGMA busy_timeout = ${Math.max(0, Math.floor(busyTimeoutMs))};`);
+    try {
+      return attempt();
+    } catch (err) {
+      if (!isBusyError(err)) throw err;
+      lastBusyError = err;
+    } finally {
+      db.exec(`PRAGMA busy_timeout = ${previousTimeout};`);
+    }
+
+    const remainingMs = timeoutMs - (Date.now() - startedAt);
+    if (remainingMs <= 0) throw lastBusyError;
+    const spread = Math.max(0, maxDelayMs - minDelayMs);
+    const delayMs = Math.min(
+      remainingMs,
+      minDelayMs + Math.floor(random() * (spread + 1)),
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
 }
 
 /** Normalize adapter-supplied usage into durable, non-negative values. */

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -18,6 +18,7 @@ import {
   MIGRATIONS,
   assertSchema,
   DB_BUSY_ATTEMPT_TIMEOUT_MS,
+  DB_BUSY_TIMEOUT_MS,
   getSchemaVersion,
   migrateDb,
   openDb,
@@ -33,26 +34,97 @@ import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
 const freshFile = () => path.join(tmpDir("evrt-db-"), "runtime.db");
 
-describe("retryBusy", () => {
+describe("retryBusy (#1349)", () => {
+  const busyError = () =>
+    Object.assign(new Error("database is locked"), { code: "SQLITE_BUSY" });
+
   test("retries busy attempts asynchronously and restores the connection timeout", async () => {
     const db = openDb(":memory:");
+    expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
+      DB_BUSY_TIMEOUT_MS,
+    );
     let attempts = 0;
-    const busy = Object.assign(new Error("database is locked"), {
-      code: "SQLITE_BUSY",
-    });
+    const busy = busyError();
     await expect(
       retryBusy(
         db,
         () => {
           attempts += 1;
+          expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
+            DB_BUSY_ATTEMPT_TIMEOUT_MS,
+          );
           throw busy;
         },
         { timeoutMs: 5, minDelayMs: 1, maxDelayMs: 1 },
       ),
     ).rejects.toBe(busy);
     expect(attempts).toBeGreaterThan(1);
+    // Other users of the connection get the plain 5 s timeout back.
     expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
-      DB_BUSY_ATTEMPT_TIMEOUT_MS,
+      DB_BUSY_TIMEOUT_MS,
+    );
+    db.close();
+  });
+
+  test("returns the first successful attempt's result", async () => {
+    const db = openDb(":memory:");
+    let attempts = 0;
+    const value = await retryBusy(
+      db,
+      () => {
+        attempts += 1;
+        if (attempts < 3) throw busyError();
+        return { attempts };
+      },
+      { minDelayMs: 1, maxDelayMs: 1 },
+    );
+    expect(value).toEqual({ attempts: 3 });
+    db.close();
+  });
+
+  test("non-busy errors propagate immediately", async () => {
+    const db = openDb(":memory:");
+    let attempts = 0;
+    await expect(
+      retryBusy(db, () => {
+        attempts += 1;
+        throw new Error("boom");
+      }),
+    ).rejects.toThrow("boom");
+    expect(attempts).toBe(1);
+    expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
+      DB_BUSY_TIMEOUT_MS,
+    );
+    db.close();
+  });
+
+  test("a connection tuned below one attempt keeps its fail-fast contract", async () => {
+    const db = openDb(":memory:");
+    db.exec("PRAGMA busy_timeout = 10;");
+    let attempts = 0;
+    const busy = busyError();
+    const startedAt = Date.now();
+    await expect(
+      retryBusy(db, () => {
+        attempts += 1;
+        expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(10);
+        throw busy;
+      }),
+    ).rejects.toBe(busy);
+    // The lowered timeout bounds the whole budget, not just one attempt.
+    expect(attempts).toBe(1);
+    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(10);
+    db.close();
+  });
+
+  test("rejects an asynchronous attempt instead of restoring the timeout under it", async () => {
+    const db = openDb(":memory:");
+    await expect(retryBusy(db, async () => "never")).rejects.toThrow(
+      /must be synchronous/,
+    );
+    expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
+      DB_BUSY_TIMEOUT_MS,
     );
     db.close();
   });

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -17,10 +17,12 @@ import {
   CURRENT_SCHEMA_VERSION,
   MIGRATIONS,
   assertSchema,
+  DB_BUSY_ATTEMPT_TIMEOUT_MS,
   getSchemaVersion,
   migrateDb,
   openDb,
   recordRunUsage,
+  retryBusy,
   runUsage,
   setSchemaVersion,
   txImmediate,
@@ -30,6 +32,31 @@ import { dbPath, isTestOrCiProcess, runtimeHome } from "./config.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
 
 const freshFile = () => path.join(tmpDir("evrt-db-"), "runtime.db");
+
+describe("retryBusy", () => {
+  test("retries busy attempts asynchronously and restores the connection timeout", async () => {
+    const db = openDb(":memory:");
+    let attempts = 0;
+    const busy = Object.assign(new Error("database is locked"), {
+      code: "SQLITE_BUSY",
+    });
+    await expect(
+      retryBusy(
+        db,
+        () => {
+          attempts += 1;
+          throw busy;
+        },
+        { timeoutMs: 5, minDelayMs: 1, maxDelayMs: 1 },
+      ),
+    ).rejects.toBe(busy);
+    expect(attempts).toBeGreaterThan(1);
+    expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(
+      DB_BUSY_ATTEMPT_TIMEOUT_MS,
+    );
+    db.close();
+  });
+});
 
 describe("cold start (OPS-376, OPS-424)", () => {
   test("a second connection to a brand-new database does not fight for the WAL switch", () => {

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -10,7 +10,7 @@
  */
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
-import { tx, txImmediate } from "./db.mjs";
+import { txImmediate } from "./db.mjs";
 import { newProposalId } from "./ids.mjs";
 import { runState, transition } from "./lifecycle.mjs";
 import { buildRunSpec } from "./planner.mjs";
@@ -261,7 +261,7 @@ export function rejectProposal(
   id,
   { actor, reason, now = Date.now(), policyVersion = "unknown" } = {},
 ) {
-  return tx(db, () => {
+  return txImmediate(db, () => {
     const proposal = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!proposal) throw new Error(`unknown proposal ${id}`);
     if (proposal.status !== "open")


### PR DESCRIPTION
Fixes watt-mind/factory#1349

Review the bounded SQLite retry and typed busy response under write contention.

## Validation

| Check                | Command                                                                                                   | Result  | Notes                              |
| -------------------- | --------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/proposals.test.mjs event-runtime/lib/db.test.mjs --timeout 20000` | pass    | 74 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`      | pass    | 1,895 pass, 10 skipped, 0 failures |
| UX critique          | `factory-ux-critic`                                                                                       | not run | skipped: backend control API only  |

UX critique: skipped

## Post-review (e42cd4ec)

- `openDb()` no longer lowers `busy_timeout` to 100 ms; every connection keeps the 5 s default (`DB_BUSY_TIMEOUT_MS`). `retryBusy` sets/restores its own 100 ms per-attempt timeout.
- Merged `origin/develop` (#1326 already carries `holdWriteLock`; the PR's copy was identical, one helper remains).
- Reconciled with #1326's "approval waits for a worker write lock / approve-busy-timeout" test: restored it alongside the new `/health`-concurrency + typed `db_busy` contention test. `retryBusy` honours a caller-lowered connection timeout — a connection tuned below one attempt (e.g. `busy_timeout = 10`) bounds the attempt and gets no retry budget, so it fails fast; the default stays the ~5 s bounded retry across event-loop turns.
- `retryBusy` rejects thenable-returning callbacks (sync-only guard) since the timeout is restored in `finally`; reject path uses the same mechanism.
- Verify: targeted 82 pass; `bun test event-runtime/lib` 1910 pass / 0 fail; `emit --check`, `format:check`, `check` clean.
