### PR TITLE
test(adapters): poll for process group exit (WM-1357)

### DIFF
--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -39,6 +39,22 @@ async function waitForPidExit(pid, { timeoutMs, stepMs }) {
   throw new Error(`pid ${pid} did not exit within ${timeoutMs}ms`);
 }
 
+// The grandchild pid file must APPEAR before the group is torn down; a test
+// that skips the liveness assertion because the file never showed up would
+// pass vacuously. Poll for it with a bounded deadline instead.
+async function waitForPidFile(pidFile, { timeoutMs, stepMs }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(pidFile)) {
+      const raw = readFileSync(pidFile, "utf8").trim();
+      const pid = parseInt(raw, 10);
+      if (Number.isInteger(pid) && pid > 0) return pid;
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+  throw new Error(`pid file ${pidFile} did not appear within ${timeoutMs}ms`);
+}
+
 describe("resolveTemplate", () => {
   test("substitutes placeholders inside argv elements", () => {
     expect(
@@ -353,18 +369,24 @@ writeFileSync("result.json", JSON.stringify({
     const pidFile = path.join(workspaceDir, "grandchild.pid");
     // sh spawns background sleep and writes its pid, then waits
     const script = `sh -c 'sleep 30 & echo $! > "${pidFile}"; wait'`;
-    const outcome = await execute({
+    const runPromise = execute({
       spec: spec({}),
       def: def(["sh", "-c", script]),
       workspaceDir,
-      timeoutMs: 200,
+      timeoutMs: 1000,
     });
-    expect(outcome.timedOut).toBe(true);
 
-    if (existsSync(pidFile)) {
-      const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
-      await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
-    }
+    // The grandchild must be running before the timeout fires, otherwise
+    // there is nothing for the group kill to prove.
+    const grandchildPid = await waitForPidFile(pidFile, {
+      timeoutMs: 800,
+      stepMs: 20,
+    });
+    expect(() => process.kill(grandchildPid, 0)).not.toThrow();
+
+    const outcome = await runPromise;
+    expect(outcome.timedOut).toBe(true);
+    await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
   }, 10_000);
 
   test("abortSignal terminates process group immediately (OPS-411)", async () => {
@@ -381,16 +403,17 @@ writeFileSync("result.json", JSON.stringify({
       abortSignal: ac.signal,
     });
 
-    // Abort after 200ms
-    setTimeout(() => ac.abort(), 200);
+    // Abort only once the grandchild is provably alive.
+    const grandchildPid = await waitForPidFile(pidFile, {
+      timeoutMs: 5000,
+      stepMs: 20,
+    });
+    expect(() => process.kill(grandchildPid, 0)).not.toThrow();
+    ac.abort();
 
     const outcome = await runPromise;
     expect(outcome.timedOut).toBe(false);
-
-    if (existsSync(pidFile)) {
-      const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
-      await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
-    }
+    await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
   }, 10_000);
 });
 

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -24,6 +24,21 @@ const spec = (input) => ({ input });
 const ws = () => tmpDir("evrt-cmd-");
 const REAPER_SCRIPT = path.join(FACTORY_ROOT, "orchestrator", "reaper.mjs");
 
+async function waitForPidExit(pid, { timeoutMs, stepMs }) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      process.kill(pid, 0);
+    } catch (error) {
+      if (error?.code === "ESRCH") return;
+      throw error;
+    }
+    await new Promise((resolve) => setTimeout(resolve, stepMs));
+  }
+
+  throw new Error(`pid ${pid} did not exit within ${timeoutMs}ms`);
+}
+
 describe("resolveTemplate", () => {
   test("substitutes placeholders inside argv elements", () => {
     expect(
@@ -346,18 +361,9 @@ writeFileSync("result.json", JSON.stringify({
     });
     expect(outcome.timedOut).toBe(true);
 
-    // Give the kernel a brief moment to finish reaping signals
-    await new Promise((r) => setTimeout(r, 100));
-
     if (existsSync(pidFile)) {
       const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
-      let alive = true;
-      try {
-        process.kill(grandchildPid, 0);
-      } catch {
-        alive = false;
-      }
-      expect(alive).toBe(false);
+      await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
     }
   }, 10_000);
 
@@ -381,16 +387,9 @@ writeFileSync("result.json", JSON.stringify({
     const outcome = await runPromise;
     expect(outcome.timedOut).toBe(false);
 
-    await new Promise((r) => setTimeout(r, 100));
     if (existsSync(pidFile)) {
       const grandchildPid = parseInt(readFileSync(pidFile, "utf8").trim(), 10);
-      let alive = true;
-      try {
-        process.kill(grandchildPid, 0);
-      } catch {
-        alive = false;
-      }
-      expect(alive).toBe(false);
+      await waitForPidExit(grandchildPid, { timeoutMs: 5000, stepMs: 50 });
     }
   }, 10_000);
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1357

Replace fixed process-reaping delays with a bounded PID-exit poll to eliminate loaded-runner flakes.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/command.test.mjs --timeout 20000` | pass | 24 pass, 2 skipped, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1926 pass, 10 skipped, clean emit and format |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

## Post-review

- Reviewer note applied: both OPS-411 tests now poll (bounded) for the grandchild pid file to APPEAR and assert the pid is alive before the timeout/abort tears the group down — the liveness assertion can no longer be skipped vacuously. Abort test aborts deterministically once the grandchild is alive instead of on a 200ms timer.
- Reconciled draft head `f65b2c2` vs reviewed `4b0230a`: `f65b2c2` is `4b0230a` rebased onto develop plus the same test change; its polling helper is kept (it is the intended fix), only the vacuous-pass gap was closed in `d5ba99b`.

## Handoff

- Local: `bun test event-runtime/lib/adapters/command.test.mjs --timeout 20000` run 5x with `bun test event-runtime/lib` running concurrently as load: 5/5 x 24 pass, 0 fail (both before and after the pid-file polling change). The earlier "pid did not exit within timeout" handoff failure did not reproduce.
- `bun run format:check`: clean. `bun run check`: exit 0.
- Only `event-runtime/lib/adapters/command.test.mjs` changed.
