### PR TITLE
perf(planner): snapshot dispatch config per tick

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -321,6 +321,7 @@ export function buildRunSpec(
     approvalPolicy = null,
     modelTierOverride,
     modelOverride,
+    configSnapshot = null,
   } = {},
 ) {
   const def = getAgent(registry, mapping.agent);
@@ -341,7 +342,13 @@ export function buildRunSpec(
   // would now admit. Scoped to work-scan to keep every other agent's input —
   // and thus its idempotency key — untouched.
   if (mapping.agent?.startsWith("work-scan") && payload?.repo) {
-    payload = { ...payload, dispatchSecurity: policyDispatchSecurity() };
+    payload = {
+      ...payload,
+      dispatchSecurity: policyDispatchSecurity(
+        configSnapshot?.root ?? reposRoot(),
+        configSnapshot,
+      ),
+    };
   }
   const inputHash = hashJson(payload);
   const placement = def.placement ?? mapping.placement ?? undefined;
@@ -618,9 +625,11 @@ function fetchTicketDefault(ticketId, repo) {
   }
 }
 
-function fetchViewerDefault(repoName) {
+function fetchViewerDefault(repoName, configSnapshot = null) {
   try {
-    const repo = repoName ? getRepo(loadRepos(), repoName) : null;
+    const repo = repoName
+      ? getRepo(snapshotRepos(configSnapshot), repoName)
+      : null;
     // GitHub App installation identities are not assignable users. The
     // GitHub control plane's claim uses the ambient `gh auth` user as the
     // lock owner, so resume checks must read that same identity via /user.
@@ -786,18 +795,46 @@ function fetchInFlightDefault(repoConfig) {
   }
 }
 
-function policyMaxInFlight(root = reposRoot()) {
-  const file = resolveConfigPath("policy", { root });
-  if (!existsSync(file)) return DEFAULT_MAX_IN_FLIGHT;
-  try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.concurrency
-      ?.max_in_flight_per_repo;
-    return typeof value === "number" && Number.isFinite(value) && value > 0
-      ? value
-      : DEFAULT_MAX_IN_FLIGHT;
-  } catch {
-    return DEFAULT_MAX_IN_FLIGHT;
+/**
+ * The serve loop evaluates every admitted event in one tick. Keep the mutable
+ * config view consistent within that tick and avoid re-parsing both YAML files
+ * for every dispatch candidate. Direct callers deliberately retain the old
+ * root-default path by omitting this snapshot.
+ */
+export function policySnapshot(root = reposRoot()) {
+  const policyFile = resolveConfigPath("policy", { root });
+  let policy = null;
+  if (existsSync(policyFile)) {
+    try {
+      const parsed = Bun.YAML.parse(readFileSync(policyFile, "utf8"));
+      policy = parsed && typeof parsed === "object" ? parsed : null;
+    } catch {
+      // Existing policy helpers fail safe on malformed policy. Preserve that
+      // behavior in the shared snapshot rather than making a whole tick fail.
+    }
   }
+
+  let repos = null;
+  let reposError = null;
+  try {
+    repos = loadRepos({ root });
+  } catch (err) {
+    reposError = err;
+  }
+  return { root, policyFile, policy, repos, reposError };
+}
+
+function snapshotRepos(snapshot) {
+  if (snapshot?.reposError) throw snapshot.reposError;
+  return snapshot?.repos ?? loadRepos();
+}
+
+function policyMaxInFlight(root = reposRoot(), snapshot = null) {
+  const value = loadRuntimePolicy(root, snapshot)?.concurrency
+    ?.max_in_flight_per_repo;
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_MAX_IN_FLIGHT;
 }
 
 /**
@@ -810,16 +847,10 @@ function policyMaxInFlight(root = reposRoot()) {
  * for conflicts that mostly never materialized.
  */
 export const DEFAULT_OWNED_PATHS_COLLISION = "strict";
-export function policyOwnedPathsCollision(root = reposRoot()) {
-  const file = resolveConfigPath("policy", { root });
-  if (!existsSync(file)) return DEFAULT_OWNED_PATHS_COLLISION;
-  try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch
-      ?.owned_paths_collision;
-    return value === "advisory" ? "advisory" : DEFAULT_OWNED_PATHS_COLLISION;
-  } catch {
-    return DEFAULT_OWNED_PATHS_COLLISION;
-  }
+export function policyOwnedPathsCollision(root = reposRoot(), snapshot = null) {
+  const value = loadRuntimePolicy(root, snapshot)?.dispatch
+    ?.owned_paths_collision;
+  return value === "advisory" ? "advisory" : DEFAULT_OWNED_PATHS_COLLISION;
 }
 
 /**
@@ -832,16 +863,10 @@ export function policyOwnedPathsCollision(root = reposRoot()) {
  * `escalate_paths` sensitive-file gate is unaffected and still applies.
  */
 export const DEFAULT_DISPATCH_SECURITY = "excluded";
-export function policyDispatchSecurity(root = reposRoot()) {
-  const file = resolveConfigPath("policy", { root });
-  if (!existsSync(file)) return DEFAULT_DISPATCH_SECURITY;
-  try {
-    const value = Bun.YAML.parse(readFileSync(file, "utf8"))?.dispatch
-      ?.security_tickets;
-    return value === "auto" ? "auto" : DEFAULT_DISPATCH_SECURITY;
-  } catch {
-    return DEFAULT_DISPATCH_SECURITY;
-  }
+export function policyDispatchSecurity(root = reposRoot(), snapshot = null) {
+  const value = loadRuntimePolicy(root, snapshot)?.dispatch
+    ?.security_tickets;
+  return value === "auto" ? "auto" : DEFAULT_DISPATCH_SECURITY;
 }
 
 /** Fail-safe merge admission cap when policy is absent or malformed. */
@@ -924,7 +949,27 @@ export function inFlightDispatchForTicket(db, payload) {
   return inFlightRunForTicket(db, "dispatch@1", payload);
 }
 
-function loadRepoEscalatePaths(repoName, root = reposRoot()) {
+function loadRepoEscalatePaths(
+  repoName,
+  root = reposRoot(),
+  snapshot = null,
+) {
+  if (snapshot) {
+    let repo;
+    try {
+      repo = getRepo(snapshotRepos(snapshot), repoName);
+    } catch (err) {
+      throw new RepoError(
+        `${reposConfigPath(root)}: cannot verify escalate_paths: ${err.message}`,
+      );
+    }
+    if (!Array.isArray(repo.escalatePaths)) {
+      throw new RepoError(
+        `${reposConfigPath(root)}: repo ${repoName} must declare escalate_paths as an array (use [] only when deliberately empty)`,
+      );
+    }
+    return [...new Set(repo.escalatePaths.map((item) => item.trim()))];
+  }
   const file = reposConfigPath(root);
   if (!existsSync(file)) {
     throw new RepoError(
@@ -963,7 +1008,8 @@ function loadRepoEscalatePaths(repoName, root = reposRoot()) {
   return [...new Set(escalate.map((item) => item.trim()))];
 }
 
-function loadRuntimePolicy(root = reposRoot()) {
+function loadRuntimePolicy(root = reposRoot(), snapshot = null) {
+  if (snapshot) return snapshot.policy;
   const file = resolveConfigPath("policy", { root });
   if (!existsSync(file)) return null;
   try {
@@ -974,8 +1020,8 @@ function loadRuntimePolicy(root = reposRoot()) {
   }
 }
 
-function defaultBudgetRefusal() {
-  const policy = loadRuntimePolicy();
+function defaultBudgetRefusal(root = reposRoot(), snapshot = null) {
+  const policy = loadRuntimePolicy(root, snapshot);
   if (!policy) return "budget_policy_unavailable";
   return budgetExhausted(policy) ? "budget_exhausted" : null;
 }
@@ -1029,9 +1075,12 @@ function evidenceTicket(ticket, ticketId) {
  * lookup time. GitHub is the parser-bearing plane today, so use the same
  * parser its adapter uses rather than duplicating a narrower regex here.
  */
-function invalidTicketIdentifierReason(repo, ticket) {
+function invalidTicketIdentifierReason(repo, ticket, snapshot = null) {
   const controlPlane =
-    repo.controlPlane ?? loadRuntimePolicy()?.controlPlane?.kind ?? "linear";
+    repo.controlPlane ??
+    loadRuntimePolicy(snapshot?.root ?? reposRoot(), snapshot)?.controlPlane
+      ?.kind ??
+    "linear";
   if (controlPlane !== "github") return null;
   try {
     parseIssueIdentifier(ticket, repo.github ?? undefined);
@@ -1114,13 +1163,15 @@ export function worktreeDispatchAutoEligibility(
         (lease) => String(lease.ticket) === String(ticket),
       ),
     maxInFlightFallback,
-    budgetRefusal = defaultBudgetRefusal,
+    budgetRefusal,
     claimedRetry = null,
     escalatedContinuation = null,
     operatorAuthorized = false,
     now = Date.now(),
+    configSnapshot = null,
   } = {},
 ) {
+  const configRoot = configSnapshot?.root ?? reposRoot();
   const evidence = {
     checkedAt: new Date(resolveNow(now)).toISOString(),
     repo: {},
@@ -1136,12 +1187,15 @@ export function worktreeDispatchAutoEligibility(
   evidence.checks.operator_authorized = operatorAuthorized === true;
   let repo;
   try {
-    repo = getRepo(loadRepos(), payload?.repo);
+    repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
   } catch (err) {
     evidence.checks.repo_found = false;
     return refusal(`repo_unknown: ${err.message}`, evidence, "human_needed");
   }
-  const cap = repo.maxInFlight ?? maxInFlightFallback ?? policyMaxInFlight();
+  const cap =
+    repo.maxInFlight ??
+    maxInFlightFallback ??
+    policyMaxInFlight(configRoot, configSnapshot);
   const live = countLeases(repo.name);
   evidence.repo = {
     name: repo.name,
@@ -1165,6 +1219,7 @@ export function worktreeDispatchAutoEligibility(
   const invalidTicketIdentifier = invalidTicketIdentifierReason(
     repo,
     payload?.ticket,
+    configSnapshot,
   );
   if (invalidTicketIdentifier) {
     evidence.checks.ticket_identifier_parseable = false;
@@ -1203,7 +1258,9 @@ export function worktreeDispatchAutoEligibility(
 
   let budgetReason;
   try {
-    budgetReason = budgetRefusal();
+    budgetReason = budgetRefusal
+      ? budgetRefusal()
+      : defaultBudgetRefusal(configRoot, configSnapshot);
   } catch {
     budgetReason = "budget_check_failed";
   }
@@ -1287,7 +1344,7 @@ export function worktreeDispatchAutoEligibility(
           : null,
       );
     }
-    const viewer = fetchViewer(payload?.repo);
+    const viewer = fetchViewer(payload?.repo, configSnapshot);
     const viewerOwnsClaim = Boolean(
       viewer?.id && String(ticket.assignee.id) === String(viewer.id),
     );
@@ -1423,7 +1480,10 @@ export function worktreeDispatchAutoEligibility(
   // merge lane refuses to merge a security PR (merge-plan §escalation), so this
   // only ever produces a PR held for human merge — never an auto-merge — and
   // the escalate_paths sensitive-file gate below still guards touched files.
-  evidence.checks.security_dispatch_mode = policyDispatchSecurity();
+  evidence.checks.security_dispatch_mode = policyDispatchSecurity(
+    configRoot,
+    configSnapshot,
+  );
   if (
     isSecurityTicket &&
     !evidence.checks.operator_authorized &&
@@ -1444,7 +1504,7 @@ export function worktreeDispatchAutoEligibility(
   evidence.inFlight = inFlight
     .filter((issue) => String(issue.identifier) !== String(payload?.ticket))
     .map(evidenceInFlight);
-  const collisionMode = policyOwnedPathsCollision();
+  const collisionMode = policyOwnedPathsCollision(configRoot, configSnapshot);
   evidence.checks.owned_paths_collision_mode = collisionMode;
   const inFlightPaths = evidence.inFlight.flatMap((issue) => issue.ownedPaths);
   if (pathsCollide(evidence.ticket.ownedPaths, inFlightPaths)) {
@@ -1486,7 +1546,11 @@ export function worktreeDispatchAutoEligibility(
     evidence.checks.owned_paths_disjoint = true;
   }
   try {
-    evidence.repo.escalatePaths = loadRepoEscalatePaths(repo.name);
+    evidence.repo.escalatePaths = loadRepoEscalatePaths(
+      repo.name,
+      configRoot,
+      configSnapshot,
+    );
   } catch (err) {
     evidence.checks.escalate_paths = { verified: false };
     return refusal(
@@ -1970,6 +2034,7 @@ export function planEvent(
     adapterOverride,
     artifactStore = artifactsRoot(),
     dispatch = {},
+    configSnapshot = null,
   } = {},
 ) {
   // Dispatch gate for tier-2 worktree agents (WM-108), evaluated BEFORE the
@@ -2006,6 +2071,7 @@ export function planEvent(
             {
               ...dispatch,
               operatorAuthorized: preEnvelope.source === "operator",
+              configSnapshot,
             },
           );
         } catch (err) {
@@ -2454,12 +2520,13 @@ export function planEvent(
       ) {
         const result = worktreeEligibility?.ok
           ? worktreeEligibility
-          : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
-              ...dispatch,
-              // Remote handoff is unattended. Only a durable operator event
-              // may exercise the sensitive/escalate-path bypass.
-              operatorAuthorized: false,
-            });
+            : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
+                ...dispatch,
+                // Remote handoff is unattended. Only a durable operator event
+                // may exercise the sensitive/escalate-path bypass.
+                operatorAuthorized: false,
+                configSnapshot,
+              });
         if (!result?.ok) {
           return humanNeeded(
             db,
@@ -2503,6 +2570,7 @@ export function planEvent(
         approvalPolicy,
         modelTierOverride,
         modelOverride: overlayModel,
+        configSnapshot,
       }),
       idempotencyKey,
     };
@@ -2640,7 +2708,8 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     .all();
   const cache = opts.linearReadCache ?? createLinearReadCache();
   const dispatch = wrapLinearReads(opts.dispatch ?? {}, cache, opts.now);
-  const planOpts = { ...opts, dispatch };
+  const configSnapshot = opts.configSnapshot ?? policySnapshot();
+  const planOpts = { ...opts, dispatch, configSnapshot };
   let planned = 0;
   let failed = 0;
   let deadLettered = 0;

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -864,8 +864,7 @@ export function policyOwnedPathsCollision(root = reposRoot(), snapshot = null) {
  */
 export const DEFAULT_DISPATCH_SECURITY = "excluded";
 export function policyDispatchSecurity(root = reposRoot(), snapshot = null) {
-  const value = loadRuntimePolicy(root, snapshot)?.dispatch
-    ?.security_tickets;
+  const value = loadRuntimePolicy(root, snapshot)?.dispatch?.security_tickets;
   return value === "auto" ? "auto" : DEFAULT_DISPATCH_SECURITY;
 }
 
@@ -949,11 +948,7 @@ export function inFlightDispatchForTicket(db, payload) {
   return inFlightRunForTicket(db, "dispatch@1", payload);
 }
 
-function loadRepoEscalatePaths(
-  repoName,
-  root = reposRoot(),
-  snapshot = null,
-) {
+function loadRepoEscalatePaths(repoName, root = reposRoot(), snapshot = null) {
   if (snapshot) {
     let repo;
     try {
@@ -2520,13 +2515,13 @@ export function planEvent(
       ) {
         const result = worktreeEligibility?.ok
           ? worktreeEligibility
-            : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
-                ...dispatch,
-                // Remote handoff is unattended. Only a durable operator event
-                // may exercise the sensitive/escalate-path bypass.
-                operatorAuthorized: false,
-                configSnapshot,
-              });
+          : worktreeDispatchAutoEligibility(pinnedEnvelope.payload, {
+              ...dispatch,
+              // Remote handoff is unattended. Only a durable operator event
+              // may exercise the sensitive/escalate-path bypass.
+              operatorAuthorized: false,
+              configSnapshot,
+            });
         if (!result?.ok) {
           return humanNeeded(
             db,
@@ -2786,6 +2781,7 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     policyVersion: opts.policyVersion ?? "unknown",
     dispatchEligibility: worktreeDispatchAutoEligibility,
     dispatch,
+    ...(opts.autoApprovalPolicy ? { policy: opts.autoApprovalPolicy } : {}),
   });
   return { planned, failed, deadLettered };
 }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1158,7 +1158,7 @@ export function worktreeDispatchAutoEligibility(
         (lease) => String(lease.ticket) === String(ticket),
       ),
     maxInFlightFallback,
-    budgetRefusal,
+    budgetRefusal = defaultBudgetRefusal,
     claimedRetry = null,
     escalatedContinuation = null,
     operatorAuthorized = false,
@@ -1253,9 +1253,7 @@ export function worktreeDispatchAutoEligibility(
 
   let budgetReason;
   try {
-    budgetReason = budgetRefusal
-      ? budgetRefusal()
-      : defaultBudgetRefusal(configRoot, configSnapshot);
+    budgetReason = budgetRefusal(configRoot, configSnapshot);
   } catch {
     budgetReason = "budget_check_failed";
   }
@@ -2781,7 +2779,6 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     policyVersion: opts.policyVersion ?? "unknown",
     dispatchEligibility: worktreeDispatchAutoEligibility,
     dispatch,
-    ...(opts.autoApprovalPolicy ? { policy: opts.autoApprovalPolicy } : {}),
   });
   return { planned, failed, deadLettered };
 }

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2834,7 +2834,8 @@ describe("planAdmittedEvents", () => {
     );
     writeFileSync(
       policyFile,
-      "concurrency:\n  max_in_flight_per_repo: 5\ndispatch:\n  security_tickets: auto\n  owned_paths_collision: advisory\n",
+      "concurrency:\n  max_in_flight_per_repo: 5\ndispatch:\n  security_tickets: auto\n  owned_paths_collision: advisory\n" +
+        "chain_auto_approval:\n  allowed_event_types: []\n",
     );
     const previous = process.env.FACTORY_REPOS_ROOT;
     process.env.FACTORY_REPOS_ROOT = root;
@@ -2898,7 +2899,6 @@ describe("planAdmittedEvents", () => {
       expect(
         planAdmittedEvents(db, snapshotRegistry, {
           now: NOW,
-          autoApprovalPolicy: { allowed: new Set(), reason: "test" },
           dispatch: {
             countLeases: () => 0,
             budgetRefusal: () => null,
@@ -2913,12 +2913,11 @@ describe("planAdmittedEvents", () => {
           },
         }),
       ).toEqual({ planned: 5, failed: 0, deadLettered: 0 });
-      expect(reads).toEqual(
-        new Map([
-          [reposFile, 1],
-          [policyFile, 1],
-        ]),
-      );
+      // Five candidates used to cost six parses of each file (#1362). The
+      // eligibility path now reads each once; the post-plan auto-approval
+      // pass may read policy.yaml one more time, never once per candidate.
+      expect(reads.get(reposFile)).toBe(1);
+      expect(reads.get(policyFile) ?? 0).toBeLessThanOrEqual(2);
     } finally {
       readSpy.mockRestore();
       if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1,7 +1,8 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-planner-test-mjs";
-import { describe, expect, test } from "bun:test";
+import { describe, expect, spyOn, test } from "bun:test";
 import { execFileSync } from "node:child_process";
 import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import * as nodeFs from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes, hashJson } from "./canonical.mjs";
 import { DEAD_LETTER_AFTER, DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
@@ -2819,6 +2820,112 @@ describe("planEvent runtime overlay (WM-887)", () => {
 });
 
 describe("planAdmittedEvents", () => {
+  test("snapshots policy.yaml and repos.yaml once for a multi-candidate dispatch tick (GH-1362)", () => {
+    const root = tmpDir("evrt-plan-config-snapshot-");
+    const configDir = path.join(root, "config");
+    mkdirSync(configDir, { recursive: true });
+    const reposFile = path.join(configDir, "repos.yaml");
+    const policyFile = path.join(configDir, "policy.yaml");
+    writeFileSync(
+      reposFile,
+      `repos:\n  - name: snapshotted\n    path: /tmp/nowhere\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
+    );
+    writeFileSync(
+      policyFile,
+      "concurrency:\n  max_in_flight_per_repo: 5\ndispatch:\n  security_tickets: auto\n  owned_paths_collision: advisory\n",
+    );
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    const reads = new Map();
+    const realReadFileSync = nodeFs.readFileSync;
+    const readSpy = spyOn(nodeFs, "readFileSync").mockImplementation(
+      (file, ...args) => {
+        const filename = String(file);
+        if (filename === reposFile || filename === policyFile) {
+          reads.set(filename, (reads.get(filename) ?? 0) + 1);
+        }
+        return realReadFileSync(file, ...args);
+      },
+    );
+    try {
+      const snapshotRegistry = {
+        ...registry,
+        agents: new Map(registry.agents),
+        eventTypes: { ...registry.eventTypes },
+      };
+      snapshotRegistry.eventTypes["test.config-snapshot.requested"] = {
+        agent: "test-config-snapshot@1",
+        adapter: "claude",
+        idempotencyScope: ["inputHash"],
+      };
+      snapshotRegistry.agents.set("test-config-snapshot@1", {
+        id: "test-config-snapshot",
+        version: 1,
+        ref: "test-config-snapshot@1",
+        output_contract: "factory.test/v1",
+        workspace: { type: "worktree" },
+        capabilities: { services: [] },
+        limits: { timeout_seconds: 60, attempts: 1 },
+        mutating: true,
+        inputSchema: {
+          type: "object",
+          required: ["repo", "ticket"],
+          properties: {
+            repo: { type: "string" },
+            ticket: { type: "string" },
+          },
+        },
+      });
+      const db = openDb(":memory:");
+      for (let i = 1; i <= 5; i++) {
+        expect(
+          admitEvent(
+            db,
+            snapshotRegistry,
+            envelope({
+              type: "test.config-snapshot.requested",
+              eventId: `snapshot-candidate-${i}`,
+              correlationId: `snapshot-candidate-${i}`,
+              payload: { repo: "snapshotted", ticket: `WM-${13620 + i}` },
+            }),
+            { now: NOW },
+          ).admitted,
+        ).toBe(true);
+      }
+
+      expect(
+        planAdmittedEvents(db, snapshotRegistry, {
+          now: NOW,
+          autoApprovalPolicy: { allowed: new Set(), reason: "test" },
+          dispatch: {
+            countLeases: () => 0,
+            budgetRefusal: () => null,
+            fetchTicket: (ticket) => ({
+              identifier: ticket,
+              state: { name: "Todo" },
+              assignee: null,
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+              description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
+            }),
+            fetchInFlight: () => [],
+          },
+        }),
+      ).toEqual({ planned: 5, failed: 0, deadLettered: 0 });
+      expect(reads).toEqual(
+        new Map([
+          [reposFile, 1],
+          [policyFile, 1],
+        ]),
+      );
+    } finally {
+      readSpy.mockRestore();
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+    }
+  });
+
   test("records and logs a typed reason for a nooped dispatch", () => {
     const root = tmpDir("evrt-plan-noop-");
     mkdirSync(path.join(root, "config"), { recursive: true });


### PR DESCRIPTION
Fixes watt-mind/factory#1362

Review the shared per-tick configuration snapshot and its five-candidate regression coverage.

## Validation

| Check                | Command                                                                                   | Result | Notes                              |
| -------------------- | ----------------------------------------------------------------------------------------- | ------ | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs --timeout 20000`                             | pass   | 92 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 1924 pass, 10 expected skips       |
| UX critique          | factory-ux-critic                                                                         | not run | no user-facing surface             |

UX critique: skipped


## Post-review

- Dropped the `opts.autoApprovalPolicy` passthrough from `planAdmittedEvents` → `autoApproveChains`; `loadChainAutoApprovalPolicy()` (with its `NEVER_AUTO_APPROVE` validation) is again the only policy source.
- GH-1362 parse-count test now sets `chain_auto_approval` in the fixture `policy.yaml` and asserts `repos.yaml` read once, `policy.yaml` read at most twice (eligibility snapshot + auto-approval pass), keeping the 5-candidates-vs-6-parses regression intent.
- `budgetRefusal` restored as a default parameter (`= defaultBudgetRefusal`, called with the config root/snapshot); an explicit `null` still refuses with `budget_check_failed`.
- Re-verified: planner suite 92 pass; `bun test event-runtime/lib` 1937 tests 0 fail; emit `--check`, `format:check`, `check` clean.
