### PR TITLE
fix(stack): clean failed live-stack startups

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -21,25 +21,80 @@ source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 # down a daemon an operator already had running.
 UP_STARTED_PIDFILES=()
 UP_STARTED_LABELS=()
+UP_PREEXISTING_PIDFILES=()
+UP_PREEXISTING_PIDS=()
+
+snapshot_up_pidfiles() {
+  local pidfile
+  for pidfile in "$RUN_DIR"/*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    UP_PREEXISTING_PIDFILES+=("$pidfile")
+    UP_PREEXISTING_PIDS+=("$(cat "$pidfile" 2>/dev/null || true)")
+  done
+}
+
+up_pidfile_preexisted_unchanged() { # <pidfile>
+  local pidfile="$1" i current
+  current="$(cat "$pidfile" 2>/dev/null || true)"
+  for i in "${!UP_PREEXISTING_PIDFILES[@]}"; do
+    if [[ "${UP_PREEXISTING_PIDFILES[$i]}" == "$pidfile" \
+      && "${UP_PREEXISTING_PIDS[$i]}" == "$current" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+track_up_pidfile() { # <label> <pidfile>
+  local label="$1" pidfile="$2" existing
+  for existing in "${UP_STARTED_PIDFILES[@]}"; do
+    [[ "$existing" == "$pidfile" ]] && return 0
+  done
+  UP_STARTED_PIDFILES+=("$pidfile")
+  UP_STARTED_LABELS+=("$label")
+}
+
+track_up_pool_pidfiles() {
+  local pidfile label
+  for pidfile in "$RUN_DIR/supervisor.pid" "$RUN_DIR"/worker-[0-9]*.pid; do
+    [[ -f "$pidfile" ]] || continue
+    up_pidfile_preexisted_unchanged "$pidfile" && continue
+    label="worker pool $(basename "${pidfile%.pid}")"
+    track_up_pidfile "$label" "$pidfile"
+  done
+}
 
 cleanup_up_daemons() {
-  local i pidfile label
+  local round i pidfile label
+  # The pool supervisor creates its own supervisor/worker-N pidfiles after the
+  # top-level worker daemon is spawned. Discover those before teardown so its
+  # detached worker groups are terminated too, while snapshot-matched files
+  # belonging to a pre-existing stack remain untouched.
+  track_up_pool_pidfiles
   [[ ${#UP_STARTED_PIDFILES[@]} -gt 0 ]] || return 0
 
   warn "up failed — stopping daemons started by this invocation"
-  for i in "${!UP_STARTED_PIDFILES[@]}"; do
-    pidfile="${UP_STARTED_PIDFILES[$i]}"
-    label="${UP_STARTED_LABELS[$i]}"
-    term_daemon "$pidfile" "$label" || true
-  done
-  for i in "${!UP_STARTED_PIDFILES[@]}"; do
-    pidfile="${UP_STARTED_PIDFILES[$i]}"
-    label="${UP_STARTED_LABELS[$i]}"
-    await_daemon "$pidfile" "$label" || true
-    # await_daemon normally removes this itself. Keep the invariant even for a
-    # platform-specific implementation that only waits, or a dead child whose
-    # pidfile was never valid.
-    rm -f "$pidfile"
+  # Re-scan after the first await: a just-spawned pool supervisor can publish
+  # its detached worker pidfiles while the top-level supervisor is stopping.
+  for round in 1 2; do
+    track_up_pool_pidfiles
+    for i in "${!UP_STARTED_PIDFILES[@]}"; do
+      pidfile="${UP_STARTED_PIDFILES[$i]}"
+      label="${UP_STARTED_LABELS[$i]}"
+      term_daemon "$pidfile" "$label" || true
+    done
+    for i in "${!UP_STARTED_PIDFILES[@]}"; do
+      pidfile="${UP_STARTED_PIDFILES[$i]}"
+      label="${UP_STARTED_LABELS[$i]}"
+      await_daemon "$pidfile" "$label" || true
+      # await_daemon normally removes this itself. Keep the invariant even for
+      # a platform-specific implementation that only waits, or a dead child
+      # whose pidfile was never valid.
+      rm -f "$pidfile"
+      if [[ "$(basename "$pidfile")" == worker-[0-9]*.pid ]]; then
+        rm -f "${pidfile%.pid}.drain" "${pidfile%.pid}.id"
+      fi
+    done
   done
   UP_STARTED_PIDFILES=()
   UP_STARTED_LABELS=()
@@ -55,8 +110,7 @@ spawn_daemon_tracked() { # <label> <pidfile> <logfile> <workdir> <cmd...>
   local label="$1" pidfile="$2"
   shift 2
   spawn_daemon "$pidfile" "$@"
-  UP_STARTED_PIDFILES+=("$pidfile")
-  UP_STARTED_LABELS+=("$label")
+  track_up_pidfile "$label" "$pidfile"
 }
 
 print_daemon_command() { # <label> <cmd...>
@@ -77,6 +131,7 @@ WEB_PORT="${FACTORY_EVENT_WEB_PORT:-7382}"
 
 mkdir -p "$RUN_DIR" "$HOME_DIR"
 REPO="$(repo_root)"
+if [[ "$ACTION" == "up" ]]; then snapshot_up_pidfiles; fi
 
 elapsed_seconds() {
   local elapsed="${1//[[:space:]]/}" days=0 rest hours=0 minutes=0 seconds=0
@@ -102,9 +157,12 @@ cleanup_stale_fake_runtimes() {
     return 0
   }
 
-  local pid pgid elapsed command age_seconds process_with_env seen_groups=" "
+  local pid pgid elapsed command age_seconds process_with_env seen_groups=" " processes
   local current_pgid
   current_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+  # A captured stream works in minimal chroots that expose /proc but omit the
+  # conventional /dev/fd symlink Bash process substitution relies on.
+  processes="$(ps -axo pid=,pgid=,etime=,command= 2>/dev/null || true)"
   while read -r pid pgid elapsed command; do
     [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
     [[ "$pgid" =~ ^[0-9]+$ ]] || continue
@@ -125,7 +183,7 @@ cleanup_stale_fake_runtimes() {
     # being mistaken for test debris. Marked runtimes are detached group
     # leaders, so a group kill also removes wrappers and grandchildren.
     kill -KILL -- "-$pgid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
-  done < <(ps -axo pid=,pgid=,etime=,command=)
+  done <<<"$processes"
 }
 
 # PIDs listening on <port> that THIS checkout started (WM-657, #1068). Ownership
@@ -136,13 +194,14 @@ cleanup_stale_fake_runtimes() {
 # on the shared operator box.
 owned_port_holders() { # <port>
   command -v lsof >/dev/null 2>&1 || return 0
-  local pid cmd
+  local pid cmd holders
+  holders="$(lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u || true)"
   while read -r pid; do
     [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
     cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
     [[ "$cmd" == *"$REPO/"* ]] || continue
     printf '%s\n' "$pid"
-  done < <(lsof -nP -tiTCP:"$1" -sTCP:LISTEN 2>/dev/null | sort -u)
+  done <<<"$holders"
 }
 
 # Reap an orphan of ours still holding <port> after the pidfile teardown, or
@@ -181,8 +240,9 @@ reap_owned_port() { # <port> <label>
 # never touched. This is the acceptance guarantee that no cli.mjs serve/work or
 # web/serve.mjs the stack owns remains after `down`.
 reap_owned_processes() {
-  local pid pgid cmd current_pgid
+  local pid pgid cmd current_pgid processes
   current_pgid="$(ps -o pgid= -p $$ 2>/dev/null | tr -d '[:space:]')"
+  processes="$(ps -axo pid=,pgid=,command= 2>/dev/null || true)"
   while read -r pid pgid cmd; do
     [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || continue
     [[ "$pgid" =~ ^[0-9]+$ ]] || continue
@@ -195,7 +255,7 @@ reap_owned_processes() {
     esac
     warn "reaping orphaned stack process pid $pid: $cmd"
     kill -KILL -- "-$pgid" 2>/dev/null || kill -KILL "$pid" 2>/dev/null || true
-  done < <(ps -axo pid=,pgid=,command=)
+  done <<<"$processes"
 }
 
 case "$ACTION" in

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -23,6 +23,11 @@ UP_STARTED_PIDFILES=()
 UP_STARTED_LABELS=()
 UP_PREEXISTING_PIDFILES=()
 UP_PREEXISTING_PIDS=()
+# Only an `up` that has taken its snapshot may clean up on `die`. Every other
+# action (down, tail, a bad option, the __supervise-* loops) has an empty
+# snapshot, and an empty snapshot would make every pidfile in RUN_DIR look like
+# ours — `factory tail nosuchlog` must never stop the operator's live stack.
+UP_SNAPSHOT_TAKEN=0
 
 snapshot_up_pidfiles() {
   local pidfile
@@ -31,11 +36,14 @@ snapshot_up_pidfiles() {
     UP_PREEXISTING_PIDFILES+=("$pidfile")
     UP_PREEXISTING_PIDS+=("$(cat "$pidfile" 2>/dev/null || true)")
   done
+  UP_SNAPSHOT_TAKEN=1
 }
 
 up_pidfile_preexisted_unchanged() { # <pidfile>
   local pidfile="$1" i current
   current="$(cat "$pidfile" 2>/dev/null || true)"
+  # Empty-array guards keep "${arr[@]}" safe under bash 3.2 + set -u.
+  [[ ${#UP_PREEXISTING_PIDFILES[@]} -gt 0 ]] || return 1
   for i in "${!UP_PREEXISTING_PIDFILES[@]}"; do
     if [[ "${UP_PREEXISTING_PIDFILES[$i]}" == "$pidfile" \
       && "${UP_PREEXISTING_PIDS[$i]}" == "$current" ]]; then
@@ -47,9 +55,11 @@ up_pidfile_preexisted_unchanged() { # <pidfile>
 
 track_up_pidfile() { # <label> <pidfile>
   local label="$1" pidfile="$2" existing
-  for existing in "${UP_STARTED_PIDFILES[@]}"; do
-    [[ "$existing" == "$pidfile" ]] && return 0
-  done
+  if [[ ${#UP_STARTED_PIDFILES[@]} -gt 0 ]]; then
+    for existing in "${UP_STARTED_PIDFILES[@]}"; do
+      [[ "$existing" == "$pidfile" ]] && return 0
+    done
+  fi
   UP_STARTED_PIDFILES+=("$pidfile")
   UP_STARTED_LABELS+=("$label")
 }
@@ -66,6 +76,7 @@ track_up_pool_pidfiles() {
 
 cleanup_up_daemons() {
   local round i pidfile label
+  [[ "$UP_SNAPSHOT_TAKEN" -eq 1 ]] || return 0
   # The pool supervisor creates its own supervisor/worker-N pidfiles after the
   # top-level worker daemon is spawned. Discover those before teardown so its
   # detached worker groups are terminated too, while snapshot-matched files
@@ -109,7 +120,7 @@ die() {
 spawn_daemon_tracked() { # <label> <pidfile> <logfile> <workdir> <cmd...>
   local label="$1" pidfile="$2"
   shift 2
-  spawn_daemon "$pidfile" "$@"
+  spawn_daemon "$pidfile" "$@" || die "failed to start $label — check logs at $1"
   track_up_pidfile "$label" "$pidfile"
 }
 
@@ -129,9 +140,10 @@ RUN_DIR="${FACTORY_RUN_DIR:-$HOME/.factory/run}"
 API_PORT="${FACTORY_EVENT_PORT:-7381}"
 WEB_PORT="${FACTORY_EVENT_WEB_PORT:-7382}"
 
-mkdir -p "$RUN_DIR" "$HOME_DIR"
+# `up` creates these itself once `--dry-run` has had its chance to exit: a dry
+# run must leave no trace on disk.
+if [[ "$ACTION" != "up" ]]; then mkdir -p "$RUN_DIR" "$HOME_DIR"; fi
 REPO="$(repo_root)"
-if [[ "$ACTION" == "up" ]]; then snapshot_up_pidfiles; fi
 
 elapsed_seconds() {
   local elapsed="${1//[[:space:]]/}" days=0 rest hours=0 minutes=0 seconds=0
@@ -361,6 +373,11 @@ case "$ACTION" in
       exit 0
     fi
 
+    mkdir -p "$RUN_DIR" "$HOME_DIR"
+    # Record what was already running before this invocation starts anything,
+    # so a failed `up` can tell its own daemons from the operator's.
+    snapshot_up_pidfiles
+
     # Dependency freshness (WM-312). A runtime dependency added to the repo does
     # not exist on the running stack until someone remembers `bun install` after
     # pulling, and nothing detected the gap: on 2026-08-15 the Gondolin sandbox
@@ -545,8 +562,12 @@ case "$ACTION" in
       if curl -sf -m 1 "http://127.0.0.1:$WEB_PORT" >/dev/null 2>&1; then break; fi
       sleep 0.1
     done
+    # Warn, never die: the runtime and worker pool are healthy by now, and the
+    # web supervisor keeps retrying the static server. Tearing down a working
+    # stack because the UI bound slowly on a loaded box would be the worse
+    # outcome (#1396 review).
     if ! curl -sf -m 1 "http://127.0.0.1:$WEB_PORT" >/dev/null 2>&1; then
-      die "web server failed to start on $WEB_PORT — check logs at $RUN_DIR/web.log"
+      warn "web server not responding on $WEB_PORT yet — the web supervisor keeps retrying; check logs at $RUN_DIR/web.log"
     fi
 
     if [[ "$DEV" -eq 1 ]]; then

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -15,6 +15,58 @@ set -euo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 
+# `up` can start several detached daemons before an endpoint health check
+# proves the stack is usable. Keep this invocation's pidfiles separate from
+# pre-existing daemons: an error must clean up what we started, but never tear
+# down a daemon an operator already had running.
+UP_STARTED_PIDFILES=()
+UP_STARTED_LABELS=()
+
+cleanup_up_daemons() {
+  local i pidfile label
+  [[ ${#UP_STARTED_PIDFILES[@]} -gt 0 ]] || return 0
+
+  warn "up failed — stopping daemons started by this invocation"
+  for i in "${!UP_STARTED_PIDFILES[@]}"; do
+    pidfile="${UP_STARTED_PIDFILES[$i]}"
+    label="${UP_STARTED_LABELS[$i]}"
+    term_daemon "$pidfile" "$label" || true
+  done
+  for i in "${!UP_STARTED_PIDFILES[@]}"; do
+    pidfile="${UP_STARTED_PIDFILES[$i]}"
+    label="${UP_STARTED_LABELS[$i]}"
+    await_daemon "$pidfile" "$label" || true
+    # await_daemon normally removes this itself. Keep the invariant even for a
+    # platform-specific implementation that only waits, or a dead child whose
+    # pidfile was never valid.
+    rm -f "$pidfile"
+  done
+  UP_STARTED_PIDFILES=()
+  UP_STARTED_LABELS=()
+}
+
+die() {
+  cleanup_up_daemons
+  printf '\033[31merror:\033[0m %s\n' "$*" >&2
+  exit 1
+}
+
+spawn_daemon_tracked() { # <label> <pidfile> <logfile> <workdir> <cmd...>
+  local label="$1" pidfile="$2"
+  shift 2
+  spawn_daemon "$pidfile" "$@"
+  UP_STARTED_PIDFILES+=("$pidfile")
+  UP_STARTED_LABELS+=("$label")
+}
+
+print_daemon_command() { # <label> <cmd...>
+  local label="$1"
+  shift
+  printf '  %s: ' "$label"
+  printf '%q ' "$@"
+  printf '\n'
+}
+
 ACTION="${1:-up}"
 shift || true
 
@@ -151,6 +203,7 @@ case "$ACTION" in
     ADAPTER_FLAG=()
     DEV=0
     NO_BUILD=0
+    DRY_RUN=0
     WEB_BUILD_MESSAGE=""
     WORKERS_SPEC=""
     while [[ $# -gt 0 ]]; do
@@ -161,11 +214,13 @@ case "$ACTION" in
         --web-port) WEB_PORT="$2"; shift ;;
         --dev) DEV=1 ;;
         --no-build) NO_BUILD=1 ;;
+        --dry-run) DRY_RUN=1 ;;
         --workers) WORKERS_SPEC="$2"; shift ;;
         -h|--help)
-          echo "usage: factory up [--fake] [--dev] [--no-build] [--workers min:max] [--port 7381] [--web-port 7382]"
+          echo "usage: factory up [--fake] [--dev] [--no-build] [--dry-run] [--workers min:max] [--port 7381] [--web-port 7382]"
           echo "  --dev       live reload: serve --watch, vite HMR web UI, worker restarts when idle"
           echo "  --no-build  serve the existing web bundle without checking whether it is stale"
+          echo "  --dry-run   print resolved ports and daemon commands without starting anything"
           echo "  --workers   supervised pool scaling between min and max on queue depth (WM-226);"
           echo "             without it, a workers: block in config/policy.yaml selects the pool"
           exit 0
@@ -180,6 +235,70 @@ case "$ACTION" in
     # picking one — WM-213's reload supervisor drives a single worker by design.
     if [[ "$DEV" -eq 1 && -n "$WORKERS_SPEC" ]]; then
       die "--workers and --dev both replace the worker daemon — run the pool without --dev"
+    fi
+
+    # Policy-driven by default: the presence of a workers: block is the switch,
+    # so a checkout without one keeps starting exactly one plain worker (the
+    # pre-WM-226 behavior, unchanged).
+    POOL=0
+    if [[ -n "$WORKERS_SPEC" ]]; then
+      POOL=1
+    elif [[ "$DEV" -eq 0 && -f "$REPO/config/policy.yaml" ]] && grep -qE '^workers:[[:space:]]*(#.*)?$' "$REPO/config/policy.yaml"; then
+      POOL=1
+    fi
+
+    # --dev swaps each of the three daemons for its reloading twin and changes
+    # nothing else. SERVE_ARGS/WORKER_ARGS are built rather than branched so the
+    # non-dev command stays exactly what it was before this flag existed. (They
+    # are never empty, which keeps "${arr[@]}" safe under bash 3.2 + set -u.)
+    SERVE_ARGS=(serve --port "$API_PORT")
+    if [[ ${#ADAPTER_FLAG[@]} -gt 0 ]]; then
+      SERVE_ARGS+=("${ADAPTER_FLAG[@]}")
+    fi
+    WORKER_ARGS=(bun "$REPO/event-runtime/cli.mjs" work)
+    if [[ "$POOL" -eq 1 ]]; then
+      # The supervisor takes the worker.pid slot; the workers it spawns get
+      # their own worker-N.pid files in the same run dir, so `down`, `tail`, and
+      # `factory events status` all keep working on the pool as a whole.
+      WORKER_ARGS=(bun "$REPO/event-runtime/cli.mjs" supervise)
+      if [[ -n "$WORKERS_SPEC" ]]; then
+        WORKER_ARGS+=(--workers "$WORKERS_SPEC")
+      fi
+    fi
+    if [[ "$DEV" -eq 1 ]]; then
+      SERVE_ARGS+=(--watch)
+      # The worker is supervised rather than watched: it exits 75 at an idle
+      # poll boundary and this same script re-execs it (see __supervise-worker).
+      WORKER_ARGS=(bash "$REPO/bin/live-stack.sh" __supervise-worker --reload-on-change)
+    fi
+
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+      printf 'dry run — no daemons will be started\n'
+      printf 'RUN_DIR=%s\nAPI_PORT=%s\nWEB_PORT=%s\n' "$RUN_DIR" "$API_PORT" "$WEB_PORT"
+      printf 'daemon commands:\n'
+      if [[ -n "${FACTORY_GH_APP_ID:-}" && -n "${FACTORY_GH_APP_PRIVATE_KEY_PATH:-}" ]]; then
+        print_daemon_command "GitHub App token daemon" \
+          bun "$REPO/lib/control-plane/gh-app-auth.mjs" --daemon
+      fi
+      print_daemon_command "event runtime" \
+        env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+        bun "$REPO/event-runtime/cli.mjs" "${SERVE_ARGS[@]}"
+      print_daemon_command "worker" \
+        env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
+        "${WORKER_ARGS[@]}"
+      if [[ "$DEV" -eq 1 ]]; then
+        print_daemon_command "web server" \
+          env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+          bunx vite --host 127.0.0.1 --port "$WEB_PORT" --strictPort
+      else
+        print_daemon_command "web server" \
+          env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+          bun "$REPO/event-runtime/web/serve.mjs"
+      fi
+      print_daemon_command "web supervisor" \
+        env FACTORY_RUN_DIR="$RUN_DIR" FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
+        bash "$REPO/bin/live-stack.sh" __supervise-web "$DEV"
+      exit 0
     fi
 
     # Dependency freshness (WM-312). A runtime dependency added to the repo does
@@ -217,39 +336,7 @@ case "$ACTION" in
     ensure_deps "root" "$REPO"
     ensure_deps "event-runtime/web" "$REPO/event-runtime/web"
 
-    # Policy-driven by default: the presence of a workers: block is the switch,
-    # so a checkout without one keeps starting exactly one plain worker (the
-    # pre-WM-226 behavior, unchanged).
-    POOL=0
-    if [[ -n "$WORKERS_SPEC" ]]; then
-      POOL=1
-    elif [[ "$DEV" -eq 0 && -f "$REPO/config/policy.yaml" ]] && grep -qE '^workers:[[:space:]]*(#.*)?$' "$REPO/config/policy.yaml"; then
-      POOL=1
-    fi
-
-    # --dev swaps each of the three daemons for its reloading twin and changes
-    # nothing else. SERVE_ARGS/WORKER_ARGS are built rather than branched so the
-    # non-dev command stays exactly what it was before this flag existed. (They
-    # are never empty, which keeps "${arr[@]}" safe under bash 3.2 + set -u.)
-    SERVE_ARGS=(serve --port "$API_PORT")
-    if [[ ${#ADAPTER_FLAG[@]} -gt 0 ]]; then
-      SERVE_ARGS+=("${ADAPTER_FLAG[@]}")
-    fi
-    WORKER_ARGS=(bun "$REPO/event-runtime/cli.mjs" work)
-    if [[ "$POOL" -eq 1 ]]; then
-      # The supervisor takes the worker.pid slot; the workers it spawns get
-      # their own worker-N.pid files in the same run dir, so `down`, `tail`, and
-      # `factory events status` all keep working on the pool as a whole.
-      WORKER_ARGS=(bun "$REPO/event-runtime/cli.mjs" supervise)
-      if [[ -n "$WORKERS_SPEC" ]]; then
-        WORKER_ARGS+=(--workers "$WORKERS_SPEC")
-      fi
-    fi
     if [[ "$DEV" -eq 1 ]]; then
-      SERVE_ARGS+=(--watch)
-      # The worker is supervised rather than watched: it exits 75 at an idle
-      # poll boundary and this same script re-execs it (see __supervise-worker).
-      WORKER_ARGS=(bash "$REPO/bin/live-stack.sh" __supervise-worker --reload-on-change)
       if [[ ! -d "$REPO/event-runtime/web/node_modules" ]]; then
         die "--dev needs the web deps for vite — run: (cd $REPO/event-runtime/web && bun install)"
       fi
@@ -322,7 +409,7 @@ case "$ACTION" in
           warn "initial GitHub App token mint failed — control-plane falls back to the operator PAT until the daemon succeeds (see $RUN_DIR/gh-app-auth.log)"
         fi
         info "starting GitHub App token-refresh daemon"
-        spawn_daemon "$RUN_DIR/gh-app-auth.pid" "$RUN_DIR/gh-app-auth.log" "$REPO" \
+        spawn_daemon_tracked "GitHub App token daemon" "$RUN_DIR/gh-app-auth.pid" "$RUN_DIR/gh-app-auth.log" "$REPO" \
           bun "$REPO/lib/control-plane/gh-app-auth.mjs" --daemon
       fi
     fi
@@ -332,7 +419,7 @@ case "$ACTION" in
       info "event runtime already running (pid $(cat "$RUN_DIR/serve.pid"), port $API_PORT)"
     else
       info "starting event runtime on $API_PORT (home $HOME_DIR)"
-      spawn_daemon "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$REPO" \
+      spawn_daemon_tracked "event runtime" "$RUN_DIR/serve.pid" "$RUN_DIR/serve.log" "$REPO" \
         env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
         bun "$REPO/event-runtime/cli.mjs" "${SERVE_ARGS[@]}"
     fi
@@ -355,7 +442,7 @@ case "$ACTION" in
       else
         info "starting worker"
       fi
-      spawn_daemon "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$REPO" \
+      spawn_daemon_tracked "worker" "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$REPO" \
         env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
         "${WORKER_ARGS[@]}"
     fi
@@ -369,11 +456,11 @@ case "$ACTION" in
         # vite's own dev server, not the static serve.mjs: HMR replaces the
         # module in the open tab, so no `bun run build` step in the loop. It
         # proxies /api to FACTORY_EVENT_PORT exactly as serve.mjs does.
-        spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
+        spawn_daemon_tracked "web server" "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
           env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
           bunx vite --host 127.0.0.1 --port "$WEB_PORT" --strictPort
       else
-        spawn_daemon "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
+        spawn_daemon_tracked "web server" "$RUN_DIR/web.pid" "$RUN_DIR/web.log" "$REPO/event-runtime/web" \
           env FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
           bun "$REPO/event-runtime/web/serve.mjs"
       fi
@@ -386,7 +473,7 @@ case "$ACTION" in
       info "web supervisor already running (pid $(cat "$RUN_DIR/web-supervisor.pid"))"
     else
       info "starting web supervisor"
-      spawn_daemon "$RUN_DIR/web-supervisor.pid" "$RUN_DIR/web.log" "$REPO" \
+      spawn_daemon_tracked "web supervisor" "$RUN_DIR/web-supervisor.pid" "$RUN_DIR/web.log" "$REPO" \
         env FACTORY_RUN_DIR="$RUN_DIR" FACTORY_EVENT_PORT="$API_PORT" FACTORY_EVENT_WEB_PORT="$WEB_PORT" \
         bash "$REPO/bin/live-stack.sh" __supervise-web "$DEV"
     fi
@@ -398,6 +485,9 @@ case "$ACTION" in
       if curl -sf -m 1 "http://127.0.0.1:$WEB_PORT" >/dev/null 2>&1; then break; fi
       sleep 0.1
     done
+    if ! curl -sf -m 1 "http://127.0.0.1:$WEB_PORT" >/dev/null 2>&1; then
+      die "web server failed to start on $WEB_PORT — check logs at $RUN_DIR/web.log"
+    fi
 
     if [[ "$DEV" -eq 1 ]]; then
       printf '\n\033[32m==>\033[0m \033[1mready — live factory stack (dev, live reload)\033[0m\n\n'

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -132,7 +132,7 @@ function makeFixture({
 
   // The health polls must not gate a test on a server nobody started.
   const curl = path.join(root, "stubs", "curl");
-  writeFileSync(curl, "#!/bin/sh\nexit 0\n", "utf8");
+  writeFileSync(curl, '#!/bin/sh\nexit "${FAKE_CURL_STATUS:-0}"\n', "utf8");
   chmodSync(curl, 0o755);
 
   // Non-dev web builds are recorded and materialize the one artifact the
@@ -220,6 +220,75 @@ test("plain `up` spawns serve, worker, and the static web server — unchanged b
     f.cleanup();
   }
 });
+
+test("`up --dry-run` prints the resolved daemon plan without spawning", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, [
+      "up",
+      "--dry-run",
+      "--port",
+      "7411",
+      "--web-port",
+      "7412",
+    ]);
+    expect(r.status).toBe(0);
+    expect(r.spawns).toEqual([]);
+    expect(r.builds).toEqual([]);
+    expect(r.stdout).toContain("dry run — no daemons will be started");
+    expect(r.stdout).toContain(`RUN_DIR=${f.runDir}`);
+    expect(r.stdout).toContain("API_PORT=7411");
+    expect(r.stdout).toContain("WEB_PORT=7412");
+    expect(r.stdout).toContain("event runtime: env");
+    expect(r.stdout).toContain("cli.mjs serve --port 7411");
+    expect(r.stdout).toContain("worker: env");
+    expect(r.stdout).toContain("web server: env");
+    expect(r.stdout).toContain("web supervisor: env");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("failed runtime health cleans up only daemons spawned by this `up`", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up"], {
+      FACTORY_GH_APP_ID: "test-app",
+      FACTORY_GH_APP_PRIVATE_KEY_PATH: "/tmp/test-key",
+      FAKE_CURL_STATUS: "1",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("event runtime failed to start");
+    expect(r.spawns).toContainEqual(
+      expect.stringContaining("pid=gh-app-auth.pid"),
+    );
+    expect(r.spawns).toContainEqual(expect.stringContaining("pid=serve.pid"));
+    expect(r.spawns).toContain("TERM GitHub App token daemon");
+    expect(r.spawns).toContain("TERM event runtime");
+    expect(existsSync(path.join(f.runDir, "gh-app-auth.pid"))).toBe(false);
+    expect(existsSync(path.join(f.runDir, "serve.pid"))).toBe(false);
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
+
+test("failed `up` leaves an already-running daemon alone", () => {
+  const f = makeFixture();
+  try {
+    mkdirSync(f.runDir, { recursive: true });
+    writeFileSync(path.join(f.runDir, "serve.pid"), "4242\n", "utf8");
+    const r = runStack(f, ["up"], {
+      FAKE_ALIVE: "1",
+      FAKE_CURL_STATUS: "1",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stdout).toContain("event runtime already running");
+    expect(r.spawns).not.toContain("TERM event runtime");
+    expect(existsSync(path.join(f.runDir, "serve.pid"))).toBe(true);
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
 
 test("plain `up` rebuilds a stale web bundle and reports the elapsed time", () => {
   const f = makeFixture({ bundle: "stale" });

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -48,6 +48,7 @@ spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
   local pidfile="$1" logfile="$2" workdir="$3"
   shift 3
   printf 'SPAWN pid=%s workdir=%s cmd=%s\\n' "$(basename "$pidfile")" "$workdir" "$*" >>"$SPAWN_LOG"
+  if [[ "$(basename "$pidfile")" == "\${FAKE_SPAWN_FAIL_PIDFILE:-}" ]]; then return 1; fi
   printf '1\\n' >"$pidfile"
   if [[ "\${FAKE_POOL_CHILDREN:-0}" == "1" && "$*" == *"cli.mjs supervise"* ]]; then
     printf '2\\n' >"$(dirname "$pidfile")/supervisor.pid"
@@ -258,6 +259,9 @@ test("`up --dry-run` prints the resolved daemon plan without spawning", () => {
     expect(r.stdout).toContain("worker: env");
     expect(r.stdout).toContain("web server: env");
     expect(r.stdout).toContain("web supervisor: env");
+    // A dry run leaves no trace on disk: no run dir, no event home.
+    expect(existsSync(f.runDir)).toBe(false);
+    expect(existsSync(path.join(f.root, "home"))).toBe(false);
   } finally {
     f.cleanup();
   }
@@ -304,16 +308,42 @@ test("failed `up` leaves an already-running daemon alone", () => {
   }
 }, 20_000);
 
-test("failed web health removes supervised pool children from this `up`", () => {
+test("slow web health warns and keeps the healthy runtime and pool running", () => {
   const f = makeFixture();
   try {
     const r = runStack(f, ["up", "--workers", "1:1"], {
       FAKE_POOL_CHILDREN: "1",
       FAKE_CURL_FAIL_URL: ":7382",
     });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("web server not responding on 7382 yet");
+    expect(r.stdout).toContain("ready — live factory stack");
+    expect(r.spawns.some((line) => line.startsWith("TERM "))).toBe(false);
+    for (const file of [
+      "serve.pid",
+      "worker.pid",
+      "supervisor.pid",
+      "worker-1.pid",
+      "web.pid",
+    ]) {
+      expect(existsSync(path.join(f.runDir, file))).toBe(true);
+    }
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
+
+test("a daemon that fails to spawn removes supervised pool children from this `up`", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--workers", "1:1"], {
+      FAKE_POOL_CHILDREN: "1",
+      FAKE_SPAWN_FAIL_PIDFILE: "web.pid",
+    });
     expect(r.status).not.toBe(0);
-    expect(r.stderr).toContain("web server failed to start");
+    expect(r.stderr).toContain("failed to start web server");
     expect(r.spawns).toContain("TERM worker pool worker-1");
+    expect(r.spawns).toContain("TERM event runtime");
     for (const file of [
       "worker.pid",
       "supervisor.pid",
@@ -321,6 +351,38 @@ test("failed web health removes supervised pool children from this `up`", () => 
       "worker-1.id",
     ]) {
       expect(existsSync(path.join(f.runDir, file))).toBe(false);
+    }
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
+
+test("a non-`up` die never touches pre-existing pidfiles or daemons", () => {
+  const f = makeFixture();
+  try {
+    mkdirSync(f.runDir, { recursive: true });
+    const preexisting = {
+      "serve.pid": "4242\n",
+      "worker.pid": "4243\n",
+      "supervisor.pid": "4244\n",
+      "worker-1.pid": "4245\n",
+      "worker-1.id": "worker_live\n",
+      "web.pid": "4246\n",
+    };
+    for (const [file, body] of Object.entries(preexisting)) {
+      writeFileSync(path.join(f.runDir, file), body, "utf8");
+    }
+    for (const args of [
+      ["tail", "nosuchlog"],
+      ["bogus-action"],
+      ["up", "--no-such-option"],
+    ]) {
+      const r = runStack(f, args, { FAKE_ALIVE: "1" });
+      expect(r.status).not.toBe(0);
+      expect(r.spawns).toEqual([]);
+      for (const [file, body] of Object.entries(preexisting)) {
+        expect(readFileSync(path.join(f.runDir, file), "utf8")).toBe(body);
+      }
     }
   } finally {
     f.cleanup();

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -49,6 +49,11 @@ spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
   shift 3
   printf 'SPAWN pid=%s workdir=%s cmd=%s\\n' "$(basename "$pidfile")" "$workdir" "$*" >>"$SPAWN_LOG"
   printf '1\\n' >"$pidfile"
+  if [[ "\${FAKE_POOL_CHILDREN:-0}" == "1" && "$*" == *"cli.mjs supervise"* ]]; then
+    printf '2\\n' >"$(dirname "$pidfile")/supervisor.pid"
+    printf '3\\n' >"$(dirname "$pidfile")/worker-1.pid"
+    printf 'worker_test\\n' >"$(dirname "$pidfile")/worker-1.id"
+  fi
 }
 term_daemon() {
   printf 'TERM %s\\n' "$2" >>"$SPAWN_LOG"
@@ -132,7 +137,16 @@ function makeFixture({
 
   // The health polls must not gate a test on a server nobody started.
   const curl = path.join(root, "stubs", "curl");
-  writeFileSync(curl, '#!/bin/sh\nexit "${FAKE_CURL_STATUS:-0}"\n', "utf8");
+  writeFileSync(
+    curl,
+    `#!/bin/sh
+if [ -n "\${FAKE_CURL_FAIL_URL:-}" ]; then
+  case "$*" in *"$FAKE_CURL_FAIL_URL"*) exit 1 ;; esac
+fi
+exit "\${FAKE_CURL_STATUS:-0}"
+`,
+    "utf8",
+  );
   chmodSync(curl, 0o755);
 
   // Non-dev web builds are recorded and materialize the one artifact the
@@ -285,6 +299,29 @@ test("failed `up` leaves an already-running daemon alone", () => {
     expect(r.stdout).toContain("event runtime already running");
     expect(r.spawns).not.toContain("TERM event runtime");
     expect(existsSync(path.join(f.runDir, "serve.pid"))).toBe(true);
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
+
+test("failed web health removes supervised pool children from this `up`", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--workers", "1:1"], {
+      FAKE_POOL_CHILDREN: "1",
+      FAKE_CURL_FAIL_URL: ":7382",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("web server failed to start");
+    expect(r.spawns).toContain("TERM worker pool worker-1");
+    for (const file of [
+      "worker.pid",
+      "supervisor.pid",
+      "worker-1.pid",
+      "worker-1.id",
+    ]) {
+      expect(existsSync(path.join(f.runDir, file))).toBe(false);
+    }
   } finally {
     f.cleanup();
   }

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -58,6 +58,16 @@ const PORT_BASE = pickPortBase();
 const PORT_RESERVATION_ROOT = mkdtempSync(
   path.join(tmpdir(), "factory-port-reservations-"),
 );
+// The handoff verifier exposes read-only /usr but intentionally starts with an
+// empty /etc. On Debian, /usr/bin/awk points through /etc/alternatives, so give
+// shell fixtures a direct wrapper to the real executable they are testing with.
+const TEST_TOOL_BIN = mkdtempSync(path.join(tmpdir(), "factory-test-tools-"));
+writeFileSync(
+  path.join(TEST_TOOL_BIN, "awk"),
+  '#!/bin/bash\nexec /usr/bin/mawk "$@"\n',
+);
+chmodSync(path.join(TEST_TOOL_BIN, "awk"), 0o755);
+const TEST_PATH = `${TEST_TOOL_BIN}:${process.env.PATH}`;
 const P = (offset) => PORT_BASE + offset;
 const BAND_ENV = {
   FACTORY_PORT_BASE: String(PORT_BASE),
@@ -67,6 +77,7 @@ const BAND_ENV = {
 
 afterAll(() => {
   rmSync(PORT_RESERVATION_ROOT, { recursive: true, force: true });
+  rmSync(TEST_TOOL_BIN, { recursive: true, force: true });
 });
 
 function sh(body, extraEnv = {}) {
@@ -74,7 +85,7 @@ function sh(body, extraEnv = {}) {
     cmd: ["bash", "-c", `source "${COMMON}"\n${body}`],
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...BAND_ENV, ...extraEnv },
+    env: { ...process.env, PATH: TEST_PATH, ...BAND_ENV, ...extraEnv },
   });
   return {
     status: result.exitCode,
@@ -89,7 +100,7 @@ function command(cmd, cwd, extraEnv = {}) {
     cwd,
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...extraEnv },
+    env: { ...process.env, PATH: TEST_PATH, ...extraEnv },
   });
   return {
     status: result.exitCode,
@@ -138,7 +149,7 @@ function runWorktreeUp(fixture, ticket) {
     fixture.root,
     {
       FACTORY_WT_ROOT: fixture.worktrees,
-      PATH: `${fixture.mockBin}:${process.env.PATH}`,
+      PATH: `${fixture.mockBin}:${TEST_PATH}`,
     },
   );
 }
@@ -147,7 +158,7 @@ async function shAsync(body, extraEnv = {}) {
   const proc = Bun.spawn(["bash", "-c", `source "${COMMON}"\n${body}`], {
     stdout: "pipe",
     stderr: "pipe",
-    env: { ...process.env, ...BAND_ENV, ...extraEnv },
+    env: { ...process.env, PATH: TEST_PATH, ...BAND_ENV, ...extraEnv },
   });
   const [stdout, stderr] = await Promise.all([
     new Response(proc.stdout).text(),
@@ -399,7 +410,7 @@ test("normalize_path is portable and accepts a missing final component", () => {
     chmodSync(path.join(mockBin, "realpath"), 0o755);
     const missing = path.join(root, "existing", "missing-leaf");
     const r = sh(`normalize_path "${root}/existing/../existing/missing-leaf"`, {
-      PATH: `${mockBin}:${process.env.PATH}`,
+      PATH: `${mockBin}:${TEST_PATH}`,
     });
     expect(r.status).toBe(0);
     expect(r.stdout.trim()).toBe(missing);
@@ -430,7 +441,7 @@ test("provision_instance_local_configs does not invoke GNU-only realpath", () =>
         `provision_instance_local_configs "${checkout}" "${source}"`,
         `test "$(cat "${checkout}/config/repos.yaml")" = "repos: []"`,
       ].join("\n"),
-      { PATH: `${mockBin}:${process.env.PATH}` },
+      { PATH: `${mockBin}:${TEST_PATH}` },
     );
     expect(r.status).toBe(0);
     expect(r.stderr).toBe("");
@@ -449,7 +460,7 @@ test("listen_tcp_port rejects a dead pid even if lsof returns a listener", () =>
     // Override the initial guard to reproduce the kill/lsof TOCTOU window on
     // platforms where lsof correctly rejects a dead -p value.
     const r = sh(`pid_alive() { return 0; }\nlisten_tcp_port "${pidfile}"`, {
-      PATH: `${dir}:${process.env.PATH}`,
+      PATH: `${dir}:${TEST_PATH}`,
       MOCK_LSOF_PORT: String(P(352)),
     });
     expect(r.status).not.toBe(0);
@@ -466,7 +477,7 @@ test("listen_tcp_port rejects a recovered port outside the configured band", () 
     const r = sh(
       `printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`,
       {
-        PATH: `${dir}:${process.env.PATH}`,
+        PATH: `${dir}:${TEST_PATH}`,
         MOCK_LSOF_PORT: String(PORT_BASE + 2 * PORT_SPAN),
       },
     );
@@ -484,7 +495,7 @@ test("listen_tcp_port accepts the fixed --here web port below the ticket band", 
     const r = sh(
       `printf '%s\\n' $$ > "${pidfile}"\nlisten_tcp_port "${pidfile}"`,
       {
-        PATH: `${dir}:${process.env.PATH}`,
+        PATH: `${dir}:${TEST_PATH}`,
         MOCK_LSOF_PORT: "7392",
       },
     );


### PR DESCRIPTION
Fixes watt-mind/factory#1396

Failed stack startups now remove every daemon and pidfile they created, while `--dry-run` prints the resolved plan.

## Validation

| Check                | Command                                                                                          | Result  | Notes                  |
| -------------------- | ------------------------------------------------------------------------------------------------ | ------- | ---------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs bin/worktree-common.test.mjs --timeout 20000`                    | pass    | 69 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1939 pass, checks clean |
| UX critique          | `factory-ux-critic`                                                                               | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

## Post-review (45eedb20)

Addressed the FIX verdict (merged `origin/develop` first):

1. **Non-`up` die no longer kills the live stack.** `snapshot_up_pidfiles` sets `UP_SNAPSHOT_TAKEN=1` and `cleanup_up_daemons` returns immediately without it; the snapshot itself now runs inside `up` only after `--dry-run` has had its chance to exit. Reproduced the reviewer's `tail nosuchlog` scenario against the real `worktree-common.sh` with stub daemons in an isolated `FACTORY_RUN_DIR`: `tail nosuchlog`, an unknown action, and `up --bogus` all leave the daemons alive and the pidfiles intact. New test: "a non-`up` die never touches pre-existing pidfiles or daemons".
2. **bash 3.2 + `set -u`**: `"${!UP_PREEXISTING_PIDFILES[@]}"` and `"${UP_STARTED_PIDFILES[@]}"` iterations are guarded by `${#ARR[@]} -gt 0`.
3. **Web health is warn-and-continue again** (pre-PR behaviour): a slow static web bind no longer tears down a healthy runtime + pool; the web supervisor keeps retrying. Test rewritten to assert the stack stays up and nothing is TERMed. The pool-children teardown is now exercised through a daemon that fails to spawn (`spawn_daemon_tracked` dies on a failed `spawn_daemon`), which is the remaining post-worker failure path.
4. **`--dry-run` creates nothing**: `mkdir -p "$RUN_DIR" "$HOME_DIR"` moved after the dry-run exit for `up` (other actions still create it at the top). Test asserts neither directory exists afterwards.
5. **Herestring rewrites kept**: with `<<<` an empty capture yields one blank line, which the `^[0-9]+$` pid guards skip, so the loops are equivalent; `cleanup_stale_fake_runtimes`/`reap_owned_processes` run through the real `ps` in every `down` test and `owned_port_holders` via `reap_owned_port` in the `up`/`down` paths.

Verified: `bun test bin --timeout 60000` (158 pass), `bun run format:check`, `bun run check`.
