### PR TITLE
fix(control-plane): paginate Linear reads

### DIFF
--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -29,6 +29,8 @@ import {
 // give what X blocks — the wrong direction). State `type`, not name: workflow
 // names are per-team config, the types are Linear's own enum.
 const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } }`;
+const PAGE_CAP = 2_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
 const ISSUE_FIELDS = `id identifier title url description createdAt startedAt updatedAt priority
   state{ id name type } assignee{ id name }
   team{ key } project{ name }
@@ -37,6 +39,13 @@ const ISSUE_FIELDS = `id identifier title url description createdAt startedAt up
   ${BLOCKERS}`;
 
 const teamOf = (key) => String(key).split("-")[0];
+
+function requestTimeoutMs(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0
+    ? Math.floor(parsed)
+    : DEFAULT_REQUEST_TIMEOUT_MS;
+}
 
 /** Flatten Linear's `{ nodes }` label wrapper into the ControlPlane shape. */
 export function normalizeTicket(issue) {
@@ -81,18 +90,61 @@ function openBlockerIdentifiers(issue) {
 }
 
 /**
- * @param {{ gql?: (query: string, variables?: object) => Promise<object> }} [options]
+ * @param {{ gql?: (query: string, variables?: object) => Promise<object>, timeoutMs?: number }} [options]
  * @returns {import("./types.mjs").ControlPlane}
  */
-export function linearControlPlane({ gql = defaultGql } = {}) {
+export function linearControlPlane({
+  gql = defaultGql,
+  timeoutMs = process.env.FACTORY_LINEAR_TIMEOUT_MS,
+} = {}) {
+  const requestTimeout = requestTimeoutMs(timeoutMs);
+
   async function call(query, variables = {}) {
+    let timer;
     try {
-      return await gql(query, variables);
+      return await Promise.race([
+        Promise.resolve().then(() => gql(query, variables)),
+        new Promise((_, reject) => {
+          timer = setTimeout(
+            () =>
+              reject(
+                new ControlPlaneError(
+                  `linear graphql timed out after ${requestTimeout}ms`,
+                ),
+              ),
+            requestTimeout,
+          );
+        }),
+      ]);
     } catch (cause) {
+      if (cause instanceof ControlPlaneError) throw cause;
       throw new ControlPlaneError(
         cause?.message ? String(cause.message) : "linear graphql failed",
         { cause },
       );
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  async function collectPages(query, variables, connectionFor, name) {
+    const nodes = [];
+    let after = null;
+    for (;;) {
+      const d = await call(query, { ...variables, after });
+      const connection = connectionFor(d);
+      const page = connection?.nodes ?? [];
+      if (nodes.length + page.length > PAGE_CAP)
+        throw new ControlPlaneError(
+          `linear ${name} pagination exceeded ${PAGE_CAP} rows`,
+        );
+      nodes.push(...page);
+      if (!connection?.pageInfo?.hasNextPage) return nodes;
+      after = connection.pageInfo.endCursor;
+      if (!after)
+        throw new ControlPlaneError(
+          `linear ${name} pagination has next page without an end cursor`,
+        );
     }
   }
 
@@ -117,9 +169,11 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
   }
 
   async function allLabels() {
-    return (
-      (await call(`query{ issueLabels(first:250){ nodes{ id name } } }`))
-        ?.issueLabels?.nodes ?? []
+    return collectPages(
+      `query($after:String){ issueLabels(first:250,after:$after){ nodes{ id name } pageInfo{ hasNextPage endCursor } } }`,
+      {},
+      (d) => d?.issueLabels,
+      "labels",
     );
   }
 
@@ -156,13 +210,19 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
     },
 
     async listComments(identifier) {
-      const d = await call(
-        `query($k:String!){ issue(id:$k){ id comments(first:50){ nodes{ id body createdAt user{ id name } } } } }`,
+      let foundIssue = false;
+      const comments = await collectPages(
+        `query($k:String!,$after:String){ issue(id:$k){ id comments(first:50,after:$after){ nodes{ id body createdAt user{ id name } } pageInfo{ hasNextPage endCursor } } } }`,
         { k: identifier },
+        (d) => {
+          foundIssue ||= Boolean(d?.issue);
+          return d?.issue?.comments;
+        },
+        "comments",
       );
-      if (!d?.issue)
+      if (!foundIssue)
         throw new ControlPlaneError(`no such issue: ${identifier}`);
-      return d.issue.comments?.nodes ?? [];
+      return comments;
     },
 
     async listTickets({ team, project, states, includeFinished = false } = {}) {
@@ -178,16 +238,12 @@ export function linearControlPlane({ gql = defaultGql } = {}) {
       const decl = states?.length ? ", $s:[String!]" : "";
       const vars = { t: team, ...(project ? { p: project } : {}) };
       if (states?.length) vars.s = states;
-      const d = project
-        ? await call(
-            `query($t:String!,$p:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } } }`,
-            vars,
-          )
-        : await call(
-            `query($t:String!${decl}){ issues(first:250, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } } }`,
-            vars,
-          );
-      return (d?.issues?.nodes ?? []).map(normalizeTicket).sort(byQueueOrder);
+      const query = project
+        ? `query($t:String!,$p:String!${decl},$after:String){ issues(first:250,after:$after, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`
+        : `query($t:String!${decl},$after:String){ issues(first:250,after:$after, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`;
+      return (await collectPages(query, vars, (d) => d?.issues, "issues"))
+        .map(normalizeTicket)
+        .sort(byQueueOrder);
     },
 
     async listDispatchable({ team, project } = {}) {

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -1,0 +1,138 @@
+import { describe, expect, test } from "bun:test";
+import { linearControlPlane } from "./linear.mjs";
+import { ControlPlaneError } from "./types.mjs";
+
+describe("Linear ControlPlane pagination (GH-1393)", () => {
+  test("listTickets concatenates cursor-paginated issue results", async () => {
+    const calls = [];
+    const cp = linearControlPlane({
+      gql: async (query, variables) => {
+        calls.push({ query, variables });
+        const page = variables.after ? 2 : 1;
+        return {
+          issues: {
+            nodes: [
+              {
+                id: `issue-${page}`,
+                identifier: `WM-${page}`,
+                title: `Issue ${page}`,
+                state: { id: "todo", name: "Todo", type: "started" },
+                assignee: null,
+                team: { key: "WM" },
+                project: null,
+                labels: { nodes: [] },
+                comments: { nodes: [] },
+                inverseRelations: { nodes: [] },
+              },
+            ],
+            pageInfo:
+              page === 1
+                ? { hasNextPage: true, endCursor: "cursor-1" }
+                : { hasNextPage: false, endCursor: null },
+          },
+        };
+      },
+    });
+
+    await expect(cp.listTickets({ team: "WM" })).resolves.toMatchObject([
+      { identifier: "WM-1" },
+      { identifier: "WM-2" },
+    ]);
+    expect(calls.map(({ variables }) => variables.after)).toEqual([
+      null,
+      "cursor-1",
+    ]);
+    expect(calls[0].query).toContain("pageInfo{ hasNextPage endCursor }");
+  });
+
+  test("setLabels resolves a label from the second cursor page", async () => {
+    const labelCursors = [];
+    let update = null;
+    const cp = linearControlPlane({
+      gql: async (query, variables) => {
+        if (query.includes("issueLabels")) {
+          labelCursors.push(variables.after);
+          const page = variables.after ? 2 : 1;
+          return {
+            issueLabels: {
+              nodes:
+                page === 1
+                  ? [{ id: "first", name: "first" }]
+                  : [{ id: "second", name: "second" }],
+              pageInfo:
+                page === 1
+                  ? { hasNextPage: true, endCursor: "labels-1" }
+                  : { hasNextPage: false, endCursor: null },
+            },
+          };
+        }
+        if (query.includes("issueUpdate")) {
+          update = variables.in;
+          return { issueUpdate: { success: true } };
+        }
+        if (query.includes("issue(id:$k)")) {
+          return {
+            issue: {
+              id: "issue-1",
+              identifier: "WM-1",
+              title: "Issue",
+              state: { id: "todo", name: "Todo", type: "started" },
+              assignee: null,
+              team: { key: "WM" },
+              project: null,
+              labels: { nodes: [] },
+              comments: { nodes: [] },
+              inverseRelations: { nodes: [] },
+            },
+          };
+        }
+        throw new Error(`unexpected query: ${query}`);
+      },
+    });
+
+    await cp.setLabels("WM-1", { add: ["second"] });
+    expect(labelCursors).toEqual([null, "labels-1"]);
+    expect(update).toEqual({ labelIds: ["second"] });
+  });
+
+  test("listComments concatenates cursor-paginated comment results", async () => {
+    const cursors = [];
+    const cp = linearControlPlane({
+      gql: async (_query, variables) => {
+        cursors.push(variables.after);
+        const page = variables.after ? 2 : 1;
+        return {
+          issue: {
+            comments: {
+              nodes: [{ id: `comment-${page}`, body: `Comment ${page}` }],
+              pageInfo:
+                page === 1
+                  ? { hasNextPage: true, endCursor: "comments-1" }
+                  : { hasNextPage: false, endCursor: null },
+            },
+          },
+        };
+      },
+    });
+
+    await expect(cp.listComments("WM-1")).resolves.toMatchObject([
+      { id: "comment-1" },
+      { id: "comment-2" },
+    ]);
+    expect(cursors).toEqual([null, "comments-1"]);
+  });
+
+  test("rejects a hung request at its configured timeout", async () => {
+    const cp = linearControlPlane({
+      gql: () => new Promise(() => {}),
+      timeoutMs: 1,
+    });
+
+    await expect(cp.raw("query { ping }")).rejects.toBeInstanceOf(
+      ControlPlaneError,
+    );
+    await expect(cp.raw("query { ping }")).rejects.toThrow(
+      "linear graphql timed out after 1ms",
+    );
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1393

Linear reads now paginate tickets, labels, and comments with bounded request timeouts.

## Validation

| Check                | Command                                                                    | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test lib/control-plane/linear.test.mjs --timeout 20000`              | pass    | 4 tests, 0 failures           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1933 pass, 0 failures         |
| UX critique          | factory-ux-critic                                                          | skipped | backend control-plane change  |

UX critique: skipped