### PR TITLE
perf(backend): cache observed transcript models

### DIFF
--- a/event-runtime/lib/api-observed-model.test.mjs
+++ b/event-runtime/lib/api-observed-model.test.mjs
@@ -3,6 +3,7 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-observed-model-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { clearObservedModelCache, handleRunApiRoute } from "./api-runs.mjs";
 import {
   GH_SECRET,
   PV,
@@ -44,6 +45,8 @@ const makeServer = async (...args) => {
 };
 
 describe("model surfacing on run views (WM-221)", () => {
+  afterAll(() => clearObservedModelCache());
+
   test("reads the claude harness's own init line", () => {
     const head = [
       `{"type":"system","subtype":"hook_started","hook_name":"SessionStart:startup"}`,
@@ -98,7 +101,68 @@ describe("model surfacing on run views (WM-221)", () => {
     ).toBeNull();
   });
 
-  test("the run list carries the plan-time pins and the detail carries observedModel", async () => {
+  test("memoizes a terminal transcript hash and reads a distinct hash", async () => {
+    clearObservedModelCache();
+    const home = tmpDir("evrt-observed-model-cache-");
+    const { db, close } = await makeServer({ env: { name: "test", home } });
+    try {
+      db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`,
+      ).run(
+        "model-cache",
+        "model-cache",
+        "{}",
+        "model-cache",
+        "2026-01-01T00:00:00.000Z",
+        "2026-01-01T00:00:00.000Z",
+      );
+      db.query(
+        `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, ?, '{}', '{}', ?)`,
+      ).run(
+        "model-cache",
+        JSON.stringify({
+          artifacts: [{ kind: "transcript", sha256: "a".repeat(64) }],
+        }),
+        "sha256:model-cache",
+        "2026-01-01T00:00:00.000Z",
+      );
+      let reads = 0;
+      const readView = () =>
+        handleRunApiRoute({
+          req: { method: "GET" },
+          url: new URL("http://test/runs/model-cache"),
+          db,
+          registry,
+          artifactsDir: home,
+          readArtifactHead: (_dir, sha256) => {
+            reads += 1;
+            return `{"type":"system","subtype":"init","model":"${sha256}"}\n`;
+          },
+          send: (_status, body) => body,
+        });
+
+      expect((await readView()).observedModel).toBe("a".repeat(64));
+      expect((await readView()).observedModel).toBe("a".repeat(64));
+      expect(reads).toBe(1);
+
+      db.query(`UPDATE results SET result_json = ? WHERE run_id = ?`).run(
+        JSON.stringify({
+          artifacts: [{ kind: "transcript", sha256: "b".repeat(64) }],
+        }),
+        "model-cache",
+      );
+      expect((await readView()).observedModel).toBe("b".repeat(64));
+      expect(reads).toBe(2);
+    } finally {
+      close();
+      clearObservedModelCache();
+    }
+  });
+
+  test("the run list carries the plan-time pins and caches terminal observedModel values", async () => {
+    clearObservedModelCache();
     const home = tmpDir("evrt-home-");
     const { db, server, port, close } = await makeServer({
       env: { name: "test", home },
@@ -144,12 +208,38 @@ describe("model surfacing on run views (WM-221)", () => {
       expect(view).toHaveProperty("observedModel");
       expect(view.observedModel).toBeNull();
 
-      // And the value really comes off the stored bytes: rewrite that same
-      // transcript with a harness init line and the next read reports it.
+      // Terminal transcript hashes are immutable, including the no-model
+      // observation. Rewriting the fixture must not make a polling read scan
+      // the same hash again.
       const transcript = view.result.artifacts.find(
         (a) => a.kind === "transcript",
       );
       expect(transcript).toBeTruthy();
+      writeFileSync(
+        path.join(home, "artifacts", transcript.sha256),
+        `{"type":"system","subtype":"init","model":"claude-opus-5[1m]"}\n`,
+        "utf8",
+      );
+      expect((await client.run(summary.runId)).observedModel).toBeNull();
+
+      // Tests clear the module-scoped cache before changing stored fixtures.
+      clearObservedModelCache();
+      expect((await client.run(summary.runId)).observedModel).toBe(
+        "claude-opus-5[1m]",
+      );
+
+      // A null model for a growing run remains uncached: a later polling read
+      // can observe the model once the transcript has gained its init line.
+      clearObservedModelCache();
+      db.query(`UPDATE runs SET state = 'RUNNING' WHERE run_id = ?`).run(
+        summary.runId,
+      );
+      writeFileSync(
+        path.join(home, "artifacts", transcript.sha256),
+        `{"type":"assistant","message":{"content":[]}}\n`,
+        "utf8",
+      );
+      expect((await client.run(summary.runId)).observedModel).toBeNull();
       writeFileSync(
         path.join(home, "artifacts", transcript.sha256),
         `{"type":"system","subtype":"init","model":"claude-opus-5[1m]"}\n`,

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1770,11 +1770,14 @@ function observedModelForRun({
   artifactsDir,
   sha256,
   state,
-  readArtifactHead,
+  readArtifactHead = artifactHead,
 }) {
   if (!artifactsDir || !sha256) return null;
   const terminal = TERMINAL_STATES.has(state);
-  if (observedModelCache.has(sha256)) return observedModelCache.get(sha256);
+  // Keyed by store root as well as hash: a test or a relocated store must not
+  // serve an observation read from a different artifacts directory.
+  const cacheKey = `${artifactsDir} ${sha256}`;
+  if (observedModelCache.has(cacheKey)) return observedModelCache.get(cacheKey);
 
   const observedModel = observedModelFromTranscript(
     readArtifactHead(artifactsDir, sha256),
@@ -1785,12 +1788,16 @@ function observedModelForRun({
     if (observedModelCache.size >= OBSERVED_MODEL_CACHE_LIMIT) {
       observedModelCache.delete(observedModelCache.keys().next().value);
     }
-    observedModelCache.set(sha256, observedModel);
+    observedModelCache.set(cacheKey, observedModel);
   }
   return observedModel;
 }
 
-function runView(db, runId, { artifactsDir, registry, readArtifactHead } = {}) {
+function runView(
+  db,
+  runId,
+  { artifactsDir, registry, readArtifactHead = artifactHead } = {},
+) {
   const row = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(runId);
   if (!row) return null;
   const attempts = db

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -6,7 +6,11 @@ import { STALE_SCAN_MS, loadLinearSupply } from "./linear.mjs";
 import { loadRepos, RepoError } from "./repos.mjs";
 import { isBusyError, retryBusy, runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
-import { IllegalTransition, lifecycleOf } from "./lifecycle.mjs";
+import {
+  IllegalTransition,
+  lifecycleOf,
+  TERMINAL_STATES,
+} from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
 import { approveProposal, rejectProposal } from "./proposals.mjs";
 import { traceOf } from "./trace.mjs";
@@ -21,6 +25,16 @@ import {
 import { proposalSubject } from "./proposal-subject.mjs";
 
 export const MAX_EXTENSION_SECONDS = 3600;
+export const OBSERVED_MODEL_CACHE_LIMIT = 512;
+
+// Transcript artifacts are content-addressed, so a model observed for a hash
+// cannot change. Keep this module-local FIFO bounded because run detail views
+// poll frequently and artifactHead performs synchronous I/O.
+const observedModelCache = new Map();
+
+export function clearObservedModelCache() {
+  observedModelCache.clear();
+}
 
 export { policyMaxRunMinutes };
 
@@ -1762,7 +1776,31 @@ export function observedModelFromTranscript(head) {
   return null;
 }
 
-function runView(db, runId, { artifactsDir, registry } = {}) {
+function observedModelForRun({
+  artifactsDir,
+  sha256,
+  state,
+  readArtifactHead,
+}) {
+  if (!artifactsDir || !sha256) return null;
+  const terminal = TERMINAL_STATES.has(state);
+  if (observedModelCache.has(sha256)) return observedModelCache.get(sha256);
+
+  const observedModel = observedModelFromTranscript(
+    readArtifactHead(artifactsDir, sha256),
+  );
+  // A growing transcript may gain its model line later, but a terminal one
+  // cannot. Cache null only for terminal runs while caching all model values.
+  if (observedModel !== null || terminal) {
+    if (observedModelCache.size >= OBSERVED_MODEL_CACHE_LIMIT) {
+      observedModelCache.delete(observedModelCache.keys().next().value);
+    }
+    observedModelCache.set(sha256, observedModel);
+  }
+  return observedModel;
+}
+
+function runView(db, runId, { artifactsDir, registry, readArtifactHead } = {}) {
   const row = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(runId);
   if (!row) return null;
   const attempts = db
@@ -1802,12 +1840,12 @@ function runView(db, runId, { artifactsDir, registry } = {}) {
     deadlineAt: Number.isFinite(deadline)
       ? new Date(deadline).toISOString()
       : null,
-    observedModel:
-      artifactsDir && transcript?.sha256
-        ? observedModelFromTranscript(
-            artifactHead(artifactsDir, transcript.sha256),
-          )
-        : null,
+    observedModel: observedModelForRun({
+      artifactsDir,
+      sha256: transcript?.sha256,
+      state: row.state,
+      readArtifactHead,
+    }),
     usage: runUsage(db, runId),
   };
 }
@@ -1825,6 +1863,7 @@ export async function handleRunApiRoute({
   actor,
   policyVersion,
   artifactsDir,
+  readArtifactHead = artifactHead,
   onEvent,
   policyRoot = FACTORY_ROOT,
   controlPlane,
@@ -2202,7 +2241,11 @@ export async function handleRunApiRoute({
 
   const runGet = url.pathname.match(/^\/runs\/([^/]+)$/);
   if (req.method === "GET" && runGet) {
-    const view = runView(db, runGet[1], { artifactsDir, registry });
+    const view = runView(db, runGet[1], {
+      artifactsDir,
+      registry,
+      readArtifactHead,
+    });
     if (!view) return send(404, { error: `unknown run ${runGet[1]}` });
     return send(200, view);
   }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -14,6 +14,7 @@ import {
 import { memoryControlPlane } from "../../lib/control-plane/index.mjs";
 import {
   TICKET_DETAIL_CACHE_TTL_MS,
+  clearObservedModelCache,
   clearTicketDetailCache,
   mergeTicketSupply,
   scanTicketSupply,
@@ -553,7 +554,8 @@ describe("list views carry repos[] (OPS-356)", () => {
 
 describe("ticket journey join (WM-595)", () => {
   test("GET /runs?ticket= joins explicit ticket activity and PR-linked merge runs", async () => {
-    const s = await makeServer();
+    const home = tmpDir("evrt-journey-home-");
+    const s = await makeServer({ env: { name: "test", home } });
     try {
       await s.client.replay(
         envelope({
@@ -678,6 +680,52 @@ describe("ticket journey join (WM-595)", () => {
 
       const unknown = await fetch(s.url("/runs?ticket=WM-999"));
       expect((await unknown.json()).activity).toBe(false);
+
+      // The journey view reaches runView without a transcript reader; on a
+      // cache miss it must fall back to the store rather than 500 (#1421).
+      clearObservedModelCache();
+      const transcriptSha = "c".repeat(64);
+      mkdirSync(path.join(home, "artifacts"), { recursive: true });
+      writeFileSync(
+        path.join(home, "artifacts", transcriptSha),
+        `{"type":"system","subtype":"init","model":"claude-opus-5[1m]"}\n`,
+        "utf8",
+      );
+      s.db.query(`UPDATE results SET result_json = ? WHERE run_id = ?`).run(
+        JSON.stringify({
+          terminalState: "completed",
+          artifact: { outcome: "PR_OPEN", ticket: "WM-595" },
+          artifacts: [{ kind: "transcript", sha256: transcriptSha }],
+        }),
+        "run_ticket",
+      );
+      const withTranscript = await fetch(s.url("/runs?ticket=WM-595"));
+      expect(withTranscript.status).toBe(200);
+      const journeyRuns = (await withTranscript.json()).runs;
+      expect(
+        journeyRuns.find((run) => run.run.runId === "run_ticket"),
+      ).toHaveProperty("observedModel", "claude-opus-5[1m]");
+
+      // The memo is keyed by store root too: the same hash under another
+      // artifacts directory is a fresh read, not a stale hit.
+      const otherStore = tmpDir("evrt-other-artifacts-");
+      mkdirSync(otherStore, { recursive: true });
+      writeFileSync(
+        path.join(otherStore, transcriptSha),
+        `{"type":"system","subtype":"init","model":"claude-sonnet-5"}\n`,
+        "utf8",
+      );
+      expect(
+        ticketJourneyView(s.db, "WM-595", {
+          artifactsDir: otherStore,
+        }).runs.find((run) => run.run.runId === "run_ticket").observedModel,
+      ).toBe("claude-sonnet-5");
+      expect(
+        ticketJourneyView(s.db, "WM-595", {
+          artifactsDir: path.join(home, "artifacts"),
+        }).runs.find((run) => run.run.runId === "run_ticket").observedModel,
+      ).toBe("claude-opus-5[1m]");
+      clearObservedModelCache();
       const invalid = await fetch(s.url("/runs?ticket=not-a-ticket"));
       expect(invalid.status).toBe(422);
     } finally {


### PR DESCRIPTION
Fixes watt-mind/factory#1421

Review the bounded transcript-model cache and its terminal/null semantics.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-observed-model.test.mjs event-runtime/lib/api-artifacts.test.mjs --timeout 20000` | pass | 47 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1934 tests, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

## Post-review

- **Blocking (fixed, 203ca9af):** `runView` and `observedModelForRun` now default `readArtifactHead = artifactHead`, so `ticketJourneyView` (`GET /runs?ticket=`, which passes only `artifactsDir`) no longer calls an undefined reader on a cache miss. New assertions in the journey test (`api-runs.test.mjs`) write a real transcript artifact under the server's artifacts root and require a 200 with `observedModel` populated; confirmed to fail (500) without the fix.
- **Minor (fixed):** the observed-model cache is keyed by `${artifactsDir} ${sha256}` instead of the hash alone; the same test reads the same hash from a second artifacts directory and asserts a fresh observation rather than a stale hit.
- Merged `origin/develop` (8 behind). Verified: `bun test event-runtime/lib --timeout 20000` (1953 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` all green.
