### PR TITLE
perf(forge): move hot PR reads to REST

### DIFF
--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -618,8 +618,8 @@ describe("github forge: REST PR reads", () => {
       { name: "Verify", bucket: "pass", state: "SUCCESS" },
       { name: "Verify", bucket: "fail", state: "FAILURE" },
       { name: "Lint", bucket: "fail", state: "FAILURE" },
-      { name: "Old", bucket: "pending", state: "STALE" },
-      { name: "Boot", bucket: "pending", state: "STARTUP_FAILURE" },
+      { name: "Old", bucket: "fail", state: "STALE" },
+      { name: "Boot", bucket: "fail", state: "STARTUP_FAILURE" },
       { name: "Stopped", bucket: "cancel", state: "CANCELLED" },
       { name: "deploy", bucket: "pass", state: "SUCCESS" },
     ]);
@@ -687,6 +687,232 @@ describe("github forge: REST PR reads", () => {
         "databaseId,status",
       ],
       ["run", "list", "--repo", "o/r", "--limit", "10", "--json", "status"],
+    ]);
+  });
+
+  test("prChecks required:true treats 401/403 on branch protection like 404 (App token)", () => {
+    const protection = (stderr) =>
+      recorder((_, args) => {
+        if (args[1] === "repos/o/r/pulls/7")
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              head: { sha: "abc123" },
+              base: { ref: "develop" },
+            }),
+            stderr: "",
+          };
+        if (args[1]?.startsWith("repos/o/r/commits/abc123/check-runs"))
+          return {
+            status: 0,
+            stdout: JSON.stringify({
+              check_runs: [
+                { name: "Verify", conclusion: "success", status: "completed" },
+              ],
+            }),
+            stderr: "",
+          };
+        if (args[1] === "repos/o/r/commits/abc123/status")
+          return {
+            status: 0,
+            stdout: JSON.stringify({ statuses: [] }),
+            stderr: "",
+          };
+        if (args[1]?.includes("/protection/required_status_checks"))
+          return { status: 1, stdout: "", stderr };
+        return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+      });
+    for (const stderr of [
+      "gh: Resource not accessible by integration (HTTP 403)",
+      "gh: Bad credentials (HTTP 401)",
+      "gh: Branch not protected (HTTP 404)",
+    ]) {
+      const exec = protection(stderr);
+      expect(
+        githubForge({ exec }).prChecks("o/r", 7, { required: true }),
+      ).toEqual([]);
+      expect(
+        exec.calls.some((call) =>
+          call.args[1]?.includes("/protection/required_status_checks"),
+        ),
+      ).toBe(true);
+    }
+    expect(() =>
+      githubForge({
+        exec: protection("gh: Server Error (HTTP 500)"),
+      }).prChecks("o/r", 7, { required: true }),
+    ).toThrow(ForgeError);
+  });
+
+  test("prList hydrates mergeability at most once per open head SHA per TTL", () => {
+    const rows = [
+      { number: 1, state: "open", head: { sha: "s1" } },
+      { number: 2, state: "open", head: { sha: "s2" } },
+      { number: 3, state: "closed", merged_at: null, head: { sha: "s3" } },
+      {
+        number: 4,
+        state: "closed",
+        merged_at: "2026-08-30T00:00:00Z",
+        head: { sha: "s4" },
+      },
+    ];
+    let clock = 1_000;
+    const exec = recorder((_, args) => {
+      if (args[1]?.startsWith("repos/o/r/pulls?"))
+        return { status: 0, stdout: JSON.stringify(rows), stderr: "" };
+      const detail = /^repos\/o\/r\/pulls\/(\d+)$/.exec(args[1] ?? "");
+      if (detail)
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            ...rows[Number(detail[1]) - 1],
+            mergeable: true,
+            mergeable_state: "clean",
+          }),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+    });
+    const detailCalls = () =>
+      exec.calls.filter((call) =>
+        /^repos\/o\/r\/pulls\/\d+$/.test(call.args[1]),
+      ).length;
+    const forge = githubForge({
+      exec,
+      hydrationTtlMs: 60_000,
+      now: () => clock,
+    });
+    const list = () =>
+      forge.prList("o/r", {
+        state: "all",
+        fields: ["number", "mergeable", "mergeStateStatus"],
+      });
+    expect(list()).toEqual([
+      { number: 1, mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" },
+      { number: 2, mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" },
+      { number: 3, mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" },
+      { number: 4, mergeable: "UNKNOWN", mergeStateStatus: "UNKNOWN" },
+    ]);
+    // Only the open rows cost a detail call; a second scan in the same tick
+    // costs none.
+    expect(detailCalls()).toBe(2);
+    list();
+    expect(detailCalls()).toBe(2);
+    // A rebase moves the head SHA: that one PR is re-hydrated.
+    rows[1].head.sha = "s2-rebased";
+    expect(list()[1]).toEqual({
+      number: 2,
+      mergeable: "MERGEABLE",
+      mergeStateStatus: "CLEAN",
+    });
+    expect(detailCalls()).toBe(3);
+    // Past the TTL everything open is refreshed once more, and no more.
+    clock += 60_000;
+    list();
+    list();
+    expect(detailCalls()).toBe(5);
+    // Bound for the reviewer's scenario: N open PRs, two scans per tick.
+    expect(detailCalls()).toBeLessThanOrEqual(rows.length * 2);
+  });
+
+  test("prList does not pin an unknown (still computing) mergeability", () => {
+    let known = false;
+    const exec = recorder((_, args) => {
+      if (args[1]?.startsWith("repos/o/r/pulls?"))
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { number: 1, state: "open", head: { sha: "s1" } },
+          ]),
+          stderr: "",
+        };
+      if (args[1] === "repos/o/r/pulls/1")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            number: 1,
+            state: "open",
+            head: { sha: "s1" },
+            mergeable: known ? false : null,
+            mergeable_state: known ? "dirty" : "unknown",
+          }),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+    });
+    const forge = githubForge({ exec });
+    const list = () =>
+      forge.prList("o/r", { state: "open", fields: ["mergeable"] });
+    expect(list()).toEqual([{ mergeable: "UNKNOWN" }]);
+    known = true;
+    expect(list()).toEqual([{ mergeable: "CONFLICTING" }]);
+    expect(list()).toEqual([{ mergeable: "CONFLICTING" }]);
+    expect(
+      exec.calls.filter((call) => call.args[1] === "repos/o/r/pulls/1"),
+    ).toHaveLength(2);
+  });
+
+  test("prChecks keeps matrix siblings of the newest check suite, drops older suites", () => {
+    const exec = recorder((_, args) => {
+      if (args[1] === "repos/o/r/pulls/7")
+        return {
+          status: 0,
+          stdout: JSON.stringify({ head: { sha: "abc123" } }),
+          stderr: "",
+        };
+      if (args[1]?.startsWith("repos/o/r/commits/abc123/check-runs"))
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            check_runs: [
+              {
+                name: "test",
+                conclusion: "success",
+                status: "completed",
+                started_at: "2026-08-30T02:20:00Z",
+                app: { id: 15368 },
+                check_suite: { id: 2 },
+              },
+              {
+                name: "test",
+                conclusion: "failure",
+                status: "completed",
+                started_at: "2026-08-30T02:19:00Z",
+                app: { id: 15368 },
+                check_suite: { id: 2 },
+              },
+              {
+                name: "test",
+                conclusion: "failure",
+                status: "completed",
+                started_at: "2026-08-30T02:00:00Z",
+                app: { id: 15368 },
+                check_suite: { id: 1 },
+              },
+              {
+                name: "lint",
+                conclusion: "success",
+                status: "completed",
+                started_at: "2026-08-30T02:00:00Z",
+                app: { id: 15368 },
+                check_suite: { id: 1 },
+              },
+            ],
+          }),
+          stderr: "",
+        };
+      if (args[1] === "repos/o/r/commits/abc123/status")
+        return {
+          status: 0,
+          stdout: JSON.stringify({ statuses: [] }),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+    });
+    expect(githubForge({ exec }).prChecks("o/r", 7)).toEqual([
+      { name: "test", bucket: "pass", state: "SUCCESS" },
+      { name: "test", bucket: "fail", state: "FAILURE" },
+      { name: "lint", bucket: "pass", state: "SUCCESS" },
     ]);
   });
 

