### PR TITLE
chore(notify): sweep stale dedup markers

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -26,7 +26,7 @@ import {
   planAdmittedEvents,
 } from "../lib/planner.mjs";
 import { resolveChains } from "../lib/chain.mjs";
-import { notifyPending } from "../lib/notify.mjs";
+import { notifyPending, sweepNotifyLog } from "../lib/notify.mjs";
 import { reconcileInbox } from "../lib/inbox.mjs";
 import { loadModelTierMap, loadRegistry } from "../lib/registry.mjs";
 import { applyModelTierCellOverrides } from "../lib/runtime-overrides.mjs";
@@ -188,6 +188,8 @@ export async function tick({
         logLine(
           `artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`,
         );
+      const swept = sweepNotifyLog(db, { now });
+      if (swept > 0) logLine(`notify: swept ${swept} stale dedup marker(s)`);
     } finally {
       nextPrune = now;
     }

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -242,6 +242,30 @@ describe("serve command", () => {
     expect(chainsRan).toBe(true);
   });
 
+  test("tick sweeps stale notify-log markers on the hourly GC cadence", async () => {
+    const { tick, PRUNE_INTERVAL_MS } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const { ensureNotifyLog } = await import("../lib/notify.mjs");
+    const db = openDb(":memory:");
+    const now = Date.now();
+    ensureNotifyLog(db);
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES ('human_needed', 'test/resolved-event', 'old marker', ?)`,
+    ).run(new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString());
+
+    await tick({
+      db,
+      registry: loadRegistry(),
+      policyVersion: "git:test",
+      now,
+      lastPrune: now - PRUNE_INTERVAL_MS - 1,
+      subsystems: { notify: () => {} },
+    });
+
+    expect(db.query("SELECT COUNT(*) AS n FROM notify_log").get().n).toBe(0);
+  });
+
   test("tick with FACTORY_EVENT_NOTIFY=1 pushes a human_needed park through the stub notifier exactly once", async () => {
     const { delivery } = await runNotifierDeliveryCase();
     expect(delivery.error).toBeNull();

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -29,7 +29,7 @@
  */
 import { spawn } from "node:child_process";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
-import { tx, txImmediate } from "./db.mjs";
+import { txImmediate } from "./db.mjs";
 import { templateFor } from "./decision-templates.mjs";
 import { proposalSubject } from "./proposal-subject.mjs";
 import { notifyCommand as resolveNotifyCommand } from "../../lib/notify.mjs";
@@ -102,7 +102,11 @@ export function sweepNotifyLog(
   }
   ensureNotifyLog(db);
   const cutoff = new Date(now - retentionDays * DAY_MS).toISOString();
-  return tx(
+  // The human_needed target is `${source}/${event_id}`; split it on the
+  // notify_log side so the events probe is plain column equality and can use
+  // the (source, event_id) primary key. Sources never contain '/', event ids
+  // may, hence the split on the first separator.
+  return txImmediate(
     db,
     () =>
       db
@@ -111,9 +115,10 @@ export function sweepNotifyLog(
          WHERE sent_at < ?
            AND (
              (kind = ? AND NOT EXISTS (
-               SELECT 1 FROM events
-               WHERE notify_log.target = events.source || '/' || events.event_id
-                 AND events.status = 'human_needed'
+               SELECT 1 FROM events e
+               WHERE e.source = substr(notify_log.target, 1, instr(notify_log.target, '/') - 1)
+                 AND e.event_id = substr(notify_log.target, instr(notify_log.target, '/') + 1)
+                 AND e.status = 'human_needed'
              ))
              OR
              (kind IN (?, ?, ?) AND NOT EXISTS (

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -29,7 +29,7 @@
  */
 import { spawn } from "node:child_process";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
-import { txImmediate } from "./db.mjs";
+import { tx, txImmediate } from "./db.mjs";
 import { templateFor } from "./decision-templates.mjs";
 import { proposalSubject } from "./proposal-subject.mjs";
 import { notifyCommand as resolveNotifyCommand } from "../../lib/notify.mjs";
@@ -85,6 +85,53 @@ const KIND_HUMAN_NEEDED = "human_needed";
 const DEDUP_PROPOSAL_TTL = "proposal_ttl";
 const KIND_DECISION_NEEDED = "decision_needed";
 const KIND_PROPOSAL_EXPIRED = "proposal_expired";
+export const DEFAULT_NOTIFY_LOG_RETENTION_DAYS = 14;
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Remove expired dedup markers only after their referent can no longer notify.
+ * Open proposals and still-parked events retain their markers regardless of
+ * age, preserving the once-only push guarantee.
+ */
+export function sweepNotifyLog(
+  db,
+  { retentionDays = DEFAULT_NOTIFY_LOG_RETENTION_DAYS, now = Date.now() } = {},
+) {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+    throw new Error("retentionDays must be a positive number of days");
+  }
+  ensureNotifyLog(db);
+  const cutoff = new Date(now - retentionDays * DAY_MS).toISOString();
+  return tx(
+    db,
+    () =>
+      db
+        .query(
+          `DELETE FROM notify_log
+         WHERE sent_at < ?
+           AND (
+             (kind = ? AND NOT EXISTS (
+               SELECT 1 FROM events
+               WHERE notify_log.target = events.source || '/' || events.event_id
+                 AND events.status = 'human_needed'
+             ))
+             OR
+             (kind IN (?, ?, ?) AND NOT EXISTS (
+               SELECT 1 FROM proposals
+               WHERE proposals.id = notify_log.target
+                 AND proposals.status = 'open'
+             ))
+           )`,
+        )
+        .run(
+          cutoff,
+          KIND_HUMAN_NEEDED,
+          DEDUP_PROPOSAL_TTL,
+          KIND_DECISION_NEEDED,
+          KIND_PROPOSAL_EXPIRED,
+        ).changes,
+  );
+}
 
 function alreadyNotified(db, kind, target) {
   return !!db

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -5,11 +5,13 @@ import path from "node:path";
 import { openDb } from "./db.mjs";
 import {
   DEFAULT_NOTIFY_CMD,
+  ensureNotifyLog,
   notifyCommand,
   notifyEnabled,
   notifyPending,
   pendingNotifications,
   sendNotification,
+  sweepNotifyLog,
 } from "./notify.mjs";
 import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 import { fileURLToPath } from "node:url";
@@ -392,6 +394,50 @@ describe("notify (WM-65)", () => {
       createdAt: new Date(now - 60 * 60_000).toISOString(),
     });
     expect(pendingNotifications(db, { now })).toEqual([]);
+  });
+
+  test("sweeps stale markers for resolved referents but preserves parked-event dedup", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    const old = new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString();
+    ensureNotifyLog(db);
+    insertEvent(db, { eventId: "evt-resolved", status: "completed" });
+    insertEvent(db, { eventId: "evt-parked", status: "human_needed" });
+    insertProposal(db, {
+      id: "prop-decided",
+      eventId: "evt-resolved",
+      status: "approved",
+    });
+    insertProposal(db, { id: "prop-open", eventId: "evt-parked" });
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'old marker', ?)`,
+    ).run("human_needed", "test/evt-resolved", old);
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'old marker', ?)`,
+    ).run("human_needed", "test/evt-parked", old);
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'old marker', ?)`,
+    ).run("proposal_ttl", "prop-decided", old);
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'old marker', ?)`,
+    ).run("proposal_ttl", "prop-open", old);
+
+    expect(sweepNotifyLog(db, { now })).toBe(2);
+    expect(
+      db.query("SELECT kind, target FROM notify_log ORDER BY target").all(),
+    ).toEqual([
+      { kind: "proposal_ttl", target: "prop-open" },
+      { kind: "human_needed", target: "test/evt-parked" },
+    ]);
+
+    // A sweep must not remove the marker for an eligible park: no duplicate.
+    expect(
+      notifyPending(db, { now, enabled: true, command: "/x/stub" }).sent,
+    ).toEqual([]);
   });
 
   test("a notifier that exits non-zero is recorded on notify_log and logged, not thrown", async () => {

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -440,6 +440,57 @@ describe("notify (WM-65)", () => {
     ).toEqual([]);
   });
 
+  test("a recent marker for an already-resolved referent survives the sweep", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    const recent = new Date(now - 2 * 24 * 60 * 60 * 1000).toISOString();
+    ensureNotifyLog(db);
+    insertEvent(db, { eventId: "evt-done", status: "completed" });
+    insertProposal(db, {
+      id: "prop-done",
+      eventId: "evt-done",
+      status: "rejected",
+    });
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'recent marker', ?)`,
+    ).run("human_needed", "test/evt-done", recent);
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'recent marker', ?)`,
+    ).run("proposal_ttl", "prop-done", recent);
+
+    expect(sweepNotifyLog(db, { now })).toBe(0);
+    expect(db.query("SELECT count(*) AS n FROM notify_log").get().n).toBe(2);
+  });
+
+  test("an event id containing '/' still matches its parked event", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    const old = new Date(now - 15 * 24 * 60 * 60 * 1000).toISOString();
+    ensureNotifyLog(db);
+    insertEvent(db, {
+      source: "github",
+      eventId: "issue/42/comment",
+      status: "human_needed",
+    });
+    db.query(
+      `INSERT INTO notify_log (kind, target, message, sent_at)
+       VALUES (?, ?, 'old marker', ?)`,
+    ).run("human_needed", "github/issue/42/comment", old);
+
+    expect(sweepNotifyLog(db, { now })).toBe(0);
+  });
+
+  test("sweepNotifyLog rejects a non-positive retention", () => {
+    const db = openDb(":memory:");
+    for (const retentionDays of [0, -1, NaN, Infinity]) {
+      expect(() => sweepNotifyLog(db, { retentionDays })).toThrow(
+        /retentionDays must be a positive number of days/,
+      );
+    }
+  });
+
   test("a notifier that exits non-zero is recorded on notify_log and logged, not thrown", async () => {
     const dir = tmp("evrt-notify-fail-");
     const stub = stubNotifier(dir, { exitCode: 3 });


### PR DESCRIPTION
Fixes #1398

Review the bounded cleanup of stale notification dedup markers and its hourly GC integration.

## Validation

| Check                | Command                                                                                         | Result  | Notes                                   |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | --------------------------------------- |
| Verification Command | `bun test event-runtime/lib/notify.test.mjs event-runtime/cli/serve.test.mjs --timeout 20000` | pass    | 20 tests, 0 failures                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,934 tests; emit and format clean      |
| UX critique          | factory-ux-critic                                                                               | not run | skipped: backend maintenance, no UI     |

UX critique: skipped — backend maintenance; no user-facing surface

## Post-review

- `sweepNotifyLog` now runs its DELETE under `txImmediate` (was deferred `tx`); unused `tx` import dropped.
- The parked-event referent check compares `events.source` / `events.event_id` by column equality (target split via `substr`/`instr` on the `notify_log` side), so the `(source, event_id)` primary key is usable instead of a concatenation scan.
- Tests: a RECENT marker for an already-resolved event/proposal survives the sweep; event ids containing `/` still match; `retentionDays <= 0` / NaN / Infinity throw.
- Verified: notify + serve suites, full `event-runtime/lib`, `emit --check`, `format:check`, `bun run check` (commit 61cdfdbb).
