### PR TITLE
fix(orchestrator): authenticate pulse and watchdog polls

### DIFF
--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -15,7 +15,11 @@ import { homedir } from "node:os";
 import { ROOT } from "../lib/schedule.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadForge } from "../lib/forge/index.mjs";
-import { fetchRecentSandboxRefusals } from "./watchdog.mjs";
+import {
+  controlApi,
+  controlApiFailureCode,
+  fetchRecentSandboxRefusals,
+} from "./watchdog.mjs";
 
 const c = {
   bold: (s) => `\x1b[1m${s}\x1b[0m`,
@@ -98,19 +102,15 @@ export async function gatherPulse({
 
   // 1. API Health & Status
   try {
-    const healthRes = await fetch(`http://${host}:${port}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    if (healthRes.ok) {
-      const healthJson = await healthRes.json();
-      pulse.stack.api = {
-        ok: true,
-        policyVersion: healthJson.policyVersion,
-        env: healthJson.env?.name,
-      };
-    }
+    const healthJson = await controlApi("/health", { host, port });
+    pulse.stack.api = {
+      ok: true,
+      policyVersion: healthJson.policyVersion,
+      env: healthJson.env?.name,
+    };
   } catch (err) {
-    pulse.stack.api = { ok: false, error: err.message };
+    const code = controlApiFailureCode(err);
+    pulse.stack.api = { ok: false, code, error: `${code}: ${err.message}` };
   }
 
   // 2. Web UI Health
@@ -139,15 +139,9 @@ export async function gatherPulse({
     try {
       const [statusRes, workersRes, runsRes, sandboxRefusals] =
         await Promise.all([
-          fetch(`http://${host}:${port}/status`, {
-            signal: AbortSignal.timeout(3000),
-          }).then((r) => r.json()),
-          fetch(`http://${host}:${port}/workers`, {
-            signal: AbortSignal.timeout(3000),
-          }).then((r) => r.json()),
-          fetch(`http://${host}:${port}/runs?state=RUNNING`, {
-            signal: AbortSignal.timeout(3000),
-          }).then((r) => r.json()),
+          controlApi("/status", { host, port }),
+          controlApi("/workers", { host, port }),
+          controlApi("/runs?state=RUNNING", { host, port }),
           fetchRecentSandboxRefusals({ host, port }),
         ]);
 
@@ -185,8 +179,17 @@ export async function gatherPulse({
         }));
       }
       pulse.runs.sandboxRefusals = sandboxRefusals;
-    } catch {
-      // partial fetch failure handled gracefully
+    } catch (err) {
+      const code = controlApiFailureCode(err);
+      // Auth and control locks are not an idle factory. Surface them to the
+      // operator instead of leaving the default empty workers/runs values.
+      if (code === "API_UNAUTHORIZED" || code === "API_LOCKED") {
+        pulse.stack.api = {
+          ok: false,
+          code,
+          error: `${code}: ${err.message}`,
+        };
+      }
     }
   }
 

--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -181,15 +181,15 @@ export async function gatherPulse({
       pulse.runs.sandboxRefusals = sandboxRefusals;
     } catch (err) {
       const code = controlApiFailureCode(err);
-      // Auth and control locks are not an idle factory. Surface them to the
-      // operator instead of leaving the default empty workers/runs values.
-      if (code === "API_UNAUTHORIZED" || code === "API_LOCKED") {
-        pulse.stack.api = {
-          ok: false,
-          code,
-          error: `${code}: ${err.message}`,
-        };
-      }
+      // A failed protected read (auth, control lock, timeout, 5xx) is not an
+      // idle factory. Surface it to the operator instead of leaving the
+      // default empty workers/runs values, keeping what /health told us.
+      pulse.stack.api = {
+        ...pulse.stack.api,
+        ok: false,
+        code,
+        error: `${code}: ${err.message}`,
+      };
     }
   }
 

--- a/orchestrator/pulse.test.mjs
+++ b/orchestrator/pulse.test.mjs
@@ -112,13 +112,45 @@ test("gatherPulse sends the control API bearer on protected reads", async () => 
       fetchGitHub: false,
     });
     expect(pulse.stack.api.ok).toBe(true);
