### PR TITLE
perf(memos): sweep retained memo records

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -18,6 +18,7 @@ import {
 import { openDb } from "../lib/db.mjs";
 import { newWorkerId } from "../lib/ids.mjs";
 import { pruneArtifacts } from "../lib/artifacts.mjs";
+import { sweepMemos } from "../lib/memos.mjs";
 import { publishOutbox } from "../lib/outbox.mjs";
 import { autoApproveScheduled, emitDueTicks } from "../lib/schedules.mjs";
 import { autoApproveChains } from "../lib/auto-approval.mjs";
@@ -183,6 +184,13 @@ export async function tick({
   await runStep("GC", () => {
     if (now - lastPrune <= pruneIntervalMs) return;
     try {
+      // Sweep first so memo artifacts become eligible for this GC pass rather
+      // than staying pinned until the next hourly artifact prune.
+      const swept = sweepMemos(db, { now });
+      if (swept.deleted > 0)
+        logLine(
+          `memos: swept ${swept.deleted} expired/retired/superseded memo(s)`,
+        );
       const pruned = pruneArtifacts(db, storeRoot ?? artifactsRoot(), { now });
       if (pruned.deleted > 0)
         logLine(

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -183,25 +183,37 @@ export async function tick({
   let nextPrune = lastPrune;
   await runStep("GC", () => {
     if (now - lastPrune <= pruneIntervalMs) return;
-    try {
-      // Sweep first so memo artifacts become eligible for this GC pass rather
-      // than staying pinned until the next hourly artifact prune.
+    // The cadence advances even when a sub-step throws: a broken sweep must
+    // not turn into a hot loop of retries on every tick.
+    nextPrune = now;
+    const gcStep = (name, fn) => {
+      try {
+        fn();
+      } catch (err) {
+        logLine(`tick GC: ${name}: ${err.message}`);
+      }
+    };
+    // Sweep first so memo artifacts become eligible for this GC pass rather
+    // than staying pinned until the next hourly artifact prune. Each sub-step
+    // is isolated: a memo-sweep failure never skips artifact GC.
+    gcStep("memos", () => {
       const swept = sweepMemos(db, { now });
       if (swept.deleted > 0)
         logLine(
           `memos: swept ${swept.deleted} expired/retired/superseded memo(s)`,
         );
+    });
+    gcStep("artifacts", () => {
       const pruned = pruneArtifacts(db, storeRoot ?? artifactsRoot(), { now });
       if (pruned.deleted > 0)
         logLine(
           `artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`,
         );
-      const markers = sweepNotifyLog(db, { now });
-      if (markers > 0)
-        logLine(`notify: swept ${markers} stale dedup marker(s)`);
-    } finally {
-      nextPrune = now;
-    }
+    });
+    gcStep("notify", () => {
+      const swept = sweepNotifyLog(db, { now });
+      if (swept > 0) logLine(`notify: swept ${swept} stale dedup marker(s)`);
+    });
   });
 
   await runStep("chains", () => {

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -242,6 +242,29 @@ describe("serve command", () => {
     expect(chainsRan).toBe(true);
   });
 
+  test("tick sweeps retained memo rows alongside artifact GC and logs the count", async () => {
+    const { tick } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    db.query(
+      `INSERT INTO memos (sha256, subject_type, subject_id, kind, created_at, expires_at)
+       VALUES (?, 'repo', 'factory', 'repo-note', ?, ?)`,
+    ).run("a".repeat(64), now - 100, now - 31 * 24 * 60 * 60 * 1000);
+    const logs = [];
+    await tick({
+      db,
+      registry: loadRegistry(),
+      now,
+      policyVersion: "git:test",
+      lastPrune: 0,
+      log: (line) => logs.push(line),
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(0);
+    expect(logs).toContain("memos: swept 1 expired/retired/superseded memo(s)");
+    db.close();
+  });
+
   test("tick with FACTORY_EVENT_NOTIFY=1 pushes a human_needed park through the stub notifier exactly once", async () => {
     const { delivery } = await runNotifierDeliveryCase();
     expect(delivery.error).toBeNull();

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -2,11 +2,13 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-cli-serve-tes
 import { describe, expect, test } from "bun:test";
 import { spawnSync } from "node:child_process";
 import { createServer } from "node:http";
+import path from "node:path";
 import {
   existsSync,
   mkdirSync,
   readFileSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import { API_HOST } from "../lib/config.mjs";
@@ -341,6 +343,41 @@ describe("serve command", () => {
     });
     expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(0);
     expect(logs).toContain("memos: swept 1 expired/retired/superseded memo(s)");
+    db.close();
+  });
+
+  test("tick still prunes artifacts when the memo sweep throws", async () => {
+    const { tick } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    db.query(
+      `INSERT INTO memos (sha256, subject_type, subject_id, kind, created_at, expires_at)
+       VALUES (?, 'repo', 'factory', 'repo-note', ?, ?)`,
+    ).run("a".repeat(64), now - 100, now - 31 * 24 * 60 * 60 * 1000);
+    // With a doomed row present the sweep's transaction touches memo_uses;
+    // removing the table makes that step throw without affecting artifact GC.
+    db.exec(`DROP TABLE memo_uses`);
+    const storeRoot = tmpDir("evrt-gc-store-");
+    const orphan = path.join(storeRoot, "b".repeat(64));
+    writeFileSync(orphan, "orphan bytes");
+    const stale = new Date(now - 8 * 24 * 60 * 60 * 1000);
+    utimesSync(orphan, stale, stale);
+    const logs = [];
+    const result = await tick({
+      db,
+      registry: loadRegistry(),
+      now,
+      policyVersion: "git:test",
+      lastPrune: 0,
+      storeRoot,
+      log: (line) => logs.push(line),
+    });
+    expect(logs.some((line) => line.startsWith("tick GC: memos: "))).toBe(true);
+    expect(existsSync(orphan)).toBe(false);
+    expect(logs).toContain("artifacts: pruned 1 orphan(s), freed 12B");
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(1);
+    expect(result.lastPrune).toBe(now);
     db.close();
   });
 

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -48,6 +48,7 @@ export const LEARNINGS_MAX = 5;
 export const BODY_MAX_BYTES = 4 * 1024;
 export const EVIDENCE_MAX_BYTES = 1024;
 export const LIST_MEMOS_DEFAULT_MAX = 20;
+export const MEMO_RETENTION_MS = 30 * 24 * 60 * 60 * 1000;
 
 /** Kind-default expiry; a binding.expiresAt always wins (§6.2). */
 export const KIND_DEFAULT_TTL_MS = Object.freeze({
@@ -551,24 +552,46 @@ function usefulCounts(db, hashes) {
   return counts;
 }
 
-function bindingHolds(row, { descriptionHash, headSha } = {}) {
-  if (
-    row.description_hash &&
-    descriptionHash !== undefined &&
-    descriptionHash !== null &&
-    row.description_hash !== descriptionHash
-  ) {
-    return { holds: false, reason: "description_hash_mismatch" };
-  }
-  if (
-    row.head_sha &&
-    headSha !== undefined &&
-    headSha !== null &&
-    row.head_sha !== headSha
-  ) {
-    return { holds: false, reason: "head_sha_mismatch" };
-  }
-  return { holds: true, reason: null };
+/**
+ * Remove memo rows whose terminal state has outlived the audit retention
+ * window. Supersession has no timestamp of its own, so the replacement memo's
+ * creation time is the point at which the predecessor became superseded.
+ */
+export function sweepMemos(
+  db,
+  { now = Date.now(), retentionMs = MEMO_RETENTION_MS } = {},
+) {
+  const cutoff = now - retentionMs;
+  const doomed = db
+    .query(
+      `SELECT memo.sha256 FROM memos AS memo
+       LEFT JOIN memos AS replacement ON replacement.sha256 = memo.superseded_by
+       WHERE (memo.expires_at IS NOT NULL AND memo.expires_at <= ?)
+          OR (memo.retired_at IS NOT NULL AND memo.retired_at <= ?)
+          OR (memo.superseded_by IS NOT NULL AND replacement.created_at <= ?)`,
+    )
+    .all(cutoff, cutoff, cutoff)
+    .map((row) => row.sha256);
+  if (doomed.length === 0) return { deleted: 0, usesDeleted: 0 };
+
+  const placeholders = doomed.map(() => "?").join(", ");
+  const result = db.transaction(() => {
+    const usesDeleted = Number(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM memo_uses WHERE sha256 IN (${placeholders})`,
+        )
+        .get(...doomed)?.n ?? 0,
+    );
+    db.query(`DELETE FROM memo_uses WHERE sha256 IN (${placeholders})`).run(
+      ...doomed,
+    );
+    db.query(`DELETE FROM memos WHERE sha256 IN (${placeholders})`).run(
+      ...doomed,
+    );
+    return { deleted: doomed.length, usesDeleted };
+  })();
+  return result;
 }
 
 /**
@@ -590,51 +613,64 @@ export function listMemos(
 ) {
   const normalized = normalizeSubject(subject);
   const params = [normalized.type, normalized.id];
-  let sql = `SELECT * FROM memos WHERE subject_type = ? AND subject_id = ?`;
+  let where = `subject_type = ? AND subject_id = ?`;
   if (Array.isArray(kinds) && kinds.length > 0) {
-    sql += ` AND kind IN (${kinds.map(() => "?").join(", ")})`;
+    where += ` AND kind IN (${kinds.map(() => "?").join(", ")})`;
     params.push(...kinds);
   }
-  const rows = db.query(sql).all(...params);
+
+  if (live) {
+    const liveWhere = `${where}
+      AND superseded_by IS NULL
+      AND retired_at IS NULL
+      AND (expires_at IS NULL OR expires_at > ?)`;
+    const liveParams = [...params, now];
+    // Match the prior folding behavior: bindings are observed only for rows
+    // that are otherwise live, and description hash wins when both mismatch.
+    if (descriptionHash !== undefined && descriptionHash !== null) {
+      db.query(
+        `UPDATE memos SET retired_at = ?, retired_reason = 'description_hash_mismatch'
+         WHERE ${liveWhere} AND description_hash IS NOT NULL AND description_hash != ?`,
+      ).run(now, ...liveParams, descriptionHash);
+    }
+    if (headSha !== undefined && headSha !== null) {
+      db.query(
+        `UPDATE memos SET retired_at = ?, retired_reason = 'head_sha_mismatch'
+         WHERE ${liveWhere} AND head_sha IS NOT NULL AND head_sha != ?`,
+      ).run(now, ...liveParams, headSha);
+    }
+
+    const limit =
+      Number.isInteger(max) && max > 0 ? max : LIST_MEMOS_DEFAULT_MAX;
+    const rows = db
+      .query(
+        `SELECT memos.*,
+                SUM(CASE WHEN memo_uses.verdict = 'useful' THEN 1 ELSE 0 END) AS useful_count,
+                SUM(CASE WHEN memo_uses.verdict = 'wrong' THEN 1 ELSE 0 END) AS wrong_count
+         FROM memos LEFT JOIN memo_uses ON memo_uses.sha256 = memos.sha256
+         WHERE ${liveWhere}
+         GROUP BY memos.sha256
+         ORDER BY useful_count DESC, memos.created_at DESC
+         LIMIT ?`,
+      )
+      .all(...liveParams, limit);
+    return rows.map((row) =>
+      foldMemo(row, {
+        useful: Number(row.useful_count),
+        wrong: Number(row.wrong_count),
+      }),
+    );
+  }
+
+  const rows = db.query(`SELECT * FROM memos WHERE ${where}`).all(...params);
   const counts = usefulCounts(
     db,
     rows.map((row) => row.sha256),
   );
   const folded = [];
   for (const row of rows) {
-    if (live) {
-      if (row.superseded_by) continue;
-      if (row.retired_at) continue;
-      if (row.expires_at !== null && row.expires_at <= now) continue;
-      const binding = bindingHolds(row, { descriptionHash, headSha });
-      if (!binding.holds) {
-        db.query(
-          `UPDATE memos SET retired_at = ?, retired_reason = ?
-           WHERE sha256 = ? AND retired_at IS NULL`,
-        ).run(now, binding.reason, row.sha256);
-        continue;
-      }
-    }
     const tally = counts.get(row.sha256) ?? { useful: 0, wrong: 0 };
-    folded.push({
-      sha256: row.sha256,
-      subject: { type: row.subject_type, id: row.subject_id },
-      kind: row.kind,
-      runId: row.run_id,
-      inboxItemId: row.inbox_item_id,
-      createdAt: new Date(row.created_at).toISOString(),
-      createdAtMs: row.created_at,
-      expiresAt:
-        row.expires_at === null ? null : new Date(row.expires_at).toISOString(),
-      descriptionHash: row.description_hash,
-      headSha: row.head_sha,
-      supersededBy: row.superseded_by,
-      retiredAt:
-        row.retired_at === null ? null : new Date(row.retired_at).toISOString(),
-      retiredReason: row.retired_reason,
-      usefulCount: tally.useful,
-      wrongCount: tally.wrong,
-    });
+    folded.push(foldMemo(row, tally));
   }
   folded.sort((a, b) => {
     if (b.usefulCount !== a.usefulCount) return b.usefulCount - a.usefulCount;
@@ -642,6 +678,28 @@ export function listMemos(
   });
   const limit = Number.isInteger(max) && max > 0 ? max : LIST_MEMOS_DEFAULT_MAX;
   return folded.slice(0, limit);
+}
+
+function foldMemo(row, tally) {
+  return {
+    sha256: row.sha256,
+    subject: { type: row.subject_type, id: row.subject_id },
+    kind: row.kind,
+    runId: row.run_id,
+    inboxItemId: row.inbox_item_id,
+    createdAt: new Date(row.created_at).toISOString(),
+    createdAtMs: row.created_at,
+    expiresAt:
+      row.expires_at === null ? null : new Date(row.expires_at).toISOString(),
+    descriptionHash: row.description_hash,
+    headSha: row.head_sha,
+    supersededBy: row.superseded_by,
+    retiredAt:
+      row.retired_at === null ? null : new Date(row.retired_at).toISOString(),
+    retiredReason: row.retired_reason,
+    usefulCount: tally.useful,
+    wrongCount: tally.wrong,
+  };
 }
 
 function learningErrors(entry, index) {

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -552,25 +552,40 @@ function usefulCounts(db, hashes) {
   return counts;
 }
 
+/** Upper bound on memo rows one `sweepMemos` pass will delete. */
+export const MEMO_SWEEP_BATCH = 500;
+
 /**
  * Remove memo rows whose terminal state has outlived the audit retention
  * window. Supersession has no timestamp of its own, so the replacement memo's
- * creation time is the point at which the predecessor became superseded.
+ * creation time is the point at which the predecessor became superseded; when
+ * the replacement is already gone (swept by an earlier pass) the predecessor's
+ * own creation time is the fallback, so a dangling `superseded_by` never pins
+ * a row forever. Each pass is bounded by `limit` so a large backlog cannot
+ * stall the serve tick; the next hourly pass drains the remainder.
  */
 export function sweepMemos(
   db,
-  { now = Date.now(), retentionMs = MEMO_RETENTION_MS } = {},
+  {
+    now = Date.now(),
+    retentionMs = MEMO_RETENTION_MS,
+    limit = MEMO_SWEEP_BATCH,
+  } = {},
 ) {
   const cutoff = now - retentionMs;
+  const batch = Number.isInteger(limit) && limit > 0 ? limit : MEMO_SWEEP_BATCH;
   const doomed = db
     .query(
       `SELECT memo.sha256 FROM memos AS memo
        LEFT JOIN memos AS replacement ON replacement.sha256 = memo.superseded_by
        WHERE (memo.expires_at IS NOT NULL AND memo.expires_at <= ?)
           OR (memo.retired_at IS NOT NULL AND memo.retired_at <= ?)
-          OR (memo.superseded_by IS NOT NULL AND replacement.created_at <= ?)`,
+          OR (memo.superseded_by IS NOT NULL
+              AND COALESCE(replacement.created_at, memo.created_at) <= ?)
+       ORDER BY memo.created_at ASC, memo.sha256 ASC
+       LIMIT ?`,
     )
-    .all(cutoff, cutoff, cutoff)
+    .all(cutoff, cutoff, cutoff, batch)
     .map((row) => row.sha256);
   if (doomed.length === 0) return { deleted: 0, usesDeleted: 0 };
 
@@ -650,7 +665,7 @@ export function listMemos(
          FROM memos LEFT JOIN memo_uses ON memo_uses.sha256 = memos.sha256
          WHERE ${liveWhere}
          GROUP BY memos.sha256
-         ORDER BY useful_count DESC, memos.created_at DESC
+         ORDER BY useful_count DESC, memos.created_at DESC, memos.sha256 DESC
          LIMIT ?`,
       )
       .all(...liveParams, limit);

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -365,6 +365,121 @@ describe("registerMemos / listMemos", () => {
     db.close();
   });
 
+  test("sweepMemos keeps memos that died inside the retention window", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const expired = accepted(repoNoteDoc({ body: "expired" }), { now });
+    const retired = accepted(repoNoteDoc({ body: "retired" }), { now });
+    const predecessor = accepted(repoNoteDoc({ body: "predecessor" }), {
+      now: now - MEMO_RETENTION_MS - 1,
+    });
+    const replacement = accepted(repoNoteDoc({ body: "replacement" }), {
+      now,
+    });
+    registerMemos(db, "run_expired", expired.result, { now });
+    registerMemos(db, "run_retired", retired.result, { now });
+    registerMemos(db, "run_predecessor", predecessor.result, {
+      now: now - MEMO_RETENTION_MS - 1,
+    });
+    registerMemos(db, "run_replacement", replacement.result, { now });
+    db.query(`UPDATE memos SET expires_at = ? WHERE sha256 = ?`).run(
+      now - 1,
+      expired.sha256,
+    );
+    db.query(`UPDATE memos SET retired_at = ? WHERE sha256 = ?`).run(
+      now - 1,
+      retired.sha256,
+    );
+    db.query(`UPDATE memos SET superseded_by = ? WHERE sha256 = ?`).run(
+      replacement.sha256,
+      predecessor.sha256,
+    );
+
+    expect(sweepMemos(db, { now })).toEqual({ deleted: 0, usesDeleted: 0 });
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(4);
+    db.close();
+  });
+
+  test("sweepMemos treats a dangling superseded_by as retained from the predecessor's own age", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const old = accepted(repoNoteDoc({ body: "old predecessor" }), {
+      now: now - MEMO_RETENTION_MS - 1,
+    });
+    const young = accepted(repoNoteDoc({ body: "young predecessor" }), {
+      now,
+    });
+    registerMemos(db, "run_old", old.result, {
+      now: now - MEMO_RETENTION_MS - 1,
+    });
+    registerMemos(db, "run_young", young.result, { now });
+    // The replacement was itself swept in an earlier pass: no row exists.
+    db.query(`UPDATE memos SET superseded_by = ? WHERE sha256 IN (?, ?)`).run(
+      "f".repeat(64),
+      old.sha256,
+      young.sha256,
+    );
+
+    expect(sweepMemos(db, { now })).toEqual({ deleted: 1, usesDeleted: 0 });
+    expect(
+      db
+        .query(`SELECT sha256 FROM memos`)
+        .all()
+        .map((row) => row.sha256),
+    ).toEqual([young.sha256]);
+    db.close();
+  });
+
+  test("sweepMemos bounds each pass and drains the backlog across passes", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const memos = ["one", "two", "three"].map((body) =>
+      accepted(repoNoteDoc({ body }), { now }),
+    );
+    for (const [i, memo] of memos.entries()) {
+      registerMemos(db, `run_${i}`, memo.result, { now });
+      db.query(`UPDATE memos SET expires_at = ? WHERE sha256 = ?`).run(
+        now - MEMO_RETENTION_MS - 1,
+        memo.sha256,
+      );
+    }
+
+    expect(sweepMemos(db, { now, limit: 2 })).toEqual({
+      deleted: 2,
+      usesDeleted: 0,
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(1);
+    expect(sweepMemos(db, { now, limit: 2 })).toEqual({
+      deleted: 1,
+      usesDeleted: 0,
+    });
+    expect(db.query(`SELECT COUNT(*) AS n FROM memos`).get().n).toBe(0);
+    db.close();
+  });
+
+  test("listMemos orders ties on useful_count and created_at by sha256", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const memos = ["alpha", "beta", "gamma"].map((body) =>
+      accepted(repoNoteDoc({ body }), { now }),
+    );
+    for (const [i, memo] of memos.entries()) {
+      registerMemos(db, `run_${i}`, memo.result, { now });
+    }
+    const expected = memos
+      .map((memo) => memo.sha256)
+      .sort()
+      .reverse();
+    for (let i = 0; i < 3; i += 1) {
+      expect(
+        listMemos(db, { type: "repo", id: "factory" }, { now }).map(
+          (row) => row.sha256,
+        ),
+      ).toEqual(expected);
+    }
+    db.close();
+  });
+
   test("a binding observed broken retires the memo", () => {
     const db = openDb(":memory:");
     const now = Date.parse("2026-08-18T14:02:11.000Z");

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -14,12 +14,14 @@ import {
 import {
   KIND_DEFAULT_TTL_MS,
   LEARNINGS_MAX,
+  MEMO_RETENTION_MS,
   MEMO_SCHEMA_VERSION,
   learningsToMemos,
   listMemos,
   memoDigest,
   normalizeSubjectId,
   registerMemos,
+  sweepMemos,
   validateMemo,
   withProvenance,
 } from "./memos.mjs";
@@ -256,6 +258,110 @@ describe("registerMemos / listMemos", () => {
         { now: now + KIND_DEFAULT_TTL_MS.postmortem + 1 },
       ),
     ).toHaveLength(0);
+    db.close();
+  });
+
+  test("live SQL filtering keeps the existing mixed-subject fold and applies max", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const useful = accepted(postmortemDoc({ body: "useful" }), { now });
+    const newer = accepted(postmortemDoc({ body: "newer" }), { now: now + 1 });
+    const expired = accepted(postmortemDoc({ body: "expired" }), { now });
+    const retired = accepted(postmortemDoc({ body: "retired" }), { now });
+    const superseded = accepted(postmortemDoc({ body: "superseded" }), {
+      now,
+    });
+    registerMemos(db, "run_useful", useful.result, { now });
+    registerMemos(db, "run_newer", newer.result, { now: now + 1 });
+    registerMemos(db, "run_expired", expired.result, { now });
+    registerMemos(db, "run_retired", retired.result, { now });
+    registerMemos(db, "run_superseded", superseded.result, { now });
+    db.query(`UPDATE memos SET expires_at = ? WHERE sha256 = ?`).run(
+      now,
+      expired.sha256,
+    );
+    db.query(`UPDATE memos SET retired_at = ? WHERE sha256 = ?`).run(
+      now,
+      retired.sha256,
+    );
+    db.query(`UPDATE memos SET superseded_by = ? WHERE sha256 = ?`).run(
+      newer.sha256,
+      superseded.sha256,
+    );
+    registerMemos(
+      db,
+      "run_consumer",
+      { usedMemos: [{ sha256: useful.sha256, verdict: "useful" }] },
+      { now: now + 2 },
+    );
+
+    const allLive = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { now: now + 2 },
+    );
+    expect(allLive.map((row) => row.sha256)).toEqual([
+      useful.sha256,
+      newer.sha256,
+    ]);
+    const live = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      { now: now + 2, max: 1 },
+    );
+    expect(live.map((row) => row.sha256)).toEqual([useful.sha256]);
+    expect(live[0].usefulCount).toBe(1);
+    db.close();
+  });
+
+  test("sweepMemos removes retained dead memos and their use rows only", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const expired = accepted(repoNoteDoc({ body: "expired" }), { now });
+    const retired = accepted(repoNoteDoc({ body: "retired" }), { now });
+    const predecessor = accepted(repoNoteDoc({ body: "predecessor" }), { now });
+    const replacement = accepted(repoNoteDoc({ body: "replacement" }), {
+      now: now - MEMO_RETENTION_MS - 1,
+    });
+    const live = accepted(repoNoteDoc({ body: "live" }), { now });
+    for (const [runId, memo] of [
+      ["run_expired", expired],
+      ["run_retired", retired],
+      ["run_predecessor", predecessor],
+      ["run_replacement", replacement],
+      ["run_live", live],
+    ]) {
+      registerMemos(db, runId, memo.result, { now });
+    }
+    db.query(`UPDATE memos SET expires_at = ? WHERE sha256 = ?`).run(
+      now - MEMO_RETENTION_MS - 1,
+      expired.sha256,
+    );
+    db.query(`UPDATE memos SET retired_at = ? WHERE sha256 = ?`).run(
+      now - MEMO_RETENTION_MS - 1,
+      retired.sha256,
+    );
+    db.query(`UPDATE memos SET superseded_by = ? WHERE sha256 = ?`).run(
+      replacement.sha256,
+      predecessor.sha256,
+    );
+    db.query(
+      `INSERT INTO memo_uses (sha256, run_id, verdict, run_state, at)
+       VALUES (?, 'run_use', 'useful', 'COMPLETED', ?)`,
+    ).run(expired.sha256, now);
+    db.query(
+      `INSERT INTO memo_uses (sha256, run_id, verdict, run_state, at)
+       VALUES (?, 'run_use', 'wrong', 'COMPLETED', ?)`,
+    ).run(predecessor.sha256, now);
+
+    expect(sweepMemos(db, { now })).toEqual({ deleted: 3, usesDeleted: 2 });
+    expect(
+      db
+        .query(`SELECT sha256 FROM memos ORDER BY sha256`)
+        .all()
+        .map((row) => row.sha256),
+    ).toEqual([live.sha256, replacement.sha256].sort());
+    expect(db.query(`SELECT COUNT(*) AS n FROM memo_uses`).get().n).toBe(0);
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1392

Sweep retained dead memo rows during hourly GC so their ledger and use records no longer pin artifact storage.

## Validation

| Check                | Command                                                                          | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/memos.test.mjs event-runtime/cli/serve.test.mjs --timeout 20000` | pass    | 35 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1935 pass, emit and format clean           |
| UX critique          | factory-ux-critic                                                                | not run | backend memo retention; no user-facing surface |

UX critique: skipped

## Post-review

Folded in the three in-scope review fixes (`dee64102`):

- `sweepMemos` is bounded per pass (`LIMIT` = `MEMO_SWEEP_BATCH` 500, overridable via `limit`); the hourly cadence drains any backlog.
- A dangling `superseded_by` (replacement already swept) no longer pins the predecessor: eligibility falls back to the predecessor's own `created_at <= cutoff` via `COALESCE(replacement.created_at, memo.created_at)`.
- `tick` GC runs memo sweep, artifact prune and notify sweep in isolated try/catch sub-steps (`tick GC: <name>: …`), so a sweep throw cannot skip artifact GC; `lastPrune` still advances.
- `listMemos` ordering is stable: `ORDER BY useful_count DESC, created_at DESC, sha256 DESC`.

Tests added: dead-inside-retention kept; dangling `superseded_by` swept after retention (young one kept); bounded pass drains across passes; serve tick prunes artifacts when the memo sweep throws; tie-break ordering stable.
