### PR TITLE
fix(adapters): cap transcript artifacts

### DIFF
--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -16,10 +16,11 @@
  * Owned Paths. Tests register the module through `createAdapterRegistry`.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, existsSync, writeFileSync } from "node:fs";
+import { existsSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { Readable } from "node:stream";
+import { transcriptMaxBytes } from "../config.mjs";
 import {
   HARNESS_LAYOUT as CLAUDE_HARNESS_LAYOUT,
   KILL_GRACE_MS as CLAUDE_KILL_GRACE_MS,
@@ -29,6 +30,7 @@ import {
   safeChildEnvironment,
   verifiedPrompt,
 } from "./claude.mjs";
+import { boundedTranscriptStream } from "./child-process.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
 export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV, killProcessGroup };
@@ -475,7 +477,8 @@ export async function execute({
   abortSignal,
   signal,
   spawnProcess = spawn,
-  transcriptFactory = createWriteStream,
+  transcriptFactory = boundedTranscriptStream,
+  transcriptMaxBytes: maxTranscriptBytes = transcriptMaxBytes(),
 }) {
   refuseSandbox("acp", def, SANDBOX_DEFERRAL_REASON);
 
@@ -502,6 +505,14 @@ export async function execute({
     // whose child reached the protocol handshake.
     const transcript = transcriptFactory(
       path.join(workspaceDir, ".transcript.json"),
+      {
+        maxBytes: maxTranscriptBytes,
+        onTruncated: ({ bytes }) =>
+          emitTrace(onTrace, {
+            kind: "lifecycle",
+            payload: { note: "transcript_truncated", bytes },
+          }),
+      },
     );
     transcript.on("error", () => {});
     // Child close only says its stdio handles are closed; the file stream may
@@ -833,6 +844,7 @@ export async function execute({
         timedOut,
         policyDenials: finalExit === 0 ? [] : policyDenials,
         ...(usage ? { usage } : {}),
+        ...(transcript.truncated ? { transcriptTruncated: true } : {}),
       });
     });
   });

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -346,8 +346,65 @@ function run(workspaceDir, extra = {}) {
     onUsage: extra.onUsage,
     onPermissionRequest: extra.onPermissionRequest,
     abortSignal: extra.abortSignal,
+    ...(extra.transcriptMaxBytes !== undefined
+      ? { transcriptMaxBytes: extra.transcriptMaxBytes }
+      : {}),
   });
 }