-    expect(authorization).toHaveLength(5);
+    expect(authorization.length).toBeGreaterThanOrEqual(4);
     expect(authorization).toEqual(
       Array(authorization.length).fill(`Bearer ${token}`),
     );
   } finally {
     if (previous === undefined) delete process.env.FACTORY_CONTROL_API_TOKEN;
     else process.env.FACTORY_CONTROL_API_TOKEN = previous;
+    server.stop(true);
+  }
+});
+
+test("gatherPulse surfaces a failed protected read even when /health is fine", async () => {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/health")
+        return Response.json({ ok: true, policyVersion: "pv-1" });
+      if (url.pathname === "/workers")
+        return new Response("boom", { status: 500 });
+      if (url.pathname === "/status")
+        return Response.json({ runs: { byState: {} } });
+      if (url.pathname === "/runs") return Response.json({ runs: [] });
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    const pulse = await gatherPulse({
+      port: server.port,
+      webPort: server.port,
+      fetchLinear: false,
+      fetchGitHub: false,
+    });
+    expect(pulse.stack.api.ok).toBe(false);
+    expect(pulse.stack.api.code).toBe("API_ERROR");
+    expect(pulse.stack.api.error).toContain("API_ERROR");
+    expect(pulse.stack.api.policyVersion).toBe("pv-1");
+  } finally {
     server.stop(true);
   }
 });

--- a/orchestrator/pulse.test.mjs
+++ b/orchestrator/pulse.test.mjs
@@ -83,3 +83,42 @@ test("gatherPulse handles unreachable API gracefully", async () => {
   expect(pulse.stack.workers.total).toBe(0);
   expect(pulse.runs.active.length).toBe(0);
 });
+
+test("gatherPulse sends the control API bearer on protected reads", async () => {
+  const token = "pulse-control-token";
+  const authorization = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname !== "/")
+        authorization.push(req.headers.get("authorization"));
+      if (url.pathname === "/health") return Response.json({ ok: true });
+      if (url.pathname === "/status")
+        return Response.json({ runs: { byState: {} } });
+      if (url.pathname === "/workers") return Response.json({ workers: [] });
+      if (url.pathname === "/runs") return Response.json({ runs: [] });
+      return new Response("not found", { status: 404 });
+    },
+  });
+  const previous = process.env.FACTORY_CONTROL_API_TOKEN;
+  process.env.FACTORY_CONTROL_API_TOKEN = token;
+
+  try {
+    const pulse = await gatherPulse({
+      port: server.port,
+      webPort: server.port,
+      fetchLinear: false,
+      fetchGitHub: false,
+    });
+    expect(pulse.stack.api.ok).toBe(true);
+    expect(authorization).toHaveLength(5);
+    expect(authorization).toEqual(
+      Array(authorization.length).fill(`Bearer ${token}`),
+    );
+  } finally {
+    if (previous === undefined) delete process.env.FACTORY_CONTROL_API_TOKEN;
+    else process.env.FACTORY_CONTROL_API_TOKEN = previous;
+    server.stop(true);
+  }
+});

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -90,6 +90,58 @@ export const SANDBOX_REFUSAL_MAX_PAGES = 2;
 export const SANDBOX_REFUSAL_MAX_RUNS = 50;
 export const SANDBOX_REFUSAL_DETAIL_CONCURRENCY = 4;
 export const SANDBOX_REFUSAL_BUDGET_MS = 5_000;