--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -141,7 +141,7 @@ function fakeGhExec(seed) {
     const fail = (stderr, status = 1) => ({ status, stdout: "", stderr });
     const repo = flags.repo;
     const data = seed.repos[repo];
-    if (positional[0] !== "api" && !data)
+    if (positional[0] !== "api" && positional[0] !== "repo" && !data)
       return fail(
         `GraphQL: Could not resolve to a Repository with the name '${repo}'.`,
       );
@@ -150,7 +150,94 @@ function fakeGhExec(seed) {
       fields ? Object.fromEntries(fields.map((f) => [f, o[f]])) : { ...o };
     const findPr = (n) => data.prs.find((p) => String(p.number) === n);
 
+    const restPull = (pr) => ({
+      number: pr.number,
+      state: pr.state === "OPEN" ? "open" : "closed",
+      merged_at:
+        pr.state === "MERGED" ? (pr.mergedAt ?? "2026-08-15T10:00:00Z") : null,
+      draft: pr.isDraft,
+      title: pr.title,
+      body: pr.body,
+      html_url: pr.url,
+      labels: pr.labels,
+      head: { ref: pr.headRefName, sha: pr.headRefOid },
+      base: { ref: "main" },
+      mergeable: true,
+      mergeable_state: "clean",
+    });
+    const api = (path) => {
+      const [pathname, query = ""] = path.split("?");
+      const match = /^repos\/([^/]+\/[^/]+)\/(.*)$/.exec(pathname);
+      const apiRepo = match?.[1];
+      const rest = match?.[2];
+      const apiData = seed.repos[apiRepo];
+      if (!apiData) return fail("gh: Not Found (HTTP 404)");
+      if (rest === "pulls") {
+        const params = new URLSearchParams(query);
+        const state = params.get("state") ?? "open";
+        const page = Number(params.get("page") ?? 1);
+        const perPage = Number(params.get("per_page") ?? 30);
+        const prs = apiData.prs.filter((pr) =>
+          state === "all"
+            ? true
+            : state === "open"
+              ? pr.state === "OPEN"
+              : pr.state !== "OPEN",
+        );
+        return ok(
+          JSON.stringify(
+            prs.slice((page - 1) * perPage, page * perPage).map(restPull),
+          ),
+        );
+      }
+      const pull = /^pulls\/(\d+)$/.exec(rest ?? "");
+      if (pull) {
+        const pr = apiData.prs.find(
+          (candidate) => String(candidate.number) === pull[1],
+        );
+        return pr
+          ? ok(JSON.stringify(restPull(pr)))
+          : fail("gh: Not Found (HTTP 404)");
+      }
+      const checkRuns = /^commits\/([^/]+)\/check-runs$/.exec(rest ?? "");
+      if (checkRuns) {
+        const pr = apiData.prs.find(
+          (candidate) => candidate.headRefOid === checkRuns[1],
+        );
+        if (!pr) return fail("gh: Not Found (HTTP 404)");
+        return ok(
+          JSON.stringify({
+            check_runs: (pr.checks ?? []).map((check) => ({
+              name: check.name,
+              conclusion: check.state?.toLowerCase(),
+              status: check.state === "PENDING" ? "in_progress" : "completed",
+            })),
+          }),
+        );
+      }
+      const status = /^commits\/([^/]+)\/status$/.exec(rest ?? "");
+      if (status) return ok(JSON.stringify({ statuses: [] }));
+      const protection =
+        /^branches\/([^/]+)\/protection\/required_status_checks$/.exec(
+          rest ?? "",
+        );
+      if (protection) {
+        return ok(
+          JSON.stringify({
+            contexts: apiData.prs.flatMap((pr) =>
+              (pr.checks ?? [])
+                .filter((check) => check.required)
+                .map((check) => check.name),
+            ),
+          }),
+        );
+      }
+      return fail("gh: Not Found (HTTP 404)");
+    };
+
     switch (`${positional[0]} ${positional[1]}`) {
+      case "repo view":
+        return ok(JSON.stringify({ nameWithOwner: REPO }));
       case "pr view": {
         const pr = findPr(positional[2]);
         if (!pr)
@@ -217,8 +304,9 @@ function fakeGhExec(seed) {
       }
       case `api ${positional[1]}`: {
         const hit = seed.api[positional[1]];
-        if (hit === undefined) return fail("gh: Not Found (HTTP 404)");
-        return ok(typeof hit === "function" ? hit({ jq: flags.jq }) : hit);
+        if (hit !== undefined)
+          return ok(typeof hit === "function" ? hit({ jq: flags.jq }) : hit);
+        return api(positional[1]);
       }
       default:
         return fail(`unknown command ${args.join(" ")}`);
@@ -397,7 +485,7 @@ for (const [name, make] of IMPLEMENTATIONS) {
   });
 }
 
-describe("github forge: gh argv shapes (byte-identical to the pre-forge call sites)", () => {
+describe("github forge: REST PR reads", () => {
   const recorder = (result = { status: 0, stdout: "[]", stderr: "" }) => {
     const exec = (cmd, args, opts) => {
       exec.calls.push({ cmd, args, opts });
@@ -407,81 +495,92 @@ describe("github forge: gh argv shapes (byte-identical to the pre-forge call sit
     return exec;
   };
 
-  test("prView with and without --repo", () => {
-    const exec = recorder({ status: 0, stdout: "{}", stderr: "" });
-    const forge = githubForge({ exec });
-    forge.prView("o/r", 7, { fields: ["state", "isDraft", "labels"] });
-    forge.prView(null, 7, { fields: ["headRefName"], cwd: "/repo" });
-    expect(exec.calls[0].cmd).toBe("gh");
-    expect(exec.calls[0].args).toEqual([
-      "pr",
-      "view",
-      "7",
-      "--repo",
-      "o/r",
-      "--json",
-      "state,isDraft,labels",
-    ]);
-    expect(exec.calls[1].args).toEqual([
-      "pr",
-      "view",
-      "7",
-      "--json",
-      "headRefName",
-    ]);
-    expect(exec.calls[1].opts.cwd).toBe("/repo");
-    expect(exec.calls[1].opts.encoding).toBe("utf8");
-  });
-
-  test("prList: janitor / stuck / queue-summary shapes", () => {
-    const exec = recorder();
-    const forge = githubForge({ exec });
-    forge.prList(null, {
+  test("prView and prList use REST endpoints and resolve a cwd repo once", () => {
+    const pull = {
+      number: 7,
       state: "open",
-      limit: 200,
-      fields: ["number", "headRefName"],
-      cwd: "/repo",
+      draft: false,
+      title: "REST PR",
+      body: "Fixes WM-7",
+      html_url: "https://github.com/o/r/pull/7",
+      labels: [{ name: "perf" }],
+      head: { ref: "feat/rest", sha: "abc123" },
+      base: { ref: "develop" },
+      mergeable: true,
+      mergeable_state: "clean",
+    };
+    const exec = recorder((_, args) => {
+      if (args[0] === "repo")
+        return {
+          status: 0,
+          stdout: JSON.stringify({ nameWithOwner: "o/r" }),
+          stderr: "",
+        };
+      if (args[1] === "repos/o/r/pulls/7")
+        return { status: 0, stdout: JSON.stringify(pull), stderr: "" };
+      if (args[1]?.startsWith("repos/o/r/pulls?"))
+        return { status: 0, stdout: JSON.stringify([pull]), stderr: "" };
+      if (args[1] === "repos/o/r/commits/abc123/check-runs?per_page=100")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            check_runs: [
+              { name: "Verify", conclusion: "success", status: "completed" },
+              { name: "Lint", conclusion: "failure", status: "completed" },
+            ],
+          }),
+          stderr: "",
+        };
+      if (args[1] === "repos/o/r/commits/abc123/status")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            statuses: [{ context: "deploy", state: "success" }],
+          }),
+          stderr: "",
+        };
+      if (
+        args[1] ===
+        "repos/o/r/branches/develop/protection/required_status_checks"
+      )
+        return {
+          status: 0,
+          stdout: JSON.stringify({ contexts: ["Verify", "deploy"] }),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" };
     });
-    forge.prList("o/r", { state: "open", fields: ["number", "isDraft"] });
-    forge.prList("o/r", {
-      state: "all",
-      limit: 250,
-      fields: ["number", "url"],
+    const forge = githubForge({ exec });
+    expect(
+      forge.prView(null, 7, { fields: ["state", "headRefName"], cwd: "/repo" }),
+    ).toEqual({
+      state: "OPEN",
+      headRefName: "feat/rest",
     });
-    expect(exec.calls.map((c) => c.args)).toEqual([
-      [
-        "pr",
-        "list",
-        "--state",
-        "open",
-        "--limit",
-        "200",
-        "--json",
-        "number,headRefName",
-      ],
-      [
-        "pr",
-        "list",
-        "--repo",
-        "o/r",
-        "--state",
-        "open",
-        "--json",
-        "number,isDraft",
-      ],
-      [
-        "pr",
-        "list",
-        "--repo",
-        "o/r",
-        "--state",
-        "all",
-        "--limit",
-        "250",
-        "--json",
-        "number,url",
-      ],
+    expect(
+      forge.prList(null, {
+        state: "open",
+        limit: 15,
+        fields: ["number", "url"],
+        cwd: "/repo",
+      }),
+    ).toEqual([{ number: 7, url: "https://github.com/o/r/pull/7" }]);
+    expect(forge.prChecks("o/r", 7, { required: true })).toEqual([
+      { name: "Verify", bucket: "pass", state: "SUCCESS" },
+      { name: "deploy", bucket: "pass", state: "SUCCESS" },
     ]);
+    expect(exec.calls.filter((call) => call.args[0] === "repo")).toHaveLength(
+      1,
+    );
+    expect(exec.calls.map((call) => call.args)).toContainEqual([
+      "api",
+      "repos/o/r/pulls/7",
+    ]);
+    expect(exec.calls.map((call) => call.args)).toContainEqual([
+      "api",
+      "repos/o/r/pulls?state=open&per_page=15&page=1",
+    ]);
+    expect(exec.calls.some((call) => call.args[0] === "pr")).toBe(false);
   });
 
   test("prDiffFiles / prSetDraft / prComment / runList / apiRaw shapes", () => {
@@ -584,91 +683,6 @@ describe("github forge: gh argv shapes (byte-identical to the pre-forge call sit
     expect(() => notArray.runList("o/r", {})).toThrow(ForgeError);
     expect(() => notArray.prChecks("o/r", 1)).toThrow(ForgeError);
   });
-
-  test("prChecks argv, empty snapshots, and JSON-on-nonzero-exit", () => {
-    const exec = recorder({
-      status: 0,
-      stdout: JSON.stringify([
-        { name: "Verify", bucket: "pass", state: "SUCCESS" },
-      ]),
-      stderr: "",
-    });
-    const forge = githubForge({ exec });
-    expect(forge.prChecks("o/r", 42)).toEqual([
-      { name: "Verify", bucket: "pass", state: "SUCCESS" },
-    ]);
-    forge.prChecks(null, "7", {
-      required: true,
-      fields: ["name", "state"],
-      cwd: "/repo",
-    });
-    expect(exec.calls.map((c) => c.args)).toEqual([
-      ["pr", "checks", "42", "--repo", "o/r", "--json", "name,bucket,state"],
-      ["pr", "checks", "7", "--required", "--json", "name,state"],
-    ]);
-    expect(exec.calls[1].opts.cwd).toBe("/repo");
-
-    const empty = githubForge({
-      exec: recorder({
-        status: 1,
-        stdout: "",
-        stderr: "no checks reported on the 'feat/a' branch\n",
-      }),
-    });
-    expect(empty.prChecks("o/r", 1)).toEqual([]);
-
-    const noRequired = githubForge({
-      exec: recorder({
-        status: 1,
-        stdout: "",
-        stderr: "no required checks reported on the 'feat/a' branch\n",
-      }),
-    });
-    expect(noRequired.prChecks("o/r", 1, { required: true })).toEqual([]);
-
-    const red = githubForge({
-      exec: recorder({
-        status: 1,
-        stdout: JSON.stringify([
-          { name: "Lint", bucket: "fail", state: "FAILURE" },
-        ]),
-        stderr: "",
-      }),
-    });
-    expect(red.prChecks("o/r", 1)).toEqual([
-      { name: "Lint", bucket: "fail", state: "FAILURE" },
-    ]);
-
-    const missing = githubForge({
-      exec: recorder({
-        status: 1,
-        stdout: "",
-        stderr:
-          "GraphQL: Could not resolve to a PullRequest with the number of 999. (repository.pullRequest)",
-      }),
-    });
-    expect(() => missing.prChecks("o/r", 999)).toThrow(ForgeError);
-  });
-
-  test("accepts Bun.spawnSync-shaped results (exitCode + Buffer stdout)", () => {
-    const forge = githubForge({
-      exec: () => ({
-        exitCode: 0,
-        stdout: Buffer.from(JSON.stringify({ state: "OPEN" })),
-      }),
-    });
-    expect(forge.prView("o/r", 1, { fields: ["state"] })).toEqual({
-      state: "OPEN",
-    });
-    const failing = githubForge({
-      exec: () => ({
-        exitCode: 1,
-        stdout: Buffer.from(""),
-        stderr: Buffer.from("boom"),
-      }),
-    });
-    expect(() => failing.prView("o/r", 1)).toThrow(ForgeError);
-  });
 });
 
 describe("loadForge selection", () => {
@@ -729,7 +743,7 @@ describe("loadForge selection", () => {
     expect(forge.kind).toBe("github");
     forge.prList("o/r", { state: "open" });
     expect(calls).toEqual([
-      ["gh", "pr", "list", "--repo", "o/r", "--state", "open"],
+      ["gh", "api", "repos/o/r/pulls?state=open&per_page=30&page=1"],
     ]);
   });
 

--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -519,14 +519,51 @@ describe("github forge: REST PR reads", () => {
       if (args[1] === "repos/o/r/pulls/7")
         return { status: 0, stdout: JSON.stringify(pull), stderr: "" };
       if (args[1]?.startsWith("repos/o/r/pulls?"))
-        return { status: 0, stdout: JSON.stringify([pull]), stderr: "" };
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { ...pull, mergeable: undefined, mergeable_state: undefined },
+          ]),
+          stderr: "",
+        };
       if (args[1] === "repos/o/r/commits/abc123/check-runs?per_page=100")
         return {
           status: 0,
           stdout: JSON.stringify({
             check_runs: [
-              { name: "Verify", conclusion: "success", status: "completed" },
+              {
+                name: "Verify",
+                conclusion: "success",
+                status: "completed",
+                started_at: "2026-08-30T02:18:51Z",
+                app: { id: 15368 },
+              },
+              {
+                name: "Verify",
+                conclusion: "failure",
+                status: "completed",
+                started_at: "2026-08-30T02:18:31Z",
+                app: { id: 15368 },
+              },
+              {
+                name: "Verify",
+                conclusion: "failure",
+                status: "completed",
+                started_at: "2026-08-30T02:10:00Z",
+                app: { id: 999 },
+              },
               { name: "Lint", conclusion: "failure", status: "completed" },
+              { name: "Old", conclusion: "stale", status: "completed" },
+              {
+                name: "Boot",
+                conclusion: "startup_failure",
+                status: "completed",
+              },
+              {
+                name: "Stopped",
+                conclusion: "cancelled",
+                status: "completed",
+              },
             ],
           }),
           stderr: "",
@@ -545,7 +582,10 @@ describe("github forge: REST PR reads", () => {
       )
         return {
           status: 0,
-          stdout: JSON.stringify({ contexts: ["Verify", "deploy"] }),
+          stdout: JSON.stringify({
+            contexts: ["Verify", "deploy"],
+            checks: [{ context: "Verify", app_id: 15368 }],
+          }),
           stderr: "",
         };
       return { status: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" };
@@ -565,6 +605,24 @@ describe("github forge: REST PR reads", () => {
         cwd: "/repo",
       }),
     ).toEqual([{ number: 7, url: "https://github.com/o/r/pull/7" }]);
+    expect(
+      forge.prList("o/r", {
+        state: "closed",
+        limit: 1,
+        fields: ["number", "mergeable", "mergeStateStatus"],
+      }),
+    ).toEqual([
+      { number: 7, mergeable: "MERGEABLE", mergeStateStatus: "CLEAN" },
+    ]);
+    expect(forge.prChecks("o/r", 7)).toEqual([
+      { name: "Verify", bucket: "pass", state: "SUCCESS" },
+      { name: "Verify", bucket: "fail", state: "FAILURE" },
+      { name: "Lint", bucket: "fail", state: "FAILURE" },
+      { name: "Old", bucket: "pending", state: "STALE" },
+      { name: "Boot", bucket: "pending", state: "STARTUP_FAILURE" },
+      { name: "Stopped", bucket: "cancel", state: "CANCELLED" },
+      { name: "deploy", bucket: "pass", state: "SUCCESS" },
+    ]);
     expect(forge.prChecks("o/r", 7, { required: true })).toEqual([
       { name: "Verify", bucket: "pass", state: "SUCCESS" },
       { name: "deploy", bucket: "pass", state: "SUCCESS" },
@@ -630,6 +688,107 @@ describe("github forge: REST PR reads", () => {
       ],
       ["run", "list", "--repo", "o/r", "--limit", "10", "--json", "status"],
     ]);
+  });
+
+  test("prList distinguishes REST's combined closed state from merged", () => {
+    const exec = recorder((_, args) => {
+      if (args[1]?.startsWith("repos/o/r/pulls?state=closed"))
+        return {
+          status: 0,
+          stdout: JSON.stringify([
+            { number: 8, state: "closed", merged_at: null },
+            {
+              number: 9,
+              state: "closed",
+              merged_at: "2026-08-30T00:00:00Z",
+            },
+          ]),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+    });
+    const forge = githubForge({ exec });
+    expect(
+      forge.prList("o/r", {
+        state: "closed",
+        fields: ["number", "state"],
+      }),
+    ).toEqual([{ number: 8, state: "CLOSED" }]);
+    expect(
+      forge.prList("o/r", { state: "merged", fields: ["number", "state"] }),
+    ).toEqual([{ number: 9, state: "MERGED" }]);
+  });
+
+  test("prChecks paginates check runs and legacy statuses", () => {
+    const runs = Array.from({ length: 101 }, (_, index) => ({
+      name: `run-${index}`,
+      status: "completed",
+      conclusion: "success",
+    }));
+    const statuses = Array.from({ length: 31 }, (_, index) => ({
+      context: `status-${index}`,
+      state: "success",
+    }));
+    const exec = recorder((_, args) => {
+      const endpoint = args[1];
+      if (endpoint === "repos/o/r/pulls/7")
+        return {
+          status: 0,
+          stdout: JSON.stringify({ head: { sha: "abc123" } }),
+          stderr: "",
+        };
+      if (endpoint === "repos/o/r/commits/abc123/check-runs?per_page=100")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            total_count: runs.length,
+            check_runs: runs.slice(0, 100),
+          }),
+          stderr: "",
+        };
+      if (
+        endpoint === "repos/o/r/commits/abc123/check-runs?per_page=100&page=2"
+      )
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            total_count: runs.length,
+            check_runs: runs.slice(100),
+          }),
+          stderr: "",
+        };
+      if (endpoint === "repos/o/r/commits/abc123/status")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            total_count: statuses.length,
+            statuses: statuses.slice(0, 30),
+          }),
+          stderr: "",
+        };
+      if (endpoint === "repos/o/r/commits/abc123/status?per_page=30&page=2")
+        return {
+          status: 0,
+          stdout: JSON.stringify({
+            total_count: statuses.length,
+            statuses: statuses.slice(30),
+          }),
+          stderr: "",
+        };
+      return { status: 1, stdout: "", stderr: "unexpected endpoint" };
+    });
+    const checks = githubForge({ exec }).prChecks("o/r", 7);
+    expect(checks).toHaveLength(132);
+    expect(checks[0]).toEqual({
+      name: "run-0",
+      bucket: "pass",
+      state: "SUCCESS",
+    });
+    expect(checks.at(-1)).toEqual({
+      name: "status-30",
+      bucket: "pass",
+      state: "SUCCESS",
+    });
   });
 
   test("failure modes: non-zero exit, invalid JSON, spawn error, non-array list", () => {

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -19,6 +19,11 @@ const text = (v) =>
 
 const REST_PAGE_SIZE = 100;
 const STATUS_PAGE_SIZE = 30;
+/** How long a hydrated `mergeable`/`mergeable_state` pair is reused. */
+const HYDRATION_TTL_MS = 120_000;
+const HYDRATION_CACHE_MAX = 2000;
+/** Shared by every real (spawnSync-backed) forge instance in this process. */
+const sharedHydration = new Map();
 
 const pick = (obj, fields) =>
   fields?.length
@@ -57,6 +62,8 @@ function checkBucket(state) {
     case "ERROR":
     case "TIMED_OUT":
     case "ACTION_REQUIRED":
+    case "STALE":
+    case "STARTUP_FAILURE":
       return "fail";
     case "SKIPPED":
     case "NEUTRAL":
@@ -87,14 +94,11 @@ function restChecks(checkRuns, statuses, { dedupe = true } = {}) {
   };
   // A workflow re-run creates a new check suite on the same commit. REST's
   // default `filter=latest` still returns both suites, while `gh pr checks`
-  // keeps only the newest run for each check identity.
-  const latestRuns = dedupe
-    ? newestBy(
-        runs,
-        (run) => `${run?.name ?? ""}\0${run?.app?.id ?? run?.app?.slug ?? ""}`,
-        (run) => run?.started_at ?? run?.completed_at,
-      )
-    : runs;
+  // keeps only the newest run for each check identity. Dedupe by check
+  // suite: for each (name, app) identity keep every run of the newest suite,
+  // so matrix siblings that share a name survive while older suites drop.
+  // Runs without a suite id fall back to newest-by-identity.
+  const latestRuns = dedupe ? latestSuiteRuns(runs) : runs;
   const latestStatuses = dedupe
     ? newestBy(
         legacy,
@@ -132,11 +136,44 @@ function restChecks(checkRuns, statuses, { dedupe = true } = {}) {
   ];
 }
 
+function latestSuiteRuns(runs) {
+  const identityOf = (run) =>
+    `${run?.name ?? ""}\0${run?.app?.id ?? run?.app?.slug ?? ""}`;
+  const suiteOf = (run) => run?.check_suite?.id ?? null;
+  const timestampOf = (run) =>
+    Date.parse(run?.started_at ?? run?.completed_at ?? 0) || 0;
+  const newest = new Map();
+  for (const run of runs) {
+    const key = identityOf(run);
+    const current = newest.get(key);
+    if (!current || timestampOf(run) > timestampOf(current))
+      newest.set(key, run);
+  }
+  return runs.filter((run) => {
+    const head = newest.get(identityOf(run));
+    if (run === head) return true;
+    const suite = suiteOf(run);
+    return suite != null && suite === suiteOf(head);
+  });
+}
+
 /**
- * @param {{ exec?: (cmd: string, args: string[], opts: object) => { status?: number|null, exitCode?: number|null, stdout?: string|Buffer, stderr?: string|Buffer, error?: Error } }} [options]
+ * @param {{
+ *   exec?: (cmd: string, args: string[], opts: object) => { status?: number|null, exitCode?: number|null, stdout?: string|Buffer, stderr?: string|Buffer, error?: Error },
+ *   hydrationTtlMs?: number, // mergeability cache TTL (tests)
+ *   now?: () => number,      // clock for that TTL (tests)
+ * }} [options]
  * @returns {import("./types.mjs").Forge}
  */
-export function githubForge({ exec = spawnSync } = {}) {
+export function githubForge({
+  exec = spawnSync,
+  hydrationTtlMs = HYDRATION_TTL_MS,
+  now = Date.now,
+} = {}) {
+  // Test fakes get a private cache so recorded call counts stay per-instance;
+  // the real `gh` shares one so back-to-back loadForge() callers in a tick
+  // (merge-scan lists open PRs twice) hydrate each head SHA once.
+  const hydration = exec === spawnSync ? sharedHydration : new Map();
   /** Run `gh <args>`; throw ForgeError on non-zero exit or spawn failure. */
   function gh(args, { cwd, timeout } = {}) {
     const r =
@@ -204,6 +241,42 @@ export function githubForge({ exec = spawnSync } = {}) {
 
   function apiJson(path, opts) {
     return ghJson(["api", path], opts);
+  }
+
+  /**
+   * `GET /pulls/{n}` for the mergeability fields the list endpoint omits,
+   * bounded so a merge-scan tick over ~100 open PRs is not ~100 REST calls
+   * every tick: closed/merged rows are never hydrated (GitHub reports no
+   * mergeability for them), and an open row is fetched at most once per
+   * (repo, number, head SHA) per TTL across every forge instance in this
+   * process. A new head SHA is a cache miss, so a rebase is seen at once.
+   */
+  function hydrateMergeability(repo, pull, opts) {
+    if (pull?.merged_at || String(pull?.state ?? "").toLowerCase() !== "open")
+      return pull;
+    const key = `${repo}#${pull?.number}@${pull?.head?.sha ?? ""}`;
+    const at = now();
+    const cached = hydration.get(key);
+    if (cached && at - cached.at < hydrationTtlMs)
+      return { ...pull, ...cached.fields };
+    const detailed = apiJson(`repos/${repo}/pulls/${pull.number}`, opts);
+    // GitHub computes mergeability asynchronously; `null` means "not yet"
+    // and must not be pinned for a whole TTL.
+    if (detailed?.mergeable != null) {
+      if (hydration.size >= HYDRATION_CACHE_MAX) {
+        for (const [k, v] of hydration)
+          if (at - v.at >= hydrationTtlMs) hydration.delete(k);
+        if (hydration.size >= HYDRATION_CACHE_MAX) hydration.clear();
+      }
+      hydration.set(key, {
+        at,
+        fields: {
+          mergeable: detailed.mergeable,
+          mergeable_state: detailed.mergeable_state,
+        },
+      });
+    }
+    return detailed;
   }
 
   function commitChecks(repo, sha, opts) {
@@ -292,7 +365,11 @@ export function githubForge({ exec = spawnSync } = {}) {
         checks,
       };
     } catch (err) {
-      if (err instanceof ForgeError && /HTTP 404/i.test(err.stderr))
+      // 404: the branch is unprotected. 401/403: the caller's token (the
+      // factory App token, notably) may not read branch protection at all;
+      // `gh pr checks --required` reports "no required checks" there too, so
+      // an unreadable rule set is an empty rule set, never a thrown scan.
+      if (err instanceof ForgeError && /HTTP (401|403|404)\b/i.test(err.stderr))
         return { contexts: new Set(), checks: [] };
       throw err;
     }
@@ -385,7 +462,7 @@ export function githubForge({ exec = spawnSync } = {}) {
         // are requested. Hydrate only callers that used those `gh pr --json`
         // fields; the hotter branch/URL lookups stay at one REST request.
         const detailedPull = needsMergeability
-          ? apiJson(`repos/${resolvedRepo}/pulls/${pull.number}`, opts)
+          ? hydrateMergeability(resolvedRepo, pull, opts)
           : pull;
         const pr = restPullToPr(detailedPull);
         if (fields?.includes("statusCheckRollup")) {

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -18,6 +18,7 @@ const text = (v) =>
   v == null ? "" : Buffer.isBuffer(v) ? v.toString() : String(v);
 
 const REST_PAGE_SIZE = 100;
+const STATUS_PAGE_SIZE = 30;
 
 const pick = (obj, fields) =>
   fields?.length
@@ -56,8 +57,6 @@ function checkBucket(state) {
     case "ERROR":
     case "TIMED_OUT":
     case "ACTION_REQUIRED":
-    case "STARTUP_FAILURE":
-    case "STALE":
       return "fail";
     case "SKIPPED":
     case "NEUTRAL":
@@ -69,11 +68,42 @@ function checkBucket(state) {
   }
 }
 
-function restChecks(checkRuns, statuses) {
+function restChecks(checkRuns, statuses, { dedupe = true } = {}) {
   const runs = Array.isArray(checkRuns) ? checkRuns : [];
   const legacy = Array.isArray(statuses) ? statuses : [];
+  const newestBy = (rows, keyOf, timestampOf) => {
+    const seen = new Set();
+    return [...rows]
+      .sort(
+        (a, b) =>
+          Date.parse(timestampOf(b) ?? 0) - Date.parse(timestampOf(a) ?? 0),
+      )
+      .filter((row) => {
+        const key = keyOf(row);
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+  };
+  // A workflow re-run creates a new check suite on the same commit. REST's
+  // default `filter=latest` still returns both suites, while `gh pr checks`
+  // keeps only the newest run for each check identity.
+  const latestRuns = dedupe
+    ? newestBy(
+        runs,
+        (run) => `${run?.name ?? ""}\0${run?.app?.id ?? run?.app?.slug ?? ""}`,
+        (run) => run?.started_at ?? run?.completed_at,
+      )
+    : runs;
+  const latestStatuses = dedupe
+    ? newestBy(
+        legacy,
+        (status) => status?.context ?? "",
+        (status) => status?.created_at ?? status?.updated_at,
+      )
+    : legacy;
   return [
-    ...runs.map((run) => {
+    ...latestRuns.map((run) => {
       const state = String(
         run?.conclusion ?? run?.status ?? "PENDING",
       ).toUpperCase();
@@ -81,18 +111,20 @@ function restChecks(checkRuns, statuses) {
         name: run?.name,
         bucket: checkBucket(state),
         state,
+        appId: run?.app?.id ?? null,
         conclusion: run?.conclusion
           ? String(run.conclusion).toUpperCase()
           : null,
         status: run?.status ? String(run.status).toUpperCase() : null,
       };
     }),
-    ...legacy.map((status) => {
+    ...latestStatuses.map((status) => {
       const state = String(status?.state ?? "PENDING").toUpperCase();
       return {
         name: status?.context,
         bucket: checkBucket(state),
         state,
+        appId: null,
         conclusion: state,
         status: state === "PENDING" ? "PENDING" : "COMPLETED",
       };
@@ -174,6 +206,57 @@ export function githubForge({ exec = spawnSync } = {}) {
     return ghJson(["api", path], opts);
   }
 
+  function commitChecks(repo, sha, opts) {
+    const checkRuns = [];
+    for (let page = 1; ; page++) {
+      const response = apiJson(
+        `repos/${repo}/commits/${sha}/check-runs?per_page=${REST_PAGE_SIZE}${
+          page === 1 ? "" : `&page=${page}`
+        }`,
+        opts,
+      );
+      const rows = response?.check_runs;
+      if (!Array.isArray(rows)) {
+        throw new ForgeError(
+          "GitHub REST check-runs endpoint did not return an array",
+          { status: 0, stdout: JSON.stringify(response) },
+        );
+      }
+      checkRuns.push(...rows);
+      if (
+        rows.length < REST_PAGE_SIZE ||
+        (Number.isFinite(response?.total_count) &&
+          checkRuns.length >= response.total_count)
+      )
+        break;
+    }
+
+    const statuses = [];
+    for (let page = 1; ; page++) {
+      const response = apiJson(
+        `repos/${repo}/commits/${sha}/status${
+          page === 1 ? "" : `?per_page=${STATUS_PAGE_SIZE}&page=${page}`
+        }`,
+        opts,
+      );
+      const rows = response?.statuses;
+      if (!Array.isArray(rows)) {
+        throw new ForgeError(
+          "GitHub REST commit-status endpoint did not return an array",
+          { status: 0, stdout: JSON.stringify(response) },
+        );
+      }
+      statuses.push(...rows);
+      if (
+        rows.length < STATUS_PAGE_SIZE ||
+        (Number.isFinite(response?.total_count) &&
+          statuses.length >= response.total_count)
+      )
+        break;
+    }
+    return { checkRuns, statuses };
+  }
+
   function pullChecks(repo, number, opts) {
     const pull = apiJson(`repos/${repo}/pulls/${number}`, opts);
     const sha = pull?.head?.sha;
@@ -183,14 +266,7 @@ export function githubForge({ exec = spawnSync } = {}) {
         stdout: JSON.stringify(pull),
       });
     }
-    const checkRuns = apiJson(
-      `repos/${repo}/commits/${sha}/check-runs?per_page=${REST_PAGE_SIZE}`,
-      opts,
-    )?.check_runs;
-    const statuses = apiJson(
-      `repos/${repo}/commits/${sha}/status`,
-      opts,
-    )?.statuses;
+    const { checkRuns, statuses } = commitChecks(repo, sha, opts);
     return { pull, checks: restChecks(checkRuns, statuses) };
   }
 
@@ -200,31 +276,44 @@ export function githubForge({ exec = spawnSync } = {}) {
         `repos/${repo}/branches/${encodeURIComponent(baseRef)}/protection/required_status_checks`,
         opts,
       );
-      return new Set([
-        ...(Array.isArray(protection?.contexts) ? protection.contexts : []),
-        ...(Array.isArray(protection?.checks)
-          ? protection.checks.map((check) => check?.context)
-          : []),
-      ]);
+      const checks = Array.isArray(protection?.checks)
+        ? protection.checks.filter(
+            (check) => typeof check?.context === "string",
+          )
+        : [];
+      const modernNames = new Set(checks.map((check) => check.context));
+      return {
+        contexts: new Set(
+          (Array.isArray(protection?.contexts)
+            ? protection.contexts
+            : []
+          ).filter((context) => !modernNames.has(context)),
+        ),
+        checks,
+      };
     } catch (err) {
       if (err instanceof ForgeError && /HTTP 404/i.test(err.stderr))
-        return new Set();
+        return { contexts: new Set(), checks: [] };
       throw err;
     }
+  }
+
+  function isRequired(check, required) {
+    if (required.contexts.has(check.name)) return true;
+    return required.checks.some(
+      (rule) =>
+        rule.context === check.name &&
+        (rule.app_id == null ||
+          rule.app_id === -1 ||
+          String(rule.app_id) === String(check.appId)),
+    );
   }
 
   function statusCheckRollup(repo, pull, opts) {
     const sha = pull?.head?.sha;
     if (typeof sha !== "string" || !sha) return [];
-    const checkRuns = apiJson(
-      `repos/${repo}/commits/${sha}/check-runs?per_page=${REST_PAGE_SIZE}`,
-      opts,
-    )?.check_runs;
-    const statuses = apiJson(
-      `repos/${repo}/commits/${sha}/status`,
-      opts,
-    )?.statuses;
-    return restChecks(checkRuns, statuses).map(
+    const { checkRuns, statuses } = commitChecks(repo, sha, opts);
+    return restChecks(checkRuns, statuses, { dedupe: false }).map(
       ({ name, conclusion, status }) => ({
         name,
         conclusion,
@@ -256,7 +345,16 @@ export function githubForge({ exec = spawnSync } = {}) {
       const requested = limit == null ? 30 : Math.max(0, limit);
       if (requested === 0) return [];
       const restState =
-        state === "merged" ? "closed" : state === "all" ? "all" : "open";
+        state === "merged"
+          ? "closed"
+          : state === "all"
+            ? "all"
+            : state === "closed"
+              ? "closed"
+              : "open";
+      const needsMergeability = fields?.some(
+        (field) => field === "mergeable" || field === "mergeStateStatus",
+      );
       const perPage = Math.min(REST_PAGE_SIZE, requested);
       const prs = [];
       for (let page = 1; prs.length < requested; page++) {
@@ -274,12 +372,22 @@ export function githubForge({ exec = spawnSync } = {}) {
           );
         }
         const filtered =
-          state === "merged" ? raw.filter((pull) => pull?.merged_at) : raw;
+          state === "merged"
+            ? raw.filter((pull) => pull?.merged_at)
+            : state === "closed"
+              ? raw.filter((pull) => !pull?.merged_at)
+              : raw;
         prs.push(...filtered);
         if (raw.length < perPage) break;
       }
       return prs.slice(0, requested).map((pull) => {
-        const pr = restPullToPr(pull);
+        // The REST list endpoint omits mergeability, even when those fields
+        // are requested. Hydrate only callers that used those `gh pr --json`
+        // fields; the hotter branch/URL lookups stay at one REST request.
+        const detailedPull = needsMergeability
+          ? apiJson(`repos/${resolvedRepo}/pulls/${pull.number}`, opts)
+          : pull;
+        const pr = restPullToPr(detailedPull);
         if (fields?.includes("statusCheckRollup")) {
           pr.statusCheckRollup = statusCheckRollup(resolvedRepo, pull, opts);
         }
@@ -321,11 +429,11 @@ export function githubForge({ exec = spawnSync } = {}) {
     prChecks(repo, number, { required, fields, ...opts } = {}) {
       const resolvedRepo = resolveRepo(repo, opts);
       const { pull, checks } = pullChecks(resolvedRepo, number, opts);
-      const contexts = required
+      const requiredRules = required
         ? requiredContexts(resolvedRepo, pull?.base?.ref, opts)
         : null;
-      const selected = contexts
-        ? checks.filter((check) => contexts.has(check.name))
+      const selected = requiredRules
+        ? checks.filter((check) => isRequired(check, requiredRules))
         : checks;
       return selected.map((check) =>
         pick(check, fields?.length ? fields : PR_CHECK_FIELDS),

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -17,8 +17,88 @@ import { ForgeError, PR_CHECK_FIELDS } from "./types.mjs";
 const text = (v) =>
   v == null ? "" : Buffer.isBuffer(v) ? v.toString() : String(v);
 
-/** GitHub CLI stderr when a PR has no check-runs / no required checks. */
-const NO_CHECKS_RE = /^no (required )?checks reported on the '.+' branch$/;
+const REST_PAGE_SIZE = 100;
+
+const pick = (obj, fields) =>
+  fields?.length
+    ? Object.fromEntries(fields.map((field) => [field, obj[field]]))
+    : { ...obj };
+
+function restPullToPr(pull) {
+  const mergeable =
+    pull?.mergeable === true
+      ? "MERGEABLE"
+      : pull?.mergeable === false
+        ? "CONFLICTING"
+        : "UNKNOWN";
+  return {
+    number: pull?.number,
+    url: pull?.html_url,
+    headRefName: pull?.head?.ref,
+    headRefOid: pull?.head?.sha,
+    baseRefName: pull?.base?.ref,
+    isDraft: pull?.draft === true,
+    title: pull?.title,
+    body: pull?.body,
+    labels: Array.isArray(pull?.labels) ? pull.labels : [],
+    state: pull?.merged_at ? "MERGED" : String(pull?.state ?? "").toUpperCase(),
+    mergedAt: pull?.merged_at,
+    mergeable,
+    mergeStateStatus: String(pull?.mergeable_state ?? "UNKNOWN").toUpperCase(),
+  };
+}
+
+function checkBucket(state) {
+  switch (state) {
+    case "SUCCESS":
+      return "pass";
+    case "FAILURE":
+    case "ERROR":
+    case "TIMED_OUT":
+    case "ACTION_REQUIRED":
+    case "STARTUP_FAILURE":
+    case "STALE":
+      return "fail";
+    case "SKIPPED":
+    case "NEUTRAL":
+      return "skipping";
+    case "CANCELLED":
+      return "cancel";
+    default:
+      return "pending";
+  }
+}
+
+function restChecks(checkRuns, statuses) {
+  const runs = Array.isArray(checkRuns) ? checkRuns : [];
+  const legacy = Array.isArray(statuses) ? statuses : [];
+  return [
+    ...runs.map((run) => {
+      const state = String(
+        run?.conclusion ?? run?.status ?? "PENDING",
+      ).toUpperCase();
+      return {
+        name: run?.name,
+        bucket: checkBucket(state),
+        state,
+        conclusion: run?.conclusion
+          ? String(run.conclusion).toUpperCase()
+          : null,
+        status: run?.status ? String(run.status).toUpperCase() : null,
+      };
+    }),
+    ...legacy.map((status) => {
+      const state = String(status?.state ?? "PENDING").toUpperCase();
+      return {
+        name: status?.context,
+        bucket: checkBucket(state),
+        state,
+        conclusion: state,
+        status: state === "PENDING" ? "PENDING" : "COMPLETED",
+      };
+    }),
+  ];
+}
 
 /**
  * @param {{ exec?: (cmd: string, args: string[], opts: object) => { status?: number|null, exitCode?: number|null, stdout?: string|Buffer, stderr?: string|Buffer, error?: Error } }} [options]
@@ -70,6 +150,89 @@ export function githubForge({ exec = spawnSync } = {}) {
     }
   }
 
+  const resolvedRepos = new Map();
+
+  function resolveRepo(repo, opts) {
+    if (repo) return repo;
+    const key = opts?.cwd ?? "";
+    if (resolvedRepos.has(key)) return resolvedRepos.get(key);
+    const resolved = ghJson(
+      ["repo", "view", "--json", "nameWithOwner"],
+      opts,
+    )?.nameWithOwner;
+    if (typeof resolved !== "string" || !resolved.includes("/")) {
+      throw new ForgeError("gh repo view did not return nameWithOwner", {
+        status: 0,
+        stdout: JSON.stringify(resolved),
+      });
+    }
+    resolvedRepos.set(key, resolved);
+    return resolved;
+  }
+
+  function apiJson(path, opts) {
+    return ghJson(["api", path], opts);
+  }
+
+  function pullChecks(repo, number, opts) {
+    const pull = apiJson(`repos/${repo}/pulls/${number}`, opts);
+    const sha = pull?.head?.sha;
+    if (typeof sha !== "string" || !sha) {
+      throw new ForgeError(`pull request #${number} has no head SHA`, {
+        status: 0,
+        stdout: JSON.stringify(pull),
+      });
+    }
+    const checkRuns = apiJson(
+      `repos/${repo}/commits/${sha}/check-runs?per_page=${REST_PAGE_SIZE}`,
+      opts,
+    )?.check_runs;
+    const statuses = apiJson(
+      `repos/${repo}/commits/${sha}/status`,
+      opts,
+    )?.statuses;
+    return { pull, checks: restChecks(checkRuns, statuses) };
+  }
+
+  function requiredContexts(repo, baseRef, opts) {
+    try {
+      const protection = apiJson(
+        `repos/${repo}/branches/${encodeURIComponent(baseRef)}/protection/required_status_checks`,
+        opts,
+      );
+      return new Set([
+        ...(Array.isArray(protection?.contexts) ? protection.contexts : []),
+        ...(Array.isArray(protection?.checks)
+          ? protection.checks.map((check) => check?.context)
+          : []),
+      ]);
+    } catch (err) {
+      if (err instanceof ForgeError && /HTTP 404/i.test(err.stderr))
+        return new Set();
+      throw err;
+    }
+  }
+
+  function statusCheckRollup(repo, pull, opts) {
+    const sha = pull?.head?.sha;
+    if (typeof sha !== "string" || !sha) return [];
+    const checkRuns = apiJson(
+      `repos/${repo}/commits/${sha}/check-runs?per_page=${REST_PAGE_SIZE}`,
+      opts,
+    )?.check_runs;
+    const statuses = apiJson(
+      `repos/${repo}/commits/${sha}/status`,
+      opts,
+    )?.statuses;
+    return restChecks(checkRuns, statuses).map(
+      ({ name, conclusion, status }) => ({
+        name,
+        conclusion,
+        status,
+      }),
+    );
+  }
+
   const repoFlag = (repo) => (repo ? ["--repo", repo] : []);
   const jsonFlag = (fields) =>
     fields?.length ? ["--json", fields.join(",")] : [];
@@ -79,25 +242,49 @@ export function githubForge({ exec = spawnSync } = {}) {
     cli: { bin: "gh", install: "brew install gh && gh auth login" },
 
     prView(repo, number, { fields, ...opts } = {}) {
-      return ghJson(
-        ["pr", "view", String(number), ...repoFlag(repo), ...jsonFlag(fields)],
-        opts,
-      );
+      const resolvedRepo = resolveRepo(repo, opts);
+      const pull = apiJson(`repos/${resolvedRepo}/pulls/${number}`, opts);
+      const pr = restPullToPr(pull);
+      if (fields?.includes("statusCheckRollup")) {
+        pr.statusCheckRollup = statusCheckRollup(resolvedRepo, pull, opts);
+      }
+      return pick(pr, fields);
     },
 
     prList(repo, { state, limit, fields, ...opts } = {}) {
-      const args = ["pr", "list", ...repoFlag(repo)];
-      if (state) args.push("--state", state);
-      if (limit != null) args.push("--limit", String(limit));
-      args.push(...jsonFlag(fields));
-      const parsed = ghJson(args, opts);
-      if (!Array.isArray(parsed)) {
-        throw new ForgeError("gh pr list did not return an array", {
-          status: 0,
-          stdout: JSON.stringify(parsed),
-        });
+      const resolvedRepo = resolveRepo(repo, opts);
+      const requested = limit == null ? 30 : Math.max(0, limit);
+      if (requested === 0) return [];
+      const restState =
+        state === "merged" ? "closed" : state === "all" ? "all" : "open";
+      const perPage = Math.min(REST_PAGE_SIZE, requested);
+      const prs = [];
+      for (let page = 1; prs.length < requested; page++) {
+        const raw = apiJson(
+          `repos/${resolvedRepo}/pulls?state=${restState}&per_page=${perPage}&page=${page}`,
+          opts,
+        );
+        if (!Array.isArray(raw)) {
+          throw new ForgeError(
+            "GitHub REST pulls endpoint did not return an array",
+            {
+              status: 0,
+              stdout: JSON.stringify(raw),
+            },
+          );
+        }
+        const filtered =
+          state === "merged" ? raw.filter((pull) => pull?.merged_at) : raw;
+        prs.push(...filtered);
+        if (raw.length < perPage) break;
       }
-      return parsed;
+      return prs.slice(0, requested).map((pull) => {
+        const pr = restPullToPr(pull);
+        if (fields?.includes("statusCheckRollup")) {
+          pr.statusCheckRollup = statusCheckRollup(resolvedRepo, pull, opts);
+        }
+        return pick(pr, fields);
+      });
     },
 
     prDiffFiles(repo, number, opts = {}) {
@@ -132,41 +319,17 @@ export function githubForge({ exec = spawnSync } = {}) {
     },
 
     prChecks(repo, number, { required, fields, ...opts } = {}) {
-      const jsonFields = fields?.length ? fields : [...PR_CHECK_FIELDS];
-      const args = [
-        "pr",
-        "checks",
-        String(number),
-        ...repoFlag(repo),
-        ...(required ? ["--required"] : []),
-        "--json",
-        jsonFields.join(","),
-      ];
-      try {
-        const parsed = ghJson(args, opts);
-        if (!Array.isArray(parsed)) {
-          throw new ForgeError("gh pr checks did not return an array", {
-            status: 0,
-            stdout: JSON.stringify(parsed),
-          });
-        }
-        return parsed;
-      } catch (err) {
-        if (!(err instanceof ForgeError)) throw err;
-        // `gh pr checks --json` still prints the array when checks are red or
-        // pending on some CLI versions (exit 1 / 8). Prefer the snapshot.
-        if (err.stdout) {
-          try {
-            const parsed = JSON.parse(err.stdout);
-            if (Array.isArray(parsed)) return parsed;
-          } catch {
-            // not JSON — fall through to the empty-snapshot diagnostics
-          }
-        }
-        const diagnostic = (err.stderr || "").trim();
-        if (err.status === 1 && NO_CHECKS_RE.test(diagnostic)) return [];
-        throw err;
-      }
+      const resolvedRepo = resolveRepo(repo, opts);
+      const { pull, checks } = pullChecks(resolvedRepo, number, opts);
+      const contexts = required
+        ? requiredContexts(resolvedRepo, pull?.base?.ref, opts)
+        : null;
+      const selected = contexts
+        ? checks.filter((check) => contexts.has(check.name))
+        : checks;
+      return selected.map((check) =>
+        pick(check, fields?.length ? fields : PR_CHECK_FIELDS),
+      );
     },
 
     runList(repo, { branch, created, limit, fields, ...opts } = {}) {

--- a/lib/forge/types.mjs
+++ b/lib/forge/types.mjs
@@ -20,8 +20,8 @@
 
 /**
  * Identifies a repository on the forge. `null` means "whatever the working
- * directory's checkout points at" — the GitHub implementation then omits
- * `--repo` and relies on `opts.cwd`, exactly as the pre-forge call sites did.
+ * directory's checkout points at" — the GitHub implementation resolves that
+ * checkout's `nameWithOwner` once before making its REST requests.
  * @typedef {string|null} RepoRef  `owner/name` or null
  */
 

--- a/orchestrator/branch-guard.test.mjs
+++ b/orchestrator/branch-guard.test.mjs
@@ -208,6 +208,38 @@ describe("evaluateBranchGuard", () => {
   });
 });
 
+/**
+ * A `gh` fake speaking the forge's REST dialect (#1422): `repo view` names
+ * the repo, `api repos/o/r/pulls/{n}` returns one pull, and the paged
+ * `api repos/o/r/pulls?state=open&...` list slices `open` by page.
+ */
+function ghRest({ open = [], ...pulls } = {}) {
+  return (_cmd, args) => {
+    const ok = (body) => ({
+      status: 0,
+      stdout: JSON.stringify(body),
+      stderr: "",
+    });
+    if (args[0] === "repo" && args[1] === "view")
+      return ok({ nameWithOwner: "o/r" });
+    if (args[0] === "api") {
+      const one = /^repos\/o\/r\/pulls\/(\d+)$/.exec(args[1]);
+      if (one && pulls[one[1]])
+        return ok({ number: Number(one[1]), ...pulls[one[1]] });
+      const list =
+        /^repos\/o\/r\/pulls\?state=open&per_page=(\d+)&page=(\d+)$/.exec(
+          args[1],
+        );
+      if (list) {
+        const perPage = Number(list[1]);
+        const page = Number(list[2]);
+        return ok(open.slice((page - 1) * perPage, page * perPage));
+      }
+    }
+    return { status: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" };
+  };
+}
+
 describe("gh helper failure modes", () => {
   test("resolveHeadBranch returns null on gh error", () => {
     const run = recorder(() => ({
@@ -219,23 +251,20 @@ describe("gh helper failure modes", () => {
   });
 
   test("resolveHeadBranch returns branch name on success", () => {
-    // The forge reads `--json headRefName` and picks the field itself (WM-836);
-    // the fake answers the way gh does, as JSON.
-    const run = recorder(() => ({
-      status: 0,
-      stdout: JSON.stringify({ headRefName: "feat/my-branch" }) + "\n",
-      stderr: "",
-    }));
+    // The forge resolves the cwd repo once (`gh repo view`), then reads the
+    // PR over REST and picks `headRefName` itself (WM-836, #1422); the fake
+    // answers each spawn the way gh does, as JSON.
+    const run = recorder(ghRest({ 123: { head: { ref: "feat/my-branch" } } }));
     expect(resolveHeadBranch("/fake", 123, run)).toBe("feat/my-branch");
-    expect(run.calls[0].cmd).toBe("gh");
+    expect(run.calls.map((call) => call.cmd)).toEqual(["gh", "gh"]);
     expect(run.calls[0].args).toEqual([
-      "pr",
+      "repo",
       "view",
-      "123",
       "--json",
-      "headRefName",
+      "nameWithOwner",
     ]);
-    expect(run.calls[0].opts.cwd).toBe("/fake");
+    expect(run.calls[1].args).toEqual(["api", "repos/o/r/pulls/123"]);
+    expect(run.calls.every((call) => call.opts.cwd === "/fake")).toBe(true);
   });
 
   test("listOpenPrs returns null on gh failure or JSON parse error", () => {
@@ -255,13 +284,21 @@ describe("gh helper failure modes", () => {
   });
 
   test("listOpenPrs returns array on success", () => {
-    const run = recorder(() => ({
-      status: 0,
-      stdout: JSON.stringify([{ number: 10, headRefName: "feat/x" }]),
-      stderr: "",
-    }));
+    const run = recorder(
+      ghRest({ open: [{ number: 10, head: { ref: "feat/x" } }] }),
+    );
     expect(listOpenPrs("/fake", run)).toEqual([
       { number: 10, headRefName: "feat/x" },
+    ]);
+    expect(run.calls[0].args).toEqual([
+      "repo",
+      "view",
+      "--json",
+      "nameWithOwner",
+    ]);
+    expect(run.calls[1].args).toEqual([
+      "api",
+      "repos/o/r/pulls?state=open&per_page=100&page=1",
     ]);
   });
 });

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -105,17 +105,52 @@ describe("openPrHold", () => {
   });
 });
 
+/**
+ * A `gh` fake speaking the forge's REST dialect (#1422): `repo view` names
+ * the repo and the paged `api repos/o/r/pulls?state=open&...` list slices
+ * `open` by page, the way GitHub does.
+ */
+function ghRest({ open = [] } = {}) {
+  return (_cmd, args) => {
+    const ok = (body) => ({
+      status: 0,
+      stdout: JSON.stringify(body),
+      stderr: "",
+    });
+    if (args[0] === "repo" && args[1] === "view")
+      return ok({ nameWithOwner: "o/r" });
+    const list =
+      /^repos\/o\/r\/pulls\?state=open&per_page=(\d+)&page=(\d+)$/.exec(
+        args[0] === "api" ? args[1] : "",
+      );
+    if (list) {
+      const perPage = Number(list[1]);
+      const page = Number(list[2]);
+      return ok(open.slice((page - 1) * perPage, page * perPage));
+    }
+    return { status: 1, stdout: "", stderr: "gh: Not Found (HTTP 404)" };
+  };
+}
+
 describe("listOpenPrs", () => {
   test("returns the parsed PR list", () => {
-    const run = recorder(() => ({
-      status: 0,
-      stdout: JSON.stringify([{ number: 261, headRefName: "feat/CLNT-520" }]),
-    }));
+    const run = recorder(
+      ghRest({ open: [{ number: 261, head: { ref: "feat/CLNT-520" } }] }),
+    );
     expect(listOpenPrs("/repo", run)).toEqual([
       { number: 261, headRefName: "feat/CLNT-520" },
     ]);
-    expect(run.calls[0].args).toContain("--state");
-    expect(run.calls[0].args).toContain("open");
+    expect(run.calls[0].args).toEqual([
+      "repo",
+      "view",
+      "--json",
+      "nameWithOwner",
+    ]);
+    expect(run.calls[1].args).toEqual([
+      "api",
+      "repos/o/r/pulls?state=open&per_page=100&page=1",
+    ]);
+    expect(run.calls.every((call) => call.opts.cwd === "/repo")).toBe(true);
   });
 
   test("a failed or unparseable `gh` is null, not an empty list", () => {
@@ -138,24 +173,18 @@ describe("listOpenPrs", () => {
   test("fails closed (returns null) when hitting the fetch limit (WM-56)", () => {
     const atLimit = Array.from({ length: 200 }, (_, i) => ({
       number: i + 1,
-      headRefName: `branch-${i + 1}`,
+      head: { ref: `branch-${i + 1}` },
     }));
-    const run = recorder(() => ({
-      status: 0,
-      stdout: JSON.stringify(atLimit),
-    }));
+    const run = recorder(ghRest({ open: atLimit }));
     expect(listOpenPrs("/repo", run, 200)).toBeNull();
   });
 
   test("returns PRs when below the fetch limit (WM-56)", () => {
     const belowLimit = Array.from({ length: 199 }, (_, i) => ({
       number: i + 1,
-      headRefName: `branch-${i + 1}`,
+      head: { ref: `branch-${i + 1}` },
     }));
-    const run = recorder(() => ({
-      status: 0,
-      stdout: JSON.stringify(belowLimit),
-    }));
+    const run = recorder(ghRest({ open: belowLimit }));
     expect(listOpenPrs("/repo", run, 200)).toHaveLength(199);
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1422

Review REST parity for mergeability, superseded checks, pagination, and app-qualified required contexts.

## Validation

| Check                | Command                                                                                                         | Result  | Notes                                  |
| -------------------- | --------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test lib/forge/contract.test.mjs event-runtime/lib/merge-reviews.test.mjs --timeout 20000`                 | pass    | 61 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`              | pass    | 1,952 pass, 10 environment skips       |
| UX critique          | factory-ux-critic                                                                                               | not run | backend-only; no user-facing surface   |

UX critique: skipped — backend-only; no user-facing surface


## Post-review (228f90e9a9a513a3252d9720bcb3e128877f58a2)
- `requiredContexts()` now treats HTTP 401/403 on `/branches/{ref}/protection/required_status_checks` like 404 (empty rule set) so `prChecks(..., { required: true })` no longer throws under the App token; 5xx still throws. Test added.
- `prList()` mergeability hydration is bounded: closed/merged rows are never hydrated, and open rows are fetched at most once per (repo, number, head SHA) per 120 s TTL across forge instances in the process (test fakes get a private cache). Null (still-computing) mergeability is not pinned. Test asserts the call count.
- `checkBucket()`: `STALE` and `STARTUP_FAILURE` are `fail`.
- `restChecks()` dedupes by check-suite id per (name, app) identity, falling back to newest-by-identity, so same-name matrix siblings survive. Test added.
- `orchestrator/branch-guard.test.mjs` / `orchestrator/janitor.test.mjs` fakes answer `gh repo view` and the REST pulls endpoints (paged) and assert the REST argv.
