### PR TITLE
perf(backend): stream artifact verification

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -3,13 +3,12 @@ import {
   closeSync,
   createReadStream,
   openSync,
-  readFileSync,
   readSync,
   rmSync,
 } from "node:fs";
 import {
   findArtifact,
-  hashFile,
+  hashFileAsync,
   listArtifactPage,
   pruneArtifacts,
 } from "./artifacts.mjs";
@@ -17,8 +16,15 @@ import { artifactsRoot } from "./config.mjs";
 
 /** Crude but honest content-type: render text in the browser, download the rest. */
 function looksLikeText(file) {
-  const head = readFileSync(file).subarray(0, 512);
-  return !head.includes(0);
+  let fd;
+  try {
+    fd = openSync(file, "r");
+    const head = Buffer.alloc(512);
+    const read = readSync(fd, head, 0, head.length, 0);
+    return !head.subarray(0, read).includes(0);
+  } finally {
+    if (fd !== undefined) closeSync(fd);
+  }
 }
 
 export const TRANSCRIPT_MODEL_SCAN_BYTES = 64 * 1024;
@@ -138,7 +144,7 @@ export async function handleArtifactApiRoute({
   if (req.method === "GET" && artifactGet) {
     const found = findArtifact(artifactsRoot(env.home), artifactGet[1]);
     if (!found) return send(404, { error: `no artifact ${artifactGet[1]}` });
-    if (hashFile(found.file) !== artifactGet[1]) {
+    if ((await hashFileAsync(found.file)) !== artifactGet[1]) {
       rmSync(found.file, { force: true });
       return send(404, { error: `no artifact ${artifactGet[1]}` });
     }

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -331,4 +331,43 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       server.close();
     }
   });
+
+  test("GET /artifacts/:hash streams large text and binary artifacts with bounded sniffing", async () => {
+    const home = tmpDir("evrt-large-artifacts-api-");
+    const store = path.join(home, "artifacts");
+    const db = openDb(path.join(home, "runtime.db"));
+    mkdirSync(store, { recursive: true });
+    const server = startApi({
+      db,
+      registry,
+      secret: SECRET,
+      policyVersion: PV,
+      port: 0,
+      env: { name: "test", home, adapter: "fake" },
+    });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const port = server.address().port;
+    const text = Buffer.alloc(1024 * 1024 + 1, "t");
+    const binary = Buffer.concat([Buffer.from([0]), text]);
+    const artifacts = [
+      { bytes: text, contentType: "text/plain; charset=utf-8" },
+      { bytes: binary, contentType: "application/octet-stream" },
+    ];
+
+    try {
+      for (const { bytes, contentType } of artifacts) {
+        const sha256 = sha256Hex(bytes);
+        writeFileSync(path.join(store, sha256), bytes);
+
+        const res = await fetch(`http://127.0.0.1:${port}/artifacts/${sha256}`);
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toBe(contentType);
+        expect(res.headers.get("content-length")).toBe(String(bytes.length));
+        expect(Buffer.from(await res.arrayBuffer())).toEqual(bytes);
+      }
+    } finally {
+      server.close();
+      db.close();
+    }
+  });
 });

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -11,6 +11,7 @@
 import { createHash, randomBytes } from "node:crypto";
 import {
   copyFileSync,
+  createReadStream,
   existsSync,
   lstatSync,
   mkdirSync,
@@ -68,6 +69,17 @@ function storeBytes({ bytes, sha256hex, storeRoot }) {
 /** Compute sha256 hex digest of a file on disk. */
 export function hashFile(filePath) {
   return createHash("sha256").update(readFileSync(filePath)).digest("hex");
+}
+
+/** Compute sha256 without buffering the file in the event loop. */
+export function hashFileAsync(filePath) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash("sha256");
+    const stream = createReadStream(filePath);
+    stream.on("error", reject);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("end", () => resolve(hash.digest("hex")));
+  });
 }
 
 /** Resolve a store path from a content hash; malformed hashes fail closed. */

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -15,6 +15,7 @@ import {
   backfillResultArtifacts,
   findArtifact,
   hashFile,
+  hashFileAsync,
   listArtifacts,
   materializeArtifact,
   pinRunArtifact,
@@ -400,6 +401,15 @@ describe("hashFile", () => {
     writeFileSync(file, "hello crypto world");
     const expected = sha256Hex(Buffer.from("hello crypto world"));
     expect(hashFile(file)).toBe(expected);
+  });
+
+  test("computes SHA256 asynchronously without buffering the file", async () => {
+    const dir = tmp("evrt-hash-async-");
+    const file = path.join(dir, "large-sample.txt");
+    const contents = Buffer.alloc(1024 * 1024 + 1, "x");
+    writeFileSync(file, contents);
+
+    expect(await hashFileAsync(file)).toBe(sha256Hex(contents));
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1415

Review the streamed artifact verification and >1 MiB text/binary coverage.

## Validation

| Check                | Command                                                                          | Result  | Notes                               |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-artifacts.test.mjs event-runtime/lib/artifacts.test.mjs --timeout 20000` | pass    | 30 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,935 pass; emit and format clean   |
| UX critique          | factory-ux-critic                                                               | skipped | backend API; no user-facing surface |

UX critique: skipped — backend API path with no user-facing surface
