### PR TITLE
fix(reaper): isolate expired lease failures

### DIFF
--- a/event-runtime/lib/reaper.mjs
+++ b/event-runtime/lib/reaper.mjs
@@ -9,11 +9,25 @@
 import { reapExpiredLeases as reapLeases } from "./worker.mjs";
 import { pruneWorkers } from "./workers.mjs";
 
+/**
+ * Reap expired leases, then prune stale workers.
+ *
+ * Every per-row failure is logged (so a poisoned row skipped tick after tick
+ * is visible in the serve log, whose caller discards the return value) AND
+ * collected as `{ runId, error }` with the original Error intact, so callers
+ * that do inspect the result keep stack and cause.
+ */
 export function reapExpiredLeases(db, opts = {}) {
   const errors = [];
+  const log = opts.log ?? ((line) => console.error(line));
   const reaped = reapLeases(db, {
     ...opts,
-    onError: (error) => errors.push(error),
+    onError: ({ runId, error }) => {
+      errors.push({ runId, error });
+      log(
+        `[reaper] expired lease ${runId} skipped: ${error?.message ?? String(error)}`,
+      );
+    },
   });
   pruneWorkers(db, opts);
   return { reaped, errors };

--- a/event-runtime/lib/reaper.mjs
+++ b/event-runtime/lib/reaper.mjs
@@ -10,9 +10,13 @@ import { reapExpiredLeases as reapLeases } from "./worker.mjs";
 import { pruneWorkers } from "./workers.mjs";
 
 export function reapExpiredLeases(db, opts = {}) {
-  const reaped = reapLeases(db, opts);
+  const errors = [];
+  const reaped = reapLeases(db, {
+    ...opts,
+    onError: (error) => errors.push(error),
+  });
   pruneWorkers(db, opts);
-  return reaped;
+  return { reaped, errors };
 }
 
 export { pruneWorkers };

--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -2,7 +2,12 @@ import { describe, expect, test } from "bun:test";
 import * as fake from "./adapters/fake.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
-import { createRun, runState, transition } from "./lifecycle.mjs";
+import {
+  createRun,
+  runState,
+  subscribeRunLifecycle,
+  transition,
+} from "./lifecycle.mjs";
 import { reapExpiredLeases } from "./reaper.mjs";
 import { cancelRun, claimNext, forceFailRun, retryRun } from "./worker.mjs";
 import { deregisterWorker, listWorkers, registerWorker } from "./workers.mjs";
@@ -141,16 +146,119 @@ describe("reaper (OPS-416)", () => {
     registerWorker(db, { workerId: "stale", now: T0 - 48 * 60 * 60 * 1000 });
     deregisterWorker(db, "stale", { now: T0 - 30 * 60 * 60 * 1000 });
 
-    const result = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
+    const logged = [];
+    const result = reapExpiredLeases(db, {
+      now: T0,
+      policyVersion: "test",
+      log: (line) => logged.push(line),
+    });
 
     expect(result.reaped).toBe(1);
     expect(result.errors).toHaveLength(1);
-    expect(result.errors[0]).toContain(corrupt.runId);
+    expect(result.errors[0].runId).toBe(corrupt.runId);
+    expect(result.errors[0].error).toBeInstanceOf(Error);
+    expect(result.errors[0].error.message).toMatch(/JSON/);
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("[reaper]");
+    expect(logged[0]).toContain(corrupt.runId);
     expect(runState(db, corrupt.runId)).toBe("VERIFYING");
     expect(runState(db, healthy.runId)).toBe("QUEUED");
     expect(
       listWorkers(db, { now: T0 }).map((worker) => worker.workerId),
     ).not.toContain("stale");
+  });
+
+  test("logs and skips a row whose transition edge is illegal; others still reap and count", () => {
+    const db = openDb(":memory:");
+    const healthy = makeSpec({ maxAttempts: 2 });
+    const poisoned = makeSpec({ maxAttempts: 2 });
+    setupVerifyingRun(db, healthy, { now: T0, expired: true });
+    setupVerifyingRun(db, poisoned, { now: T0, expired: true });
+
+    // The reaper drives VERIFYING -> FAILED -> QUEUED. Yank the poisoned run
+    // to a terminal state right after its first hop so the second hop is an
+    // illegal edge (COMPLETED -> QUEUED). The spec itself stays valid, so this
+    // exercises the non-corrupt failure path with a real Error object.
+    const unsubscribe = subscribeRunLifecycle((event) => {
+      if (event.runId === poisoned.runId && event.to === "FAILED") {
+        db.query(`UPDATE runs SET state = 'COMPLETED' WHERE run_id = ?`).run(
+          poisoned.runId,
+        );
+      }
+    });
+    const logged = [];
+    let result;
+    try {
+      result = reapExpiredLeases(db, {
+        now: T0,
+        policyVersion: "test",
+        log: (line) => logged.push(line),
+      });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(result.reaped).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0].runId).toBe(poisoned.runId);
+    expect(result.errors[0].error).toBeInstanceOf(Error);
+    expect(result.errors[0].error.name).toBe("IllegalTransition");
+    expect(result.errors[0].error.stack).toBeString();
+    expect(logged).toHaveLength(1);
+    expect(logged[0]).toContain("[reaper]");
+    expect(logged[0]).toContain(poisoned.runId);
+    expect(logged[0]).toContain("illegal transition");
+    // The poisoned row's partial work rolled back with its transaction.
+    expect(runState(db, poisoned.runId)).toBe("VERIFYING");
+    expect(
+      db
+        .query(`SELECT terminal_state FROM attempts WHERE run_id = ?`)
+        .get(poisoned.runId).terminal_state,
+    ).toBeNull();
+    expect(runState(db, healthy.runId)).toBe("QUEUED");
+  });
+
+  test("does not reap a lease renewed between the candidate scan and the per-row transaction", () => {
+    const db = openDb(":memory:");
+    const first = makeSpec({ maxAttempts: 2 });
+    const renewed = makeSpec({ maxAttempts: 2 });
+    setupVerifyingRun(db, first, { now: T0, expired: true });
+    setupVerifyingRun(db, renewed, { now: T0, expired: true });
+
+    // Both rows are expired when the reaper scans. While it is reaping the
+    // first, a worker renews the second's lease; the per-row transaction must
+    // re-validate the lease and leave the renewed run alone.
+    const renewedAt = new Date(T0 + 10 * 60 * 1000).toISOString();
+    const unsubscribe = subscribeRunLifecycle((event) => {
+      if (event.runId === first.runId) {
+        db.query(
+          `UPDATE attempts SET lease_expires_at = ? WHERE run_id = ? AND attempt = 1`,
+        ).run(renewedAt, renewed.runId);
+      }
+    });
+    const eventsBefore = db
+      .query(`SELECT COUNT(*) AS n FROM lifecycle_events WHERE run_id = ?`)
+      .get(renewed.runId).n;
+    let result;
+    try {
+      result = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
+    } finally {
+      unsubscribe();
+    }
+
+    expect(result).toEqual({ reaped: 1, errors: [] });
+    expect(runState(db, first.runId)).toBe("QUEUED");
+    expect(runState(db, renewed.runId)).toBe("VERIFYING");
+    const attempt = db
+      .query(`SELECT * FROM attempts WHERE run_id = ?`)
+      .get(renewed.runId);
+    expect(attempt.terminal_state).toBeNull();
+    expect(attempt.lease_expires_at).toBe(renewedAt);
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM lifecycle_events WHERE run_id = ?`)
+        .get(renewed.runId).n,
+    ).toBe(eventsBefore);
   });
 
   test("cancelRun from VERIFYING transitions cleanly to FAILED without 409", () => {

--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -89,7 +89,7 @@ describe("reaper (OPS-416)", () => {
     expect(runState(db, spec.runId)).toBe("VERIFYING");
 
     const reaped = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
-    expect(reaped).toBe(1);
+    expect(reaped).toEqual({ reaped: 1, errors: [] });
     expect(runState(db, spec.runId)).toBe("QUEUED");
 
     const events = db
@@ -118,7 +118,7 @@ describe("reaper (OPS-416)", () => {
     expect(runState(db, spec.runId)).toBe("VERIFYING");
 
     const reaped = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
-    expect(reaped).toBe(1);
+    expect(reaped).toEqual({ reaped: 1, errors: [] });
     expect(runState(db, spec.runId)).toBe("FAILED");
 
     const attempt = db
@@ -126,6 +126,31 @@ describe("reaper (OPS-416)", () => {
       .get(spec.runId);
     expect(attempt.terminal_state).toBe("FAILED");
     expect(attempt.reason_code).toBe("lease_expired");
+  });
+
+  test("continues reaping and pruning when one expired lease has corrupt spec JSON", () => {
+    const db = openDb(":memory:");
+    const corrupt = makeSpec({ maxAttempts: 2 });
+    const healthy = makeSpec({ maxAttempts: 2 });
+    setupVerifyingRun(db, corrupt, { now: T0, expired: true });
+    setupVerifyingRun(db, healthy, { now: T0, expired: true });
+    db.query(`UPDATE runs SET spec_json = '{' WHERE run_id = ?`).run(
+      corrupt.runId,
+    );
+
+    registerWorker(db, { workerId: "stale", now: T0 - 48 * 60 * 60 * 1000 });
+    deregisterWorker(db, "stale", { now: T0 - 30 * 60 * 60 * 1000 });
+
+    const result = reapExpiredLeases(db, { now: T0, policyVersion: "test" });
+
+    expect(result.reaped).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain(corrupt.runId);
+    expect(runState(db, corrupt.runId)).toBe("VERIFYING");
+    expect(runState(db, healthy.runId)).toBe("QUEUED");
+    expect(
+      listWorkers(db, { now: T0 }).map((worker) => worker.workerId),
+    ).not.toContain("stale");
   });
 
   test("cancelRun from VERIFYING transitions cleanly to FAILED without 409", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4408,22 +4408,33 @@ export function reapExpiredLeases(
   {
     now = () => Date.now(),
     policyVersion = "unknown",
-    onError = (error) => console.error(`[worker] ${error}`),
+    onError = ({ runId, error }) =>
+      console.error(
+        `[worker] expired lease ${runId}: ${error?.message ?? String(error)}`,
+      ),
   } = {},
 ) {
   const currentNow = resolveNow(now);
-  const rows = db
-    .query(
-      `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
+  const nowIso = iso(currentNow);
+  const candidateSql = `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
        JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-       WHERE r.state IN ('LEASED', 'RUNNING', 'VERIFYING') AND a.lease_expires_at < ?`,
-    )
-    .all(iso(currentNow));
+       WHERE r.state IN ('LEASED', 'RUNNING', 'VERIFYING') AND a.lease_expires_at < ?`;
+  const candidates = db.query(candidateSql).all(nowIso);
   let reaped = 0;
 
-  for (const row of rows) {
+  for (const candidate of candidates) {
     try {
-      txImmediate(db, () => {
+      const outcome = txImmediate(db, () => {
+        // The candidate list is a snapshot taken outside this transaction. A
+        // worker may have renewed the lease (or the run may have moved on)
+        // since; re-read under the write lock and only act when the row is
+        // still exactly the expired attempt we selected.
+        const row = db
+          .query(
+            `${candidateSql} AND r.run_id = ? AND r.attempts = ? AND r.state = ?`,
+          )
+          .get(nowIso, candidate.run_id, candidate.attempts, candidate.state);
+        if (!row) return "skipped";
         const spec = JSON.parse(row.spec_json);
         const decision = retryDecision(db, row.run_id, spec, "lease_expired", {
           includeCurrentFailure: true,
@@ -4460,7 +4471,7 @@ export function reapExpiredLeases(
             policyVersion,
             now: currentNow,
           });
-          return;
+          return "reaped";
         }
 
         // LEASED has no direct FAILED edge; advance through RUNNING only when
@@ -4487,10 +4498,11 @@ export function reapExpiredLeases(
             now: currentNow,
           });
         }
+        return "reaped";
       });
-      reaped += 1;
-    } catch (err) {
-      onError(`expired lease ${row.run_id}: ${err?.message ?? String(err)}`);
+      if (outcome === "reaped") reaped += 1;
+    } catch (error) {
+      onError({ runId: candidate.run_id, error });
     }
   }
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4405,84 +4405,96 @@ export function releaseStalledWorkerLease(
  */
 export function reapExpiredLeases(
   db,
-  { now = () => Date.now(), policyVersion = "unknown" } = {},
+  {
+    now = () => Date.now(),
+    policyVersion = "unknown",
+    onError = (error) => console.error(`[worker] ${error}`),
+  } = {},
 ) {
   const currentNow = resolveNow(now);
-  return txImmediate(db, () => {
-    const rows = db
-      .query(
-        `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
-         JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-         WHERE r.state IN ('LEASED', 'RUNNING', 'VERIFYING') AND a.lease_expires_at < ?`,
-      )
-      .all(iso(currentNow));
-    for (const row of rows) {
-      const spec = JSON.parse(row.spec_json);
-      const decision = retryDecision(db, row.run_id, spec, "lease_expired", {
-        includeCurrentFailure: true,
+  const rows = db
+    .query(
+      `SELECT r.run_id, r.attempts, r.spec_json, r.state FROM runs r
+       JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+       WHERE r.state IN ('LEASED', 'RUNNING', 'VERIFYING') AND a.lease_expires_at < ?`,
+    )
+    .all(iso(currentNow));
+  let reaped = 0;
+
+  for (const row of rows) {
+    try {
+      txImmediate(db, () => {
+        const spec = JSON.parse(row.spec_json);
+        const decision = retryDecision(db, row.run_id, spec, "lease_expired", {
+          includeCurrentFailure: true,
+        });
+        const failureReason = terminalFailureReason(decision, "lease_expired");
+
+        // VERIFYING cannot transition directly to QUEUED; record its failure first.
+        if (row.state === "VERIFYING") {
+          transition(db, {
+            runId: row.run_id,
+            to: "FAILED",
+            actor: "reaper",
+            reason: failureReason,
+            attempt: row.attempts,
+            policyVersion,
+            now: currentNow,
+          });
+        }
+        finishAttempt(
+          db,
+          row.run_id,
+          row.attempts,
+          "FAILED",
+          "lease_expired",
+          currentNow,
+        );
+        if (decision.retry) {
+          transition(db, {
+            runId: row.run_id,
+            to: "QUEUED",
+            actor: "reaper",
+            reason: `retry:${decision.cause}`,
+            attempt: row.attempts,
+            policyVersion,
+            now: currentNow,
+          });
+          return;
+        }
+
+        // LEASED has no direct FAILED edge; advance through RUNNING only when
+        // the environment retry ceiling is exhausted and the run must terminate.
+        if (row.state === "LEASED") {
+          transition(db, {
+            runId: row.run_id,
+            to: "RUNNING",
+            actor: "reaper",
+            reason: failureReason,
+            attempt: row.attempts,
+            policyVersion,
+            now: currentNow,
+          });
+        }
+        if (row.state !== "VERIFYING") {
+          transition(db, {
+            runId: row.run_id,
+            to: "FAILED",
+            actor: "reaper",
+            reason: failureReason,
+            attempt: row.attempts,
+            policyVersion,
+            now: currentNow,
+          });
+        }
       });
-      const failureReason = terminalFailureReason(decision, "lease_expired");
-
-      // VERIFYING cannot transition directly to QUEUED; record its failure first.
-      if (row.state === "VERIFYING") {
-        transition(db, {
-          runId: row.run_id,
-          to: "FAILED",
-          actor: "reaper",
-          reason: failureReason,
-          attempt: row.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-      }
-      finishAttempt(
-        db,
-        row.run_id,
-        row.attempts,
-        "FAILED",
-        "lease_expired",
-        currentNow,
-      );
-      if (decision.retry) {
-        transition(db, {
-          runId: row.run_id,
-          to: "QUEUED",
-          actor: "reaper",
-          reason: `retry:${decision.cause}`,
-          attempt: row.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-        continue;
-      }
-
-      // LEASED has no direct FAILED edge; advance through RUNNING only when
-      // the environment retry ceiling is exhausted and the run must terminate.
-      if (row.state === "LEASED") {
-        transition(db, {
-          runId: row.run_id,
-          to: "RUNNING",
-          actor: "reaper",
-          reason: failureReason,
-          attempt: row.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-      }
-      if (row.state !== "VERIFYING") {
-        transition(db, {
-          runId: row.run_id,
-          to: "FAILED",
-          actor: "reaper",
-          reason: failureReason,
-          attempt: row.attempts,
-          policyVersion,
-          now: currentNow,
-        });
-      }
+      reaped += 1;
+    } catch (err) {
+      onError(`expired lease ${row.run_id}: ${err?.message ?? String(err)}`);
     }
-    return rows.length;
-  });
+  }
+
+  return reaped;
 }
 
 /** Claim and execute one run, or return a typed refusal/null without execution. */


### PR DESCRIPTION
Fixes #1391

Expired lease sweeps now isolate corrupt rows so healthy attempts and worker pruning continue.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/reaper.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass | 103 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1934 passed, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

## Post-review

- `reaper.mjs`: the wrapper now logs every skipped row (`[reaper] expired lease <runId> skipped: <message>`, via `opts.log` or `console.error`) as well as collecting it, so `serve` — which discards the return value — no longer hides a poisoned row that is skipped every tick. Errors are collected as `{ runId, error }` with the original Error (stack/cause intact); `worker.mjs`'s default `onError` takes the same shape.
- `worker.mjs`: the candidate SELECT is a snapshot taken outside the write lock. Each per-row `txImmediate` now re-reads the run + current attempt with the same predicate plus `run_id`/`attempts`/`state` and no-ops (not counted in `reaped`) unless the lease is still expired and the row unchanged — a lease renewed between scan and transaction is left alone.
- Tests: non-corrupt failure path (illegal transition edge is logged, rolled back and skipped while the healthy row still reaps and `reaped` counts only successes), and a "lease renewed concurrently is NOT reaped" case.
