### PR TITLE
fix(api): validate control API list parameters

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -928,6 +928,9 @@ are **clients, not the runtime**: every read and every verb goes through the
 same control API the runtime exposes, never directly into the database. That keeps a future web app a second client of
 identical endpoints, with the same audit trail, rather than a reimplementation.
 
+All control-API list endpoints reject non-integer, out-of-range `limit` values
+with `422 { error: "invalid_limit", message }`.
+
 **Push notifications (WM-65).** For the operator who is _not_ watching, the
 serve tick carries a push channel (`event-runtime/lib/notify.mjs`) over the
 configured notify transport, covering exactly the two states that wait on a

--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -14,6 +14,7 @@ import {
   pruneArtifacts,
 } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
+import { ApiParameterError, parseListLimit } from "./api-params.mjs";
 
 /** Crude but honest content-type: render text in the browser, download the rest. */
 function looksLikeText(file) {
@@ -67,13 +68,12 @@ export async function handleArtifactApiRoute({
     ) {
       return send(422, { error: "orphan must be true or false" });
     }
-    const limitParam = url.searchParams.get("limit");
-    const limit = limitParam === null ? 100 : Number(limitParam);
-    if (
-      limit !== undefined &&
-      (!Number.isInteger(limit) || limit < 1 || limit > 500)
-    ) {
-      return send(422, { error: "limit must be an integer between 1 and 500" });
+    let limit;
+    try {
+      limit = parseListLimit(url, { defaultLimit: 100, maxLimit: 500 });
+    } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
+      throw err;
     }
     const rawBefore = url.searchParams.get("before");
     let before = null;

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -148,7 +148,14 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(secondPage.artifacts).toHaveLength(1);
       expect(secondPage.nextBefore).toBeNull();
       expect((await fetch(`${base}/artifacts?orphan=maybe`)).status).toBe(422);
-      expect((await fetch(`${base}/artifacts?limit=0`)).status).toBe(422);
+      for (const limit of ["abc", "0", "501"]) {
+        const response = await fetch(`${base}/artifacts?limit=${limit}`);
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_limit",
+          message: "limit must be an integer between 1 and 500",
+        });
+      }
 
       const dry = await fetch(`${base}/artifacts/prune`, {
         method: "POST",

--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -10,6 +10,7 @@
  * flat event + run lists; the client builds the graph.
  */
 import { repoNamesFromInput } from "./api-runs.mjs";
+import { ApiParameterError, parseListLimit } from "./api-params.mjs";
 
 const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_LIMIT = 100;
@@ -256,27 +257,24 @@ function windowMs(value) {
   return Number.isSafeInteger(result) && result > 0 ? result : null;
 }
 
-function rowLimit(value) {
-  if (value == null || value === "") return DEFAULT_LIMIT;
-  if (!/^\d+$/.test(value)) return null;
-  const result = Number(value);
-  return Number.isSafeInteger(result) && result >= 1 && result <= MAX_LIMIT
-    ? result
-    : null;
-}
-
 export function handleChainApiRoute({ route, url, send, db, nowMs }) {
   if (route === "GET /chains") {
     const parsedWindow = windowMs(url.searchParams.get("window"));
-    const parsedLimit = rowLimit(url.searchParams.get("limit"));
     if (parsedWindow == null)
-      return send(400, {
-        error: "window must be a positive duration such as 24h",
+      return send(422, {
+        error: "invalid_window",
+        message: "window must be a positive duration such as 24h",
       });
-    if (parsedLimit == null)
-      return send(400, {
-        error: `limit must be an integer from 1 to ${MAX_LIMIT}`,
+    let parsedLimit;
+    try {
+      parsedLimit = parseListLimit(url, {
+        defaultLimit: DEFAULT_LIMIT,
+        maxLimit: MAX_LIMIT,
       });
+    } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
+      throw err;
+    }
     return send(200, {
       chains: chainsView(db, {
         windowMs: parsedWindow,

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -369,8 +369,19 @@ describe("GET /chains (WM-537)", () => {
   });
 
   test("validates window and limit and applies the limit", async () => {
-    expect((await fetch(s.url("/chains?window=soon"))).status).toBe(400);
-    expect((await fetch(s.url("/chains?limit=0"))).status).toBe(400);
+    for (const path of [
+      "/chains?window=soon",
+      "/chains?limit=abc",
+      "/chains?limit=0",
+      "/chains?limit=501",
+    ]) {
+      const response = await fetch(s.url(path));
+      expect(response.status).toBe(422);
+      expect(await response.json()).toMatchObject({
+        error: path.includes("window") ? "invalid_window" : "invalid_limit",
+        message: expect.any(String),
+      });
+    }
     const body = await (await fetch(s.url("/chains?window=2h&limit=2"))).json();
     expect(body.chains).toHaveLength(2);
   });

--- a/event-runtime/lib/api-inbox.mjs
+++ b/event-runtime/lib/api-inbox.mjs
@@ -6,6 +6,7 @@ import {
   listInboxPage,
   resolveInboxItem,
 } from "./inbox.mjs";
+import { ApiParameterError, parseListLimit } from "./api-params.mjs";
 
 export async function handleInboxApiRoute({
   route,
@@ -64,6 +65,7 @@ export async function handleInboxApiRoute({
     try {
       return send(200, listInboxPage(db, { status, ...listPage(url) }));
     } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
       return send(422, { error: err.message });
     }
   }
@@ -120,11 +122,10 @@ const LIST_DEFAULT_LIMIT = 100;
 const LIST_MAX_LIMIT = 200;
 
 function listPage(url) {
-  const rawLimit = url.searchParams.get("limit");
-  const limit = rawLimit === null ? LIST_DEFAULT_LIMIT : Number(rawLimit);
-  if (!Number.isInteger(limit) || limit < 1 || limit > LIST_MAX_LIMIT) {
-    throw new Error(`limit must be an integer between 1 and ${LIST_MAX_LIMIT}`);
-  }
+  const limit = parseListLimit(url, {
+    defaultLimit: LIST_DEFAULT_LIMIT,
+    maxLimit: LIST_MAX_LIMIT,
+  });
   const rawBefore = url.searchParams.get("before");
   if (!rawBefore) return { limit, before: null };
   try {

--- a/event-runtime/lib/api-inbox.test.mjs
+++ b/event-runtime/lib/api-inbox.test.mjs
@@ -70,7 +70,14 @@ describe("human inbox API (WM-285)", () => {
       ).json();
       expect(second.items).toHaveLength(1);
       expect(second.nextBefore).toBeNull();
-      expect((await fetch(s.url("/inbox?limit=201"))).status).toBe(422);
+      for (const limit of ["abc", "0", "201"]) {
+        const response = await fetch(s.url(`/inbox?limit=${limit}`));
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_limit",
+          message: "limit must be an integer between 1 and 200",
+        });
+      }
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-params.mjs
+++ b/event-runtime/lib/api-params.mjs
@@ -1,0 +1,33 @@
+/** Shared validation for bounded control-API list parameters. */
+export class ApiParameterError extends Error {
+  constructor(error, message) {
+    super(message);
+    this.body = { error, message };
+  }
+}
+
+export function parseListLimit(url, { defaultLimit, maxLimit }) {
+  const rawLimit = url.searchParams.get("limit");
+  if (rawLimit === null) return defaultLimit;
+  const limit = Number(rawLimit);
+  if (!Number.isInteger(limit) || limit < 1 || limit > maxLimit) {
+    throw new ApiParameterError(
+      "invalid_limit",
+      `limit must be an integer between 1 and ${maxLimit}`,
+    );
+  }
+  return limit;
+}
+
+export function parseNonNegativeSince(url) {
+  const rawSince = url.searchParams.get("since");
+  if (rawSince === null) return 0;
+  const since = Number(rawSince);
+  if (rawSince.trim() === "" || !Number.isSafeInteger(since) || since < 0) {
+    throw new ApiParameterError(
+      "invalid_since",
+      "since must be a non-negative integer",
+    );
+  }
+  return since;
+}

--- a/event-runtime/lib/api-params.test.mjs
+++ b/event-runtime/lib/api-params.test.mjs
@@ -1,0 +1,24 @@
+import { describe, expect, test } from "bun:test";
+import { parseListLimit } from "./api-params.mjs";
+
+describe("parseListLimit", () => {
+  test("uses the default for an omitted limit", () => {
+    expect(
+      parseListLimit(new URL("http://localhost/list"), {
+        defaultLimit: 25,
+        maxLimit: 100,
+      }),
+    ).toBe(25);
+  });
+
+  test("rejects non-integers and values outside the configured range", () => {
+    for (const value of ["abc", "0", "101"]) {
+      expect(() =>
+        parseListLimit(new URL(`http://localhost/list?limit=${value}`), {
+          defaultLimit: 25,
+          maxLimit: 100,
+        }),
+      ).toThrow("limit must be an integer between 1 and 100");
+    }
+  });
+});

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -19,6 +19,11 @@ import {
   retryRun,
 } from "./worker.mjs";
 import { proposalSubject } from "./proposal-subject.mjs";
+import {
+  ApiParameterError,
+  parseListLimit,
+  parseNonNegativeSince,
+} from "./api-params.mjs";
 
 export const MAX_EXTENSION_SECONDS = 3600;
 
@@ -1709,21 +1714,6 @@ function outboxView(db, limit) {
     }));
 }
 
-function journalLimit(url, defaultLimit) {
-  const rawLimit = url.searchParams.get("limit");
-  if (rawLimit === null || rawLimit.trim() === "") return defaultLimit;
-  const limit = Number(rawLimit);
-  if (!Number.isInteger(limit)) return defaultLimit;
-  return Math.max(1, Math.min(limit, 500));
-}
-
-function journalSince(url) {
-  const since = Number(url.searchParams.get("since") ?? 0);
-  if (!Number.isFinite(since)) return 0;
-  const normalized = Math.floor(since);
-  return Number.isSafeInteger(normalized) ? Math.max(0, normalized) : 0;
-}
-
 export function observedModelFromTranscript(head) {
   if (typeof head !== "string" || head === "") return null;
   const lines = head.split("\n");
@@ -1893,14 +1883,29 @@ export async function handleRunApiRoute({
   }
 
   if (route === "GET /journal") {
-    const since = journalSince(url);
-    const limit = journalLimit(url, 100);
-    return send(200, journalView(db, since, limit));
+    try {
+      return send(
+        200,
+        journalView(
+          db,
+          parseNonNegativeSince(url),
+          parseListLimit(url, { defaultLimit: 100, maxLimit: 500 }),
+        ),
+      );
+    } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
+      throw err;
+    }
   }
 
   if (route === "GET /outbox") {
-    const limit = journalLimit(url, 50);
-    return send(200, { outbox: outboxView(db, limit) });
+    try {
+      const limit = parseListLimit(url, { defaultLimit: 50, maxLimit: 500 });
+      return send(200, { outbox: outboxView(db, limit) });
+    } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
+      throw err;
+    }
   }
 
   if (route === "POST /events/requeue" || route === "POST /events/archive") {
@@ -2042,23 +2047,13 @@ export async function handleRunApiRoute({
 
   if (route === "GET /tickets") {
     const since = url.searchParams.get("since") ?? undefined;
-    const limitParam = url.searchParams.get("limit");
     const repo = url.searchParams.get("repo") ?? undefined;
-    let limit = 50;
-    if (limitParam !== null && limitParam !== undefined && limitParam !== "") {
-      const parsedLimit = Number(limitParam);
-      if (!Number.isInteger(parsedLimit) || parsedLimit <= 0) {
-        return send(422, {
-          error: "invalid_limit",
-          message: "limit must be a positive integer",
-        });
-      }
-      limit = Math.min(parsedLimit, 200);
-    }
     try {
+      const limit = parseListLimit(url, { defaultLimit: 50, maxLimit: 200 });
       const tickets = ticketIndexView(db, { since, limit, repo, nowMs });
       return send(200, { tickets });
     } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
       if (err instanceof ListQueryError) return send(422, err.body);
       throw err;
     }
@@ -2189,15 +2184,18 @@ export async function handleRunApiRoute({
     if (!db.query(`SELECT run_id FROM runs WHERE run_id = ?`).get(runId)) {
       return send(404, { error: `unknown run ${runId}` });
     }
-    const since = Number(url.searchParams.get("since") ?? 0);
-    const limit = Math.min(Number(url.searchParams.get("limit") ?? 100), 500);
-    return send(
-      200,
-      traceOf(db, runId, {
-        since: Number.isFinite(since) ? since : 0,
-        limit: Number.isFinite(limit) ? limit : 100,
-      }),
-    );
+    try {
+      return send(
+        200,
+        traceOf(db, runId, {
+          since: parseNonNegativeSince(url),
+          limit: parseListLimit(url, { defaultLimit: 100, maxLimit: 500 }),
+        }),
+      );
+    } catch (err) {
+      if (err instanceof ApiParameterError) return send(422, err.body);
+      throw err;
+    }
   }
 
   const runGet = url.pathname.match(/^\/runs\/([^/]+)$/);

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1090,13 +1090,14 @@ describe("recent-ticket index (WM-821)", () => {
       expect(errBody.error).toBe("invalid_since");
 
       // Verify invalid limit returns 422
-      const resInvalidLimit = await fetch(s.url("/tickets?limit=abc"));
-      expect(resInvalidLimit.status).toBe(422);
-      expect((await resInvalidLimit.json()).error).toBe("invalid_limit");
-
-      const resNegativeLimit = await fetch(s.url("/tickets?limit=-5"));
-      expect(resNegativeLimit.status).toBe(422);
-      expect((await resNegativeLimit.json()).error).toBe("invalid_limit");
+      for (const limit of ["abc", "0", "201"]) {
+        const response = await fetch(s.url(`/tickets?limit=${limit}`));
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_limit",
+          message: "limit must be an integer between 1 and 200",
+        });
+      }
 
       // Verify alternative valid duration units (1w, 24h, 30m, 60s, ISO string)
       const resWeek = await fetch(s.url("/tickets?since=1w"));
@@ -1534,7 +1535,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
     }
   });
 
-  test("journal and outbox bound malformed limits and normalize journal cursors", async () => {
+  test("journal and outbox reject malformed limits and journal cursors", async () => {
     const s = await makeServer();
     try {
       const insertJournal = s.db.query(
@@ -1555,33 +1556,25 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         }
       })();
 
-      for (const path of ["/journal?limit=-1", "/outbox?limit=-1"]) {
-        const response = await fetch(s.url(path));
-        expect(response.status).toBe(200);
-        const body = await response.json();
-        expect(body.entries ?? body.outbox).toHaveLength(1);
+      for (const endpoint of ["/journal", "/outbox"]) {
+        for (const limit of ["abc", "0", "501"]) {
+          const response = await fetch(s.url(`${endpoint}?limit=${limit}`));
+          expect(response.status).toBe(422);
+          expect(await response.json()).toMatchObject({
+            error: "invalid_limit",
+            message: "limit must be an integer between 1 and 500",
+          });
+        }
       }
 
-      for (const path of ["/journal?limit=999", "/outbox?limit=999"]) {
-        const response = await fetch(s.url(path));
-        expect(response.status).toBe(200);
-        const body = await response.json();
-        expect(body.entries ?? body.outbox).toHaveLength(500);
+      for (const since of ["not-a-cursor", "-1"]) {
+        const response = await fetch(s.url(`/journal?since=${since}`));
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_since",
+          message: expect.any(String),
+        });
       }
-
-      const journalFallback = await fetch(s.url("/journal?limit=abc"));
-      expect(journalFallback.status).toBe(200);
-      expect((await journalFallback.json()).entries).toHaveLength(100);
-
-      const outboxFallback = await fetch(s.url("/outbox?limit=abc"));
-      expect(outboxFallback.status).toBe(200);
-      expect((await outboxFallback.json()).outbox).toHaveLength(50);
-
-      const normalizedSince = await fetch(
-        s.url("/journal?since=not-a-cursor&limit=500"),
-      );
-      expect(normalizedSince.status).toBe(200);
-      expect((await normalizedSince.json()).entries).toHaveLength(500);
     } finally {
       s.close();
     }
@@ -1769,6 +1762,27 @@ describe("run trace surfacing (OPS-295)", () => {
       expect(rest.head).toBe(rest.entries.at(-1).seq);
       expect(rest.entries[0].attempt).toBe(1);
       expect(typeof rest.entries[0].ts).toBe("string");
+
+      for (const limit of ["abc", "0", "501"]) {
+        const response = await fetch(
+          `http://127.0.0.1:${port}/runs/${summary.runId}/trace?limit=${limit}`,
+        );
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_limit",
+          message: "limit must be an integer between 1 and 500",
+        });
+      }
+      for (const since of ["abc", "-1"]) {
+        const response = await fetch(
+          `http://127.0.0.1:${port}/runs/${summary.runId}/trace?since=${since}`,
+        );
+        expect(response.status).toBe(422);
+        expect(await response.json()).toMatchObject({
+          error: "invalid_since",
+          message: expect.any(String),
+        });
+      }
 
       // Caught up: since=head → no entries, head unchanged.
       const done = await client.trace(summary.runId, { since: rest.head });


### PR DESCRIPTION
Fixes watt-mind/factory#1419

Use uniform 422 error shapes for invalid control-API list limits and cursors.

## Validation

| Check                | Command                                                                                                                                                    | Result  | Notes                                   |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-params.test.mjs event-runtime/lib/api-chain.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-artifacts.test.mjs event-runtime/lib/api-inbox.test.mjs --timeout 20000` | pass    | 53 tests, 0 failures                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`                                                        | pass    | 1,935 passed; emit and formatting clean |
| UX critique          | factory-ux-critic                                                                                                                                           | not run | no user-facing surface                  |

UX critique: skipped