### PR TITLE
fix(verify): harden handoff sandbox

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -357,12 +357,20 @@ Consequences, all inherited from the dispatcher's rules rather than invented:
 The worker runs repository and ticket verification in a user, mount, PID, and
 network namespace. `sandbox.tmpfs_mb` in local `config/policy.yaml` controls
 the guest `/tmp` size in MiB; absent, malformed, or smaller-than-safe values
-use the 1024 MiB default. PID 1 is a reaping init, so orphaned descendants
-from process-group tests cannot remain zombies. When every explicit ticket
-`bun test` path is contained by an explicit repository-verify `bun test` path,
-the worker records `ticket_verify_covered_by_repo_verify` and does not run a
-redundant second sandbox step. It otherwise preserves the independent ticket
-command check; unparseable shell commands never qualify for skipping.
+use the 1024 MiB default, and values above 8192 MiB are capped there. PID 1 is
+a reaping init: after the command exits it SIGTERMs every leftover, and
+anything still alive after a short grace is SIGKILLed, so orphaned descendants
+from process-group tests can neither remain zombies nor keep the sandbox
+alive. The host must provide unprivileged user namespaces and
+`/usr/bin/python3` (the init/setup interpreter); otherwise the gate refuses
+with `sandbox_unavailable` rather than reporting the ticket's command red.
+When every explicit ticket `bun test` path is either named verbatim by
+repository verify, or is an existing `*.test.*`/`*.spec.*` file under a
+directory that repository verify runs, the worker records
+`ticket_verify_covered_by_repo_verify` and does not run a redundant second
+sandbox step. It otherwise preserves the independent ticket command check;
+unparseable shell commands, missing files, non-test modules and flag values
+(`--preload x`) never qualify for skipping.
 
 ---
 

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -352,6 +352,18 @@ Consequences, all inherited from the dispatcher's rules rather than invented:
   already reads the `worktree_*` and `verify` fields, unused until now). A
   second repo registry is the same drift argument as §4, applied to ports.
 
+### Handoff verification sandbox limits
+
+The worker runs repository and ticket verification in a user, mount, PID, and
+network namespace. `sandbox.tmpfs_mb` in local `config/policy.yaml` controls
+the guest `/tmp` size in MiB; absent, malformed, or smaller-than-safe values
+use the 1024 MiB default. PID 1 is a reaping init, so orphaned descendants
+from process-group tests cannot remain zombies. When every explicit ticket
+`bun test` path is contained by an explicit repository-verify `bun test` path,
+the worker records `ticket_verify_covered_by_repo_verify` and does not run a
+redundant second sandbox step. It otherwise preserves the independent ticket
+command check; unparseable shell commands never qualify for skipping.
+
 ---
 
 ## 6. Execution form: the `claude` adapter, `mutating: true`

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -126,6 +126,13 @@ export const HANDOFF_GUEST_PATH =
   "/opt/factory-bin:/usr/local/bin:/usr/bin:/bin";
 /** Where the verified worktree is mounted inside the chroot. */
 export const HANDOFF_GUEST_WORKSPACE = "/workspace";
+export const DEFAULT_HANDOFF_SANDBOX_TMPFS_MB = 1024;
+export const HANDOFF_SANDBOX_NAMESPACES = Object.freeze([
+  "user",
+  "mount",
+  "pid",
+  "network",
+]);
 /**
  * Set in the guest environment so a handoff gate running INSIDE the sandbox
  * knows not to try to build another one. `clone(CLONE_NEWUSER)` is EPERM for
@@ -137,6 +144,74 @@ export const HANDOFF_GUEST_WORKSPACE = "/workspace";
  * environment, cwd confinement and timeout.
  */
 export const HANDOFF_SANDBOX_MARKER = "FACTORY_HANDOFF_SANDBOX";