+export const CONTROL_API_TIMEOUT_MS = 3_000;
+
+/**
+ * Read a control-API endpoint with the loopback bearer and a bounded timeout.
+ *
+ * Health checks, pulse, and watchdog must share this rather than treating an
+ * auth response as an empty status payload. Keep the token out of errors: this
+ * function is called from reporting paths whose output reaches operators.
+ */
+export async function controlApi(
+  pathname,
+  {
+    host = "127.0.0.1",
+    port = 7381,
+    method = "GET",
+    body = null,
+    timeoutMs = CONTROL_API_TIMEOUT_MS,
+    fetchFn = fetch,
+  } = {},
+) {
+  const headers = {};
+  const token = process.env.FACTORY_CONTROL_API_TOKEN ?? "";
+  if (token) headers.authorization = `Bearer ${token}`;
+  if (body) headers["content-type"] = "application/json";
+
+  const res = await fetchFn(`http://${host}:${port}${pathname}`, {
+    method,
+    headers,
+    body,
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+  if (!res.ok) {
+    const err = new Error(`${method} ${pathname} → HTTP ${res.status}`);
+    err.status = res.status;
+    err.code =
+      res.status === 401
+        ? "API_UNAUTHORIZED"
+        : res.status === 503
+          ? "API_LOCKED"
+          : "API_ERROR";
+    throw err;
+  }
+  return res.json();
+}
+
+export function controlApiFailureCode(err) {
+  return err?.code === "API_UNAUTHORIZED" || err?.status === 401
+    ? "API_UNAUTHORIZED"
+    : err?.code === "API_LOCKED" || err?.status === 503
+      ? "API_LOCKED"
+      : "API_ERROR";
+}
 
 /**
  * Read recent scan refusals caused by a missing host sandbox capability.
@@ -127,9 +179,11 @@ export async function fetchRecentSandboxRefusals({
     url.searchParams.set("to", new Date(now + 1_000).toISOString());
     url.searchParams.set("limit", String(maxRuns));
     if (before) url.searchParams.set("before", before);
-    const body = await fetchFn(url, {
-      signal: AbortSignal.timeout(3000),
-    }).then((response) => response.json());
+    const body = await controlApi(`${url.pathname}${url.search}`, {
+      host,
+      port,
+      fetchFn,
+    });
     for (const run of body?.runs ?? []) {
       if (!isScanLoopAgent(run.agent)) continue;
       runs.push(run);
@@ -143,10 +197,11 @@ export async function fetchRecentSandboxRefusals({
   const refusals = [];
   let next = 0;
   const readOne = async (run) => {
-    const detail = await fetchFn(
-      `http://${host}:${port}/runs/${encodeURIComponent(run.runId)}`,
-      { signal: AbortSignal.timeout(3000) },
-    ).then((response) => response.json());
+    const detail = await controlApi(`/runs/${encodeURIComponent(run.runId)}`, {
+      host,
+      port,
+      fetchFn,
+    });
     const refusal = [...(detail?.lifecycle ?? [])]
       .reverse()
       .find(
@@ -196,23 +251,14 @@ export async function runWatchdogCheck({
 
   // 1. Control API Health
   try {
-    const res = await fetch(`http://${host}:${port}/health`, {
-      signal: AbortSignal.timeout(3000),
-    });
-    if (res.ok) {
-      metrics.apiOk = true;
-    } else {
-      issues.push({
-        severity: "CRITICAL",
-        code: "API_ERROR",
-        message: `Control API returned HTTP ${res.status}`,
-      });
-    }
+    await controlApi("/health", { host, port });
+    metrics.apiOk = true;
   } catch (err) {
+    const code = controlApiFailureCode(err);
     issues.push({
       severity: "CRITICAL",
-      code: "API_DOWN",
-      message: `Control API on :${port} unreachable: ${err.message}`,
+      code: code === "API_ERROR" && !err?.status ? "API_DOWN" : code,
+      message: `Control API on :${port} unavailable: ${err.message}`,
     });
   }
 
@@ -239,15 +285,9 @@ export async function runWatchdogCheck({
   try {
     const [statusRes, workersRes, runningRes, sandboxRefusals] =
       await Promise.all([
-        fetch(`http://${host}:${port}/status`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/workers`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
-        fetch(`http://${host}:${port}/runs?state=RUNNING`, {
-          signal: AbortSignal.timeout(3000),
-        }).then((r) => r.json()),
+        controlApi("/status", { host, port }),
+        controlApi("/workers", { host, port }),
+        controlApi("/runs?state=RUNNING", { host, port }),
         fetchRecentSandboxRefusals({ host, port }),
       ]);
 
@@ -328,9 +368,16 @@ export async function runWatchdogCheck({
       }
     }
   } catch (err) {
+    const code = controlApiFailureCode(err);
     issues.push({
-      severity: "WARNING",
-      code: "STATUS_FETCH_ERROR",
+      severity:
+        code === "API_UNAUTHORIZED" || code === "API_LOCKED"
+          ? "CRITICAL"
+          : "WARNING",
+      code:
+        code === "API_UNAUTHORIZED" || code === "API_LOCKED"
+          ? code
+          : "STATUS_FETCH_ERROR",
       message: `Failed fetching status details: ${err.message}`,
     });
   }
@@ -856,26 +903,6 @@ export async function runIdleWatchdogTick({
 }
 
 /* --- default (live) observations and effects ---------------------------- */
-
-const controlApiToken = () => process.env.FACTORY_CONTROL_API_TOKEN ?? "";
-
-async function controlApi(
-  pathname,
-  { host, port, method = "GET", body = null, timeoutMs = 8000 } = {},
-) {
-  const headers = {};
-  const token = controlApiToken();
-  if (token) headers.authorization = `Bearer ${token}`;
-  if (body) headers["content-type"] = "application/json";
-  const res = await fetch(`http://${host}:${port}${pathname}`, {
-    method,
-    headers,
-    body,
-    signal: AbortSignal.timeout(timeoutMs),
-  });
-  if (!res.ok) throw new Error(`${method} ${pathname} → HTTP ${res.status}`);
-  return res.json();
-}
 
 /**
  * Live dependencies for `runIdleWatchdogTick`.

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -918,7 +918,8 @@ export function liveIdleWatchdogDeps({
   stateFile = path.join(STATE_DIR, "idle-watchdog.json"),
   logFile = path.join(homedir(), ".factory", "logs", "idle-watchdog.log"),
 } = {}) {
-  const api = (pathname, opts) => controlApi(pathname, { host, port, ...opts });
+  const api = (pathname, opts) =>
+    controlApi(pathname, { host, port, timeoutMs: 8000, ...opts });
   return {
     repo,
     serveOk: async () => {

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -307,6 +307,45 @@ test("runWatchdogCheck detects unreachable API as critical", async () => {
   expect(result.issues.some((i) => i.code === "API_DOWN")).toBe(true);
 });
 
+test("runWatchdogCheck reports control API 401 instead of an empty fleet", async () => {
+  const token = "watchdog-control-token";
+  const authorization = [];
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/") return new Response("web");
+      authorization.push(req.headers.get("authorization"));
+      if (url.pathname === "/health") return Response.json({ ok: true });
+      return Response.json({ error: "unauthorized" }, { status: 401 });
+    },
+  });
+  const previous = process.env.FACTORY_CONTROL_API_TOKEN;
+  process.env.FACTORY_CONTROL_API_TOKEN = token;
+
+  try {
+    const result = await runWatchdogCheck({
+      port: server.port,
+      webPort: server.port,
+      checkShadowFleet: false,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.issues).toContainEqual(
+      expect.objectContaining({
+        severity: "CRITICAL",
+        code: "API_UNAUTHORIZED",
+      }),
+    );
+    expect(authorization).toEqual(
+      Array(authorization.length).fill(`Bearer ${token}`),
+    );
+  } finally {
+    if (previous === undefined) delete process.env.FACTORY_CONTROL_API_TOKEN;
+    else process.env.FACTORY_CONTROL_API_TOKEN = previous;
+    server.stop(true);
+  }
+});
+
 /* ---------------- idle watchdog (#1063) ---------------- */
 
 const openProposal = (over = {}) => ({


### PR DESCRIPTION
Fixes watt-mind/factory#1380

Pulse and watchdog now authenticate protected control API polls and flag auth/lock failures rather than an idle factory.

## Validation

| Check                | Command                                                                        | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `bun test orchestrator/pulse.test.mjs orchestrator/watchdog.test.mjs --timeout 20000` | pass    | 36 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,926 pass, emit and format clean  |
| UX critique          | factory-ux-critic                                                              | not run | skipped: no user-facing surface    |

UX critique: skipped — backend-only control API polling


## Handoff

- **Head:** merged `origin/develop` (no conflicts); post-review fold-in on top.
- **Verified:** `bun test orchestrator/pulse.test.mjs orchestrator/watchdog.test.mjs` (37 pass), `bun run format:check`, `bun run check`, `bun test event-runtime/lib` (1927 pass), `bun build/emit.mjs --check`.
- **Ticket:** #1380 moved to `ai:needs-review` / In Review.

### Post-review

- `orchestrator/watchdog.mjs`: idle-watchdog `api` helper passes `timeoutMs: 8000` explicitly (had inherited the 3 s default).
- `orchestrator/pulse.mjs`: every failed protected read (auth, lock, timeout, 5xx) now sets `pulse.stack.api = { ...api, ok: false, code, error }`, preserving `policyVersion`/`env` from `/health`.
- `orchestrator/pulse.test.mjs`: new test for a 5xx on `/workers` after a healthy `/health`; dropped the brittle `toHaveLength(5)` for a `>= 4` bound.
