### PR TITLE
fix(web): paginate Events history

### DIFF
--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -81,6 +81,42 @@ function ticketSchemaRegistry(eventType: string): AgentsView {
 }
 
 describe("Events component harness: selection & detail view", () => {
+  test("loads older event pages with the cursor and keeps existing rows", async () => {
+    const newest = stubEvent("evt_newest", "admitted");
+    const older = stubEvent("evt_older", "admitted");
+    const pages: Array<{ before?: string }> = [];
+
+    await withApi(
+      {
+        events: async (_status, page = {}) => {
+          pages.push(page);
+          return page.before === "cursor-1"
+            ? { events: [older], nextBefore: null }
+            : { events: [newest], nextBefore: "cursor-1" };
+        },
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { container, getByRole } = renderEvents();
+
+        await waitFor(() =>
+          expect(
+            container.querySelector('td[title="evt_newest"]'),
+          ).toBeTruthy(),
+        );
+        fireEvent.click(getByRole("button", { name: "Older events" }));
+
+        await waitFor(() => {
+          expect(
+            container.querySelector('td[title="evt_newest"]'),
+          ).toBeTruthy();
+          expect(container.querySelector('td[title="evt_older"]')).toBeTruthy();
+        });
+        expect(pages.some((page) => page.before === "cursor-1")).toBe(true);
+      },
+    );
+  });
+
   test("renders an x-ui ticket payload column from its route schema", async () => {
     localStorage.setItem(
       "evrt-display-events",

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -97,13 +97,14 @@ describe("Events component harness: selection & detail view", () => {
         status: async () => createStatusFixture(),
       },
       async () => {
-        const { container, getByRole } = renderEvents();
+        const { container, getByRole, getByText } = renderEvents();
 
         await waitFor(() =>
           expect(
             container.querySelector('td[title="evt_newest"]'),
           ).toBeTruthy(),
         );
+        expect(getByText(/1 loaded row · more events available/)).toBeTruthy();
         fireEvent.click(getByRole("button", { name: "Older events" }));
 
         await waitFor(() => {

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -489,6 +489,37 @@ describe("Events component harness: cross-tab reveal", () => {
   });
 });
 
+describe("Events component harness: malformed /events pages (#1394)", () => {
+  test("a page without an events key renders the empty state instead of throwing", async () => {
+    await withApi(
+      {
+        events: async () =>
+          ({ nextBefore: null }) as unknown as { events: AdmittedEvent[] },
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { findByText } = renderEvents();
+        expect(await findByText(/No events\./i)).toBeTruthy();
+        expect(await findByText(/0 loaded rows/i)).toBeTruthy();
+      },
+    );
+  });
+
+  test("a bare [] /events response renders the empty state instead of throwing", async () => {
+    await withApi(
+      {
+        events: async () => [] as unknown as { events: AdmittedEvent[] },
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { findByText } = renderEvents();
+        expect(await findByText(/No events\./i)).toBeTruthy();
+        expect(await findByText(/0 loaded rows/i)).toBeTruthy();
+      },
+    );
+  });
+});
+
 describe("Events component harness: facet chips grouping and visual distinction", () => {
   test("renders Type and Source category groups with labels and numerical counts", async () => {
     const e1 = stubEvent("evt_1", "admitted", {

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { retriggerEnvelope } from "../templates";
@@ -454,9 +459,14 @@ export function Events({
   const [confirmReplay, setConfirmReplay] = useState(false);
 
   const fetchAll = context.kind === "repo";
-  const list = useQuery({
+  const list = useInfiniteQuery({
     queryKey: ["events", fetchAll ? "all" : tab],
-    queryFn: () => api.events(fetchAll || tab === "all" ? undefined : tab),
+    queryFn: ({ pageParam }) =>
+      api.events(fetchAll || tab === "all" ? undefined : tab, {
+        before: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     ...refetchIntervals.primary,
   });
   const statusQ = useQuery({
@@ -521,7 +531,7 @@ export function Events({
     decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
   const rows: EventFilterRow[] = useMemo(
     () =>
-      (list.data?.events ?? []).map((e) => {
+      (list.data?.pages.flatMap((page) => page.events) ?? []).map((e) => {
         const d = decisionOf(
           e,
           decisions.byId,
@@ -1042,6 +1052,10 @@ export function Events({
                 rows naming this repo.
               </p>
             )}
+            <p className="mb-3 text-[11px] text-(--text-faint)">
+              Facet counts reflect loaded rows.
+              {fetchAll && " Tab counts reflect loaded rows."}
+            </p>
 
             {(types.length > 1 || sources.length > 1) && (
               <div className="mb-2 flex min-w-0 items-center gap-x-4 whitespace-nowrap text-[11px]">
@@ -1412,6 +1426,20 @@ export function Events({
               range={[windowStart, windowEnd, tokens.length]}
               move={moveWindow}
             />
+            {list.hasNextPage && (
+              <tr>
+                <td colSpan={listCols.length}>
+                  <Button
+                    onClick={() => list.fetchNextPage()}
+                    disabled={list.isFetchingNextPage}
+                  >
+                    {list.isFetchingNextPage
+                      ? "Loading older events…"
+                      : "Older events"}
+                  </Button>
+                </td>
+              </tr>
+            )}
             {visible.length === 0 && (
               <ListEmpty
                 colSpan={listCols.length}

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -531,15 +531,17 @@ export function Events({
     decisionOf(e, decisions.byId, decisions.byEvent, decisions.runsById);
   const rows: EventFilterRow[] = useMemo(
     () =>
-      (list.data?.pages.flatMap((page) => page.events) ?? []).map((e) => {
-        const d = decisionOf(
-          e,
-          decisions.byId,
-          decisions.byEvent,
-          decisions.runsById,
-        );
-        return d?.reason ? { ...e, decisionReason: d.reason } : e;
-      }),
+      (list.data?.pages ?? [])
+        .flatMap((page) => page?.events ?? [])
+        .map((e) => {
+          const d = decisionOf(
+            e,
+            decisions.byId,
+            decisions.byEvent,
+            decisions.runsById,
+          );
+          return d?.reason ? { ...e, decisionReason: d.reason } : e;
+        }),
     [list.data, decisions],
   );
   const scoped = useMemo(() => {

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -1053,8 +1053,12 @@ export function Events({
               </p>
             )}
             <p className="mb-3 text-[11px] text-(--text-faint)">
-              Facet counts reflect loaded rows.
-              {fetchAll && " Tab counts reflect loaded rows."}
+              {rows.length} loaded {rows.length === 1 ? "row" : "rows"}
+              {list.hasNextPage && " · more events available"}. Facet counts
+              reflect loaded rows.
+              {fetchAll
+                ? " Status-tab counts reflect loaded rows."
+                : " Status-tab counts reflect all available events."}
             </p>
 
             {(types.length > 1 || sources.length > 1) && (


### PR DESCRIPTION
Fixes watt-mind/factory#1394

Events now append older pages while showing operators what is loaded and whether more history is available.

## Validation

| Check                | Command                                                                        | Result | Notes                              |
| -------------------- | ------------------------------------------------------------------------------ | ------ | ---------------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Events.test.tsx`                   | pass   | 30 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 1933 pass, 10 skip; emit/format clean |
| Web build            | `cd event-runtime/web && bun run build`                                       | pass   | TypeScript and Vite build clean    |
| UX critique          | `factory-ux-critic`                                                           | pass   | SHIP, round 2; browser evidence   |

UX critique: required

run:$FACTORY_RUN_ID


## Post-review

- Review FIX: `rows` guarded `list.data` but not `page.events`; a `/events` page without an `events` key (or a bare `[]` body) produced `[undefined]` and the following `.map` threw, unmounting the App tree (34 `App.test.tsx` failures in run 33286779060). Now `(list.data?.pages ?? []).flatMap((page) => page?.events ?? [])` (579e25e4).
- Added two `Events.test.tsx` cases (page without `events`, bare `[]` response) asserting the empty state renders with `0 loaded rows`; both fail on the previous code and pass now.
- Verified in a fresh worktree merged with `origin/develop`: `bunx tsc --noEmit`, the FULL `event-runtime/web` suite (`bun test`: 1364 pass, 0 fail, `App.test.tsx` 44/44 green), root `bun run format:check` and `bun run check`.
