### PR TITLE
fix(control-plane): paginate GitHub issue comments

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -813,6 +813,31 @@ export function githubControlPlane(options = {}) {
     return target;
   }
 
+  /**
+   * Read a bounded GitHub REST collection. GitHub defaults to 30 records, so
+   * callers that need complete comment history must opt into pagination rather
+   * than silently treating the first page as the entire collection.
+   */
+  async function listAllPages(pathName, query = {}) {
+    const items = [];
+    for (let page = 1; page <= MAX_PAGES; page += 1) {
+      const rows = await call("GET", pathName, {
+        query: {
+          ...query,
+          per_page: String(PAGE_SIZE),
+          page: String(page),
+        },
+      });
+      const pageItems = Array.isArray(rows) ? rows : [];
+      items.push(...pageItems);
+      if (pageItems.length < PAGE_SIZE) return items;
+    }
+    console.warn(
+      `GitHub pagination reached the ${MAX_PAGES}-page safety ceiling for ${pathName}; results may be incomplete`,
+    );
+    return items;
+  }
+
   async function projectItems() {
     const project = await loadProject();
     const t = now();
@@ -1212,9 +1237,7 @@ export function githubControlPlane(options = {}) {
   async function fetchReadyPin(repo, number) {
     let rows;
     try {
-      rows = await call("GET", `repos/${repo}/issues/${number}/comments`, {
-        query: { per_page: "100" },
-      });
+      rows = await listAllPages(`repos/${repo}/issues/${number}/comments`);
     } catch {
       // Absence — including an unfetchable comment list — is not itself a
       // refusal (see the docstring above): only a mismatched pin is.
@@ -1244,10 +1267,8 @@ export function githubControlPlane(options = {}) {
     const body = `Queued for automated implementation.\n\n${readyPinMarker(description)}`;
     let comments = [];
     try {
-      const rows = await call(
-        "GET",
+      const rows = await listAllPages(
         `repos/${repo}/issues/${number}/comments`,
-        { query: { per_page: "100" } },
       );
       comments = Array.isArray(rows) ? rows : [];
     } catch {
@@ -1326,8 +1347,10 @@ export function githubControlPlane(options = {}) {
     async listComments(identifier) {
       const { repo, number } = locate(identifier);
       await fetchIssue(repo, number);
-      const rows = await call("GET", `repos/${repo}/issues/${number}/comments`);
-      return (Array.isArray(rows) ? rows : []).map((c) => ({
+      const rows = await listAllPages(
+        `repos/${repo}/issues/${number}/comments`,
+      );
+      return rows.map((c) => ({
         id: c.id != null ? String(c.id) : undefined,
         body: c.body,
         createdAt: c.created_at ?? c.createdAt,

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -376,7 +376,14 @@ function fakeApi(seed) {
         commentsMatch[1],
         Number(commentsMatch[2]),
       );
-      if (method === "GET") return issue.comments ?? [];
+      if (method === "GET") {
+        const perPage = Number(q.per_page ?? 30);
+        const page = Number(q.page ?? 1);
+        return (issue.comments ?? []).slice(
+          (page - 1) * perPage,
+          page * perPage,
+        );
+      }
       if (method === "POST") {
         const comment = {
           id: 300 + (issue.comments?.length ?? 0),
@@ -525,13 +532,14 @@ function fakeApi(seed) {
 
 function makePlane() {
   const seed = contractSeed();
+  const api = fakeApi(seed);
   const cp = githubControlPlane({
-    api: fakeApi(seed),
+    api,
     repo: REPO,
     teams: { WM: REPO, CLNT: OTHER_REPO },
     project: PROJECT,
   });
-  return { cp, seed };
+  return { api, cp, seed };
 }
 
 describe("control-plane contract: github", () => {
@@ -566,7 +574,7 @@ describe("control-plane contract: github", () => {
   });
 
   test("listComments returns the comment bodies", async () => {
-    const { cp } = makePlane();
+    const { api, cp } = makePlane();
     expect(await cp.listComments(`${REPO}#2`)).toEqual([
       {
         id: "201",
@@ -579,6 +587,46 @@ describe("control-plane contract: github", () => {
     await expect(cp.listComments(`${REPO}#999`)).rejects.toThrow(
       ControlPlaneError,
     );
+    const commentReads = api.calls.filter(
+      (call) =>
+        call.method === "GET" &&
+        call.pathName === `repos/${REPO}/issues/2/comments`,
+    );
+    expect(commentReads).toHaveLength(1);
+    expect(commentReads[0].query).toEqual({ per_page: "100", page: "1" });
+  });
+
+  test("comment readers paginate and find a ready pin beyond the first page", async () => {
+    const { api, cp, seed } = makePlane();
+    const issue = requireIssue(seed, REPO, 1);
+    const readyPin = `<!-- factory:ready-pin ${hashJson(issue.body)} -->`;
+    issue.comments = Array.from({ length: 130 }, (_, i) => ({
+      id: 400 + i,
+      body: i === 120 ? readyPin : `comment ${i + 1}`,
+      created_at: "2026-08-19T10:00:00Z",
+      user: { id: 99, login: "Other" },
+    }));
+
+    expect(await cp.listComments(`${REPO}#1`)).toHaveLength(130);
+    expect((await cp.getTicket(`${REPO}#1`)).readyPinHash).toBe(
+      hashJson(issue.body),
+    );
+
+    await cp.setLabels(`${REPO}#1`, { add: [AGENT_READY_LABEL] });
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "PATCH" &&
+          call.pathName === `repos/${REPO}/issues/comments/520`,
+      ),
+    ).toBe(true);
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "POST" &&
+          call.pathName === `repos/${REPO}/issues/1/comments`,
+      ),
+    ).toBe(false);
   });
 
   test("hasOpenPullRequest uses a bounded repository-scoped closing-reference lookup", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1351

Paginate GitHub issue comments so late operator replies and ready pins remain discoverable.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000` | pass | 95 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1896 pass, 10 skip |
| UX critique          | factory-ux-critic                | not run | backend-only change |

UX critique: skipped