### PR TITLE
fix(control-plane): bound gh retries and timeouts

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -254,7 +254,7 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
   const {
     env = process.env,
     resolveToken = readCachedAppToken,
-    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+    sleep = defaultSleep,
   } = options;
   let warnedAppAuth = false;
   const spawn = (cmd, args, opts, { allowApp = true } = {}) => {
@@ -358,7 +358,7 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
  * @param {string} cmd
  * @param {string[]} args
  * @param {{ env?: NodeJS.ProcessEnv, input?: string, timeoutMs?: number }} [opts]
- * @param {{ spawnImpl?: typeof import("node:child_process").spawn, setTimeoutImpl?: typeof setTimeout, clearTimeoutImpl?: typeof clearTimeout, killGraceMs?: number }} [runtime]
+ * @param {{ spawnImpl?: typeof import("node:child_process").spawn, setTimeoutImpl?: typeof setTimeout, clearTimeoutImpl?: typeof clearTimeout, killGraceMs?: number, killImpl?: typeof process.kill }} [runtime]
  * @returns {Promise<{status: number|null, stdout: string, stderr: string, error: Error|null}>}
  */
 export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
@@ -368,8 +368,16 @@ export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
     setTimeoutImpl = setTimeout,
     clearTimeoutImpl = clearTimeout,
     killGraceMs = 1_000,
+    killImpl = process.kill,
   } = runtime;
-  const timeoutMs = validTimeout(opts.timeoutMs ?? env?.FACTORY_GH_TIMEOUT_MS);
+  // The child env is only materialised in App-token mode; in PAT mode `gh`
+  // inherits the ambient environment, so the operator's FACTORY_GH_TIMEOUT_MS
+  // must be honoured from process.env as well.
+  const timeoutMs = validTimeout(
+    opts.timeoutMs ??
+      env?.FACTORY_GH_TIMEOUT_MS ??
+      process.env.FACTORY_GH_TIMEOUT_MS,
+  );
   return new Promise((resolve) => {
     let settled = false;
     let timeoutTimer;
@@ -382,8 +390,11 @@ export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
     };
     let child;
     try {
+      // `detached` puts gh in its own process group so a timeout kill also
+      // reaches any helper it spawned (pager, credential helper, browser).
       child = spawnImpl(cmd, args, {
         stdio: ["pipe", "pipe", "pipe"],
+        detached: process.platform !== "win32",
         ...(env ? { env } : {}),
       });
     } catch (error) {
@@ -412,18 +423,11 @@ export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
     });
     timeoutTimer = setTimeoutImpl(() => {
       const error = new Error(`gh timed out after ${timeoutMs}ms`);
-      try {
-        child.kill("SIGTERM");
-      } catch {
-        // The process may have exited in the narrow window before this timer.
-      }
-      killTimer = setTimeoutImpl(() => {
-        try {
-          child.kill("SIGKILL");
-        } catch {
-          // A process that exited after SIGTERM needs no further handling.
-        }
-      }, killGraceMs);
+      killProcessGroup(child, "SIGTERM", killImpl);
+      killTimer = setTimeoutImpl(
+        () => killProcessGroup(child, "SIGKILL", killImpl),
+        killGraceMs,
+      );
       // Do not keep the control-plane process alive solely for a stuck child.
       killTimer?.unref?.();
       finish({ status: null, stdout, stderr, error });
@@ -438,18 +442,47 @@ export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
   });
 }
 
