### PR TITLE
fix(tools): standardize CLI usage exits

### DIFF
--- a/tools/launch-numbers.mjs
+++ b/tools/launch-numbers.mjs
@@ -29,6 +29,9 @@ import { LOG_DIR } from "../lib/transcript.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 
 export const DEFAULT_SINCE = "2026-08-03T00:00:00.000Z";
+export const USAGE = `usage: bun tools/launch-numbers.mjs [--json] [--since YYYY-MM-DD]`;
+
+class UsageError extends Error {}
 
 export const DISPATCH_LABELS = new Set([
   "ai:in-progress",
@@ -389,19 +392,39 @@ export async function buildLaunchNumbers({
   };
 }
 
-function parseArgv(argv) {
-  const val = (f) => {
-    const i = argv.indexOf(f);
-    return i === -1 ? null : argv[i + 1];
-  };
-  return {
-    json: argv.includes("--json"),
-    since: val("--since") ?? DEFAULT_SINCE,
-  };
+export function parseArgv(argv) {
+  const flags = { json: false, since: DEFAULT_SINCE };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--help") {
+      if (argv.length !== 1) throw new UsageError(USAGE);
+      return { help: true };
+    }
+    if (arg === "--json" && !flags.json) {
+      flags.json = true;
+      continue;
+    }
+    if (arg === "--since" && flags.since === DEFAULT_SINCE) {
+      const since = argv[++i];
+      if (!since || since.startsWith("--")) throw new UsageError(USAGE);
+      try {
+        flags.since = parseSince(since).iso;
+      } catch {
+        throw new UsageError(USAGE);
+      }
+      continue;
+    }
+    throw new UsageError(USAGE);
+  }
+  return flags;
 }
 
 async function main(argv = process.argv.slice(2)) {
   const flags = parseArgv(argv);
+  if (flags.help) {
+    console.log(USAGE);
+    return 0;
+  }
   const { metrics, transcripts } = await buildLaunchNumbers({
     since: flags.since,
   });
@@ -417,5 +440,15 @@ async function main(argv = process.argv.slice(2)) {
 }
 
 if (import.meta.main) {
-  process.exitCode = await main();
+  try {
+    process.exitCode = await main();
+  } catch (error) {
+    if (error instanceof UsageError) {
+      console.error(error.message);
+      process.exitCode = 2;
+    } else {
+      console.error(`launch-numbers: ${error.message}`);
+      process.exitCode = 1;
+    }
+  }
 }

--- a/tools/launch-numbers.test.mjs
+++ b/tools/launch-numbers.test.mjs
@@ -21,6 +21,35 @@ import {
   weeksUnattended,
 } from "./launch-numbers.mjs";
 
+const ROOT = path.resolve(import.meta.dir, "..");
+
+function runTool(name, args = []) {
+  return Bun.spawnSync({
+    cmd: [process.execPath, path.join(ROOT, "tools", name), ...args],
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function output(proc, stream) {
+  return proc[stream]?.toString().trim() ?? "";
+}
+
+test("launch-numbers help prints usage and argument errors exit 2", () => {
+  const help = runTool("launch-numbers.mjs", ["--help"]);
+  expect(help.exitCode).toBe(0);
+  expect(output(help, "stdout")).toStartWith("usage:");
+  expect(output(help, "stderr")).toBe("");
+
+  for (const args of [["--unknown"], ["--since"]]) {
+    const invalid = runTool("launch-numbers.mjs", args);
+    expect(invalid.exitCode).toBe(2);
+    expect(output(invalid, "stderr").split("\n")).toHaveLength(1);
+    expect(output(invalid, "stderr")).toStartWith("usage:");
+  }
+});
+
 const issue = (over = {}) => ({
   identifier: "WM-1",
   createdAt: "2026-08-04T10:00:00.000Z",

--- a/tools/publish.mjs
+++ b/tools/publish.mjs
@@ -26,6 +26,9 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+export const USAGE = "usage: bun tools/publish.mjs --dry-run";
+
+class UsageError extends Error {}
 
 const SEMVER_RE = /^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?(\+[0-9A-Za-z.-]+)?$/;
 
@@ -41,13 +44,10 @@ const DENYLIST_PATTERNS = [
   /(^|\/)test-support\//,
 ];
 
-function usage() {
-  return "usage: bun tools/publish.mjs --dry-run";
-}
-
 export function parseArgs(args) {
+  if (args.length === 1 && args[0] === "--help") return { help: true };
   if (args.length === 1 && args[0] === "--dry-run") return { dryRun: true };
-  throw new Error(usage());
+  throw new UsageError(USAGE);
 }
 
 export function validatePackage(dir = ROOT) {
@@ -114,7 +114,8 @@ export function assertNoLeaks(report) {
 }
 
 export function run(args = process.argv.slice(2), { log = console.log } = {}) {
-  parseArgs(args);
+  const parsed = parseArgs(args);
+  if (parsed.help) return { help: true };
   const { manifest } = validatePackage();
   const report = dryRunPackage();
   const { item, files } = assertNoLeaks(report);
@@ -129,9 +130,15 @@ export function run(args = process.argv.slice(2), { log = console.log } = {}) {
 
 if (import.meta.main) {
   try {
-    run();
+    const result = run();
+    if (result.help) console.log(USAGE);
   } catch (error) {
-    console.error(`publish: ${error.message}`);
-    process.exit(1);
+    if (error instanceof UsageError) {
+      console.error(error.message);
+      process.exitCode = 2;
+    } else {
+      console.error(`publish: ${error.message}`);
+      process.exitCode = 1;
+    }
   }
 }

--- a/tools/publish.test.mjs
+++ b/tools/publish.test.mjs
@@ -1,0 +1,31 @@
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+function run(args) {
+  return Bun.spawnSync({
+    cmd: [process.execPath, path.join(ROOT, "tools", "publish.mjs"), ...args],
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function output(proc, stream) {
+  return proc[stream]?.toString().trim() ?? "";
+}
+
+test("publish help prints usage and invalid arguments exit 2", () => {
+  const help = run(["--help"]);
+  expect(help.exitCode).toBe(0);
+  expect(output(help, "stdout")).toStartWith("usage:");
+  expect(output(help, "stderr")).toBe("");
+
+  for (const args of [[], ["--unknown"]]) {
+    const invalid = run(args);
+    expect(invalid.exitCode).toBe(2);
+    expect(output(invalid, "stderr").split("\n")).toHaveLength(1);
+    expect(output(invalid, "stderr")).toStartWith("usage:");
+  }
+});

--- a/tools/security-env.mjs
+++ b/tools/security-env.mjs
@@ -17,40 +17,84 @@ import { homedir } from "node:os";
 import path from "node:path";
 import { loadConfigYaml } from "../lib/schedule.mjs";
 
-const cfg = loadConfigYaml("repos");
+export const USAGE = "usage: bun tools/security-env.mjs [PATH]";
 
-const target = realpathSync(process.argv[2] || process.cwd());
-const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
+class UsageError extends Error {}
 
-// Worktrees live outside the configured path, so also match by origin remote
-// (normalized to owner/repo).
-const remote = (() => {
-  const r = Bun.spawnSync(["git", "-C", target, "remote", "get-url", "origin"]);
-  if (r.exitCode !== 0) return null;
-  const m = r.stdout
-    .toString()
-    .trim()
-    .match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?$/);
-  return m ? m[1] : null;
-})();
+export function parseArgs(argv) {
+  if (argv.length === 1 && argv[0] === "--help") return { help: true };
+  if (argv.length > 1 || argv[0]?.startsWith("-")) throw new UsageError(USAGE);
+  return { path: argv[0] ?? process.cwd() };
+}
 
-for (const repo of cfg.repos || []) {
-  let byPath = false;
-  try {
-    const repoPath = expand(repo.path);
-    byPath = target === repoPath || target.startsWith(repoPath + path.sep);
-  } catch {
-    /* intentionally ignored */
+export function run(argv = process.argv.slice(2)) {
+  const args = parseArgs(argv);
+  if (args.help) {
+    console.log(USAGE);
+    return;
   }
-  if (!byPath && !(remote && repo.github === remote)) continue;
-  const sec = repo.security || {};
-  if (sec.semgrep_args)
-    console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
-  if (sec.gitleaks_args)
-    console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
-  if (sec.python_version)
-    console.log(
-      `export PYTHON_VERSION=${JSON.stringify(String(sec.python_version))}`,
-    );
-  break;
+
+  let target;
+  try {
+    target = realpathSync(args.path);
+  } catch {
+    throw new UsageError(USAGE);
+  }
+
+  const cfg = loadConfigYaml("repos");
+  const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
+
+  // Worktrees live outside the configured path, so also match by origin remote
+  // (normalized to owner/repo).
+  const remote = (() => {
+    const r = Bun.spawnSync([
+      "git",
+      "-C",
+      target,
+      "remote",
+      "get-url",
+      "origin",
+    ]);
+    if (r.exitCode !== 0) return null;
+    const m = r.stdout
+      .toString()
+      .trim()
+      .match(/[:/]([^/:]+\/[^/:]+?)(?:\.git)?$/);
+    return m ? m[1] : null;
+  })();
+
+  for (const repo of cfg.repos || []) {
+    let byPath = false;
+    try {
+      const repoPath = expand(repo.path);
+      byPath = target === repoPath || target.startsWith(repoPath + path.sep);
+    } catch {
+      /* intentionally ignored */
+    }
+    if (!byPath && !(remote && repo.github === remote)) continue;
+    const sec = repo.security || {};
+    if (sec.semgrep_args)
+      console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
+    if (sec.gitleaks_args)
+      console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
+    if (sec.python_version)
+      console.log(
+        `export PYTHON_VERSION=${JSON.stringify(String(sec.python_version))}`,
+      );
+    break;
+  }
+}
+
+if (import.meta.main) {
+  try {
+    run();
+  } catch (error) {
+    if (error instanceof UsageError) {
+      console.error(error.message);
+      process.exitCode = 2;
+    } else {
+      console.error(`security-env: ${error.message}`);
+      process.exitCode = 1;
+    }
+  }
 }

--- a/tools/security-env.test.mjs
+++ b/tools/security-env.test.mjs
@@ -5,7 +5,11 @@ const ROOT = path.resolve(import.meta.dir, "..");
 
 function run(args) {
   return Bun.spawnSync({
-    cmd: [process.execPath, path.join(ROOT, "tools", "security-env.mjs"), ...args],
+    cmd: [
+      process.execPath,
+      path.join(ROOT, "tools", "security-env.mjs"),
+      ...args,
+    ],
     cwd: ROOT,
     stdout: "pipe",
     stderr: "pipe",

--- a/tools/security-env.test.mjs
+++ b/tools/security-env.test.mjs
@@ -1,0 +1,32 @@
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+function run(args) {
+  return Bun.spawnSync({
+    cmd: [process.execPath, path.join(ROOT, "tools", "security-env.mjs"), ...args],
+    cwd: ROOT,
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+}
+
+function output(proc, stream) {
+  return proc[stream]?.toString().trim() ?? "";
+}
+
+test("security-env help prints usage and invalid arguments exit 2 without stacks", () => {
+  const help = run(["--help"]);
+  expect(help.exitCode).toBe(0);
+  expect(output(help, "stdout")).toStartWith("usage:");
+  expect(output(help, "stderr")).toBe("");
+
+  for (const args of [["--unknown"], ["/definitely/not/a/repository"]]) {
+    const invalid = run(args);
+    expect(invalid.exitCode).toBe(2);
+    expect(output(invalid, "stderr").split("\n")).toHaveLength(1);
+    expect(output(invalid, "stderr")).toStartWith("usage:");
+    expect(output(invalid, "stderr")).not.toContain("ENOENT");
+  }
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1364

Standardize help and usage-error behavior for the three Factory tool CLIs.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test tools/security-env.test.mjs tools/launch-numbers.test.mjs tools/publish.test.mjs --timeout 20000` | pass    | 16 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1914 passed, 10 skipped; formatted |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface             |

UX critique: skipped — backend CLI maintenance with no user-facing surface
