### PR TITLE
fix(worker): make claim git probe timeouts observable

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -119,14 +119,28 @@ const INSTANCE_LOCAL_CONFIG_FILES = Object.freeze([
  * run while staying un-stageable — a copied-but-committable instance config
  * would leak the operator's routing/policy into the repo.
  */
-async function runClaimPathGitProbe({ checkoutPath, args, name, onTimeout }) {
+/**
+ * Run one bounded `git` probe on the claim path. Always settles: on normal
+ * exit (`close`), on a spawn failure (`error`, e.g. ENOENT — Node need not
+ * emit `close` after that), and on the subprocess-timeout ceiling. stderr is
+ * discarded rather than piped so a chatty git can never stall the probe on an
+ * undrained pipe. `command` exists only so tests can point the probe at a
+ * non-existent binary.
+ */
+export async function runClaimPathGitProbe({
+  checkoutPath,
+  args,
+  name,
+  onTimeout,
+  command = "git",
+}) {
   const timeoutMs = workerSubprocessTimeoutMs();
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn("git", args, {
+      child = spawn(command, args, {
         ...DETACHED_SPAWN_OPTIONS,
-        stdio: ["ignore", "pipe", "pipe"],
+        stdio: ["ignore", "pipe", "ignore"],
       });
     } catch (error) {
       resolve({ status: null, stdout: "", error });
@@ -135,12 +149,22 @@ async function runClaimPathGitProbe({ checkoutPath, args, name, onTimeout }) {
 
     let stdout = "";
     let error = null;
+    let settled = false;
+    const settle = (status) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve({ status, stdout, error });
+    };
     child.stdout?.setEncoding("utf8");
     child.stdout?.on("data", (chunk) => {
       stdout += chunk;
     });
     child.once("error", (spawnError) => {
       error = spawnError;
+      // A failed spawn (ENOENT, EACCES) may never reach `close`; settle now so
+      // the claim path cannot hang on a missing or broken git binary.
+      settle(null);
     });
     const timer = setTimeout(() => {
       error = Object.assign(
@@ -158,10 +182,7 @@ async function runClaimPathGitProbe({ checkoutPath, args, name, onTimeout }) {
       killProcessGroup(child, { signal: "SIGKILL" });
     }, timeoutMs);
     timer.unref?.();
-    child.once("close", (status) => {
-      clearTimeout(timer);
-      resolve({ status, stdout, error });
-    });
+    child.once("close", (status) => settle(status));
   });
 }
 
@@ -205,24 +226,12 @@ async function ensureLocallyIgnored(checkoutPath, rel, { onTimeout } = {}) {
  * back to examples and cannot use this factory instance's routing or policy.
  * The schedule overlay is excluded on purpose (see INSTANCE_LOCAL_CONFIG_FILES).
  */
-export function provisionInstanceLocalConfigs({
+export async function provisionInstanceLocalConfigs({
   checkoutPath,
   factoryRoot = process.env.FACTORY_ROOT || FACTORY_ROOT,
   onProbeTimeout,
 } = {}) {
   if (!checkoutPath) return [];
-  return provisionInstanceLocalConfigsAsync({
-    checkoutPath,
-    factoryRoot,
-    onProbeTimeout,
-  });
-}
-
-async function provisionInstanceLocalConfigsAsync({
-  checkoutPath,
-  factoryRoot,
-  onProbeTimeout,
-}) {
   const sourceConfig = path.join(factoryRoot, "config");
   const destinationConfig = path.join(checkoutPath, "config");
   const isGitCheckout =
@@ -3410,6 +3419,10 @@ export async function executeClaimed(
     // separately for an escalation ownership transfer.
     checkoutPath = created.checkout?.path ?? null;
     worktreePath = created.worktree?.path ?? null;
+    // The guard is load-bearing, not redundant: provisioning is async, and
+    // awaiting it for a checkout-less run would yield before the adapter
+    // starts, letting a cancel issued right after the claim short-circuit the
+    // attempt instead of aborting a started adapter (OPS-417).
     if (checkoutPath) {
       await provisionInstanceLocalConfigs({
         checkoutPath,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -10,7 +10,7 @@
  * mid-flight surfaces here as IllegalTransition; the worker stops quietly,
  * publishing nothing.
  */
-import { execFileSync, spawnSync } from "node:child_process";
+import { execFileSync, spawn, spawnSync } from "node:child_process";
 import { createHash } from "node:crypto";
 import {
   cpSync,
@@ -86,6 +86,10 @@ import {
 import { createInboxItem } from "./inbox.mjs";
 import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { templateFor } from "./decision-templates.mjs";
+import {
+  DETACHED_SPAWN_OPTIONS,
+  killProcessGroup,
+} from "./adapters/child-process.mjs";
 
 const HARNESS_UNKNOWN_CODES = Object.freeze({
   skills: "harness_unknown_skill",
@@ -115,23 +119,69 @@ const INSTANCE_LOCAL_CONFIG_FILES = Object.freeze([
  * run while staying un-stageable — a copied-but-committable instance config
  * would leak the operator's routing/policy into the repo.
  */
-function ensureLocallyIgnored(checkoutPath, rel) {
-  const isIgnored = () =>
-    spawnSync("git", ["-C", checkoutPath, "check-ignore", "-q", "--", rel], {
-      encoding: "utf8",
-      timeout: workerSubprocessTimeoutMs(),
-      killSignal: "SIGKILL",
-    }).status === 0;
-  if (isIgnored()) return true;
-  const resolved = spawnSync(
-    "git",
-    ["-C", checkoutPath, "rev-parse", "--git-path", "info/exclude"],
-    {
-      encoding: "utf8",
-      timeout: workerSubprocessTimeoutMs(),
-      killSignal: "SIGKILL",
-    },
-  );
+async function runClaimPathGitProbe({ checkoutPath, args, name, onTimeout }) {
+  const timeoutMs = workerSubprocessTimeoutMs();
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn("git", args, {
+        ...DETACHED_SPAWN_OPTIONS,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      resolve({ status: null, stdout: "", error });
+      return;
+    }
+
+    let stdout = "";
+    let error = null;
+    child.stdout?.setEncoding("utf8");
+    child.stdout?.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.once("error", (spawnError) => {
+      error = spawnError;
+    });
+    const timer = setTimeout(() => {
+      error = Object.assign(
+        new Error(`git ${name} timed out after ${timeoutMs}ms`),
+        { code: "ETIMEDOUT" },
+      );
+      console.warn(
+        `[worker] claim-path git probe timed out: repo=${checkoutPath} probe=${name} ceiling=${timeoutMs}ms`,
+      );
+      try {
+        onTimeout?.({ repo: checkoutPath, name, ceilingMs: timeoutMs });
+      } catch {
+        // Trace observability cannot interfere with config provisioning.
+      }
+      killProcessGroup(child, { signal: "SIGKILL" });
+    }, timeoutMs);
+    timer.unref?.();
+    child.once("close", (status) => {
+      clearTimeout(timer);
+      resolve({ status, stdout, error });
+    });
+  });
+}
+
+async function ensureLocallyIgnored(checkoutPath, rel, { onTimeout } = {}) {
+  const isIgnored = async () =>
+    (
+      await runClaimPathGitProbe({
+        checkoutPath,
+        args: ["-C", checkoutPath, "check-ignore", "-q", "--", rel],
+        name: "check-ignore",
+        onTimeout,
+      })
+    ).status === 0;
+  if (await isIgnored()) return true;
+  const resolved = await runClaimPathGitProbe({
+    checkoutPath,
+    args: ["-C", checkoutPath, "rev-parse", "--git-path", "info/exclude"],
+    name: "rev-parse",
+    onTimeout,
+  });
   if (resolved.status !== 0) return false;
   const excludeFile = path.resolve(checkoutPath, resolved.stdout.trim());
   try {
@@ -158,8 +208,21 @@ function ensureLocallyIgnored(checkoutPath, rel) {
 export function provisionInstanceLocalConfigs({
   checkoutPath,
   factoryRoot = process.env.FACTORY_ROOT || FACTORY_ROOT,
+  onProbeTimeout,
 } = {}) {
   if (!checkoutPath) return [];
+  return provisionInstanceLocalConfigsAsync({
+    checkoutPath,
+    factoryRoot,
+    onProbeTimeout,
+  });
+}
+
+async function provisionInstanceLocalConfigsAsync({
+  checkoutPath,
+  factoryRoot,
+  onProbeTimeout,
+}) {
   const sourceConfig = path.join(factoryRoot, "config");
   const destinationConfig = path.join(checkoutPath, "config");
   const isGitCheckout =
@@ -192,7 +255,12 @@ export function provisionInstanceLocalConfigs({
     // silently skipped the copy, leaving only the tracked example, which the
     // client repo does not ship). Only fall back to the example if the path
     // cannot be made ignore-protected.
-    if (isGitCheckout && !ensureLocallyIgnored(checkoutPath, rel)) {
+    if (
+      isGitCheckout &&
+      !(await ensureLocallyIgnored(checkoutPath, rel, {
+        onTimeout: onProbeTimeout,
+      }))
+    ) {
       continue;
     }
     mkdirSync(destinationConfig, { recursive: true });
@@ -3342,7 +3410,17 @@ export async function executeClaimed(
     // separately for an escalation ownership transfer.
     checkoutPath = created.checkout?.path ?? null;
     worktreePath = created.worktree?.path ?? null;
-    provisionInstanceLocalConfigs({ checkoutPath });
+    if (checkoutPath) {
+      await provisionInstanceLocalConfigs({
+        checkoutPath,
+        onProbeTimeout: ({ repo, name, ceilingMs }) =>
+          recorder("lifecycle", {
+            note: `probe_timeout:${name}`,
+            repo,
+            ceilingMs,
+          }),
+      });
+    }
     checkoutBaseline = checkoutPath ? repositoryStatus(checkoutPath) : null;
     worktreeRecord = created.worktree
       ? {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -94,6 +94,7 @@ import {
   repositoryIsClean,
   repositoryStatus,
   provisionInstanceLocalConfigs,
+  runClaimPathGitProbe,
   resolveLinearApiKey,
   reconcileTierEscalations,
   scheduleTierEscalation,
@@ -431,6 +432,34 @@ sh -c 'sleep 5 & wait'
       rmSync(checkout, { recursive: true, force: true });
       rmSync(bin, { recursive: true, force: true });
     }
+  });
+
+  test("claim-path git probe settles as a failed probe when the binary does not exist", async () => {
+    const missing = path.join(
+      tmpDir("evrt-claim-probe-missing-bin-"),
+      "definitely-not-git",
+    );
+    const timeouts = [];
+    const started = Date.now();
+    const probe = await runClaimPathGitProbe({
+      checkoutPath: "/nonexistent/checkout",
+      args: ["rev-parse", "--git-path", "info/exclude"],
+      name: "rev-parse",
+      command: missing,
+      onTimeout: (timeout) => timeouts.push(timeout),
+    });
+    expect(Date.now() - started).toBeLessThan(1_000);
+    expect(probe.status).not.toBe(0);
+    expect(probe.stdout).toBe("");
+    expect(probe.error?.code).toBe("ENOENT");
+    expect(timeouts).toEqual([]);
+    rmSync(path.dirname(missing), { recursive: true, force: true });
+  });
+
+  test("provisioning always returns a promise, even without a checkout path", async () => {
+    const result = provisionInstanceLocalConfigs({});
+    expect(result).toBeInstanceOf(Promise);
+    expect(await result).toEqual([]);
   });
 
   test("repository integrity gate rejects any checkout dirt before output acceptance", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -210,7 +210,7 @@ describe("worker", () => {
     });
   });
 
-  test("provisions present instance configs into an ignored checkout and skips absent files", () => {
+  test("provisions present instance configs into an ignored checkout and skips absent files", async () => {
     const factoryRoot = tmpDir("evrt-instance-config-source-");
     const checkout = tmpDir("evrt-instance-config-checkout-");
     try {
@@ -233,7 +233,10 @@ describe("worker", () => {
       );
 
       expect(
-        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+        await provisionInstanceLocalConfigs({
+          factoryRoot,
+          checkoutPath: checkout,
+        }),
       ).toEqual(["config/repos.yaml", "config/policy.yaml"]);
       expect(
         readFileSync(path.join(checkout, "config", "repos.yaml"), "utf8"),
@@ -253,7 +256,7 @@ describe("worker", () => {
     }
   });
 
-  test("does not materialize a stale operator schedule overlay, so a worktree stays verifiable after client schedules leave the kernel (#1051)", () => {
+  test("does not materialize a stale operator schedule overlay, so a worktree stays verifiable after client schedules leave the kernel (#1051)", async () => {
     const factoryRoot = tmpDir("evrt-schedule-overlay-source-");
     const checkout = tmpDir("evrt-schedule-overlay-checkout-");
     try {
@@ -287,7 +290,10 @@ describe("worker", () => {
       );
 
       expect(
-        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+        await provisionInstanceLocalConfigs({
+          factoryRoot,
+          checkoutPath: checkout,
+        }),
       ).toEqual(["config/repos.yaml"]);
 
       // The stale overlay never lands in the checkout ...
@@ -311,12 +317,15 @@ describe("worker", () => {
     }
   });
 
-  test("silently skips instance config provisioning when no local files exist", () => {
+  test("silently skips instance config provisioning when no local files exist", async () => {
     const factoryRoot = tmpDir("evrt-instance-config-empty-source-");
     const checkout = tmpDir("evrt-instance-config-empty-checkout-");
     try {
       expect(
-        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+        await provisionInstanceLocalConfigs({
+          factoryRoot,
+          checkoutPath: checkout,
+        }),
       ).toEqual([]);
     } finally {
       rmSync(factoryRoot, { recursive: true, force: true });
@@ -324,7 +333,7 @@ describe("worker", () => {
     }
   });
 
-  test("provisions instance config into a client checkout but makes it un-stageable", () => {
+  test("provisions instance config into a client checkout but makes it un-stageable", async () => {
     // A client repo (bj29, cashsaas, …) does not gitignore config/repos.yaml,
     // so the old guard skipped the copy and left the review with no config —
     // failing it closed. Now the path is added to the checkout's local exclude
@@ -343,7 +352,10 @@ describe("worker", () => {
       );
 
       expect(
-        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+        await provisionInstanceLocalConfigs({
+          factoryRoot,
+          checkoutPath: checkout,
+        }),
       ).toEqual(["config/repos.yaml"]);
       // Copied in, so the run can read it.
       expect(existsSync(path.join(checkout, "config", "repos.yaml"))).toBe(
@@ -363,7 +375,7 @@ describe("worker", () => {
     }
   });
 
-  test("does not hang or copy instance config when a git ignore probe times out", () => {
+  test("kills timed-out claim-path probe groups and traces both probes", async () => {
     const factoryRoot = tmpDir("evrt-instance-config-timeout-source-");
     const checkout = tmpDir("evrt-instance-config-timeout-checkout-");
     const bin = tmpDir("evrt-instance-config-timeout-bin-");
@@ -387,21 +399,29 @@ case "$3" in
       printf 'true\\n'
       exit 0
     fi
-    exit 1
     ;;
 esac
-exec sleep 1
+sh -c 'sleep 5 & wait'
 `,
         { mode: 0o755 },
       );
       process.env.PATH = `${bin}${path.delimiter}${previousPath}`;
       process.env.FACTORY_WORKER_SUBPROCESS_TIMEOUT_MS = "25";
 
+      const timeouts = [];
       const started = Date.now();
       expect(
-        provisionInstanceLocalConfigs({ factoryRoot, checkoutPath: checkout }),
+        await provisionInstanceLocalConfigs({
+          factoryRoot,
+          checkoutPath: checkout,
+          onProbeTimeout: (timeout) => timeouts.push(timeout),
+        }),
       ).toEqual([]);
       expect(Date.now() - started).toBeLessThan(1_000);
+      expect(timeouts).toEqual([
+        expect.objectContaining({ name: "check-ignore", ceilingMs: 25 }),
+        expect.objectContaining({ name: "rev-parse", ceilingMs: 25 }),
+      ]);
     } finally {
       process.env.PATH = previousPath;
       if (previousTimeout === undefined)


### PR DESCRIPTION
Fixes #1389

Makes claim-path git timeouts visible and kills hook/credential-helper process groups.

## Validation

| Check                | Command                                                                          | Result  | Notes                           |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000`                     | pass    | 96 pass, 0 fail                 |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1933 pass, 10 skipped, 0 fail |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing backend surface  |

UX critique: skipped

## Post-review (b1ae6979584a61ebf27f91c964bfc2ae28bae428)

- `runClaimPathGitProbe` now settles from the `error` handler too (ENOENT/EACCES spawn failures need not reach `close`), guarded by a single `settle`; stderr is `ignore`d instead of piped so an undrained pipe cannot stall the claim path. Exported with an injectable `command` and covered by a test that points it at a non-existent binary.
- `provisionInstanceLocalConfigs` is uniformly `async` (the early return now yields a promise; test added). The `if (checkoutPath)` guard at the call site was kept deliberately: dropping it makes the checkout-less path yield before the adapter starts, which turns a cancel issued right after the claim into a no-adapter short-circuit and fails OPS-417 deterministically. Comment added at the call site.
- Verified: worker suites, `bun test event-runtime/lib` (1935 pass / 0 fail), `emit --check`, `format:check`, `bun run check`.
