### PR TITLE
refactor(adapters): share child process cleanup

### DIFF
--- a/docs/event-runtime-conventions.md
+++ b/docs/event-runtime-conventions.md
@@ -267,7 +267,8 @@ The LLM adapter shutdown contract is:
    capture streams on every exit/error path.
 
 Adapters that can create process trees must terminate the relevant process
-group; `command.mjs:killProcessGroup()` is the precedent. Never resolve while a
+group; `child-process.mjs:killProcessGroup()` is the shared helper (TERM, then
+KILL after `killGraceMs`; repeat calls for one child are no-ops). Never resolve while a
 background child remains running.
 
 ### CLI preflight

--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -562,7 +562,7 @@ export async function execute({
     let settled = false;
     let timedOut = false;
     let aborted = false;
-    let killTimer = null;
+    let cancelTermination = null;
     let cancelledPermissions = false;
 
     const finishHandshakeError = (err) => {
@@ -594,14 +594,7 @@ export async function execute({
         }
       }
       cancelPendingPermissions();
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
     };
 
     const rpc = createAcpRpc({
@@ -761,13 +754,8 @@ export async function execute({
         } catch {
           // already closed
         }
-        if (!timedOut && !killTimer) {
-          killProcessGroup(child, "SIGTERM");
-          killTimer = setTimeout(
-            () => killProcessGroup(child, "SIGKILL"),
-            killGraceMs,
-          );
-          killTimer.unref?.();
+        if (!timedOut) {
+          cancelTermination ??= killProcessGroup(child, { killGraceMs });
         }
       })
       .catch((err) => {
@@ -778,14 +766,7 @@ export async function execute({
         } catch {
           // ignore
         }
-        killProcessGroup(child, "SIGTERM");
-        if (!killTimer) {
-          killTimer = setTimeout(
-            () => killProcessGroup(child, "SIGKILL"),
-            killGraceMs,
-          );
-          killTimer.unref?.();
-        }
+        cancelTermination ??= killProcessGroup(child, { killGraceMs });
       });
 
     const termTimer = setTimeout(() => onAbortOrTimeout(true), timeoutMs);
@@ -801,7 +782,7 @@ export async function execute({
       if (settled) return;
       settled = true;
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       cancelPendingPermissions();
       rpc.rejectAll(new Error("ACP child closed"));

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -854,6 +854,22 @@ describe("execute against a fake ACP agent", () => {
     expect(outcome.exitCode).toBeNull();
   });
 
+  test("a child that ignores SIGTERM is SIGKILLed after the grace", async () => {
+    const workspaceDir = ws();
+    const started = Date.now();
+    const outcome = await run(workspaceDir, {
+      behavior: "ignore_sigterm",
+      timeoutMs: 200,
+      killGraceMs: 150,
+    });
+    const elapsed = Date.now() - started;
+    expect(outcome.timedOut).toBe(true);
+    expect(outcome.exitCode).toBeNull();
+    // TERM at 200 ms is ignored; only the KILL escalation settles the run.
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(elapsed).toBeLessThan(4000);
+  });
+
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
   testProcessGroup("timeout kills a long-lived grandchild", async () => {
     const workspaceDir = ws();

--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -16,6 +16,7 @@ import { spawn } from "node:child_process";
 import { createWriteStream, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
+import { killProcessGroup } from "./child-process.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import { FACTORY_ROOT } from "../config.mjs";
 import {
@@ -66,28 +67,11 @@ export const HARNESS_LAYOUT = Object.freeze({
   }),
 });
 
+export { killProcessGroup };
+
 export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
 const STDERR_FILE_CHARS = 16_384;
-
-/** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(
-  child,
-  signal = "SIGTERM",
-  kill = process.kill,
-) {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already terminated
-    }
-  }
-}
 
 /**
  * How much sooner agy's own print-mode wait expires than the worker's timeout.
@@ -481,16 +465,9 @@ export async function execute({
 
     let timedOut = false;
     let timer = null;
-    let killTimer = null;
+    let cancelTermination = null;
     const terminate = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
     };
     if (timeoutMs) {
       timer = setTimeout(() => {
@@ -505,7 +482,7 @@ export async function execute({
 
     child.on("close", async (exitCode) => {
       if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       abortSignal?.removeEventListener("abort", cancel);
       signal?.removeEventListener("abort", cancel);
       await transcriptClosed;
@@ -533,7 +510,7 @@ export async function execute({
 
     child.on("error", (err) => {
       if (timer) clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       abortSignal?.removeEventListener("abort", cancel);
       signal?.removeEventListener("abort", cancel);
       transcript.destroy();

--- a/event-runtime/lib/adapters/child-process.mjs
+++ b/event-runtime/lib/adapters/child-process.mjs
@@ -1,0 +1,56 @@
+/** Spawn options that make a child its own process group on POSIX hosts. */
+export const DETACHED_SPAWN_OPTIONS = Object.freeze({ detached: true });
+
+const terminations = new WeakMap();
+
+function sendSignal(child, signal, kill) {
+  try {
+    kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // already terminated
+    }
+  }
+}
+
+/**
+ * Terminate a detached child and every subprocess in its process group.
+ *
+ * A second request for the same child is intentionally a no-op: timeout and
+ * abort handlers can race, but only one TERM→KILL escalation should be armed.
+ * The returned function cancels the pending escalation when the child closes.
+ */
+export function killProcessGroup(
+  child,
+  {
+    killGraceMs,
+    signal = "SIGTERM",
+    kill = process.kill,
+    setTimeoutFn = setTimeout,
+    clearTimeoutFn = clearTimeout,
+  } = {},
+) {
+  if (!child?.pid) return undefined;
+
+  const existing = terminations.get(child);
+  if (existing) return existing.cancel;
+
+  sendSignal(child, signal, kill);
+
+  let timer = null;
+  const cancel = () => {
+    if (timer) clearTimeoutFn(timer);
+    timer = null;
+  };
+  terminations.set(child, { cancel });
+
+  if (signal === "SIGTERM" && Number.isFinite(killGraceMs)) {
+    timer = setTimeoutFn(() => sendSignal(child, "SIGKILL", kill), killGraceMs);
+    timer.unref?.();
+    child.once?.("close", cancel);
+  }
+
+  return cancel;
+}

--- a/event-runtime/lib/adapters/child-process.test.mjs
+++ b/event-runtime/lib/adapters/child-process.test.mjs
@@ -1,0 +1,85 @@
+import { describe, expect, test } from "bun:test";
+import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
+
+describe("child process helpers", () => {
+  test("keeps spawned children in their own process group", () => {
+    expect(DETACHED_SPAWN_OPTIONS).toEqual({ detached: true });
+  });
+
+  test("signals the process group when it exists", () => {
+    const groupSignals = [];
+    const childSignals = [];
+    const child = {
+      pid: 42,
+      kill: (signal) => childSignals.push(signal),
+    };
+
+    killProcessGroup(child, {
+      signal: "SIGTERM",
+      kill: (pid, signal) => groupSignals.push([pid, signal]),
+    });
+
+    expect(groupSignals).toEqual([[-42, "SIGTERM"]]);
+    expect(childSignals).toEqual([]);
+  });
+
+  test("falls back to the direct child when the group is already gone", () => {
+    const childSignals = [];
+    const child = {
+      pid: 42,
+      kill: (signal) => childSignals.push(signal),
+    };
+
+    killProcessGroup(child, {
+      kill: () => {
+        throw Object.assign(new Error("gone"), { code: "ESRCH" });
+      },
+    });
+
+    expect(childSignals).toEqual(["SIGTERM"]);
+  });
+
+  test("escalates to SIGKILL after the configured grace period", () => {
+    const signals = [];
+    const timers = [];
+    const child = { pid: 42, kill: () => {} };
+
+    killProcessGroup(child, {
+      killGraceMs: 25,
+      kill: (pid, signal) => signals.push([pid, signal]),
+      setTimeoutFn: (callback, delay) => {
+        timers.push({ callback, delay });
+        return { unref: () => {} };
+      },
+    });
+
+    expect(signals).toEqual([[-42, "SIGTERM"]]);
+    expect(timers).toHaveLength(1);
+    expect(timers[0].delay).toBe(25);
+    timers[0].callback();
+    expect(signals).toEqual([
+      [-42, "SIGTERM"],
+      [-42, "SIGKILL"],
+    ]);
+  });
+
+  test("does not arm duplicate termination sequences", () => {
+    const signals = [];
+    const timers = [];
+    const child = { pid: 42, kill: () => {} };
+    const options = {
+      killGraceMs: 25,
+      kill: (pid, signal) => signals.push([pid, signal]),
+      setTimeoutFn: (callback) => {
+        timers.push(callback);
+        return { unref: () => {} };
+      },
+    };
+
+    killProcessGroup(child, options);
+    killProcessGroup(child, options);
+
+    expect(signals).toEqual([[-42, "SIGTERM"]]);
+    expect(timers).toHaveLength(1);
+  });
+});

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -36,6 +36,7 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment,
 } from "./child-env.mjs";
+import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
 export {
   BASE_INHERITED_ENV,
   PROVIDER_CREDENTIAL_ENV,
@@ -98,23 +99,7 @@ export const HARNESS_LAYOUT = Object.freeze({
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(
-  child,
-  signal = "SIGTERM",
-  kill = process.kill,
-) {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already terminated
-    }
-  }
-}
+export { killProcessGroup };
 
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
@@ -470,7 +455,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
+      ...DETACHED_SPAWN_OPTIONS,
     });
 
     // Capture the CLI's structured output as a runtime artifact: the worker
@@ -568,26 +553,17 @@ export async function execute({
     }
 
     let timedOut = false;
-    let killTimer = null;
+    let cancelTermination = null;
+    const terminate = () => {
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
+    };
     const termTimer = setTimeout(() => {
       timedOut = true;
-      killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(
-        () => killProcessGroup(child, "SIGKILL"),
-        killGraceMs,
-      );
-      killTimer.unref?.();
+      terminate();
     }, timeoutMs);
 
     const onAbort = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      terminate();
     };
     const abortSig = abortSignal ?? signal;
     if (abortSig) {
@@ -600,14 +576,14 @@ export async function execute({
 
     child.on("error", (err) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       transcript.destroy();
       reject(err);
     });
     child.on("close", async (exitCode) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       // A denial observed mid-run is evidence, not a verdict: the model can
       // recover (run_38deabb4 retried a failed push over gh auth, opened its

--- a/event-runtime/lib/adapters/command.mjs
+++ b/event-runtime/lib/adapters/command.mjs
@@ -35,6 +35,7 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment as sharedSafeChildEnvironment,
 } from "./child-env.mjs";
+import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
 import { runSandboxed, sandboxRequested } from "./sandboxed.mjs";
 
 /** This adapter executes inside the VM when a definition asks (WM-185). */
@@ -108,20 +109,6 @@ export function resolveTemplate(template, input) {
       return String(value);
     }),
   );
-}
-
-function killProcessGroup(child, signal = "SIGTERM") {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    process.kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already terminated
-    }
-  }
 }
 
 /**
@@ -241,7 +228,7 @@ export async function execute({
       cwd: workspaceDir,
       env: safeChildEnvironment(env, def),
       stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
+      ...DETACHED_SPAWN_OPTIONS,
     });
 
     let output = "";
@@ -260,24 +247,19 @@ export async function execute({
     child.stderr.on("data", collect);
 
     let timedOut = false;
-    let killTimer = null;
+    let cancelTermination = null;
+    const terminate = () => {
+      cancelTermination ??= killProcessGroup(child, {
+        killGraceMs: KILL_GRACE_MS,
+      });
+    };
     const termTimer = setTimeout(() => {
       timedOut = true;
-      killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(
-        () => killProcessGroup(child, "SIGKILL"),
-        KILL_GRACE_MS,
-      );
+      terminate();
     }, timeoutMs);
 
     const onAbort = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          KILL_GRACE_MS,
-        );
-      }
+      terminate();
     };
     const abortSig = abortSignal ?? signal;
     if (abortSig) {
@@ -290,14 +272,14 @@ export async function execute({
 
     child.on("error", (err) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       reject(err);
     });
 
     child.on("close", (exitCode) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       if (exitCode === 0 && !timedOut) {
         const write = () => {

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -38,6 +38,7 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment as sharedSafeChildEnvironment,
 } from "./child-env.mjs";
+import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
 export {
@@ -76,23 +77,7 @@ export const HARNESS_LAYOUT = Object.freeze({
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(
-  child,
-  signal = "SIGTERM",
-  kill = process.kill,
-) {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already terminated
-    }
-  }
-}
+export { killProcessGroup };
 
 const TEXT_PREVIEW_CHARS = 4000;
 
@@ -321,7 +306,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["ignore", "pipe", "pipe"],
-      detached: true,
+      ...DETACHED_SPAWN_OPTIONS,
     });
 
     const transcript = createWriteStream(
@@ -405,26 +390,17 @@ export async function execute({
     }
 
     let timedOut = false;
-    let killTimer = null;
+    let cancelTermination = null;
+    const terminate = () => {
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
+    };
     const termTimer = setTimeout(() => {
       timedOut = true;
-      killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(
-        () => killProcessGroup(child, "SIGKILL"),
-        killGraceMs,
-      );
-      killTimer.unref?.();
+      terminate();
     }, timeoutMs);
 
     const onAbort = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      terminate();
     };
     const abortSig = abortSignal ?? signal;
     if (abortSig) {
@@ -437,14 +413,14 @@ export async function execute({
 
     child.on("error", (err) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       transcript.destroy();
       reject(err);
     });
     child.on("close", async (exitCode) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       try {
         onUsage?.({

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -63,6 +63,7 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment as sharedSafeChildEnvironment,
 } from "./child-env.mjs";
+import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
 import {
   guestBinary,
   guestEnvironment,
@@ -116,23 +117,7 @@ export const SANDBOX_PROMPT_FILE = ".prompt.md";
 export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
-export function killProcessGroup(
-  child,
-  signal = "SIGTERM",
-  kill = process.kill,
-) {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already terminated
-    }
-  }
-}
+export { killProcessGroup };
 
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
@@ -725,7 +710,7 @@ export async function execute({
       cwd: workspaceDir,
       env: childEnv,
       stdio: ["pipe", "pipe", "pipe"],
-      detached: true,
+      ...DETACHED_SPAWN_OPTIONS,
     });
 
     child.stdin.on("error", () => {}); // a child that exits before reading stdin must not crash the worker
@@ -742,26 +727,17 @@ export async function execute({
     });
 
     let timedOut = false;
-    let killTimer = null;
+    let cancelTermination = null;
+    const terminate = () => {
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
+    };
     const termTimer = setTimeout(() => {
       timedOut = true;
-      killProcessGroup(child, "SIGTERM");
-      killTimer = setTimeout(
-        () => killProcessGroup(child, "SIGKILL"),
-        killGraceMs,
-      );
-      killTimer.unref?.();
+      terminate();
     }, timeoutMs);
 
     const onAbort = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      terminate();
     };
     const abortSig = abortSignal ?? signal;
     if (abortSig) {
@@ -774,14 +750,14 @@ export async function execute({
 
     child.on("error", (err) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       transcript.destroy();
       reject(err);
     });
     child.on("close", (exitCode) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
       resolve(finish({ exitCode, timedOut }));
     });


### PR DESCRIPTION
Fixes watt-mind/factory#1374

Review the shared child-process helper and the preserved adapter timeout/abort cleanup behavior.

## Validation

| Check                | Command                                                                       | Result  | Notes                      |
| -------------------- | ----------------------------------------------------------------------------- | ------- | -------------------------- |
| Verification Command | `bun test event-runtime/lib/adapters --timeout 20000`                       | pass    | 306 tests, 0 failures      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1931 tests, emit, format clean |
| UX critique          | factory-ux-critic                                                             | not run | no user-facing surface     |

UX critique: skipped

## Post-review (4c81431a)

- `acp.mjs` (and `hermes.mjs`, which delegates to it): the four `killProcessGroup(child, "SIGTERM")` / `"SIGKILL"` positional pairs and the local `killTimer` bookkeeping are replaced by the shared pattern `cancelTermination ??= killProcessGroup(child, { killGraceMs })`; `settle()` calls `cancelTermination?.()`. With the old calls the second (KILL) call hit the helper's dedupe and was a no-op, so acp/hermes never escalated.
- `acp.test.mjs`: new case — a fake agent that ignores SIGTERM is SIGKILLed after `killGraceMs` (run settles `timedOut: true`, `exitCode: null`, only after the grace elapses).
- `agy.mjs`: local `killProcessGroup` copy removed; imports (and re-exports) the shared helper. 16 KiB stderr tail, `.stderr.txt` and trace behaviour unchanged.
- `docs/event-runtime-conventions.md`: process-tree termination now points at `child-process.mjs:killProcessGroup()`.
- Behaviour delta worth noting: the shared helper `unref()`s the SIGKILL timer, which `command.mjs` did not do before — a pending KILL escalation no longer keeps the event loop alive on its own (the child's stdio handles still do until it exits).
- `grep -rn 'function killProcessGroup' event-runtime/lib/adapters` → only `child-process.mjs`. `bun test event-runtime/lib` 1932 pass / 0 fail; `emit --check`, `format:check`, `check` green.
