### PR TITLE
fix(worker): bound claim-path git probes

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -119,12 +119,18 @@ function ensureLocallyIgnored(checkoutPath, rel) {
   const isIgnored = () =>
     spawnSync("git", ["-C", checkoutPath, "check-ignore", "-q", "--", rel], {
       encoding: "utf8",
+      timeout: workerSubprocessTimeoutMs(),
+      killSignal: "SIGKILL",
     }).status === 0;
   if (isIgnored()) return true;
   const resolved = spawnSync(
     "git",
     ["-C", checkoutPath, "rev-parse", "--git-path", "info/exclude"],
-    { encoding: "utf8" },
+    {
+      encoding: "utf8",
+      timeout: workerSubprocessTimeoutMs(),
+      killSignal: "SIGKILL",
+    },
   );
   if (resolved.status !== 0) return false;
   const excludeFile = path.resolve(checkoutPath, resolved.stdout.trim());
@@ -162,6 +168,8 @@ export function provisionInstanceLocalConfigs({
       ["-C", checkoutPath, "rev-parse", "--is-inside-work-tree"],
       {
         encoding: "utf8",
+        timeout: workerSubprocessTimeoutMs(),
+        killSignal: "SIGKILL",
       },
     ).status === 0;
   const copied = [];

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -471,6 +471,56 @@ describe("worker", () => {
     }
   });
 
+  test("does not hang or copy instance config when a git ignore probe times out", () => {
+    const factoryRoot = tmpDir("evrt-instance-config-timeout-source-");
+    const checkout = tmpDir("evrt-instance-config-timeout-checkout-");
+    const bin = tmpDir("evrt-instance-config-timeout-bin-");
+    const previousPath = process.env.PATH;
+    const previousTimeout = process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
+    try {
+      mkdirSync(path.join(factoryRoot, "config"), { recursive: true });
+      writeFileSync(
+        path.join(factoryRoot, "config", "repos.yaml"),
+        "repos: []\n",
+      );
+      expect(spawnSync("git", ["init", "-q"], { cwd: checkout }).status).toBe(
+        0,
+      );
+      writeFileSync(
+        path.join(bin, "git"),
+        `#!/bin/sh
+case "$3" in
+  rev-parse)
+    if [ "$4" = "--is-inside-work-tree" ]; then
+      printf 'true\\n'
+      exit 0
+    fi
+    exit 1
+    ;;
+esac
+exec sleep 1
+`,
+        { mode: 0o755 },
+      );
+      process.env.PATH = `${bin}${path.delimiter}${previousPath}`;
+      process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = "25";
+
+      const started = Date.now();
+      expect(
+        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+      ).toEqual([]);
+      expect(Date.now() - started).toBeLessThan(1_000);
+    } finally {
+      process.env.PATH = previousPath;
+      if (previousTimeout === undefined)
+        delete process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS;
+      else process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = previousTimeout;
+      rmSync(factoryRoot, { recursive: true, force: true });
+      rmSync(checkout, { recursive: true, force: true });
+      rmSync(bin, { recursive: true, force: true });
+    }
+  });
+
   test("repository integrity gate rejects any checkout dirt before output acceptance", () => {
     const repo = tmpDir("evrt-clean-repo-");
     const git = (args) =>


### PR DESCRIPTION
Fixes #1363

Bounds all worker claim-path git probes so a blocked probe cannot strand config provisioning.

## Validation

| Check                | Command                                                                  | Result  | Notes                            |
| -------------------- | ------------------------------------------------------------------------ | ------- | -------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000`             | pass    | 165 tests, 0 failures            |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1924 tests; emit and format clean |
| UX critique          | factory-ux-critic                                                        | not run | no user-facing surface           |

UX critique: skipped