+
+/** Missing or invalid local policy must not restore the old 256 MiB mount. */
+export function policyHandoffSandboxTmpfsMb(root = reposRoot()) {
+  try {
+    const value = Bun.YAML.parse(
+      readFileSync(resolveConfigPath("policy", { root }), "utf8"),
+    )?.sandbox?.tmpfs_mb;
+    return Number.isSafeInteger(value) &&
+      value >= DEFAULT_HANDOFF_SANDBOX_TMPFS_MB
+      ? value
+      : DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
+  } catch {
+    return DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
+  }
+}
+
+function handoffSandboxLimits(tmpfsMb) {
+  return `tmpfs=${tmpfsMb}MiB; namespaces=${HANDOFF_SANDBOX_NAMESPACES.join(",")}`;
+}
+
+/**
+ * PID 1 must reap orphaned test processes. This Python init runs before the
+ * chroot, supervises the setup shell, and terminates/reaps leftovers once the
+ * command returns so a ticket check cannot leave a guest daemon behind.
+ */
+export const HANDOFF_SANDBOX_INIT = String.raw`
+import os
+import signal
+import sys
+
+child = os.fork()
+if child == 0:
+    os.execv(sys.argv[1], sys.argv[1:])
+
+def forward(signum, _frame):
+    try:
+        os.kill(child, signum)
+    except ProcessLookupError:
+        pass
+
+signal.signal(signal.SIGTERM, forward)
+signal.signal(signal.SIGINT, forward)
+child_status = 1
+while True:
+    try:
+        pid, status = os.wait()
+    except InterruptedError:
+        continue
+    if pid == child:
+        child_status = status
+        break
+
+try:
+    os.kill(-1, signal.SIGTERM)
+except ProcessLookupError:
+    pass
+while True:
+    try:
+        os.wait()
+    except ChildProcessError:
+        break
+
+if os.WIFEXITED(child_status):
+    sys.exit(os.WEXITSTATUS(child_status))
+if os.WIFSIGNALED(child_status):
+    sys.exit(128 + os.WTERMSIG(child_status))
+sys.exit(1)
+`;
 
 /** True when this process is itself running inside a handoff sandbox. */
 export function insideHandoffSandbox(env = process.env) {
@@ -164,7 +239,8 @@ export function handoffRuntimeBinaries(which = (name) => Bun.which(name)) {
  *   `.git` file points at, ephemeral /tmp, proc and basic devices;
  * - chroot makes host absolute paths and worktree symlink escapes unreachable.
  *
- * Argument protocol: root, workspace, guest_cwd, git_mount_count, then
+ * Argument protocol: root, workspace, guest_cwd, git_mount_count, tmpfs_mb,
+ * then
  * `git_mount_count` × (host_path, ro|rw), then (name, executable) pairs for
  * the package runners, then the command as the last argument.
  *
@@ -187,7 +263,8 @@ root=$1
 workspace=$2
 guest_cwd=$3
 git_mounts=$4
-shift 4
+tmpfs_mb=$5
+shift 5
 mount --make-rprivate /
 mount -t tmpfs -o mode=0755,size=64m tmpfs "$root"
 mkdir -p "$root/usr" "$root/workspace" "$root/tmp" "$root/dev" \
@@ -201,7 +278,7 @@ mount --make-rslave "$root/usr"
 mount -o remount,bind,ro "$root/usr"
 mount --rbind "$workspace" "$root/workspace"
 mount --make-rslave "$root/workspace"
-mount -t tmpfs -o mode=1777,size=256m tmpfs "$root/tmp"
+mount -t tmpfs -o mode=1777,size="${"$"}{tmpfs_mb}m" tmpfs "$root/tmp"
 mount -t proc proc "$root/proc"
 for dev in null zero random urandom; do
   touch "$root/dev/$dev"
@@ -399,6 +476,7 @@ export function runHandoffCommand({
   runtimeBinaries = handoffRuntimeBinaries(),
   nested = insideHandoffSandbox(),
   sandboxAvailable = () => handoffSandboxAvailable({ nested }),
+  tmpfsMb = policyHandoffSandboxTmpfsMb(),
 }) {
   if (!sandboxAvailable()) throw new SandboxUnavailable();
   const root = realpathSync(worktreePath);
@@ -418,6 +496,10 @@ export function runHandoffCommand({
     path.join(sandboxParent, ".handoff-sandbox-"),
   );
   const gitMounts = handoffGitMounts(root);
+  const sandboxTmpfsMb =
+    Number.isSafeInteger(tmpfsMb) && tmpfsMb >= DEFAULT_HANDOFF_SANDBOX_TMPFS_MB
+      ? tmpfsMb
+      : DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
   const fd = openSync(logPath, "w");
   let res;
   const startedAt = Date.now();
@@ -470,6 +552,9 @@ export function runHandoffCommand({
             "--pid",
             "--fork",
             "--kill-child=KILL",
+            "/usr/bin/python3",
+            "-c",
+            HANDOFF_SANDBOX_INIT,
             "/bin/bash",
             "-ceu",
             HANDOFF_SANDBOX_SETUP,
@@ -478,6 +563,7 @@ export function runHandoffCommand({
             root,
             guestCwd,
             String(gitMounts.length),
+            String(sandboxTmpfsMb),
             ...gitMounts.flatMap(({ path: gitPath, mode }) => [gitPath, mode]),
             ...runtimeArgs,
             command,
@@ -515,7 +601,11 @@ export function runHandoffCommand({
     cwd: commandCwd,
     confinement: nested
       ? "inherited handoff sandbox (already namespaced + chrooted); minimal env"
-      : "user+mount+pid+network namespace; chroot; minimal env",
+      : `user+mount+pid+network namespace; chroot; ${handoffSandboxLimits(sandboxTmpfsMb)}`,
+    sandbox: {
+      tmpfsMb: sandboxTmpfsMb,
+      namespaces: HANDOFF_SANDBOX_NAMESPACES,
+    },
     elapsedMs,
     exitCode,
     timedOut,
@@ -524,6 +614,56 @@ export function runHandoffCommand({
     tail: outputTail(output),
     logPath,
   };
+}
+
+function bunTestPaths(command) {
+  if (typeof command !== "string") return null;
+  const paths = [];
+  const segments = command.split(/(?:&&|;)/);
+  for (const segment of segments) {
+    // Shell expansion or a pipeline makes the set of executed tests unclear.
+    if (/[$`'"\\(){}[\]|<>*?]/.test(segment)) return null;
+    const words = segment.trim().split(/\s+/);
+    if (words[0] !== "bun" || words[1] !== "test") continue;
+    for (const word of words.slice(2)) {
+      if (
+        word.startsWith("-") ||
+        /^\d+(?:\.\d+)?$/.test(word) ||
+        !(/[/.]/.test(word) || word.endsWith("test"))
+      ) {
+        continue;
+      }
+      const normalized = path.posix.normalize(word);
+      if (
+        normalized === "." ||
+        normalized.startsWith("../") ||
+        path.isAbsolute(normalized)
+      )
+        return null;
+      paths.push(normalized.replace(/\/$/, ""));
+    }
+  }
+  return paths.length > 0 ? paths : null;
+}
+
+/**
+ * True only when every explicit ticket test path is contained by an explicit
+ * `bun test` path in repo verify. Unparseable commands and default test
+ * discovery return false, preserving the independent ticket check.
+ */
+export function ticketVerifyCoveredByRepoVerify(ticketCommand, repoVerify) {
+  const ticketPaths = bunTestPaths(ticketCommand);
+  const repoPaths = bunTestPaths(repoVerify);
+  return Boolean(
+    ticketPaths &&
+    repoPaths &&
+    ticketPaths.every((ticketPath) =>
+      repoPaths.some(
+        (repoPath) =>
+          ticketPath === repoPath || ticketPath.startsWith(`${repoPath}/`),
+      ),
+    ),
+  );
 }
 
 /** Best-effort timeout for the pre-diff `git fetch origin <base>` (F4). */
@@ -633,9 +773,15 @@ export function composeHandoffVerification(handoff) {
     lines.push(commandLine("Verification", primary));
     lines.push(fenceBlock(primary.tail));
     if (primary.source === "repo_verify") {
-      lines.push(
-        "  (no `## Verification Command` parsed on the ticket — the repo `verify:` command stood in for it)",
-      );
+      if (handoff.ticketVerifyCoveredByRepoVerify) {
+        lines.push(
+          "  (ticket verification skipped: its explicit test paths are covered by repo verify)",
+        );
+      } else {
+        lines.push(
+          "  (no `## Verification Command` parsed on the ticket — the repo `verify:` command stood in for it)",
+        );
+      }
     }
   } else if (handoff.reasonCode === "handoff_verification_unspecified") {
     lines.push(
@@ -1328,6 +1474,10 @@ function verifyCompleted({
             output: claim.output ?? null,
           }
         : null,
+      ticketVerifyCoveredByRepoVerify: ticketVerifyCoveredByRepoVerify(
+        ticketCommand,
+        worktreeRecord.verify,
+      ),
       reasonCode: null,
     };
     const refuse = (reasonCode, violation) => {
@@ -1388,7 +1538,13 @@ function verifyCompleted({
     }
 
     // 2. The ticket's exact Verification Command on the final tree.
-    if (ticketCommand) {
+    if (ticketCommand && handoff.ticketVerifyCoveredByRepoVerify) {
+      // Step 1 ran the broader repository test scope on this final tree, so a
+      // second namespaced execution would only duplicate it (and its fixture
+      // scratch space). Keep the worker observation as the ticket evidence.
+      handoff.verification = handoff.repoVerify;
+      handoffChecks.push("ticket_verify_covered_by_repo_verify");
+    } else if (ticketCommand) {
       const obs = runHandoffStep({
         command: ticketCommand,
         cwd: worktreePath,
@@ -1401,7 +1557,7 @@ function verifyCompleted({
       if (!obs.passed) {
         refuse(
           "handoff_verification_failed",
-          `ticket_verify_failed: ${failureWhy(obs)}`,
+          `ticket_verify_failed: ${failureWhy(obs)}; sandbox_limits: ${handoffSandboxLimits(obs.sandbox.tmpfsMb)}`,
         );
       }
       handoffChecks.push("ticket_verify_passed");

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -145,16 +145,28 @@ export const HANDOFF_SANDBOX_NAMESPACES = Object.freeze([
  */
 export const HANDOFF_SANDBOX_MARKER = "FACTORY_HANDOFF_SANDBOX";
 
+/**
+ * Upper bound for the guest tmpfs. A tmpfs is only a promise to the guest, but
+ * a runaway suite can fill it all from host RAM/swap, so policy cannot hand
+ * out more than this.
+ */
+export const MAX_HANDOFF_SANDBOX_TMPFS_MB = 8192;
+
+/** Clamp a candidate tmpfs size into [default, max]; anything else -> default. */
+export function clampHandoffSandboxTmpfsMb(value) {
+  if (!Number.isSafeInteger(value) || value < DEFAULT_HANDOFF_SANDBOX_TMPFS_MB)
+    return DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
+  return Math.min(value, MAX_HANDOFF_SANDBOX_TMPFS_MB);
+}
+
 /** Missing or invalid local policy must not restore the old 256 MiB mount. */
 export function policyHandoffSandboxTmpfsMb(root = reposRoot()) {
   try {
-    const value = Bun.YAML.parse(
-      readFileSync(resolveConfigPath("policy", { root }), "utf8"),
-    )?.sandbox?.tmpfs_mb;
-    return Number.isSafeInteger(value) &&
-      value >= DEFAULT_HANDOFF_SANDBOX_TMPFS_MB
-      ? value
-      : DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
+    return clampHandoffSandboxTmpfsMb(
+      Bun.YAML.parse(
+        readFileSync(resolveConfigPath("policy", { root }), "utf8"),
+      )?.sandbox?.tmpfs_mb,
+    );
   } catch {
     return DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
   }
@@ -173,6 +185,7 @@ export const HANDOFF_SANDBOX_INIT = String.raw`
 import os
 import signal
 import sys
+import time
 
 child = os.fork()
 if child == 0:
@@ -196,15 +209,40 @@ while True:
         child_status = status
         break
 
+def reap_all(grace_seconds):
+    # Returns True once no children remain; False if the grace ran out.
+    deadline = time.monotonic() + grace_seconds
+    while True:
+        try:
+            pid, _ = os.waitpid(-1, os.WNOHANG)
+        except ChildProcessError:
+            return True
+        except InterruptedError:
+            continue
+        if pid == 0:
+            if time.monotonic() >= deadline:
+                return False
+            time.sleep(0.05)
+
 try:
     os.kill(-1, signal.SIGTERM)
 except ProcessLookupError:
     pass
-while True:
+if not reap_all(2.0):
+    # A leftover that ignores SIGTERM (or is stuck in a handler) would keep
+    # the sandbox alive past the command; escalate so the worker's reap never
+    # hangs on it.
     try:
-        os.wait()
-    except ChildProcessError:
-        break
+        os.kill(-1, signal.SIGKILL)
+    except ProcessLookupError:
+        pass
+    while True:
+        try:
+            os.wait()
+        except ChildProcessError:
+            break
+        except InterruptedError:
+            continue
 
 if os.WIFEXITED(child_status):
     sys.exit(os.WEXITSTATUS(child_status))
@@ -368,6 +406,9 @@ export const HANDOFF_SANDBOX_UNAVAILABLE = "sandbox_unavailable";
 
 let sandboxProbeCache = null;
 
+/** Interpreter for the sandbox setup program and PID 1 init. */
+export const HANDOFF_SANDBOX_PYTHON = "/usr/bin/python3";
+
 /**
  * Can this host build the isolation boundary at all? Unprivileged user
  * namespaces are a kernel/distro toggle (`kernel.unprivileged_userns_clone`,
@@ -382,11 +423,19 @@ export function handoffSandboxAvailable({
   spawn = spawnSync,
   cache = true,
   nested = insideHandoffSandbox(),
+  exists = existsSync,
 } = {}) {
   if (nested) return true;
   if (cache && sandboxProbeCache !== null) return sandboxProbeCache;
   let available;
   try {
+    // The setup program runs under /usr/bin/python3 inside the namespace; a
+    // host without it cannot build the boundary either, and must report
+    // `sandbox_unavailable` rather than a bogus red for the ticket's command.
+    if (!exists(HANDOFF_SANDBOX_PYTHON)) {
+      if (cache) sandboxProbeCache = false;
+      return false;
+    }
     const res = spawn(
       "/usr/bin/unshare",
       [
@@ -496,10 +545,7 @@ export function runHandoffCommand({
     path.join(sandboxParent, ".handoff-sandbox-"),
   );
   const gitMounts = handoffGitMounts(root);
-  const sandboxTmpfsMb =
-    Number.isSafeInteger(tmpfsMb) && tmpfsMb >= DEFAULT_HANDOFF_SANDBOX_TMPFS_MB
-      ? tmpfsMb
-      : DEFAULT_HANDOFF_SANDBOX_TMPFS_MB;
+  const sandboxTmpfsMb = clampHandoffSandboxTmpfsMb(tmpfsMb);
   const fd = openSync(logPath, "w");
   let res;
   const startedAt = Date.now();
@@ -552,7 +598,7 @@ export function runHandoffCommand({
             "--pid",
             "--fork",
             "--kill-child=KILL",
-            "/usr/bin/python3",
+            HANDOFF_SANDBOX_PYTHON,
             "-c",
             HANDOFF_SANDBOX_INIT,
             "/bin/bash",
@@ -616,6 +662,58 @@ export function runHandoffCommand({
   };
 }
 
+/**
+ * `bun test` flags that consume the following word. Their values must never
+ * widen the covering set (`--preload ./setup.mjs`, `-t verify`, ...).
+ */
+const BUN_TEST_VALUE_FLAGS = new Set([
+  "--preload",
+  "-r",
+  "--require",
+  "--timeout",
+  "-t",
+  "--test-name-pattern",
+  "--path-ignore-patterns",
+  "--max-concurrency",
+  "--rerun-each",
+  "--reporter",
+  "--reporter-outfile",
+  "--coverage-dir",
+  "--coverage-reporter",
+  "--coverage-threshold",
+  "--env-file",
+  "--cwd",
+  "--filter",
+  "--tsconfig-override",
+  "--define",
+  "-d",
+  "--loader",
+  "-l",
+  "--conditions",
+  "--port",
+  "--inspect",
+  "--inspect-wait",
+  "--inspect-brk",
+  "--concurrent-workers",
+  "--randomize-seed",
+  "--seed",
+  "--main-fields",
+  "--jsx-factory",
+  "--jsx-fragment",
+  "--jsx-import-source",
+  "--jsx-runtime",
+  "--config",
+  "-c",
+]);
+
+/** Filename shapes bun's default discovery treats as tests. */
+const BUN_TEST_FILE_RE =
+  /(?:^|[._-])(?:test|spec)\.(?:[cm]?[jt]sx?)$|(?:^|\/)(?:test|spec)\.[cm]?[jt]sx?$/;
+
+export function isBunTestFile(filePath) {
+  return BUN_TEST_FILE_RE.test(path.posix.basename(filePath));
+}
+
 function bunTestPaths(command) {
   if (typeof command !== "string") return null;
   const paths = [];
@@ -625,9 +723,18 @@ function bunTestPaths(command) {
     if (/[$`'"\\(){}[\]|<>*?]/.test(segment)) return null;
     const words = segment.trim().split(/\s+/);
     if (words[0] !== "bun" || words[1] !== "test") continue;
+    let skipValue = false;
     for (const word of words.slice(2)) {
+      if (skipValue) {
+        // The value of a value-taking flag is never a test path.
+        skipValue = false;
+        continue;
+      }
+      if (word.startsWith("-")) {
+        skipValue = !word.includes("=") && BUN_TEST_VALUE_FLAGS.has(word);
+        continue;
+      }
       if (
-        word.startsWith("-") ||
         /^\d+(?:\.\d+)?$/.test(word) ||
         !(/[/.]/.test(word) || word.endsWith("test"))
       ) {
@@ -650,20 +757,32 @@ function bunTestPaths(command) {
  * True only when every explicit ticket test path is contained by an explicit
  * `bun test` path in repo verify. Unparseable commands and default test
  * discovery return false, preserving the independent ticket check.
+ *
+ * Exact-path matches stand on their own. A ticket path covered only by a
+ * repo-verify DIRECTORY additionally has to be a real file under `root` whose
+ * name matches bun's test pattern: directory discovery only ever runs
+ * `*.test.*` / `*.spec.*` files, so a missing path or a helper module named on
+ * the ticket would NOT actually have been exercised by step 1 — step 2 must
+ * still run for it.
  */
-export function ticketVerifyCoveredByRepoVerify(ticketCommand, repoVerify) {
+export function ticketVerifyCoveredByRepoVerify(
+  ticketCommand,
+  repoVerify,
+  { root = null, exists = existsSync } = {},
+) {
   const ticketPaths = bunTestPaths(ticketCommand);
   const repoPaths = bunTestPaths(repoVerify);
-  return Boolean(
-    ticketPaths &&
-    repoPaths &&
-    ticketPaths.every((ticketPath) =>
-      repoPaths.some(
-        (repoPath) =>
-          ticketPath === repoPath || ticketPath.startsWith(`${repoPath}/`),
-      ),
-    ),
-  );
+  if (!ticketPaths || !repoPaths) return false;
+  return ticketPaths.every((ticketPath) => {
+    if (repoPaths.includes(ticketPath)) return true;
+    const underDirectory = repoPaths.some((repoPath) =>
+      ticketPath.startsWith(`${repoPath}/`),
+    );
+    if (!underDirectory) return false;
+    if (!isBunTestFile(ticketPath)) return false;
+    if (typeof root !== "string" || root === "") return false;
+    return exists(path.join(root, ticketPath));
+  });
 }
 
 /** Best-effort timeout for the pre-diff `git fetch origin <base>` (F4). */
@@ -1477,6 +1596,7 @@ function verifyCompleted({
       ticketVerifyCoveredByRepoVerify: ticketVerifyCoveredByRepoVerify(
         ticketCommand,
         worktreeRecord.verify,
+        { root: worktreePath },
       ),
       reasonCode: null,
     };

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -28,6 +28,10 @@ import {
   HANDOFF_SANDBOX_MARKER,
   handoffGitMounts,
   handoffSandboxAvailable,
+  HANDOFF_SANDBOX_PYTHON,
+  MAX_HANDOFF_SANDBOX_TMPFS_MB,
+  clampHandoffSandboxTmpfsMb,
+  isBunTestFile,
   insideHandoffSandbox,
   policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
@@ -1613,6 +1617,29 @@ describe("handoff verification helpers (WM-718)", () => {
         nested: false,
       }),
     ).toBe(false);
+    // The init/setup interpreter is part of the boundary: without
+    // /usr/bin/python3 the host reports sandbox_unavailable before spawning.
+    let spawned = 0;
+    expect(
+      handoffSandboxAvailable({
+        spawn: () => {
+          spawned += 1;
+          return { status: 0, error: null };
+        },
+        exists: (p) => p !== HANDOFF_SANDBOX_PYTHON,
+        cache: false,
+        nested: false,
+      }),
+    ).toBe(false);
+    expect(spawned).toBe(0);
+    expect(
+      handoffSandboxAvailable({
+        spawn: () => ({ status: 0, error: null }),
+        exists: () => true,
+        cache: false,
+        nested: false,
+      }),
+    ).toBe(true);
   });
 
   test("only timeout's own verdict counts as a timeout", () => {
@@ -1928,6 +1955,15 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(policyHandoffSandboxTmpfsMb(root)).toBe(1024);
     writeFileSync(file, "sandbox:\n  tmpfs_mb: 1024.5\n");
     expect(policyHandoffSandboxTmpfsMb(root)).toBe(1024);
+    // Policy cannot hand the guest more host memory than the cap.
+    writeFileSync(file, "sandbox:\n  tmpfs_mb: 65536\n");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(
+      MAX_HANDOFF_SANDBOX_TMPFS_MB,
+    );
+    writeFileSync(file, "sandbox:\n  tmpfs_mb: 8192\n");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(8192);
+    expect(clampHandoffSandboxTmpfsMb(Number.MAX_SAFE_INTEGER)).toBe(8192);
+    expect(clampHandoffSandboxTmpfsMb(4096)).toBe(4096);
   });
 
   test("ticket verification coverage requires every test path within repo verify", () => {
@@ -1935,6 +1971,7 @@ describe("handoff verification helpers (WM-718)", () => {
       ticketVerifyCoveredByRepoVerify(
         "bun test event-runtime/lib/verify.test.mjs --timeout 30000",
         "bun test event-runtime/lib --timeout 20000 && bun run format:check",
+        { root: path.resolve(import.meta.dir, "..", "..") },
       ),
     ).toBe(true);
     expect(
@@ -1943,6 +1980,73 @@ describe("handoff verification helpers (WM-718)", () => {
         "bun test event-runtime/cli.test.mjs",
       ),
     ).toBe(false);
+  });
+
+  test("directory coverage requires an existing bun test file; flag values never widen it", () => {
+    const root = tmpDir("evrt-handoff-coverage-");
+    mkdirSync(path.join(root, "event-runtime", "lib"), { recursive: true });
+    writeFileSync(
+      path.join(root, "event-runtime", "lib", "verify.test.mjs"),
+      "",
+    );
+    writeFileSync(path.join(root, "event-runtime", "lib", "verify.mjs"), "");
+    const repoVerify = "bun test event-runtime/lib --timeout 20000";
+    // Real test file under the covering directory: covered.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.test.mjs",
+        repoVerify,
+        { root },
+      ),
+    ).toBe(true);
+    // Missing file: directory discovery never ran it, so step 2 must run.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/missing.test.mjs",
+        repoVerify,
+        { root },
+      ),
+    ).toBe(false);
+    // Existing non-test module: not picked up by discovery either.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.mjs",
+        repoVerify,
+        { root },
+      ),
+    ).toBe(false);
+    // Without a root, directory containment alone is not proof.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.test.mjs",
+        repoVerify,
+      ),
+    ).toBe(false);
+    // Exact path match still stands on its own.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/other.test.mjs",
+        "bun test event-runtime/lib/other.test.mjs",
+      ),
+    ).toBe(true);
+    // A value-taking flag's argument is not a covering path.
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.test.mjs",
+        "bun test --preload event-runtime/lib -t verify.test event-runtime/cli.test.mjs",
+        { root },
+      ),
+    ).toBe(false);
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test --timeout 30000 event-runtime/lib/verify.test.mjs",
+        "bun test --preload ./setup.mjs event-runtime/lib",
+        { root },
+      ),
+    ).toBe(true);
+    expect(isBunTestFile("a/b.spec.ts")).toBe(true);
+    expect(isBunTestFile("a/b_test.tsx")).toBe(true);
+    expect(isBunTestFile("a/b.mjs")).toBe(false);
   });
 
   test("composeHandoffVerification is built from observation; the agent's claim is only agent-reported", () => {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -17,6 +17,7 @@ import { execFileSync } from "node:child_process";
 import {
   ContractViolation,
   HANDOFF_HOST_ENV,
+  HANDOFF_SANDBOX_INIT,
   HANDOFF_SANDBOX_SETUP,
   SandboxUnavailable,
   changedFilesSince,
@@ -28,8 +29,10 @@ import {
   handoffGitMounts,
   handoffSandboxAvailable,
   insideHandoffSandbox,
+  policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
   runHandoffCommand,
+  ticketVerifyCoveredByRepoVerify,
   verifyResult,
 } from "./verify.mjs";
 
@@ -1235,6 +1238,65 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(out.result.verification.checks).toContain("repo_verify_passed");
   });
 
+  test("a ticket test command covered by the repo verify does not run a second sandbox step", () => {
+    const { dir, record } = worktreeWorkspace(
+      "bun test event-runtime/lib --timeout 20000",
+      null,
+    );
+    const testFile = path.join(
+      record.path,
+      "event-runtime",
+      "lib",
+      "covered.test.mjs",
+    );
+    mkdirSync(path.dirname(testFile), { recursive: true });
+    writeFileSync(
+      testFile,
+      'import { expect, test } from "bun:test"; test("covered", () => expect(true).toBe(true));\n',
+    );
+    record.handoff = {
+      verificationCommand:
+        "bun test event-runtime/lib/covered.test.mjs --timeout 30000",
+    };
+
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(out.handoff.verification).toBe(out.handoff.repoVerify);
+    expect(out.result.verification.checks).toContain(
+      "ticket_verify_covered_by_repo_verify",
+    );
+    expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
+  });
+
+  test("a ticket-step failure names its sandbox limits", () => {
+    const { dir, record } = worktreeWorkspace("true", null);
+    record.handoff = { verificationCommand: "printf ticket-red >&2; exit 7" };
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations[0]).toContain("ticket_verify_failed");
+      expect(err.violations[0]).toContain("sandbox_limits: tmpfs=1024MiB");
+      expect(err.violations[0]).toContain("namespaces=user,mount,pid,network");
+    }
+  });
+
   test("a timed-out repository verification fails closed without hanging", () => {
     const { dir, record } = worktreeWorkspace("while :; do :; done", null);
     const previous = process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
@@ -1477,6 +1539,8 @@ describe("handoff verification helpers (WM-718)", () => {
         "--pid",
         "--fork",
         "--kill-child=KILL",
+        "/usr/bin/python3",
+        HANDOFF_SANDBOX_INIT,
         HANDOFF_SANDBOX_SETUP,
         realpathSync(worktree),
         "/workspace",
@@ -1486,8 +1550,11 @@ describe("handoff verification helpers (WM-718)", () => {
       ]),
     );
     expect(HANDOFF_SANDBOX_SETUP).toContain("/usr/sbin/chroot");
+    expect(HANDOFF_SANDBOX_INIT).toContain("os.wait()");
+    expect(HANDOFF_SANDBOX_INIT).toContain("os.kill(-1, signal.SIGTERM)");
     expect(HANDOFF_SANDBOX_SETUP).toContain('mount --rbind "$workspace"');
     expect(HANDOFF_SANDBOX_SETUP).toContain('mount -t proc proc "$root/proc"');
+    expect(HANDOFF_SANDBOX_SETUP).toContain('size="${tmpfs_mb}m"');
     expect(invocation.options.env).toEqual(HANDOFF_HOST_ENV);
     // GH-967: FACTORY_ROOT (which reposRoot() only reads as a fallback, and
     // which config.mjs derives from its own location anyway) is gone; the
@@ -1721,6 +1788,23 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(obs.output.trim().split("\n").pop().trim()).toBe("1");
   });
 
+  test("the PID-namespace init reaps a forked grandchild", () => {
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
+    const worktree = realpathSync(tmpDir("evrt-handoff-reap-"));
+    const obs = runHandoffCommand({
+      // The Python child exits without waiting for its forked child. The shell
+      // remains active while polling /proc, so a zombie is observable unless
+      // namespace PID 1 reaps it.
+      command: String.raw`pid=$(/usr/bin/python3 -c 'import os; pid = os.fork(); os.write(1, f"{pid}\n".encode()) if pid else None; os._exit(0)'); for i in $(seq 1 10000); do [ ! -e /proc/$pid ] && exit 0; done; echo unreaped:$pid; exit 1`,
+      cwd: worktree,
+      worktreePath: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.passed).toBe(true);
+  });
+
   test("outputTail keeps the last N non-empty lines, ANSI stripped", () => {
     const out = Array.from({ length: 50 }, (_, i) => `line ${i + 1}`).join(
       "\n\n",
@@ -1831,6 +1915,34 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(policyOwnedPathsConformance(root)).toBe("advisory");
     writeFileSync(file, "dispatch: [not: valid\n");
     expect(policyOwnedPathsConformance(root)).toBe("advisory");
+  });
+
+  test("handoff tmpfs policy defaults safely and accepts configured MiB", () => {
+    const root = tmpDir("evrt-handoff-tmpfs-policy-");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(1024);
+    mkdirSync(path.join(root, "config"));
+    const file = path.join(root, "config", "policy.yaml");
+    writeFileSync(file, "sandbox:\n  tmpfs_mb: 2048\n");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(2048);
+    writeFileSync(file, "sandbox:\n  tmpfs_mb: 512\n");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(1024);
+    writeFileSync(file, "sandbox:\n  tmpfs_mb: 1024.5\n");
+    expect(policyHandoffSandboxTmpfsMb(root)).toBe(1024);
+  });
+
+  test("ticket verification coverage requires every test path within repo verify", () => {
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.test.mjs --timeout 30000",
+        "bun test event-runtime/lib --timeout 20000 && bun run format:check",
+      ),
+    ).toBe(true);
+    expect(
+      ticketVerifyCoveredByRepoVerify(
+        "bun test event-runtime/lib/verify.test.mjs",
+        "bun test event-runtime/cli.test.mjs",
+      ),
+    ).toBe(false);
   });
 
   test("composeHandoffVerification is built from observation; the agent's claim is only agent-reported", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1405

Avoid redundant covered ticket checks and make handoff sandboxes resilient to tmpfs and zombie-process failures.

## Validation

| Check                | Command                                                                      | Result  | Notes                            |
| -------------------- | ---------------------------------------------------------------------------- | ------- | -------------------------------- |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs --timeout 30000`                 | pass    | 63 pass, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1948 pass, 10 capability skips  |
| UX critique          | factory-ux-critic                                                            | not run | no user-facing surface           |

UX critique: skipped

## Post-review

Folded in review tightening (756caea1b19116a78649bbc478e4742d9fbe8fd6):
- `ticketVerifyCoveredByRepoVerify`: a ticket path covered only by a repo-verify directory must also exist under the worktree and match bun's `*.test.*`/`*.spec.*` pattern; otherwise step 2 runs.
- `bunTestPaths`: values of value-taking flags (`--preload`, `--timeout`, `-t`, `--path-ignore-patterns`, ...) are skipped, never widening the covering set.
- `handoffSandboxAvailable()`: also requires `/usr/bin/python3`; missing -> `sandbox_unavailable` instead of a bogus red.
- `policyHandoffSandboxTmpfsMb`: capped at 8192 MiB (`MAX_HANDOFF_SANDBOX_TMPFS_MB`).
- `HANDOFF_SANDBOX_INIT`: post-exit reap escalates to SIGKILL after a 2 s SIGTERM grace.
Tests added for 1-4; docs updated.
