### PR TITLE
fix(cli): supervise web serve lifecycle

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -112,8 +112,30 @@ case "$cmd" in
       for _a in "$@"; do
         [[ "$_a" != "--web" && "$_a" != "--all" ]] && _args+=("$_a")
       done
+      _web_pid=""
+      _runtime_pid=""
+      _cleanup_serve() {
+        local _status=$?
+        trap - EXIT INT TERM
+        for _pid in "$_runtime_pid" "$_web_pid"; do
+          [[ -n "$_pid" ]] && kill -TERM "$_pid" 2>/dev/null || true
+        done
+        for _pid in "$_runtime_pid" "$_web_pid"; do
+          [[ -n "$_pid" ]] && wait "$_pid" 2>/dev/null || true
+        done
+        exit "$_status"
+      }
+      trap _cleanup_serve EXIT
+      trap 'exit 130' INT
+      trap 'exit 143' TERM
       bun "$ROOT/event-runtime/web/serve.mjs" &
-      exec bun "$ROOT/event-runtime/cli.mjs" serve "${_args[@]}"
+      _web_pid=$!
+      bun "$ROOT/event-runtime/cli.mjs" serve "${_args[@]}" &
+      _runtime_pid=$!
+      _runtime_status=0
+      wait "$_runtime_pid" || _runtime_status=$?
+      _runtime_pid=""
+      exit "$_runtime_status"
     else
       run_bun event-runtime/cli.mjs serve "$@"
     fi

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -1,7 +1,9 @@
 import { test, expect } from "bun:test";
 import {
   chmodSync,
+  copyFileSync,
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   rmSync,
@@ -11,6 +13,46 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 const FACTORY = path.resolve(import.meta.dir, "factory");
+
+function makeServeFixture() {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-serve-"));
+  const webDir = path.join(root, "event-runtime", "web");
+  mkdirSync(path.join(root, "bin"), { recursive: true });
+  mkdirSync(webDir, { recursive: true });
+  copyFileSync(FACTORY, path.join(root, "bin", "factory"));
+  writeFileSync(
+    path.join(webDir, "serve.mjs"),
+    `import { writeFileSync } from "node:fs";
+writeFileSync(process.env.WEB_STARTED, String(process.pid));
+process.on("SIGTERM", () => {
+  writeFileSync(process.env.WEB_STOPPED, "stopped");
+  process.exit(0);
+});
+setInterval(() => {}, 1_000);
+`,
+  );
+  writeFileSync(
+    path.join(root, "event-runtime", "cli.mjs"),
+    `if (process.env.RUNTIME_EXIT_CODE)
+  process.exit(Number(process.env.RUNTIME_EXIT_CODE));
+process.on("SIGTERM", () => process.exit(0));
+setInterval(() => {}, 1_000);
+`,
+  );
+  return {
+    root,
+    cleanup: () => rmSync(root, { recursive: true, force: true }),
+  };
+}
+
+async function waitForFile(file) {
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    if (existsSync(file)) return true;
+    await Bun.sleep(25);
+  }
+  return false;
+}
 
 test("factory help documents every dispatcher verb", () => {
   const source = readFileSync(FACTORY, "utf8");
@@ -30,6 +72,62 @@ test("factory help documents every dispatcher verb", () => {
   const help = result.stdout.toString();
   for (const verb of verbs) {
     expect(help).toMatch(new RegExp(`^  ${verb}\\s`, "m"));
+  }
+});
+
+test("factory serve --web stops the web server when the runtime receives SIGTERM", async () => {
+  const fixture = makeServeFixture();
+  const webStarted = path.join(fixture.root, "web-started");
+  const webStopped = path.join(fixture.root, "web-stopped");
+  let webPid = null;
+  const proc = Bun.spawn({
+    cmd: ["bash", path.join(fixture.root, "bin", "factory"), "serve", "--web"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      WEB_STARTED: webStarted,
+      WEB_STOPPED: webStopped,
+    },
+  });
+  try {
+    expect(await waitForFile(webStarted)).toBe(true);
+    webPid = Number(readFileSync(webStarted, "utf8"));
+
+    proc.kill("SIGTERM");
+    await proc.exited;
+
+    expect(existsSync(webStopped)).toBe(true);
+    expect(
+      Bun.spawnSync({ cmd: ["kill", "-0", String(webPid)] }).exitCode,
+    ).not.toBe(0);
+  } finally {
+    proc.kill("SIGTERM");
+    await proc.exited;
+    if (Number.isInteger(webPid) && webPid > 0)
+      Bun.spawnSync({ cmd: ["kill", "-TERM", String(webPid)] });
+    fixture.cleanup();
+  }
+}, 10_000);
+
+test("factory serve --web propagates the runtime exit code", () => {
+  const fixture = makeServeFixture();
+  try {
+    const result = Bun.spawnSync({
+      cmd: [
+        "bash",
+        path.join(fixture.root, "bin", "factory"),
+        "serve",
+        "--web",
+      ],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, RUNTIME_EXIT_CODE: "23" },
+    });
+
+    expect(result.exitCode).toBe(23);
+  } finally {
+    fixture.cleanup();
   }
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1395

Use one lifecycle owner for `factory serve --web|--all`, so ending the runtime also terminates its web server.

## Validation

| Check                | Command                                                                                         | Result  | Notes                         |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test bin/factory.test.mjs --timeout 20000`                                                | pass    | 17 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1933 pass, 10 skipped         |
| UX critique          | factory-ux-critic                                                                               | skipped | no user-facing surface        |

UX critique: skipped