### PR TITLE
fix(handoff): surface runtime warning details

### DIFF
--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -148,17 +148,22 @@ function validateTicketForRepo(ticket, repo) {
 }
 
 async function responseJson(response, code) {
-  const text = await response.text();
+  let text;
+  try {
+    text = await response.text();
+  } catch (err) {
+    fail(code, `${code}: runtime response could not be read`, err);
+  }
   let body;
   try {
     body = text ? JSON.parse(text) : null;
-  } catch {
-    fail(code, `${code}: runtime returned non-JSON`);
+  } catch (err) {
+    fail(code, `${code}: runtime returned non-JSON`, err);
   }
   if (!response.ok) {
     const reason =
       body?.error ?? body?.errors?.join("; ") ?? `HTTP ${response.status}`;
-    fail(code, `${code}: ${reason}`);
+    fail(code, `${code}: ${reason}`, new Error(`HTTP ${response.status}`));
   }
   return body;
 }
@@ -293,6 +298,7 @@ export async function acceptHandoff(
   }
 
   let state = null;
+  let stateLookupFailed = false;
   const warnings = [];
   try {
     state = await runtimeState(
@@ -306,7 +312,13 @@ export async function acceptHandoff(
     // A duplicate must be bound to its original request, so lookup failures
     // fail closed instead of returning a misleading retry receipt.
     if (admission.duplicate) throw err;
+    stateLookupFailed = true;
     const warning = `state_unavailable: ${String(err?.message ?? err)}`;
+    warnings.push(warning);
+    console.error(warning);
+  }
+  if (!state?.event && !admission.duplicate && !stateLookupFailed) {
+    const warning = "state_unavailable: event not found";
     warnings.push(warning);
     console.error(warning);
   }
@@ -448,6 +460,20 @@ export function assertForcedCommandEnvironment(env = process.env) {
   }
 }
 
+export function printReceipt(receipt, log = console.log) {
+  const disposition = receipt.duplicate ? "duplicate" : "admitted";
+  log(`Handoff ${disposition}: ${receipt.requestId}`);
+  log(`Event: ${receipt.event.state}`);
+  for (const warning of receipt.warnings ?? []) log(`Warning: ${warning}`);
+  if (receipt.proposal)
+    log(
+      `Proposal: ${receipt.proposal.id} (${receipt.proposal.state ?? "pending"})`,
+    );
+  if (receipt.run)
+    log(`Run: ${receipt.run.id} (${receipt.run.state ?? "pending"})`);
+  if (receipt.dashboardUrl) log(`Dashboard: ${receipt.dashboardUrl}`);
+}
+
 async function main(argv = process.argv.slice(2)) {
   if (argv[0] === "accept") {
     if (argv.length !== 1)
@@ -489,16 +515,7 @@ async function main(argv = process.argv.slice(2)) {
     console.log(JSON.stringify(receipt));
     return;
   }
-  const disposition = receipt.duplicate ? "duplicate" : "admitted";
-  console.log(`Handoff ${disposition}: ${receipt.requestId}`);
-  console.log(`Event: ${receipt.event.state}`);
-  if (receipt.proposal)
-    console.log(
-      `Proposal: ${receipt.proposal.id} (${receipt.proposal.state ?? "pending"})`,
-    );
-  if (receipt.run)
-    console.log(`Run: ${receipt.run.id} (${receipt.run.state ?? "pending"})`);
-  if (receipt.dashboardUrl) console.log(`Dashboard: ${receipt.dashboardUrl}`);
+  printReceipt(receipt);
 }
 
 if (import.meta.main) {

--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -157,8 +157,13 @@ async function responseJson(response, code) {
   let body;
   try {
     body = text ? JSON.parse(text) : null;
-  } catch (err) {
-    fail(code, `${code}: runtime returned non-JSON`, err);
+  } catch {
+    // Never forward the SyntaxError: engines embed a prefix of the body in it.
+    fail(
+      code,
+      `${code}: runtime returned non-JSON`,
+      new Error(`invalid JSON body (${Buffer.byteLength(text, "utf8")} bytes)`),
+    );
   }
   if (!response.ok) {
     const reason =
@@ -354,6 +359,24 @@ export async function acceptHandoff(
   };
 }
 
+const RECEIPT_WARNING_MAX_LENGTH = 512;
+
+function validReceiptWarnings(warnings) {
+  if (warnings === undefined) return true;
+  return (
+    Array.isArray(warnings) &&
+    warnings.length <= 32 &&
+    warnings.every(
+      (warning) =>
+        typeof warning === "string" &&
+        warning.length > 0 &&
+        warning.length <= RECEIPT_WARNING_MAX_LENGTH &&
+        // eslint-disable-next-line no-control-regex
+        !/[\0-\x1f\x7f]/.test(warning),
+    )
+  );
+}
+
 function validReceipt(value, requestId) {
   return Boolean(
     value &&
@@ -363,7 +386,8 @@ function validReceipt(value, requestId) {
     typeof value.admitted === "boolean" &&
     typeof value.duplicate === "boolean" &&
     value.event?.id === requestId &&
-    typeof value.event?.state === "string",
+    typeof value.event?.state === "string" &&
+    validReceiptWarnings(value.warnings),
   );
 }
 

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -384,9 +384,9 @@ describe("forced-command accept server", () => {
     expect(body.cause).not.toContain("runtime unavailable");
   });
 
-  test("preserves a malformed admission response's parse error cause", async () => {
+  test("keeps a malformed admission response's body out of the error cause", async () => {
     const fetchImpl = async () =>
-      new Response("{runtime-secret", { status: 200 });
+      new Response("secret-token-xyz", { status: 200 });
 
     let err;
     try {
@@ -402,8 +402,8 @@ describe("forced-command accept server", () => {
 
     const body = handoffErrorBody(err);
     expect(body.error).toBe("runtime_admission_failed");
-    expect(body.cause).toBeDefined();
-    expect(body.cause).not.toContain("runtime-secret");
+    expect(body.cause).toBe("Error: invalid JSON body (16 bytes)");
+    expect(JSON.stringify(body)).not.toContain("secret-token-xyz");
   });
 
   test("warns when a fresh admission's event cannot be found", async () => {
@@ -523,5 +523,38 @@ describe("handoff SSH client", () => {
         ssh: async () => ({ exitCode: 0, stdout: "not-json", stderr: "" }),
       }),
     ).rejects.toThrow(/invalid receipt/);
+  });
+
+  test("rejects receipts whose warnings are not short printable strings", async () => {
+    const receipt = (warnings) => ({
+      schemaVersion: "factory.handoff-receipt/v1",
+      requestId: REQUEST.requestId,
+      admitted: true,
+      duplicate: false,
+      event: { id: REQUEST.requestId, state: "unknown" },
+      warnings,
+    });
+    const send = (warnings) =>
+      sendHandoff(REQUEST, {
+        host: "factory-runner",
+        ssh: async () => ({
+          exitCode: 0,
+          stdout: JSON.stringify(receipt(warnings)),
+          stderr: "",
+        }),
+      });
+    for (const bad of [
+      "not-an-array",
+      [42],
+      [""],
+      ["line\nbreak"],
+      ["\x1b[31mred"],
+      ["x".repeat(513)],
+    ]) {
+      await expect(send(bad)).rejects.toThrow(/invalid receipt/);
+    }
+    await expect(send(["state_unavailable: event not found"])).resolves.toEqual(
+      receipt(["state_unavailable: event not found"]),
+    );
   });
 });

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -8,6 +8,7 @@ import {
   createHandoffRequest,
   fail,
   handoffErrorBody,
+  printReceipt,
   resolveHandoffRepo,
   sendHandoff,
   validateHandoffRequest,
@@ -359,6 +360,82 @@ describe("forced-command accept server", () => {
     }
   });
 
+  test("preserves an HTTP admission failure cause without response contents", async () => {
+    const fetchImpl = async () =>
+      new Response(JSON.stringify({ error: "runtime unavailable" }), {
+        status: 500,
+      });
+
+    let err;
+    try {
+      await acceptHandoff(JSON.stringify(REQUEST), {
+        repos,
+        secret: "secret",
+        fetchImpl,
+      });
+      expect.unreachable();
+    } catch (caught) {
+      err = caught;
+    }
+
+    const body = handoffErrorBody(err);
+    expect(body.error).toBe("runtime_admission_failed");
+    expect(body.cause).toBeDefined();
+    expect(body.cause).not.toContain("runtime unavailable");
+  });
+
+  test("preserves a malformed admission response's parse error cause", async () => {
+    const fetchImpl = async () =>
+      new Response("{runtime-secret", { status: 200 });
+
+    let err;
+    try {
+      await acceptHandoff(JSON.stringify(REQUEST), {
+        repos,
+        secret: "secret",
+        fetchImpl,
+      });
+      expect.unreachable();
+    } catch (caught) {
+      err = caught;
+    }
+
+    const body = handoffErrorBody(err);
+    expect(body.error).toBe("runtime_admission_failed");
+    expect(body.cause).toBeDefined();
+    expect(body.cause).not.toContain("runtime-secret");
+  });
+
+  test("warns when a fresh admission's event cannot be found", async () => {
+    const stderr = [];
+    const fetchImpl = async (_url, options = {}) => {
+      if (options.method === "POST") {
+        return Response.json({
+          admitted: true,
+          duplicate: false,
+          eventId: REQUEST.requestId,
+        });
+      }
+      return Response.json({ events: [], nextBefore: null });
+    };
+    const originalError = console.error;
+    console.error = (line) => stderr.push(line);
+    let receipt;
+    try {
+      receipt = await acceptHandoff(JSON.stringify(REQUEST), {
+        repos,
+        secret: "secret",
+        fetchImpl,
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(receipt.event).toEqual({ id: REQUEST.requestId, state: "unknown" });
+    expect(receipt.warnings).toEqual(["state_unavailable: event not found"]);
+    expect(stderr).toEqual(receipt.warnings);
+  });
+
   test("rejects a caller-supplied SSH original command", () => {
     expect(() =>
       assertForcedCommandEnvironment({ SSH_ORIGINAL_COMMAND: "uname -a" }),
@@ -368,6 +445,28 @@ describe("forced-command accept server", () => {
 });
 
 describe("handoff SSH client", () => {
+  test("prints receipt warnings next to the event state", () => {
+    const lines = [];
+    printReceipt(
+      {
+        requestId: REQUEST.requestId,
+        duplicate: false,
+        event: { state: "unknown" },
+        warnings: ["state_unavailable: event not found"],
+        proposal: null,
+        run: null,
+        dashboardUrl: null,
+      },
+      (line) => lines.push(line),
+    );
+
+    expect(lines).toEqual([
+      `Handoff admitted: ${REQUEST.requestId}`,
+      "Event: unknown",
+      "Warning: state_unavailable: event not found",
+    ]);
+  });
+
   test("rejects option-like SSH hosts before spawning ssh", async () => {
     let called = false;
     await expect(


### PR DESCRIPTION
Fixes watt-mind/factory#1390

Surface runtime handoff failures and warning context to operators.

## Validation

| Check                | Command                                                        | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test tools/handoff.test.mjs --timeout 20000`              | pass    | 18 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1933 pass; emit and format clean |
| UX critique          | factory-ux-critic                                              | not run | skipped — backend CLI only         |

UX critique: skipped — backend CLI only

## Handoff

Post-review (0f214eff): folded in the two review nits.
- `responseJson` non-JSON branch no longer forwards the raw `SyntaxError` as `cause` (engines embed a prefix of the response body in its message); it now uses an opaque `new Error("invalid JSON body (<n> bytes)")`, mirroring the HTTP branch. Test body changed to `secret-token-xyz` and asserts the token is absent from the serialized error.
- `validReceipt` now validates `warnings` as an optional array (≤32) of non-empty strings ≤512 chars with no control characters before `printReceipt` prints them; new test covers non-array, non-string, empty, newline, ESC, and over-length cases.
- Verified: `bun test tools/handoff.test.mjs`, `bun run format:check`, `bun run check`, `bun test event-runtime/lib`, `bun build/emit.mjs --check`.
