### PR TITLE
fix(web): scope artifact inventory queries

### DIFF
--- a/event-runtime/web/src/views/ArtifactFull.test.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.test.tsx
@@ -101,6 +101,20 @@ describe("ArtifactFull reader view (WM-828)", () => {
     );
   });
 
+  test("ignores a positional hit whose digest differs from the requested one", async () => {
+    globalThis.fetch = mock(
+      async () => new Response("{}", { status: 200 }),
+    ) as unknown as typeof fetch;
+
+    const view = renderArtifactFull({
+      seed: { items: [{ ...ITEMS[0], sha256: "b".repeat(64) }] },
+    });
+
+    await view.findByRole("button", { name: /← Artifacts/ });
+    expect(view.queryByText("1.0 KB")).toBeNull();
+    expect(view.queryByRole("button", { name: "run_12345678" })).toBeNull();
+  });
+
   test("renders header with back button, kind badges, short digest, size, timestamp, producing run jump link, and copy actions", async () => {
     const raw = JSON.stringify({ summary: "report content", status: "ok" });
     globalThis.fetch = mock(

--- a/event-runtime/web/src/views/ArtifactFull.test.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.test.tsx
@@ -47,18 +47,23 @@ function renderArtifactFull({
   onBack = mock(() => {}),
   onJumpRun = mock(() => {}),
   seed = {},
+  seedArtifacts = true,
 }: {
   digest?: string;
   onBack?: () => void;
   onJumpRun?: (runId: string) => void;
   seed?: { items?: ArtifactInventoryItem[]; agents?: unknown[] };
+  seedArtifacts?: boolean;
 } = {}) {
   const client = new QueryClient({
     defaultOptions: {
       queries: { retry: false, refetchInterval: false, staleTime: Infinity },
     },
   });
-  client.setQueryData(["artifacts"], { artifacts: seed.items ?? ITEMS });
+  if (seedArtifacts)
+    client.setQueryData(["artifact", digest], {
+      artifacts: seed.items ?? ITEMS,
+    });
   if (seed.agents) {
     client.setQueryData(["agents"], {
       agents: seed.agents,
@@ -80,6 +85,22 @@ function renderArtifactFull({
 }
 
 describe("ArtifactFull reader view (WM-828)", () => {
+  test("requests only the selected digest", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({ artifacts: ITEMS }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    renderArtifactFull({ seedArtifacts: false });
+
+    await waitFor(() =>
+      expect(requests).toContain(`/api/artifacts?search=${SHA_A}&limit=1`),
+    );
+  });
+
   test("renders header with back button, kind badges, short digest, size, timestamp, producing run jump link, and copy actions", async () => {
     const raw = JSON.stringify({ summary: "report content", status: "ok" });
     globalThis.fetch = mock(

--- a/event-runtime/web/src/views/ArtifactFull.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.tsx
@@ -58,7 +58,9 @@ export function ArtifactFull({
   });
   const artifacts = artifactsQ.data?.artifacts ?? [];
 
-  const selected = artifacts[0] ?? null;
+  // The search endpoint matches broadly; only trust the row when it is the
+  // requested digest rather than a positional hit.
+  const selected = artifacts[0]?.sha256 === digest ? artifacts[0] : null;
 
   const contentQ = useQuery({
     queryKey: ["artifact-content", digest],

--- a/event-runtime/web/src/views/ArtifactFull.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.tsx
@@ -51,16 +51,14 @@ export function ArtifactFull({
   const [artifactRaw, setArtifactRaw] = useState(loadArtifactRaw);
 
   const artifactsQ = useQuery({
-    queryKey: ["artifacts"],
-    queryFn: () => fetchArtifacts(),
+    queryKey: ["artifact", digest],
+    queryFn: () => fetchArtifacts({ search: digest, limit: 1 }),
+    enabled: Boolean(digest),
     ...refetchIntervals.primary,
   });
   const artifacts = artifactsQ.data?.artifacts ?? [];
 
-  const selected = useMemo(
-    () => artifacts.find((artifact) => artifact.sha256 === digest) ?? null,
-    [artifacts, digest],
-  );
+  const selected = artifacts[0] ?? null;
 
   const contentQ = useQuery({
     queryKey: ["artifact-content", digest],

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -76,7 +76,11 @@ afterEach(() => {
 function renderArtifacts(
   onJumpRun = mock(() => {}),
   initialFilters: ArtifactFilters = { kind: null, orphan: null, search: "" },
-  seed: { items?: ArtifactInventoryItem[]; agents?: unknown[] } = {},
+  seed: {
+    items?: ArtifactInventoryItem[];
+    agents?: unknown[];
+    nextBefore?: string | null;
+  } = {},
   onOpenFull = mock(() => {}),
 ) {
   const client = new QueryClient({
@@ -84,7 +88,18 @@ function renderArtifacts(
       queries: { retry: false, refetchInterval: false, staleTime: Infinity },
     },
   });
-  client.setQueryData(["artifacts"], { artifacts: seed.items ?? ITEMS });
+  client.setQueryData(
+    [
+      "artifacts",
+      initialFilters.kind,
+      initialFilters.orphan,
+      initialFilters.search,
+    ],
+    {
+      artifacts: seed.items ?? ITEMS,
+      nextBefore: seed.nextBefore,
+    },
+  );
   if (seed.agents)
     client.setQueryData(["agents"], {
       agents: seed.agents,
@@ -244,6 +259,44 @@ describe("Artifacts inventory (WM-207)", () => {
     const grid = view.getByRole("grid");
     expect(within(grid).queryByText("aaaaaaaaaaaa")).toBeNull();
     expect(within(grid).queryByText("cccccccccccc")).toBeNull();
+  });
+
+  test("requests the active kind, orphan, and search filters", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({ artifacts: ITEMS }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
+      target: { value: "report" },
+    });
+    fireEvent.click(view.getByRole("tab", { name: "Orphans 28" }));
+    changeControlledInput(
+      view.getByRole("combobox", { name: "Search artifacts" }),
+      "reporter@1",
+    );
+
+    await waitFor(() =>
+      expect(requests).toContain(
+        "/api/artifacts?kind=report&orphan=true&search=reporter%401",
+      ),
+    );
+  });
+
+  test("warns when the server has more artifacts than this page", async () => {
+    const view = renderArtifacts(undefined, undefined, {
+      nextBefore: "older-artifacts",
+    });
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    expect(view.getByRole("status").textContent).toMatch(
+      /showing 3 artifacts.*more.*narrow the filter/i,
+    );
   });
 
   test("opens a deep-linked inspector with formatted preview, actions, search, and bidirectional references", async () => {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -277,7 +277,9 @@ describe("Artifacts inventory (WM-207)", () => {
     });
     fireEvent.click(view.getByRole("tab", { name: "Orphans 28" }));
     changeControlledInput(
-      view.getByRole("combobox", { name: "Search artifacts" }),
+      view.getByRole("combobox", {
+        name: "Search artifacts",
+      }) as HTMLInputElement,
       "reporter@1",
     );
 

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -290,6 +290,87 @@ describe("Artifacts inventory (WM-207)", () => {
     );
   });
 
+  test("trims the search term before querying the server", async () => {
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      requests.push(String(input));
+      return new Response(JSON.stringify({ artifacts: ITEMS }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+    const view = renderArtifacts();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    changeControlledInput(
+      view.getByRole("combobox", {
+        name: "Search artifacts",
+      }) as HTMLInputElement,
+      "  reporter@1  ",
+    );
+
+    await waitFor(() =>
+      expect(requests).toContain("/api/artifacts?search=reporter%401"),
+    );
+  });
+
+  test("resolves a deep-linked artifact outside the filtered page", async () => {
+    const requests: string[] = [];
+    const orphanOnly = ITEMS.filter((item) => !item.referenced);
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input);
+      requests.push(url);
+      if (url.startsWith("/api/artifacts?")) {
+        const params = new URL(url, "http://localhost").searchParams;
+        const search = params.get("search");
+        const hit = ITEMS.filter((item) => !search || item.sha256 === search);
+        return new Response(JSON.stringify({ artifacts: hit }), {
+          status: 200,
+        });
+      }
+      return new Response(JSON.stringify({ message: "deep" }), {
+        status: 200,
+      });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${"a".repeat(64)}`;
+    const view = renderArtifacts(
+      undefined,
+      { kind: null, orphan: true, search: "" },
+      { items: orphanOnly },
+    );
+
+    const references = await view.findByRole("region", {
+      name: "Artifact run references",
+    });
+    expect(within(references).getByText(/run_12345678/)).toBeTruthy();
+    expect(requests).toContain(
+      `/api/artifacts?search=${"a".repeat(64)}&limit=1`,
+    );
+    expect(view.queryByText(/metadata is unavailable/i)).toBeNull();
+  });
+
+  test("ignores a fallback row whose digest differs from the deep link", async () => {
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.startsWith("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: [ITEMS[1]] }), {
+          status: 200,
+        });
+      }
+      return new Response("{}", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${"a".repeat(64)}`;
+    const view = renderArtifacts(
+      undefined,
+      { kind: null, orphan: true, search: "" },
+      { items: [ITEMS[2]] },
+    );
+
+    await view.findByText(/metadata is unavailable/i);
+    expect(view.queryByText(/run_trace/)).toBeNull();
+  });
+
   test("warns when the server has more artifacts than this page", async () => {
     const view = renderArtifacts(undefined, undefined, {
       nextBefore: "older-artifacts",
@@ -298,6 +379,19 @@ describe("Artifacts inventory (WM-207)", () => {
 
     expect(view.getByRole("status").textContent).toMatch(
       /showing 3 artifacts.*more.*narrow the filter/i,
+    );
+  });
+
+  test("the more-available notice counts the visible rows", async () => {
+    const view = renderArtifacts(
+      undefined,
+      { kind: "report", orphan: null, search: "" },
+      { nextBefore: "older-artifacts" },
+    );
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+
+    expect(view.getByRole("status").textContent).toMatch(
+      /showing 1 artifacts?.*more/i,
     );
   });
 

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -279,8 +279,14 @@ export function Artifacts({
 }) {
   const now = useNow();
   const artifactsQ = useQuery({
-    queryKey: ["artifacts"],
-    queryFn: () => fetchArtifacts(),
+    queryKey: ["artifacts", filters.kind, filters.orphan, filters.search],
+    queryFn: () =>
+      fetchArtifacts({
+        kind: filters.kind ?? undefined,
+        orphan: filters.orphan ?? undefined,
+        search: filters.search || undefined,
+      }),
+    placeholderData: (previousData) => previousData,
     ...refetchIntervals.primary,
   });
   const artifacts = artifactsQ.data?.artifacts ?? [];
@@ -609,6 +615,12 @@ export function Artifacts({
                 </>
               }
             />
+            {artifactsQ.data?.nextBefore && (
+              <p role="status" className="mt-2 text-[12px] text-(--text-dim)">
+                Showing {artifacts.length.toLocaleString()} artifacts; more are
+                available. Narrow the filter to see a smaller result set.
+              </p>
+            )}
           </>
         }
       >

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -284,7 +284,7 @@ export function Artifacts({
       fetchArtifacts({
         kind: filters.kind ?? undefined,
         orphan: filters.orphan ?? undefined,
-        search: filters.search || undefined,
+        search: filters.search.trim() || undefined,
       }),
     placeholderData: (previousData) => previousData,
     ...refetchIntervals.primary,
@@ -302,10 +302,28 @@ export function Artifacts({
     return () => window.removeEventListener("hashchange", syncSelection);
   }, []);
 
-  const selected = useMemo(
+  const listMatch = useMemo(
     () => artifacts.find((artifact) => artifact.sha256 === selectedSha) ?? null,
     [artifacts, selectedSha],
   );
+  // The list is server-filtered by the active facets, so a deep link
+  // (`#/artifacts/<sha>` or a jump from Runs) may target an artifact outside
+  // the current page. Resolve it directly, the same way ArtifactFull does.
+  const fallbackQ = useQuery({
+    queryKey: ["artifact", selectedSha],
+    queryFn: () => fetchArtifacts({ search: selectedSha as string, limit: 1 }),
+    enabled:
+      selectedSha !== null && listMatch === null && !artifactsQ.isPending,
+    ...refetchIntervals.primary,
+  });
+  const selected = useMemo(() => {
+    if (listMatch) return listMatch;
+    const fallback = fallbackQ.data?.artifacts[0];
+    return fallback && fallback.sha256 === selectedSha ? fallback : null;
+  }, [listMatch, fallbackQ.data, selectedSha]);
+  const metadataPending =
+    artifactsQ.isPending ||
+    (fallbackQ.isPending && fallbackQ.fetchStatus !== "idle");
   const contentQ = useQuery({
     queryKey: ["artifact-content", selectedSha],
     queryFn: async () => {
@@ -617,7 +635,7 @@ export function Artifacts({
             />
             {artifactsQ.data?.nextBefore && (
               <p role="status" className="mt-2 text-[12px] text-(--text-dim)">
-                Showing {artifacts.length.toLocaleString()} artifacts; more are
+                Showing {visible.length.toLocaleString()} artifacts; more are
                 available. Narrow the filter to see a smaller result set.
               </p>
             )}
@@ -892,12 +910,12 @@ export function Artifacts({
           }
           close={<Button onClick={closeInspector}>Close</Button>}
         >
-          {!selected && artifactsQ.isPending && (
+          {!selected && metadataPending && (
             <div className="text-(--text-faint)">
               Loading artifact metadata…
             </div>
           )}
-          {!selected && !artifactsQ.isPending && (
+          {!selected && !metadataPending && (
             <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
               Artifact metadata is unavailable. The content may have been
               pruned.


### PR DESCRIPTION
Fixes watt-mind/factory#1417

Review the server-scoped artifact filtering. The UX critique's FIX-FIRST findings are deferred to follow-up #1446 (accepted at review); the PR is now ready so the web suite runs in CI.

## Validation

| Check                | Command                                                                                             | Result | Notes                                  |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------ | -------------------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Artifacts.test.tsx src/views/ArtifactFull.test.tsx`     | pass   | 33 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 1,933 pass, 10 skipped; emit/format clean |
| UX critique          | `factory-ux-critic`                                                                                 | fail   | required — FIX-FIRST; follow-up #1446 |

UX critique: required — FIX-FIRST unresolved

## Post-review

Commit `2023429a` — fix(web): artifact inspector resolves deep links under active filters (#1417)

- **Blocking:** `Artifacts.tsx` `selected` searched only the server-filtered page, so a deep link (`#/artifacts/<sha>` or a jump from Runs) with an active kind/orphan/search facet rendered an empty inspector. When the row is not in the list, a fallback `fetchArtifacts({ search: sha, limit: 1 })` query (`["artifact", sha]`, same shape/key as ArtifactFull) resolves it, guarded by `sha256 === selectedSha`; the loading/unavailable states account for the fallback query. Tests: deep link outside the filtered page resolves; a mismatched fallback row is ignored.
- `search: filters.search.trim() || undefined` (test: trimmed query string).
- The "more available" notice now counts `visible.length` (test).
- `ArtifactFull.tsx` keeps the `artifacts[0]?.sha256 === digest` guard instead of trusting position (test).
- Verified: `cd event-runtime/web && bunx tsc --noEmit && bun test` (1372 pass), root `bun run format:check`, `bun run check`.