+
+describe("transcript cap (GH-1420)", () => {
+  test("caps the transcript, flags truncation, and still exits cleanly", async () => {
+    const workspaceDir = ws();
+    const traceEvents = [];
+    const outcome = await run(workspaceDir, {
+      transcriptMaxBytes: 64,
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.transcriptTruncated).toBe(true);
+    expect(
+      traceEvents.some(
+        (event) =>
+          event.kind === "lifecycle" &&
+          event.payload.note === "transcript_truncated" &&
+          event.payload.bytes === 64,
+      ),
+    ).toBe(true);
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    expect(Buffer.byteLength(transcript)).toBeLessThanOrEqual(
+      64 +
+        Buffer.byteLength(
+          '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+        ),
+    );
+    expect(
+      transcript.endsWith(
+        '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+      ),
+    ).toBe(true);
+  });
+
+  test("a transcript under the cap is stored whole with no truncation flag", async () => {
+    const workspaceDir = ws();
+    const outcome = await run(workspaceDir);
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.transcriptTruncated).toBeUndefined();
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    const lines = transcript.split("\n");
+    expect(lines.at(-1)).toBe("");
+    const parsed = lines.slice(0, -1).map(JSON.parse);
+    expect(parsed.length).toBeGreaterThan(1);
+    expect(parsed.some((msg) => msg.type === "factory")).toBe(false);
+  });
+});
 
 describe("adapter contract", () => {
   test("satisfies WM-837: execute + SANDBOX_SUPPORT unsupported", () => {

--- a/event-runtime/lib/adapters/child-process.mjs
+++ b/event-runtime/lib/adapters/child-process.mjs
@@ -1,5 +1,78 @@
+import { createWriteStream } from "node:fs";
+import { Writable } from "node:stream";
+import { transcriptMaxBytes } from "../config.mjs";
+
 /** Spawn options that make a child its own process group on POSIX hosts. */
 export const DETACHED_SPAWN_OPTIONS = Object.freeze({ detached: true });
+
+/**
+ * A writable transcript sink that caps stored bytes without backpressuring a
+ * child after the cap is reached. The appended marker is its own NDJSON line,
+ * even when the capped source chunk did not end with a newline.
+ */
+export function boundedTranscriptStream(
+  filePath,
+  { maxBytes = transcriptMaxBytes(), onTruncated } = {},
+) {
+  const limit =
+    Number.isSafeInteger(maxBytes) && maxBytes >= 0
+      ? maxBytes
+      : transcriptMaxBytes();
+  const destination = createWriteStream(filePath);
+  destination.on("error", () => {});
+
+  let bytes = 0;
+  let truncated = false;
+  const transcript = new Writable({
+    write(chunk, encoding, callback) {
+      if (truncated) {
+        callback();
+        return;
+      }
+
+      const source = Buffer.isBuffer(chunk)
+        ? chunk
+        : Buffer.from(chunk, encoding);
+      const remaining = limit - bytes;
+      if (source.byteLength <= remaining) {
+        bytes += source.byteLength;
+        if (destination.write(source)) callback();
+        else destination.once("drain", callback);
+        return;
+      }
+
+      if (remaining > 0) destination.write(source.subarray(0, remaining));
+      bytes += Math.max(remaining, 0);
+      truncated = true;
+      destination.write(
+        `\n${JSON.stringify({
+          type: "factory",
+          subtype: "transcript_truncated",
+          bytes,
+        })}\n`,
+      );
+      try {
+        onTruncated?.({ bytes });
+      } catch {
+        // Trace reporting is observational; continue draining stdout.
+      }
+      callback();
+    },
+    final(callback) {
+      destination.end(callback);
+    },
+    destroy(error, callback) {
+      destination.destroy();
+      callback(error);
+    },
+  });
+
+  Object.defineProperties(transcript, {
+    truncated: { get: () => truncated },
+    bytes: { get: () => bytes },
+  });
+  return transcript;
+}
 
 const terminations = new WeakMap();
 

--- a/event-runtime/lib/adapters/child-process.mjs
+++ b/event-runtime/lib/adapters/child-process.mjs
@@ -12,14 +12,36 @@ export const DETACHED_SPAWN_OPTIONS = Object.freeze({ detached: true });
  */
 export function boundedTranscriptStream(
   filePath,
-  { maxBytes = transcriptMaxBytes(), onTruncated } = {},
+  {
+    maxBytes = transcriptMaxBytes(),
+    onTruncated,
+    createDestination = createWriteStream,
+  } = {},
 ) {
   const limit =
     Number.isSafeInteger(maxBytes) && maxBytes >= 0
       ? maxBytes
       : transcriptMaxBytes();
-  const destination = createWriteStream(filePath);
-  destination.on("error", () => {});
+  const destination = createDestination(filePath);
+  let destinationFailed = false;
+  destination.on("error", () => {
+    // Capture is best-effort. In particular, ENOSPC must not leave a pending
+    // write waiting forever for a drain event that can no longer happen.
+    destinationFailed = true;
+  });
+
+  const writeDestination = (chunk, callback) => {
+    if (destinationFailed || destination.destroyed) {
+      callback();
+      return;
+    }
+    destination.write(chunk, (error) => {
+      if (error) destinationFailed = true;
+      // A transcript failure must not backpressure the child. Keep the outer
+      // writable healthy so stdout continues to drain through process exit.
+      callback();
+    });
+  };
 
   let bytes = 0;
   let truncated = false;
@@ -36,30 +58,36 @@ export function boundedTranscriptStream(
       const remaining = limit - bytes;
       if (source.byteLength <= remaining) {
         bytes += source.byteLength;
-        if (destination.write(source)) callback();
-        else destination.once("drain", callback);
+        writeDestination(source, callback);
         return;
       }
 
-      if (remaining > 0) destination.write(source.subarray(0, remaining));
       bytes += Math.max(remaining, 0);
       truncated = true;
-      destination.write(
+      const marker = Buffer.from(
         `\n${JSON.stringify({
           type: "factory",
           subtype: "transcript_truncated",
           bytes,
         })}\n`,
       );
+      const stored =
+        remaining > 0
+          ? Buffer.concat([source.subarray(0, remaining), marker])
+          : marker;
       try {
         onTruncated?.({ bytes });
       } catch {
         // Trace reporting is observational; continue draining stdout.
       }
-      callback();
+      writeDestination(stored, callback);
     },
     final(callback) {
-      destination.end(callback);
+      if (destinationFailed || destination.destroyed) {
+        callback();
+        return;
+      }
+      destination.end(() => callback());
     },
     destroy(error, callback) {
       destination.destroy();

--- a/event-runtime/lib/adapters/child-process.test.mjs
+++ b/event-runtime/lib/adapters/child-process.test.mjs
@@ -1,9 +1,29 @@
 import { describe, expect, test } from "bun:test";
-import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
+import { readFileSync } from "node:fs";
+import { finished } from "node:stream/promises";
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-child-process-test-mjs";
+import {
+  DEFAULT_TRANSCRIPT_MAX_BYTES,
+  transcriptMaxBytes,
+} from "../config.mjs";
+import {
+  boundedTranscriptStream,
+  DETACHED_SPAWN_OPTIONS,
+  killProcessGroup,
+} from "./child-process.mjs";
 
 describe("child process helpers", () => {
   test("keeps spawned children in their own process group", () => {
     expect(DETACHED_SPAWN_OPTIONS).toEqual({ detached: true });
+  });
+
+  test("reads a positive transcript cap from the environment", () => {
+    expect(
+      transcriptMaxBytes({ FACTORY_EVENT_TRANSCRIPT_MAX_BYTES: "1234" }),
+    ).toBe(1234);
+    expect(
+      transcriptMaxBytes({ FACTORY_EVENT_TRANSCRIPT_MAX_BYTES: "0" }),
+    ).toBe(DEFAULT_TRANSCRIPT_MAX_BYTES);
   });
 
   test("signals the process group when it exists", () => {
@@ -81,5 +101,35 @@ describe("child process helpers", () => {
 
     expect(signals).toEqual([[-42, "SIGTERM"]]);
     expect(timers).toHaveLength(1);
+  });
+
+  test("caps transcript bytes, writes an NDJSON truncation marker, and keeps accepting output", async () => {
+    const transcriptPath = `${tmpDir("evrt-bounded-transcript-")}/.transcript.json`;
+    const transcript = boundedTranscriptStream(transcriptPath, { maxBytes: 7 });
+
+    transcript.write("abcd");
+    transcript.write("efghijkl");
+    transcript.end();
+    await finished(transcript);
+
+    expect(transcript.truncated).toBe(true);
+    expect(transcript.bytes).toBe(7);
+    expect(readFileSync(transcriptPath, "utf8")).toBe(
+      'abcdefg\n{"type":"factory","subtype":"transcript_truncated","bytes":7}\n',
+    );
+  });
+
+  test("preserves under-cap transcript bytes exactly", async () => {
+    const transcriptPath = `${tmpDir("evrt-bounded-transcript-")}/.transcript.json`;
+    const transcript = boundedTranscriptStream(transcriptPath, {
+      maxBytes: 64,
+    });
+    const output = '{"type":"result","text":"complete"}\n';
+
+    transcript.end(output);
+    await finished(transcript);
+
+    expect(transcript.truncated).toBe(false);
+    expect(readFileSync(transcriptPath, "utf8")).toBe(output);
   });
 });

--- a/event-runtime/lib/adapters/child-process.test.mjs
+++ b/event-runtime/lib/adapters/child-process.test.mjs
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
+import { Writable } from "node:stream";
 import { finished } from "node:stream/promises";
 import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-child-process-test-mjs";
 import {
@@ -131,5 +132,26 @@ describe("child process helpers", () => {
 
     expect(transcript.truncated).toBe(false);
     expect(readFileSync(transcriptPath, "utf8")).toBe(output);
+  });
+
+  test("keeps draining when the transcript destination fails", async () => {
+    const destination = new Writable({
+      highWaterMark: 1,
+      write(_chunk, _encoding, callback) {
+        callback(new Error("disk full"));
+      },
+    });
+    destination.on("error", () => {});
+    const transcript = boundedTranscriptStream("unused", {
+      maxBytes: 64,
+      createDestination: () => destination,
+    });
+
+    transcript.write("first chunk");
+    transcript.write("output after destination failure");
+    transcript.end();
+    await finished(transcript);
+
+    expect(transcript.destroyed).toBe(true);
   });
 });

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -24,10 +24,10 @@
  * the pi path did not have to solve.
  */
 import { spawn, spawnSync } from "node:child_process";
-import { createWriteStream, mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { FACTORY_ROOT } from "../config.mjs";
+import { FACTORY_ROOT, transcriptMaxBytes } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import {
   BASE_INHERITED_ENV,
@@ -36,7 +36,11 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment,
 } from "./child-env.mjs";
-import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
+import {
+  boundedTranscriptStream,
+  DETACHED_SPAWN_OPTIONS,
+  killProcessGroup,
+} from "./child-process.mjs";
 export {
   BASE_INHERITED_ENV,
   PROVIDER_CREDENTIAL_ENV,
@@ -426,6 +430,7 @@ export async function execute({
   resume = null,
   abortSignal,
   signal,
+  transcriptMaxBytes: maxTranscriptBytes = transcriptMaxBytes(),
 }) {
   // First, before the prompt is read or the env assembled: a sandboxed
   // definition never reaches the host spawn below (WM-313).
@@ -463,8 +468,13 @@ export async function execute({
     // what the agent reported long after the workspace is gone. With
     // stream-json the artifact is NDJSON, one message per line — consumers
     // stream bytes, none parses it as a single JSON document.
-    const transcript = createWriteStream(
+    const transcript = boundedTranscriptStream(
       path.join(workspaceDir, ".transcript.json"),
+      {
+        maxBytes: maxTranscriptBytes,
+        onTruncated: ({ bytes }) =>
+          onTrace?.("lifecycle", { note: "transcript_truncated", bytes }),
+      },
     );
     transcript.on("error", () => {});
     // Child close only says its stdio handles are closed; the file stream may
@@ -617,6 +627,7 @@ export async function execute({
         exitCode,
         timedOut,
         policyDenials: exitCode === 0 ? [] : policyDenials,
+        ...(transcript.truncated ? { transcriptTruncated: true } : {}),
       });
     });
   });

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -905,6 +905,42 @@ if (behavior === "emit_denial_then_recovery") {
     );
   });
 
+  test("caps the transcript and reports truncation without blocking child exit", async () => {
+    const workspaceDir = ws();
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      transcriptMaxBytes: 64,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "large_transcript",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome.transcriptTruncated).toBe(true);
+    expect(
+      traceEvents.some(
+        (event) =>
+          event.kind === "lifecycle" &&
+          event.payload.note === "transcript_truncated" &&
+          event.payload.bytes === 64,
+      ),
+    ).toBe(true);
+    expect(
+      readFileSync(path.join(workspaceDir, ".transcript.json")).byteLength,
+    ).toBeLessThanOrEqual(
+      64 +
+        Buffer.byteLength(
+          '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+        ),
+    );
+  });
+
   test("nonzero exit code propagates and timedOut is false", async () => {
     const workspaceDir = ws();
     const outcome = await execute({

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -26,10 +26,10 @@
  * editor CLI.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
-import { FACTORY_ROOT } from "../config.mjs";
+import { FACTORY_ROOT, transcriptMaxBytes } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import {
@@ -38,7 +38,11 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment as sharedSafeChildEnvironment,
 } from "./child-env.mjs";
-import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
+import {
+  boundedTranscriptStream,
+  DETACHED_SPAWN_OPTIONS,
+  killProcessGroup,
+} from "./child-process.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
 export {
@@ -283,6 +287,7 @@ export async function execute({
   onUsage,
   abortSignal,
   signal,
+  transcriptMaxBytes: maxTranscriptBytes = transcriptMaxBytes(),
 }) {
   refuseSandbox("cursor", def, SANDBOX_REFUSAL_REASON);
   const prompt = verifiedPrompt(def, "cursor");
@@ -309,8 +314,13 @@ export async function execute({
       ...DETACHED_SPAWN_OPTIONS,
     });
 
-    const transcript = createWriteStream(
+    const transcript = boundedTranscriptStream(
       path.join(workspaceDir, ".transcript.json"),
+      {
+        maxBytes: maxTranscriptBytes,
+        onTruncated: ({ bytes }) =>
+          onTrace?.("lifecycle", { note: "transcript_truncated", bytes }),
+      },
     );
     transcript.on("error", () => {});
     // Child close only says its stdio handles are closed; the file stream may
@@ -465,6 +475,7 @@ export async function execute({
         exitCode,
         timedOut,
         policyDenials: exitCode === 0 ? [] : policyDenials,
+        ...(transcript.truncated ? { transcriptTruncated: true } : {}),
       });
     });
   });

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -617,6 +617,89 @@ if (behavior === "emit_error_tool_result") {
     );
   });
 
+  test("caps the transcript, flags truncation, and still exits cleanly (GH-1420)", async () => {
+    const workspaceDir = ws();
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: loadAdjustedTimeout(5_000),
+      transcriptMaxBytes: 64,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "large_transcript",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.transcriptTruncated).toBe(true);
+    expect(
+      traceEvents.some(
+        (event) =>
+          event.kind === "lifecycle" &&
+          event.payload.note === "transcript_truncated" &&
+          event.payload.bytes === 64,
+      ),
+    ).toBe(true);
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    expect(Buffer.byteLength(transcript)).toBeLessThanOrEqual(
+      64 +
+        Buffer.byteLength(
+          '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+        ),
+    );
+    expect(
+      transcript.endsWith(
+        '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+      ),
+    ).toBe(true);
+  });
+
+  test("a transcript under the cap is byte-identical to the child's output (GH-1420)", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: loadAdjustedTimeout(5_000),
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "normal",
+      },
+    });
+    expect(outcome.transcriptTruncated).toBeUndefined();
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    const lines = transcript.split("\n");
+    expect(lines.at(-1)).toBe("");
+    expect(lines.slice(0, -1).map(JSON.parse)).toEqual([
+      { type: "system", subtype: "init", model: "Composer 2.5" },
+      {
+        type: "assistant",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Working..." }],
+        },
+      },
+      {
+        type: "result",
+        subtype: "success",
+        duration_ms: 1200,
+        is_error: false,
+        result: "Working...",
+      },
+    ]);
+  });
+
   test("nonzero exit code propagates and timedOut is false", async () => {
     const outcome = await execute({
       spec: defaultSpec,

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -456,6 +456,10 @@ function attachOutput({
   transcript.on("error", () => {});
   if (stdout) {
     stdout.pipe(transcript);
+  } else {
+    // No stdout means nothing will ever end the transcript; close it now so
+    // execute()'s wait for the stream to finish cannot hang (mirrors acp).
+    transcript.end();
   }
 
   // Live trace: same stdout, line by line. Observational only — a trace

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -49,11 +49,11 @@
  * path, so the two cannot drift. See lib/adapters/sandboxed.mjs.
  */
 import { spawn } from "node:child_process";
-import { createWriteStream, writeFileSync } from "node:fs";
+import { writeFileSync } from "node:fs";
 import path from "node:path";
 import { createInterface } from "node:readline";
 import { PassThrough } from "node:stream";
-import { FACTORY_ROOT } from "../config.mjs";
+import { FACTORY_ROOT, transcriptMaxBytes } from "../config.mjs";
 import { normalizePolicy } from "../sandbox/gondolin.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import {
@@ -63,7 +63,11 @@ import {
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment as sharedSafeChildEnvironment,
 } from "./child-env.mjs";
-import { DETACHED_SPAWN_OPTIONS, killProcessGroup } from "./child-process.mjs";
+import {
+  boundedTranscriptStream,
+  DETACHED_SPAWN_OPTIONS,
+  killProcessGroup,
+} from "./child-process.mjs";
 import {
   guestBinary,
   guestEnvironment,
@@ -430,11 +434,24 @@ export function extractUsage(msg) {
  *
  * @param {import("node:stream").Readable|null} stdout
  */
-function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
+function attachOutput({
+  stdout,
+  workspaceDir,
+  spec,
+  def,
+  onTrace,
+  onUsage,
+  transcriptMaxBytes: maxTranscriptBytes,
+}) {
   // Capture the CLI's structured output as a runtime artifact, same
   // contract as the claude adapter: NDJSON, one message per line.
-  const transcript = createWriteStream(
+  const transcript = boundedTranscriptStream(
     path.join(workspaceDir, ".transcript.json"),
+    {
+      maxBytes: maxTranscriptBytes,
+      onTruncated: ({ bytes }) =>
+        onTrace?.("lifecycle", { note: "transcript_truncated", bytes }),
+    },
   );
   transcript.on("error", () => {});
   if (stdout) {
@@ -542,6 +559,7 @@ function attachOutput({ stdout, workspaceDir, spec, def, onTrace, onUsage }) {
       timedOut,
       policyDenials: exitCode === 0 ? [] : policyDenials,
       usage: normalized,
+      ...(transcript.truncated ? { transcriptTruncated: true } : {}),
     };
   };
 
@@ -577,6 +595,7 @@ async function executeSandboxed({
   timeoutMs,
   onTrace,
   onUsage,
+  transcriptMaxBytes: maxTranscriptBytes,
   resume,
   abortSignal,
   runSandbox,
@@ -608,6 +627,7 @@ async function executeSandboxed({
     def,
     onTrace,
     onUsage,
+    transcriptMaxBytes: maxTranscriptBytes,
   });
   const transcriptClosed = new Promise((done) => {
     transcript.on("close", done);
@@ -658,6 +678,7 @@ export async function execute({
   abortSignal,
   signal,
   runSandbox,
+  transcriptMaxBytes: maxTranscriptBytes = transcriptMaxBytes(),
 }) {
   // The sandbox decision comes first, before the host env is assembled or a
   // host CLI is looked for: a sandboxed definition must never reach the host
@@ -670,6 +691,7 @@ export async function execute({
       timeoutMs,
       onTrace,
       onUsage,
+      transcriptMaxBytes: maxTranscriptBytes,
       resume,
       abortSignal: abortSignal ?? signal,
       runSandbox,
@@ -724,6 +746,11 @@ export async function execute({
       def,
       onTrace,
       onUsage,
+      transcriptMaxBytes: maxTranscriptBytes,
+    });
+    const transcriptClosed = new Promise((done) => {
+      transcript.once("close", done);
+      transcript.once("finish", done);
     });
 
     let timedOut = false;
@@ -755,10 +782,11 @@ export async function execute({
       transcript.destroy();
       reject(err);
     });
-    child.on("close", (exitCode) => {
+    child.on("close", async (exitCode) => {
       clearTimeout(termTimer);
       cancelTermination?.();
       if (abortSig) abortSig.removeEventListener?.("abort", onAbort);
+      await transcriptClosed;
       resolve(finish({ exitCode, timedOut }));
     });
   });

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -559,6 +559,17 @@ process.stdin.on("end", () => {
     process.exit(code);
   }
 
+  if (behavior === "large_transcript") {
+    process.stdout.write(JSON.stringify({
+      type: "message_end",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "x".repeat(1024 * 1024) }],
+        usage: { input: 15, output: 25, cost: { total: 0.001 } },
+      },
+    }) + "\\n", () => process.exit(0));
+  }
+
   if (behavior === "sleep_sigterm") {
     setInterval(() => {}, 10_000);
   }
@@ -802,6 +813,82 @@ process.stdin.on("end", () => {
     });
     expect(outcome.exitCode).toBe(42);
     expect(outcome.timedOut).toBe(false);
+  });
+
+  test("caps the transcript, flags truncation, and still exits cleanly (GH-1420)", async () => {
+    const workspaceDir = ws();
+    const traceEvents = [];
+
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      transcriptMaxBytes: 64,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "large_transcript",
+      },
+      onTrace: (kind, payload) => traceEvents.push({ kind, payload }),
+    });
+
+    expect(outcome.exitCode).toBe(0);
+    expect(outcome.timedOut).toBe(false);
+    expect(outcome.transcriptTruncated).toBe(true);
+    expect(
+      traceEvents.some(
+        (event) =>
+          event.kind === "lifecycle" &&
+          event.payload.note === "transcript_truncated" &&
+          event.payload.bytes === 64,
+      ),
+    ).toBe(true);
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    expect(Buffer.byteLength(transcript)).toBeLessThanOrEqual(
+      64 +
+        Buffer.byteLength(
+          '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+        ),
+    );
+    expect(
+      transcript.endsWith(
+        '\n{"type":"factory","subtype":"transcript_truncated","bytes":64}\n',
+      ),
+    ).toBe(true);
+  });
+
+  test("a transcript under the cap is byte-identical to the child's output (GH-1420)", async () => {
+    const workspaceDir = ws();
+    const outcome = await execute({
+      spec: defaultSpec,
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "normal",
+      },
+    });
+    expect(outcome.transcriptTruncated).toBeUndefined();
+    const transcript = readFileSync(
+      path.join(workspaceDir, ".transcript.json"),
+      "utf8",
+    );
+    const lines = transcript.split("\n");
+    expect(lines.at(-1)).toBe("");
+    expect(lines.slice(0, -1).map(JSON.parse)).toEqual([
+      {
+        type: "message_end",
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "Working..." }],
+          usage: { input: 15, output: 25, cost: { total: 0.001 } },
+        },
+      },
+    ]);
   });
 
   testProcessGroup(

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -176,6 +176,16 @@ export const DEAD_LETTER_AFTER = 3;
 /** Default cap when neither repo nor policy config supplies one. */
 export const DEFAULT_MAX_IN_FLIGHT = 3;
 
+/** Bound each raw CLI transcript before artifact storage can amplify it. */
+export const DEFAULT_TRANSCRIPT_MAX_BYTES = 64 * 1024 * 1024;
+
+export function transcriptMaxBytes(env = process.env) {
+  const configured = Number(env.FACTORY_EVENT_TRANSCRIPT_MAX_BYTES);
+  return Number.isSafeInteger(configured) && configured > 0
+    ? configured
+    : DEFAULT_TRANSCRIPT_MAX_BYTES;
+}
+
 export const DEFAULT_PROPOSAL_TTL_SECONDS = 30 * 60;
 
 let cachedPolicyVersion;


### PR DESCRIPTION
Fixes watt-mind/factory#1420

Caps transcript artifacts across all CLI adapters without risking stdout backpressure or write-error deadlocks.

## What changed
- `event-runtime/lib/adapters/child-process.mjs`: `boundedTranscriptStream(path, { maxBytes, onTruncated })` stops storing bytes after `maxBytes`, appends one NDJSON marker line `{"type":"factory","subtype":"transcript_truncated","bytes":N}`, and keeps accepting (discarding) further chunks so the child's stdout is never back-pressured. Destination write errors (e.g. ENOSPC) also degrade to drain-only instead of wedging the pipe.
- `event-runtime/lib/config.mjs`: `DEFAULT_TRANSCRIPT_MAX_BYTES` (64 MiB) and `transcriptMaxBytes(env)` reading `FACTORY_EVENT_TRANSCRIPT_MAX_BYTES` (positive safe integer, else default).
- claude, pi (host + sandboxed), cursor and acp adapters use the bounded writer, accept a `transcriptMaxBytes` override, emit `onTrace("lifecycle", { note: "transcript_truncated", bytes })` when the cap is hit, and return `transcriptTruncated: true` in the outcome. pi's host path now also waits for the transcript stream to close before resolving (parity with claude/cursor/acp).
- Tests: child-process (cap + marker, under-cap byte-identical, failing destination keeps draining, env knob) and one over-cap + one under-cap test per adapter (claude, pi, cursor, acp).

## Handoff

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/child-process.test.mjs event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/pi.test.mjs event-runtime/lib/adapters/cursor.test.mjs event-runtime/lib/adapters/acp.test.mjs --timeout 20000` | pass | 169 pass, 3 QEMU-dependent skips, 0 fail (172 tests) |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` | pass | 1970 pass, 10 QEMU-dependent skips, 0 fail; emit, format and check clean |
| UX critique          | factory-ux-critic                | not run | backend-only; no user-facing surface |

- Files: 11 changed, all within Owned Paths (child-process, claude, pi, cursor, acp + their tests, config.mjs).
- Branch merged with `origin/develop` (post #1403 / #1366); no conflicts.
- Earlier handoff-gate failures on this ticket were the `timeout/abort kills a real long-lived grandchild` process-group tests failing inside the verify sandbox (since fixed by #1440); they are unrelated to this change and pass locally.
- Risk: a capped transcript ends with a partial NDJSON record immediately before the explicit marker line; consumers that stream lines already tolerate a malformed line.

## Post-review

- Review nit folded in (7476bad955b33acfbbb3cbb453275eb7e8fe3003): `attachOutput` in `pi.mjs` now calls `transcript.end()` when `stdout` is null, mirroring `acp.mjs`, so the new `await transcriptClosed` in `execute()` cannot hang. No dedicated test: `attachOutput` is not exported and `execute()` always spawns with `stdio: pipe`, so the null-stdout branch is unreachable from the public surface. A `dropped` byte counter in the truncation marker was not added: the marker is written at the moment the cap is hit, before any bytes are dropped, so reporting a drop count would require deferring the marker to stream end (a larger change than the nit warrants).
- Re-verified after merging `origin/develop`: ticket Verification Command 169 pass / 3 skip / 0 fail; `bun test event-runtime/lib` 1970 pass / 10 skip / 0 fail; emit, format:check and check clean.
