### PR TITLE
perf(web): share visibility-aware useNow ticker

### DIFF
--- a/event-runtime/web/src/hooks.test.tsx
+++ b/event-runtime/web/src/hooks.test.tsx
@@ -1,8 +1,8 @@
 import "./test-dom";
-import { afterEach, describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, jest, test } from "bun:test";
 import { act, cleanup, render } from "@testing-library/react";
 import { useState } from "react";
-import { CONTEXT_TABS_ATTR, useTabKeys } from "./hooks";
+import { CONTEXT_TABS_ATTR, useNow, useTabKeys } from "./hooks";
 
 const VIEW_TABS = ["queued", "running"] as const;
 
@@ -59,6 +59,88 @@ describe("useTabKeys", () => {
       expect(scrolled).not.toContain(r.getByRole("tab", { name: "All" }));
     } finally {
       HTMLElement.prototype.scrollIntoView = original;
+    }
+  });
+});
+
+function NowProbe() {
+  return <output data-testid="now">{useNow()}</output>;
+}
+
+describe("useNow", () => {
+  test("shares one ticker across consumers", () => {
+    jest.useFakeTimers();
+    const setIntervalSpy = jest.spyOn(globalThis, "setInterval");
+
+    try {
+      render(
+        <>
+          <NowProbe />
+          <NowProbe />
+          <NowProbe />
+        </>,
+      );
+
+      expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      cleanup();
+      jest.restoreAllMocks();
+      jest.useRealTimers();
+    }
+  });
+
+  test("pauses while hidden and ticks immediately when visible again", () => {
+    const originalHidden = Object.getOwnPropertyDescriptor(document, "hidden");
+    const originalVisibility = Object.getOwnPropertyDescriptor(
+      document,
+      "visibilityState",
+    );
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-30T00:00:00.000Z"));
+
+    try {
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      const r = render(<NowProbe />);
+      const beforeHidden = r.getByTestId("now").textContent;
+
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: true,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "hidden",
+      });
+      act(() => document.dispatchEvent(new Event("visibilitychange")));
+      act(() => jest.advanceTimersByTime(1_000));
+      expect(r.getByTestId("now").textContent).toBe(beforeHidden);
+
+      Object.defineProperty(document, "hidden", {
+        configurable: true,
+        value: false,
+      });
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        value: "visible",
+      });
+      act(() => document.dispatchEvent(new Event("visibilitychange")));
+      expect(r.getByTestId("now").textContent).not.toBe(beforeHidden);
+    } finally {
+      cleanup();
+      if (originalHidden)
+        Object.defineProperty(document, "hidden", originalHidden);
+      else Reflect.deleteProperty(document, "hidden");
+      if (originalVisibility)
+        Object.defineProperty(document, "visibilityState", originalVisibility);
+      else Reflect.deleteProperty(document, "visibilityState");
+      jest.useRealTimers();
     }
   });
 });

--- a/event-runtime/web/src/hooks.ts
+++ b/event-runtime/web/src/hooks.ts
@@ -1,4 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from "react";
 import { api } from "./api";
 import { notify } from "./components/ui";
 import { goPrefixActive } from "./goSequence";
@@ -367,14 +373,59 @@ export function useTheme(): [Theme, () => void] {
   return [theme, cycle];
 }
 
-/** Ticks every second — drives TTL countdowns and relative timestamps. */
+/** One clock subscription drives every TTL countdown and relative timestamp. */
+let now = Date.now();
+let nowTimer: ReturnType<typeof setInterval> | null = null;
+const nowListeners = new Set<() => void>();
+
+function tickNow() {
+  now = Date.now();
+  nowListeners.forEach((listener) => listener());
+}
+
+function pauseNowTicker() {
+  if (nowTimer === null) return;
+  clearInterval(nowTimer);
+  nowTimer = null;
+}
+
+function startNowTicker() {
+  if (nowTimer !== null || document.hidden) return;
+  nowTimer = setInterval(tickNow, 1_000);
+}
+
+function onNowVisibilityChange() {
+  if (document.hidden) {
+    pauseNowTicker();
+    return;
+  }
+  tickNow();
+  startNowTicker();
+}
+
+function subscribeToNow(listener: () => void) {
+  nowListeners.add(listener);
+  if (nowListeners.size === 1) {
+    document.addEventListener("visibilitychange", onNowVisibilityChange);
+    tickNow();
+    startNowTicker();
+  }
+  return () => {
+    nowListeners.delete(listener);
+    if (nowListeners.size === 0) {
+      pauseNowTicker();
+      document.removeEventListener("visibilitychange", onNowVisibilityChange);
+    }
+  };
+}
+
+/** Ticks every second while visible — shared across all consumers. */
 export function useNow(): number {
-  const [now, setNow] = useState(Date.now());
-  useEffect(() => {
-    const t = setInterval(() => setNow(Date.now()), 1000);
-    return () => clearInterval(t);
-  }, []);
-  return now;
+  return useSyncExternalStore(
+    subscribeToNow,
+    () => now,
+    () => now,
+  );
 }
 
 /**


### PR DESCRIPTION
Fixes watt-mind/factory#1354

Review the shared visibility-aware useNow ticker and its regression coverage.

## Validation

| Check                | Command                                                        | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/hooks.test.tsx src/hooks.test.ts` | pass    | 19 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1895 tests passed; generated clean |
| UX critique          | factory-ux-critic                                              | not run | no user-facing flow changed        |

UX critique: skipped — no user-facing flow changed