+/**
+ * Signal the whole process group `gh` was started in (mirrors
+ * event-runtime/lib/adapters/cursor.mjs). Falls back to the child alone when
+ * the group is already gone (ESRCH) or the platform has no groups.
+ */
+function killProcessGroup(child, signal, kill = process.kill) {
+  const pid = child?.pid;
+  if (!pid) {
+    try {
+      child?.kill?.(signal);
+    } catch {
+      // already terminated
+    }
+    return;
+  }
+  try {
+    kill(-pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
 function validTimeout(value) {
   const parsed = Number(value);
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 60_000;
 }
 
 function ghResponse(stdout) {
-  const match = /^HTTP\/[^\r\n]+\r?\n([\s\S]*?)\r?\n\r?\n([\s\S]*)$/.exec(
-    stdout,
-  );
-  if (!match) return { body: stdout, headers: {} };
+  // Status line, zero or more header lines, a blank line, then the body.
+  const match =
+    /^HTTP\/\S+(?:\s+(\d{3}))?[^\r\n]*\r?\n((?:[^\r\n]+\r?\n)*)\r?\n([\s\S]*)$/.exec(
+      stdout,
+    );
+  if (!match) return { body: stdout, headers: {}, httpStatus: null };
+  const httpStatus = match[1] ? Number(match[1]) : null;
   const headers = Object.fromEntries(
-    match[1]
+    match[2]
       .split(/\r?\n/)
       .map((line) => {
         const index = line.indexOf(":");
@@ -459,17 +492,37 @@ function ghResponse(stdout) {
       })
       .filter(Boolean),
   );
-  return { body: match[2], headers };
+  return { body: match[3], headers, httpStatus };
 }
 
-function retryDelayMs(retryAfter, attempt) {
-  const seconds = Number(retryAfter);
-  if (Number.isFinite(seconds) && seconds >= 0)
-    return Math.min(seconds * 1_000, 60_000);
-  return 2 ** (attempt + 1) * 1_000;
+const MAX_RETRY_DELAY_MS = 60_000;
+
+/**
+ * Back-off before the next `gh` attempt: `Retry-After` (seconds) wins, then
+ * `X-RateLimit-Reset` (epoch seconds; delay = reset - now, jittered so a
+ * fleet of callers does not stampede at the reset instant), else exponential.
+ * Every branch is capped at MAX_RETRY_DELAY_MS.
+ */
+function retryDelayMs(
+  headers,
+  attempt,
+  { now = Date.now, random = Math.random } = {},
+) {
+  const retryAfter = Number(headers?.["retry-after"]);
+  if (Number.isFinite(retryAfter) && retryAfter >= 0)
+    return Math.min(retryAfter * 1_000, MAX_RETRY_DELAY_MS);
+  const reset = Number(headers?.["x-ratelimit-reset"]);
+  if (Number.isFinite(reset) && reset > 0) {
+    const untilReset = Math.max(0, reset * 1_000 - now());
+    const jitter = Math.floor(random() * 1_000);
+    return Math.min(untilReset + jitter, MAX_RETRY_DELAY_MS);
+  }
+  return Math.min(2 ** (attempt + 1) * 1_000, MAX_RETRY_DELAY_MS);
 }
 
-async function ghJson(exec, args, input, { sleep } = {}) {
+const defaultSleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function ghJson(exec, args, input, { sleep = defaultSleep } = {}) {
   const command = args
     .filter((arg) => arg !== "--include")
     .slice(0, 2)
@@ -489,7 +542,10 @@ async function ghJson(exec, args, input, { sleep } = {}) {
       text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
     if (status !== 0) {
       let message = `gh ${command} failed (status ${status})`;
-      let apiStatus = status;
+      // The HTTP status line from `--include` is the fallback when the JSON
+      // body carries no `status` (GraphQL errors, some 429 bodies) so those
+      // still key rate-limit retries and named failures correctly.
+      let apiStatus = response.httpStatus ?? status;
       let secondaryRateLimit = false;
       try {
         const parsed = JSON.parse(stdout);
@@ -507,7 +563,7 @@ async function ghJson(exec, args, input, { sleep } = {}) {
         if (stderr) message = `${message}: ${stderr.trim()}`;
       }
       if (secondaryRateLimit && attempt < 2) {
-        await sleep(retryDelayMs(response.headers["retry-after"], attempt));
+        await sleep(retryDelayMs(response.headers, attempt));
         continue;
       }
       throw new ControlPlaneError(message, {

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -248,10 +248,14 @@ function cachedTokenFileToken(env) {
  * a log or error.
  *
  * @param {(cmd: string, args: string[], opts: object) => (object|Promise<object>)} exec
- * @param {{ env?: NodeJS.ProcessEnv, resolveToken?: (args: {env: NodeJS.ProcessEnv}) => (string|null) }} [options]
+ * @param {{ env?: NodeJS.ProcessEnv, resolveToken?: (args: {env: NodeJS.ProcessEnv}) => (string|null), sleep?: (ms: number) => Promise<void> }} [options]
  */
 export function makeGhApi(exec = ghSpawn, options = {}) {
-  const { env = process.env, resolveToken = readCachedAppToken } = options;
+  const {
+    env = process.env,
+    resolveToken = readCachedAppToken,
+    sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms)),
+  } = options;
   let warnedAppAuth = false;
   const spawn = (cmd, args, opts, { allowApp = true } = {}) => {
     let childEnv;
@@ -293,7 +297,9 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
     return exec(cmd, args, childEnv ? { ...opts, env: childEnv } : opts);
   };
   return function ghApi(method, pathName, { body, query } = {}) {
-    const args = ["api"];
+    // `--include` exposes Retry-After on secondary rate limits. ghJson strips
+    // the response envelope before parsing the JSON body.
+    const args = ["api", "--include"];
     const isGraphql =
       pathName === "graphql" || pathName === "/graphql" || method === "GRAPHQL";
     if (isGraphql) {
@@ -305,6 +311,7 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
           query: body?.query ?? body,
           variables: body?.variables ?? query ?? {},
         }),
+        { sleep },
       );
     }
     if (method && method !== "GET") args.push("-X", method);
@@ -326,12 +333,15 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
           spawn(cmd, childArgs, opts, { allowApp: !isUserIdentityRead }),
         args,
         JSON.stringify(body),
+        { sleep },
       );
     }
     return ghJson(
       (cmd, childArgs, opts) =>
         spawn(cmd, childArgs, opts, { allowApp: !isUserIdentityRead }),
       args,
+      undefined,
+      { sleep },
     );
   };
 }
@@ -347,21 +357,32 @@ export function makeGhApi(exec = ghSpawn, options = {}) {
  *
  * @param {string} cmd
  * @param {string[]} args
- * @param {{ env?: NodeJS.ProcessEnv, input?: string }} [opts]
+ * @param {{ env?: NodeJS.ProcessEnv, input?: string, timeoutMs?: number }} [opts]
+ * @param {{ spawnImpl?: typeof import("node:child_process").spawn, setTimeoutImpl?: typeof setTimeout, clearTimeoutImpl?: typeof clearTimeout, killGraceMs?: number }} [runtime]
  * @returns {Promise<{status: number|null, stdout: string, stderr: string, error: Error|null}>}
  */
-function ghSpawn(cmd, args, opts = {}) {
+export function ghSpawn(cmd, args, opts = {}, runtime = {}) {
   const { env, input } = opts;
+  const {
+    spawnImpl = spawnProcess,
+    setTimeoutImpl = setTimeout,
+    clearTimeoutImpl = clearTimeout,
+    killGraceMs = 1_000,
+  } = runtime;
+  const timeoutMs = validTimeout(opts.timeoutMs ?? env?.FACTORY_GH_TIMEOUT_MS);
   return new Promise((resolve) => {
     let settled = false;
+    let timeoutTimer;
+    let killTimer;
     const finish = (r) => {
       if (settled) return;
       settled = true;
+      if (timeoutTimer) clearTimeoutImpl(timeoutTimer);
       resolve(r);
     };
     let child;
     try {
-      child = spawnProcess(cmd, args, {
+      child = spawnImpl(cmd, args, {
         stdio: ["pipe", "pipe", "pipe"],
         ...(env ? { env } : {}),
       });
@@ -386,8 +407,28 @@ function ghSpawn(cmd, args, opts = {}) {
     // status is the exit code, or null when the process died on a signal —
     // exactly spawnSync's `status` semantics.
     child.on("close", (code) => {
+      if (killTimer) clearTimeoutImpl(killTimer);
       finish({ status: code, stdout, stderr, error: null });
     });
+    timeoutTimer = setTimeoutImpl(() => {
+      const error = new Error(`gh timed out after ${timeoutMs}ms`);
+      try {
+        child.kill("SIGTERM");
+      } catch {
+        // The process may have exited in the narrow window before this timer.
+      }
+      killTimer = setTimeoutImpl(() => {
+        try {
+          child.kill("SIGKILL");
+        } catch {
+          // A process that exited after SIGTERM needs no further handling.
+        }
+      }, killGraceMs);
+      // Do not keep the control-plane process alive solely for a stuck child.
+      killTimer?.unref?.();
+      finish({ status: null, stdout, stderr, error });
+    }, timeoutMs);
+    timeoutTimer?.unref?.();
     if (child.stdin) {
       // Never let a broken pipe (gh exiting before reading stdin) crash serve.
       child.stdin.on("error", () => {});
@@ -397,46 +438,92 @@ function ghSpawn(cmd, args, opts = {}) {
   });
 }
 
-async function ghJson(exec, args, input) {
-  const r =
-    (await exec("gh", args, {
-      encoding: "utf8",
-      stdio:
-        input != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
-      input: input != null ? input : undefined,
-    })) ?? {};
-  const status = r.status ?? r.exitCode ?? null;
-  const stdout = text(r.stdout);
-  const stderr =
-    text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
-  if (status !== 0) {
-    let message = `gh ${args.slice(0, 2).join(" ")} failed (status ${status})`;
-    let apiStatus = status;
-    try {
-      const parsed = JSON.parse(stdout);
-      if (parsed?.message) message = `github api: ${parsed.message}`;
-      // `gh` reports the HTTP status as a string ("401"); a raw REST error
-      // body may carry a number. Accept either — the claim path keys its
-      // named failures off this value.
-      const parsedStatus = Number(parsed?.status);
-      if (Number.isInteger(parsedStatus) && parsedStatus > 0)
-        apiStatus = parsedStatus;
-    } catch {
-      if (stderr) message = `${message}: ${stderr.trim()}`;
+function validTimeout(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : 60_000;
+}
+
+function ghResponse(stdout) {
+  const match = /^HTTP\/[^\r\n]+\r?\n([\s\S]*?)\r?\n\r?\n([\s\S]*)$/.exec(
+    stdout,
+  );
+  if (!match) return { body: stdout, headers: {} };
+  const headers = Object.fromEntries(
+    match[1]
+      .split(/\r?\n/)
+      .map((line) => {
+        const index = line.indexOf(":");
+        return index === -1
+          ? null
+          : [line.slice(0, index).toLowerCase(), line.slice(index + 1).trim()];
+      })
+      .filter(Boolean),
+  );
+  return { body: match[2], headers };
+}
+
+function retryDelayMs(retryAfter, attempt) {
+  const seconds = Number(retryAfter);
+  if (Number.isFinite(seconds) && seconds >= 0)
+    return Math.min(seconds * 1_000, 60_000);
+  return 2 ** (attempt + 1) * 1_000;
+}
+
+async function ghJson(exec, args, input, { sleep } = {}) {
+  const command = args
+    .filter((arg) => arg !== "--include")
+    .slice(0, 2)
+    .join(" ");
+  for (let attempt = 0; attempt <= 2; attempt += 1) {
+    const r =
+      (await exec("gh", args, {
+        encoding: "utf8",
+        stdio:
+          input != null ? ["pipe", "pipe", "pipe"] : ["ignore", "pipe", "pipe"],
+        input: input != null ? input : undefined,
+      })) ?? {};
+    const status = r.status ?? r.exitCode ?? null;
+    const response = ghResponse(text(r.stdout));
+    const stdout = response.body;
+    const stderr =
+      text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
+    if (status !== 0) {
+      let message = `gh ${command} failed (status ${status})`;
+      let apiStatus = status;
+      let secondaryRateLimit = false;
+      try {
+        const parsed = JSON.parse(stdout);
+        if (parsed?.message) message = `github api: ${parsed.message}`;
+        // `gh` reports the HTTP status as a string ("401"); a raw REST error
+        // body may carry a number. Accept either — the claim path keys its
+        // named failures off this value.
+        const parsedStatus = Number(parsed?.status);
+        if (Number.isInteger(parsedStatus) && parsedStatus > 0)
+          apiStatus = parsedStatus;
+        secondaryRateLimit =
+          apiStatus === 429 ||
+          (apiStatus === 403 && /secondary rate limit/i.test(parsed?.message));
+      } catch {
+        if (stderr) message = `${message}: ${stderr.trim()}`;
+      }
+      if (secondaryRateLimit && attempt < 2) {
+        await sleep(retryDelayMs(response.headers["retry-after"], attempt));
+        continue;
+      }
+      throw new ControlPlaneError(message, {
+        status: apiStatus,
+        cause: r.error,
+      });
     }
-    throw new ControlPlaneError(message, {
-      status: apiStatus,
-      cause: r.error,
-    });
-  }
-  if (!stdout.trim()) return {};
-  try {
-    return JSON.parse(stdout);
-  } catch (cause) {
-    throw new ControlPlaneError(
-      `gh ${args.slice(0, 2).join(" ")} returned invalid JSON`,
-      { status: 0, cause },
-    );
+    if (!stdout.trim()) return {};
+    try {
+      return JSON.parse(stdout);
+    } catch (cause) {
+      throw new ControlPlaneError(`gh ${command} returned invalid JSON`, {
+        status: 0,
+        cause,
+      });
+    }
   }
 }
 

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -2751,4 +2751,184 @@ describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () =>
     );
     expect(sleeps).toEqual([2000, 4000]);
   });
+
+  function fakeChild(pid) {
+    const child = new EventEmitter();
+    child.pid = pid;
+    child.stdout = new EventEmitter();
+    child.stdout.setEncoding = () => {};
+    child.stderr = new EventEmitter();
+    child.stderr.setEncoding = () => {};
+    child.stdin = new EventEmitter();
+    child.stdin.write = () => {};
+    child.stdin.end = () => {};
+    child.signals = [];
+    child.kill = (signal) => child.signals.push(signal);
+    return child;
+  }
+
+  test("ambient FACTORY_GH_TIMEOUT_MS is honoured when no child env is injected (PAT mode)", async () => {
+    const previous = process.env.FACTORY_GH_TIMEOUT_MS;
+    process.env.FACTORY_GH_TIMEOUT_MS = "37";
+    try {
+      const child = fakeChild(undefined);
+      const timers = [];
+      const result = ghSpawn(
+        "gh",
+        ["api", "user"],
+        {},
+        {
+          spawnImpl: () => child,
+          setTimeoutImpl: (callback, ms) => {
+            timers.push({ callback, ms });
+            return timers.length;
+          },
+          clearTimeoutImpl: () => {},
+          killGraceMs: 1,
+        },
+      );
+      expect(timers[0].ms).toBe(37);
+      timers.shift().callback();
+      await expect(result).resolves.toMatchObject({
+        status: null,
+        error: new Error("gh timed out after 37ms"),
+      });
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_GH_TIMEOUT_MS;
+      else process.env.FACTORY_GH_TIMEOUT_MS = previous;
+    }
+  });
+
+  test("timeout kills the gh process group, falling back to the child on ESRCH", async () => {
+    const run = (killImpl) => {
+      const child = fakeChild(4242);
+      const timers = [];
+      const result = ghSpawn(
+        "gh",
+        ["api", "user"],
+        { timeoutMs: 5 },
+        {
+          spawnImpl: (cmd, args, opts) => {
+            child.spawnOpts = opts;
+            return child;
+          },
+          setTimeoutImpl: (callback) => {
+            timers.push(callback);
+            return timers.length;
+          },
+          clearTimeoutImpl: () => {},
+          killGraceMs: 1,
+          killImpl,
+        },
+      );
+      return { child, timers, result };
+    };
+
+    const groupKills = [];
+    const ok = run((pid, signal) => groupKills.push([pid, signal]));
+    expect(ok.child.spawnOpts.detached).toBe(process.platform !== "win32");
+    ok.timers.shift()();
+    await expect(ok.result).resolves.toMatchObject({ status: null });
+    ok.timers.shift()();
+    expect(groupKills).toEqual([
+      [-4242, "SIGTERM"],
+      [-4242, "SIGKILL"],
+    ]);
+    expect(ok.child.signals).toEqual([]);
+
+    const gone = run(() => {
+      const err = new Error("no such process");
+      err.code = "ESRCH";
+      throw err;
+    });
+    gone.timers.shift()();
+    await gone.result;
+    gone.timers.shift()();
+    expect(gone.child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("the HTTP status line is the apiStatus fallback when the body has no status", async () => {
+    const calls = [];
+    const sleeps = [];
+    const exec = async (cmd, args) => {
+      calls.push(args);
+      if (calls.length === 1)
+        return {
+          status: 1,
+          stdout:
+            'HTTP/2 429\r\nRetry-After: 2\r\n\r\n{"message":"API rate limit exceeded"}',
+          stderr: "",
+        };
+      if (calls.length === 2)
+        return {
+          status: 1,
+          stdout:
+            'HTTP/2 403\r\nRetry-After: 1\r\n\r\n{"message":"You have exceeded a secondary rate limit. Please wait."}',
+          stderr: "",
+        };
+      return { status: 0, stdout: '{"data":{"ok":true}}', stderr: "" };
+    };
+    const api = makeGhApi(exec, {
+      env: { PATH: "/usr/bin" },
+      sleep: async (ms) => sleeps.push(ms),
+    });
+
+    await expect(
+      api("GRAPHQL", "graphql", { body: "query {}" }),
+    ).resolves.toEqual({ data: { ok: true } });
+    expect(calls).toHaveLength(3);
+    expect(sleeps).toEqual([2000, 1000]);
+
+    // Without --include (no status line) and no body status, exit code stays.
+    const bare = makeGhApi(
+      async () => ({
+        status: 1,
+        stdout: '{"message":"Not Found"}',
+        stderr: "",
+      }),
+      { env: { PATH: "/usr/bin" }, sleep: async () => {} },
+    );
+    await expect(
+      bare("GET", "repos/acme/widget/issues/1"),
+    ).rejects.toMatchObject({ status: 1 });
+    const lined = makeGhApi(
+      async () => ({
+        status: 1,
+        stdout: 'HTTP/2 404\r\n\r\n{"message":"Not Found"}',
+        stderr: "",
+      }),
+      { env: { PATH: "/usr/bin" }, sleep: async () => {} },
+    );
+    await expect(
+      lined("GET", "repos/acme/widget/issues/1"),
+    ).rejects.toMatchObject({ status: 404 });
+  });
+
+  test("x-ratelimit-reset drives the backoff when retry-after is absent (jittered, capped)", async () => {
+    const sleeps = [];
+    let calls = 0;
+    const soon = Math.floor(Date.now() / 1000) + 5;
+    const far = Math.floor(Date.now() / 1000) + 3600;
+    const exec = async () => {
+      calls += 1;
+      const reset = calls === 1 ? soon : far;
+      return {
+        status: 1,
+        stdout: `HTTP/2 429\r\nX-RateLimit-Reset: ${reset}\r\n\r\n{"message":"API rate limit exceeded","status":"429"}`,
+        stderr: "",
+      };
+    };
+    const api = makeGhApi(exec, {
+      env: { PATH: "/usr/bin" },
+      sleep: async (ms) => sleeps.push(ms),
+    });
+
+    await expect(
+      api("GET", "repos/acme/widget/issues/1"),
+    ).rejects.toMatchObject({ status: 429 });
+    expect(sleeps).toHaveLength(2);
+    expect(sleeps[0]).toBeGreaterThan(4_000);
+    expect(sleeps[0]).toBeLessThanOrEqual(6_000);
+    expect(sleeps[1]).toBe(60_000);
+  });
 });

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -6,6 +6,7 @@
  * Linear/memory and fail here is an adapter bug.
  */
 import { afterAll, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
 import {
   copyFileSync,
   mkdirSync,
@@ -23,6 +24,7 @@ import { loadControlPlane } from "./index.mjs";
 import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
 import {
   GITHUB_FACTORY_STATES,
+  ghSpawn,
   githubControlPlane,
   githubPolicyStanza,
   makeGhApi,
@@ -2555,6 +2557,7 @@ describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
     // Leading slash stripped, -X for non-GET, blank/null query keys dropped.
     expect(exec.calls[0].args).toEqual([
       "api",
+      "--include",
       "-X",
       "POST",
       "repos/x/y/issues?state=open",
@@ -2568,6 +2571,7 @@ describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
     await api("PATCH", "repos/x/y/issues/1", { body: { state: "closed" } });
     expect(exec.calls[0].args).toEqual([
       "api",
+      "--include",
       "-X",
       "PATCH",
       "repos/x/y/issues/1",
@@ -2583,7 +2587,13 @@ describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
     await api("POST", "graphql", {
       body: { query: "query{x}", variables: { a: 1 } },
     });
-    expect(exec.calls[0].args).toEqual(["api", "graphql", "--input", "-"]);
+    expect(exec.calls[0].args).toEqual([
+      "api",
+      "--include",
+      "graphql",
+      "--input",
+      "-",
+    ]);
     expect(JSON.parse(exec.calls[0].input)).toEqual({
       query: "query{x}",
       variables: { a: 1 },
@@ -2655,5 +2665,90 @@ describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
     await api("GET", "repos/acme/widget/issues/1");
     expect(exec.calls[0].opts.env.GH_TOKEN).toBe("ghs_async");
     expect(exec.calls[0].opts.env.PATH).toBe("/usr/bin");
+  });
+});
+
+describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () => {
+  test("a gh process that never closes is terminated after its configured timeout", async () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.stdout.setEncoding = () => {};
+    child.stderr = new EventEmitter();
+    child.stderr.setEncoding = () => {};
+    child.stdin = new EventEmitter();
+    child.stdin.write = () => {};
+    child.stdin.end = () => {};
+    const signals = [];
+    child.kill = (signal) => signals.push(signal);
+
+    const timers = [];
+    const result = ghSpawn(
+      "gh",
+      ["api", "user"],
+      { timeoutMs: 25 },
+      {
+        spawnImpl: () => child,
+        setTimeoutImpl: (callback) => {
+          timers.push(callback);
+          return timers.length;
+        },
+        clearTimeoutImpl: () => {},
+        killGraceMs: 1,
+      },
+    );
+
+    timers.shift()();
+    await expect(result).resolves.toMatchObject({
+      status: null,
+      error: new Error("gh timed out after 25ms"),
+    });
+    expect(signals).toEqual(["SIGTERM"]);
+    timers.shift()();
+    expect(signals).toEqual(["SIGTERM", "SIGKILL"]);
+  });
+
+  test("retries a secondary rate limit once and uses injected retry sleep", async () => {
+    const calls = [];
+    const sleeps = [];
+    const exec = async () => {
+      calls.push("gh");
+      return calls.length === 1
+        ? {
+            status: 1,
+            stdout:
+              'HTTP/2 403\r\nRetry-After: 3\r\n\r\n{"message":"You have exceeded a secondary rate limit","status":"403"}',
+            stderr: "",
+          }
+        : { status: 0, stdout: '{"ok":true}', stderr: "" };
+    };
+    const api = makeGhApi(exec, {
+      env: { PATH: "/usr/bin" },
+      sleep: async (ms) => sleeps.push(ms),
+    });
+
+    await expect(api("GET", "repos/acme/widget/issues/1")).resolves.toEqual({
+      ok: true,
+    });
+    expect(calls).toHaveLength(2);
+    expect(sleeps).toEqual([3000]);
+  });
+
+  test("stops after two secondary-rate-limit retries with exponential backoff", async () => {
+    const sleeps = [];
+    const exec = async () => ({
+      status: 1,
+      stdout:
+        '{"message":"You have exceeded a secondary rate limit","status":403}',
+      stderr: "",
+    });
+    const api = makeGhApi(exec, {
+      env: { PATH: "/usr/bin" },
+      sleep: async (ms) => sleeps.push(ms),
+    });
+
+    await expect(api("GET", "repos/acme/widget/issues/1")).rejects.toThrow(
+      "secondary rate limit",
+    );
+    expect(sleeps).toEqual([2000, 4000]);
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1352

Bound GitHub CLI calls and retry secondary rate limits instead of stalling dispatch.

## Validation

| Check                | Command                                                                          | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000`                  | pass    | 98 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1933 tests; emit and format clean      |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface                 |

UX critique: skipped

## Post-review (28a0f9f6)

- `ghSpawn` timeout now falls back to ambient `process.env.FACTORY_GH_TIMEOUT_MS` when no child env is injected (PAT mode) — test added.
- `ghResponse` keeps the HTTP status line; it is the `apiStatus` fallback when the JSON body carries no `status`, so bare 429 / GraphQL 403 secondary-rate-limit bodies are retried and named failures key off the real status — tests added.
- `retryDelayMs` honours `X-RateLimit-Reset` (delay = reset − now, jittered <1 s, capped 60 s) when `Retry-After` is absent — test added.
- Timeout kill spawns `gh` detached and signals the process group with an ESRCH fallback to the child (`killProcessGroup`, mirrors the cursor adapter; injectable `killImpl`) — test added.
- `ghJson` gets a setTimeout-based default `sleep` shared with `makeGhApi`.
