### PR TITLE
fix(handoff): surface state enrichment failures

### DIFF
--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -27,15 +27,25 @@ const LINEAR_TICKET = /^[A-Z][A-Z0-9]{1,9}-[1-9][0-9]{0,9}$/;
 const GITHUB_TICKET = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#[1-9][0-9]{0,9}$/;
 
 export class HandoffError extends Error {
-  constructor(code, message = code) {
-    super(message);
+  constructor(code, message = code, cause) {
+    super(message, cause === undefined ? undefined : { cause });
     this.name = "HandoffError";
     this.code = code;
   }
 }
 
-function fail(code, message) {
-  throw new HandoffError(code, message);
+export function fail(code, message, cause) {
+  throw new HandoffError(code, message, cause);
+}
+
+export function handoffErrorBody(err) {
+  const body = {
+    schemaVersion: "factory.handoff-error/v1",
+    error: err?.code ?? "handoff_failed",
+    message: String(err?.message ?? err),
+  };
+  if (err?.cause !== undefined) body.cause = String(err.cause);
+  return body;
 }
 
 export function createHandoffRequest({ requestId, repo, ticket }) {
@@ -283,6 +293,7 @@ export async function acceptHandoff(
   }
 
   let state = null;
+  const warnings = [];
   try {
     state = await runtimeState(
       fetchImpl,
@@ -295,6 +306,9 @@ export async function acceptHandoff(
     // A duplicate must be bound to its original request, so lookup failures
     // fail closed instead of returning a misleading retry receipt.
     if (admission.duplicate) throw err;
+    const warning = `state_unavailable: ${String(err?.message ?? err)}`;
+    warnings.push(warning);
+    console.error(warning);
   }
   if (admission.duplicate) {
     if (!state?.event)
@@ -315,7 +329,7 @@ export async function acceptHandoff(
     duplicate: admission.duplicate,
     event: {
       id: request.requestId,
-      state: state?.event?.status ?? "admitted",
+      state: state?.event?.status ?? "unknown",
     },
     proposal: state?.event?.proposalId
       ? { id: state.event.proposalId, state: state.proposalState }
@@ -323,6 +337,7 @@ export async function acceptHandoff(
     run: state?.event?.runId
       ? { id: state.event.runId, state: state.runState }
       : null,
+    ...(warnings.length > 0 ? { warnings } : {}),
     dashboardUrl,
   };
 }
@@ -488,11 +503,7 @@ async function main(argv = process.argv.slice(2)) {
 
 if (import.meta.main) {
   main().catch((err) => {
-    const body = {
-      schemaVersion: "factory.handoff-error/v1",
-      error: err?.code ?? "handoff_failed",
-      message: String(err?.message ?? err),
-    };
+    const body = handoffErrorBody(err);
     // Forced-command clients need one machine-readable failure. No environment
     // values (especially the signing secret) are projected into this object.
     process.stdout.write(`${JSON.stringify(body)}\n`);

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -6,6 +6,8 @@ import {
   acceptHandoff,
   assertForcedCommandEnvironment,
   createHandoffRequest,
+  fail,
+  handoffErrorBody,
   resolveHandoffRepo,
   sendHandoff,
   validateHandoffRequest,
@@ -258,6 +260,39 @@ describe("forced-command accept server", () => {
     expect(receipt.run).toEqual({ id: "run-old", state: "QUEUED" });
   });
 
+  test("warns when fresh-admission state lookup fails instead of claiming admitted state", async () => {
+    const lookupFailure = new Error("connect ECONNREFUSED 127.0.0.1:7381");
+    const stderr = [];
+    const fetchImpl = async (_url, options = {}) => {
+      if (options.method === "POST") {
+        return Response.json({
+          admitted: true,
+          duplicate: false,
+          eventId: REQUEST.requestId,
+        });
+      }
+      throw lookupFailure;
+    };
+    const originalError = console.error;
+    console.error = (line) => stderr.push(line);
+    let receipt;
+    try {
+      receipt = await acceptHandoff(JSON.stringify(REQUEST), {
+        repos,
+        secret: "secret",
+        fetchImpl,
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(receipt.event).toEqual({ id: REQUEST.requestId, state: "unknown" });
+    expect(receipt.warnings).toEqual([
+      "state_unavailable: connect ECONNREFUSED 127.0.0.1:7381",
+    ]);
+    expect(stderr).toEqual(receipt.warnings);
+  });
+
   test("rejects request-id reuse for a different ticket", async () => {
     const fetchImpl = async (url, options = {}) => {
       if (options.method === "POST") {
@@ -307,6 +342,21 @@ describe("forced-command accept server", () => {
     await expect(
       acceptHandoff(JSON.stringify(REQUEST), { repos, secret: null }),
     ).rejects.toThrow(/FACTORY_EVENT_SECRET/);
+  });
+
+  test("preserves a fail cause in the forced-command error body", () => {
+    const cause = new Error("HTTP 503 runtime unavailable");
+    try {
+      fail("runtime_status_failed", "runtime status lookup failed", cause);
+      expect.unreachable();
+    } catch (err) {
+      expect(handoffErrorBody(err)).toEqual({
+        schemaVersion: "factory.handoff-error/v1",
+        error: "runtime_status_failed",
+        message: "runtime status lookup failed",
+        cause: "Error: HTTP 503 runtime unavailable",
+      });
+    }
   });
 
   test("rejects a caller-supplied SSH original command", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1365

Review that fresh-admission lookup failures remain visible without leaking environment values.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test tools/handoff.test.mjs --timeout 20000`                                | pass    | 14 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1914 tests, 0 failures; clean      |
| UX critique          | factory-ux-critic                                                               | not run | no user-facing surface             |

UX critique: skipped
