### PR TITLE
fix(adapters): agy drains stderr and kills the process group (#1356)

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -8,11 +8,12 @@
  * `./input.json` → `./result.json` PROMPT_SUFFIX contract, cwd = workspace),
  * enforces the run spec's timeout with
  * TERM→KILL(killGraceMs), strips API keys so the CLI authenticates against the
- * session/subscription instead of per-token billing, and captures full stdout as
- * the `.transcript.json` artifact.
+ * session/subscription instead of per-token billing, captures full stdout as
+ * the `.transcript.json` artifact, and preserves a bounded stderr tail for
+ * failed runs.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream } from "node:fs";
+import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
@@ -67,6 +68,26 @@ export const HARNESS_LAYOUT = Object.freeze({
 
 export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
+const STDERR_FILE_CHARS = 16_384;
+
+/** Terminate a detached CLI and every subprocess it started (WM-263). */
+export function killProcessGroup(
+  child,
+  signal = "SIGTERM",
+  kill = process.kill,
+) {
+  const pid = child?.pid;
+  if (!pid) return;
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
 
 /**
  * How much sooner agy's own print-mode wait expires than the worker's timeout.
@@ -393,6 +414,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
+      detached: true,
     });
 
     const transcript = createWriteStream(
@@ -408,6 +430,14 @@ export async function execute({
     });
     if (child.stdout) {
       child.stdout.pipe(transcript);
+    }
+
+    let stderrBuf = "";
+    if (child.stderr) {
+      child.stderr.setEncoding("utf8");
+      child.stderr.on("data", (chunk) => {
+        stderrBuf = (stderrBuf + chunk).slice(-STDERR_FILE_CHARS);
+      });
     }
 
     let finalUsage = null;
@@ -451,30 +481,61 @@ export async function execute({
 
     let timedOut = false;
     let timer = null;
+    let killTimer = null;
+    const terminate = () => {
+      killProcessGroup(child, "SIGTERM");
+      if (!killTimer) {
+        killTimer = setTimeout(
+          () => killProcessGroup(child, "SIGKILL"),
+          killGraceMs,
+        );
+        killTimer.unref?.();
+      }
+    };
     if (timeoutMs) {
       timer = setTimeout(() => {
         timedOut = true;
-        child.kill("SIGTERM");
-        setTimeout(() => child.kill("SIGKILL"), killGraceMs).unref();
+        terminate();
       }, timeoutMs);
     }
 
-    const cancel = () => {
-      child.kill("SIGTERM");
-      setTimeout(() => child.kill("SIGKILL"), killGraceMs).unref();
-    };
+    const cancel = () => terminate();
     abortSignal?.addEventListener("abort", cancel, { once: true });
     signal?.addEventListener("abort", cancel, { once: true });
 
     child.on("close", async (exitCode) => {
       if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
       abortSignal?.removeEventListener("abort", cancel);
       signal?.removeEventListener("abort", cancel);
       await transcriptClosed;
+      if (exitCode !== 0 && stderrBuf) {
+        try {
+          writeFileSync(
+            path.join(workspaceDir, ".stderr.txt"),
+            stderrBuf,
+            "utf8",
+          );
+        } catch {
+          // workspace may already be gone; trace still carries the tail
+        }
+        try {
+          onTrace?.("lifecycle", {
+            note: "adapter_stderr",
+            text: clip(stderrBuf),
+          });
+        } catch {
+          // observability
+        }
+      }
       resolve({ exitCode, timedOut, usage: finalUsage });
     });
 
     child.on("error", (err) => {
+      if (timer) clearTimeout(timer);
+      if (killTimer) clearTimeout(killTimer);
+      abortSignal?.removeEventListener("abort", cancel);
+      signal?.removeEventListener("abort", cancel);
       transcript.destroy();
       reject(err);
     });

--- a/event-runtime/lib/adapters/agy.test.mjs
+++ b/event-runtime/lib/adapters/agy.test.mjs
@@ -429,14 +429,14 @@ describe("execute with fake binary", () => {
   });
 
   /** Fake agy emitting the line shapes captured from the real CLI (WM-435). */
-  function writeFakeAgy(binDir, lines) {
+  function writeFakeAgy(binDir, lines, beforeOutput = "") {
     const fakeAgy = path.join(binDir, "agy");
     const body = lines
       .map((l) => `echo ${JSON.stringify(JSON.stringify(l))}`)
       .join("\n");
     writeFileSync(
       fakeAgy,
-      `#!/usr/bin/env bash\nif [[ -n "\${FACTORY_TEST_ARGV_FILE:-}" ]]; then printf '%s\\n' "$@" > "$FACTORY_TEST_ARGV_FILE"; fi\n${body}\n`,
+      `#!/usr/bin/env bash\nif [[ -n "\${FACTORY_TEST_ARGV_FILE:-}" ]]; then printf '%s\\n' "$@" > "$FACTORY_TEST_ARGV_FILE"; fi\n${beforeOutput}\n${body}\n`,
       { mode: 0o755 },
     );
     return fakeAgy;
@@ -596,6 +596,104 @@ describe("execute with fake binary", () => {
     // swallow the terminal result's events too.
     expect(attempted).toEqual(["tool_use", "assistant_text", "usage"]);
   });
+
+  test("drains more than a pipe buffer from stderr without timing out", async () => {
+    tmp = tmpDir("agy-test-");
+    const binDir = path.join(tmp, "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFakeAgy(
+      binDir,
+      [
+        {
+          event: "result",
+          result: {
+            status: "SUCCESS",
+            response: "done",
+            duration_seconds: 0,
+            num_turns: 1,
+            usage: {},
+          },
+        },
+      ],
+      "head -c 70000 /dev/zero | tr '\\0' x >&2",
+    );
+
+    const res = await execute({
+      spec: {},
+      def: { promptText: "Do task" },
+      workspaceDir: tmp,
+      timeoutMs: 2_000,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+    });
+
+    expect(res).toMatchObject({ exitCode: 0, timedOut: false });
+  }, 5_000);
+
+  test("surfaces a bounded stderr tail in the failure trace", async () => {
+    tmp = tmpDir("agy-test-");
+    const binDir = path.join(tmp, "bin");
+    mkdirSync(binDir, { recursive: true });
+    writeFakeAgy(
+      binDir,
+      [],
+      "head -c 20000 /dev/zero | tr '\\0' x >&2; echo final-stderr >&2; exit 1",
+    );
+
+    const traces = [];
+    const res = await execute({
+      spec: {},
+      def: { promptText: "Do task" },
+      workspaceDir: tmp,
+      env: { PATH: `${binDir}:${process.env.PATH}` },
+      onTrace: (kind, payload) => traces.push({ kind, payload }),
+    });
+
+    expect(res.exitCode).toBe(1);
+    const stderr = readFileSync(path.join(tmp, ".stderr.txt"), "utf8");
+    expect(stderr.length).toBe(16_384);
+    expect(stderr).toEndWith("final-stderr\n");
+    expect(traces).toContainEqual({
+      kind: "lifecycle",
+      payload: { note: "adapter_stderr", text: expect.any(String) },
+    });
+  });
+
+  test("timeout kills the detached process group without orphaning a grandchild", async () => {
+    tmp = tmpDir("agy-test-");
+    const binDir = path.join(tmp, "bin");
+    const pidFile = path.join(tmp, "grandchild.pid");
+    mkdirSync(binDir, { recursive: true });
+    writeFakeAgy(
+      binDir,
+      [],
+      'sleep 30 & echo $! > "$FACTORY_TEST_PID_FILE"; wait',
+    );
+
+    const outcome = await execute({
+      spec: {},
+      def: { promptText: "Do task" },
+      workspaceDir: tmp,
+      timeoutMs: 200,
+      killGraceMs: 200,
+      env: {
+        PATH: `${binDir}:${process.env.PATH}`,
+        FACTORY_TEST_PID_FILE: pidFile,
+      },
+    });
+    expect(outcome.timedOut).toBe(true);
+
+    // Give the kernel a brief moment to reap the signalled process group.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(existsSync(pidFile)).toBe(true);
+    const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
+    let alive = true;
+    try {
+      process.kill(grandchildPid, 0);
+    } catch {
+      alive = false;
+    }
+    expect(alive).toBe(false);
+  }, 10_000);
 });
 
 describe("FACTORY_ROOT injection (WM-433 parity with pi)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1356

`agy.mjs` now spawns the CLI `detached: true` and terminates it via a `killProcessGroup(child, signal)` helper (SIGTERM, then SIGKILL after `killGraceMs`) on timeout and on abort; the SIGKILL timer is cleared on `close`/`error`. `child.stderr` is drained into a bounded tail (`STDERR_FILE_CHARS`, same style as `cursor.mjs`) which is written to `.stderr.txt` and emitted as an `adapter_stderr` lifecycle trace on non-zero exit, so a chatty child can no longer block at the 64 KiB pipe limit or grow memory unbounded.

Tests (fake-binary harness): >64 KiB stderr exits 0 within the timeout; bounded tail surfaced on failure; a grandchild recorded in a pid file is dead after a timeout outcome resolves.

## Handoff
- Verification: `bun test event-runtime/lib/adapters/agy.test.mjs --timeout 20000` — pass, 27 tests, 0 failures (re-run on branch merged with current `origin/develop`)
- Repo gate: `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` — pass (1907 pass, 0 fail)
- Files: 2 changed, all within Owned Paths
- UX critique: skipped — backend adapter change, no user-facing surface
- Note: the dispatch run's handoff verification failed on a harness-side check and its tier-escalation continuation was refused; finished manually from the retained branch.
