### PR TITLE
perf(web): share hidden-tab polling policy

### DIFF
--- a/event-runtime/web/src/hooks.test.ts
+++ b/event-runtime/web/src/hooks.test.ts
@@ -10,6 +10,7 @@ import { createElement as h, useEffect, useState } from "react";
 import { api } from "./api";
 import {
   modal,
+  pollingOptions,
   refetchIntervals,
   useHashRoute,
   useListKeys,
@@ -73,11 +74,13 @@ describe("API ETag cache", () => {
 describe("collection refetch intervals", () => {
   test("use a 15 second hidden-tab cadence and keep background polling active", () => {
     const originalHidden = Object.getOwnPropertyDescriptor(document, "hidden");
+    const customCadence = pollingOptions(30_000);
     try {
       Object.defineProperty(document, "hidden", {
         configurable: true,
         value: false,
       });
+      expect(customCadence.refetchInterval()).toBe(30_000);
       expect(refetchIntervals.primary.refetchInterval()).toBe(2_000);
       expect(refetchIntervals.fast.refetchInterval()).toBe(5_000);
       expect(refetchIntervals.secondary.refetchInterval()).toBe(10_000);
@@ -86,6 +89,7 @@ describe("collection refetch intervals", () => {
         configurable: true,
         value: true,
       });
+      expect(customCadence.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.primary.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.fast.refetchInterval()).toBe(15_000);
       expect(refetchIntervals.secondary.refetchInterval()).toBe(15_000);

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -23,7 +23,7 @@ export const modal = { depth: 0 };
 
 const HIDDEN_REFETCH_INTERVAL = 15_000;
 
-function pollingOptions(visibleInterval: number) {
+export function pollingOptions(visibleInterval: number) {
   return {
     refetchInterval: () =>
       typeof document !== "undefined" && document.hidden

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -18,6 +18,7 @@ import { CustomCell } from "../components/CustomCell";
 import type { FilterFacets } from "../filterQuery";
 import { matchesFilterQuery, parseFilterQuery } from "../filterQuery";
 import {
+  pollingOptions,
   tableTokens,
   useDisplayOptions,
   useListKeys,
@@ -284,7 +285,7 @@ export function Chains({
   const list = useQuery({
     queryKey: ["chains", "24h", 100],
     queryFn: () => api.chains("24h", 100),
-    refetchInterval: 3000,
+    ...pollingOptions(3_000),
   });
   const parsed = useMemo(
     () => parseFilterQuery(filter, CHAIN_FACETS),

--- a/event-runtime/web/src/views/Metrics.tsx
+++ b/event-runtime/web/src/views/Metrics.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { fetchMetrics, fetchMetricsBreakdown } from "../api";
+import { pollingOptions } from "../hooks";
 import {
   Band,
   ShareBars,
@@ -535,7 +536,7 @@ export function Metrics() {
   const query = useQuery({
     queryKey: ["metrics", window, bucket],
     queryFn: () => fetchMetrics(window, bucket),
-    refetchInterval: 30_000,
+    ...pollingOptions(30_000),
     retry: false,
   });
 
@@ -553,14 +554,14 @@ export function Metrics() {
     queryKey: ["metrics-breakdown", window, "adapter", "runs"],
     queryFn: () => fetchMetricsBreakdown(window, "adapter", "runs", 8),
     enabled: chartsReady,
-    refetchInterval: 30_000,
+    ...pollingOptions(30_000),
     retry: false,
   });
   const modelQuery = useQuery({
     queryKey: ["metrics-breakdown", window, "model", "tokens"],
     queryFn: () => fetchMetricsBreakdown(window, "model", "tokens", 8),
     enabled: chartsReady,
-    refetchInterval: 30_000,
+    ...pollingOptions(30_000),
     retry: false,
   });
   const derived = useMemo(() => {

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -11,6 +11,7 @@ import { api } from "../api";
 import { goPrefixActive } from "../goSequence";
 import {
   keyGuard,
+  pollingOptions,
   refetchIntervals,
   useListKeys,
   useNow,
@@ -1136,7 +1137,7 @@ export function Ticket({
     queryFn: () => fetchTicketJourney(normalized!),
     enabled: valid,
     // fetchTicketJourney uses raw fetch() and bypasses the ETag wrapper in api.ts, so it stays at 5s.
-    refetchInterval: 5000,
+    ...pollingOptions(5_000),
   });
   const schedules = useQuery({
     queryKey: ["schedules"],
@@ -1149,7 +1150,7 @@ export function Ticket({
     queryFn: () => fetchTicketDetail(normalized!),
     enabled: valid,
     staleTime: 15_000,
-    refetchInterval: 30_000,
+    ...pollingOptions(30_000),
   });
 
   if (!ticketId || ticketId.trim() === "")


### PR DESCRIPTION
Fixes watt-mind/factory#1353

Use the shared hidden-tab polling backoff in Chains, Ticket, and Metrics.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `cd event-runtime/web && bun test src/hooks.test.ts src/views/Chains.test.tsx src/views/Ticket.test.tsx src/views/Metrics.test.tsx` | pass    | 52 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1896 tests, 0 failures |
| UX critique          | factory-ux-critic                | not run | background polling policy only |

UX critique: skipped — background polling policy only
