### PR TITLE
fix(intake): reject mismatched duplicate payloads

### DIFF
--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -364,6 +364,12 @@ function admit(
   const outcome = admitEnvelope(db, registry, parsed.value, {
     now: nowMs,
   });
+  if (outcome.conflict) {
+    return send(409, {
+      error: "payload_mismatch",
+      eventId: parsed.value.eventId,
+    });
+  }
   if (!outcome.admitted && !outcome.duplicate)
     return send(422, { errors: outcome.errors });
   // Respond first, then plan off the response path (WM-1162).

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -120,6 +120,75 @@ describe("webhook intake (§14)", () => {
     expect(s.onEvents).toEqual(["admitted"]); // no second wake-up for a duplicate
   });
 
+  test("same event id with a different payload returns payload_mismatch", async () => {
+    const isolated = await makeServer();
+    try {
+      const firstBody = JSON.stringify(
+        envelope({ eventId: "hook-payload-mismatch" }),
+      );
+      const secondBody = JSON.stringify(
+        envelope({
+          eventId: "hook-payload-mismatch",
+          payload: { repos: ["different"] },
+        }),
+      );
+      const timestamp = String(Date.now());
+      const headers = (body) => ({
+        "content-type": "application/json",
+        "x-factory-timestamp": timestamp,
+        "x-factory-signature": sign(body, timestamp),
+      });
+
+      const first = await fetch(isolated.url("/events"), {
+        method: "POST",
+        headers: headers(firstBody),
+        body: firstBody,
+      });
+      expect(first.status).toBe(200);
+
+      const mismatch = await fetch(isolated.url("/events"), {
+        method: "POST",
+        headers: headers(secondBody),
+        body: secondBody,
+      });
+      expect(mismatch.status).toBe(409);
+      expect(await mismatch.json()).toEqual({
+        error: "payload_mismatch",
+        eventId: "hook-payload-mismatch",
+      });
+
+      const replay = await fetch(isolated.url("/replay"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          envelope({
+            eventId: "replay-payload-mismatch",
+            payload: { repos: ["first"] },
+          }),
+        ),
+      });
+      expect(replay.status).toBe(200);
+
+      const replayMismatch = await fetch(isolated.url("/replay"), {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify(
+          envelope({
+            eventId: "replay-payload-mismatch",
+            payload: { repos: ["second"] },
+          }),
+        ),
+      });
+      expect(replayMismatch.status).toBe(409);
+      expect(await replayMismatch.json()).toEqual({
+        error: "payload_mismatch",
+        eventId: "replay-payload-mismatch",
+      });
+    } finally {
+      isolated.close();
+    }
+  });
+
   test("bad signature → 401 and nothing written", async () => {
     const before = await (await fetch(s.url("/status"))).json();
 

--- a/event-runtime/lib/decision-effects.test.mjs
+++ b/event-runtime/lib/decision-effects.test.mjs
@@ -254,6 +254,33 @@ describe("runtime decision effects", () => {
     expect(admitted).toBe(false);
   });
 
+  test("authorise records a payload conflict as a retryable failed effect", () => {
+    const result = applyDecisionEffect(
+      null,
+      item("authorise"),
+      response({ paths: ["a"] }),
+      {
+        linear: { get: () => ({ description: "Current Linear body" }) },
+        planner: {
+          admit: () => ({
+            admitted: false,
+            duplicate: false,
+            conflict: true,
+            errors: ["eventId: already admitted with a different payload"],
+          }),
+        },
+        now: NOW,
+      },
+    );
+
+    expect(result).toEqual({
+      kind: "authorise",
+      outcome: "failed",
+      error:
+        "dispatch admission failed: eventId: already admitted with a different payload",
+    });
+  });
+
   test("transport failure stays open with the response recorded and retry resolves", () => {
     const db = openDb(":memory:");
     const request = {

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -246,6 +246,7 @@ export function translateGitHubEvent({
  *
  * @returns {{ admitted: true, duplicate: false, event: object }
  *         | { admitted: false, duplicate: true, event: object }
+ *         | { admitted: false, duplicate: false, conflict: true, errors: string[] }
  *         | { admitted: false, duplicate: false, errors: string[] }}
  */
 /**
@@ -345,10 +346,21 @@ export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
   }
 
   return txImmediate(db, () => {
+    const payloadHash = hashJson(stored.payload);
     const existing = db
       .query(`SELECT * FROM events WHERE source = ? AND event_id = ?`)
       .get(stored.source, stored.eventId);
-    if (existing) return { admitted: false, duplicate: true, event: existing };
+    if (existing) {
+      if (existing.payload_hash !== payloadHash) {
+        return {
+          admitted: false,
+          duplicate: false,
+          conflict: true,
+          errors: ["eventId: already admitted with a different payload"],
+        };
+      }
+      return { admitted: false, duplicate: true, event: existing };
+    }
     db.query(
       `INSERT INTO events
          (source, event_id, type, subject, occurred_at, received_at,
@@ -364,7 +376,7 @@ export function admitEvent(db, registry, envelope, { now = Date.now() } = {}) {
       stored.correlationId ?? null,
       stored.causationId ?? null,
       canonicalJson(stored),
-      hashJson(stored.payload),
+      payloadHash,
       receivedAt,
     );
     const event = db

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -195,7 +195,21 @@ describe("admitEvent", () => {
     expect(result.event.payload_hash.startsWith("sha256:")).toBe(true);
   });
 
-  test("same (source, eventId) delivered twice yields one row and duplicate: true", () => {
+  test("identical same (source, eventId) retry yields one row and duplicate: true", () => {
+    const db = openDb(":memory:");
+    const first = admitEvent(db, registry, envelope(), { now: NOW });
+    const second = admitEvent(db, registry, envelope(), { now: NOW + 5000 });
+    expect(first.admitted).toBe(true);
+    expect(second).toEqual({
+      admitted: false,
+      duplicate: true,
+      event: first.event,
+    });
+    const rows = db.query(`SELECT COUNT(*) AS n FROM events`).get();
+    expect(rows.n).toBe(1);
+  });
+
+  test("same (source, eventId) with a different payload is a conflict without a write", () => {
     const db = openDb(":memory:");
     const first = admitEvent(db, registry, envelope(), { now: NOW });
     const second = admitEvent(
@@ -204,11 +218,13 @@ describe("admitEvent", () => {
       envelope({ payload: { repos: ["different"] } }),
       { now: NOW + 5000 },
     );
+
     expect(first.admitted).toBe(true);
     expect(second).toEqual({
       admitted: false,
-      duplicate: true,
-      event: first.event,
+      duplicate: false,
+      conflict: true,
+      errors: ["eventId: already admitted with a different payload"],
     });
     const rows = db.query(`SELECT COUNT(*) AS n FROM events`).get();
     expect(rows.n).toBe(1);


### PR DESCRIPTION
Fixes watt-mind/factory#1432

Return a 409 payload_mismatch instead of silently discarding a conflicting event retry.

## Validation

| Check                | Command                                                                                                     | Result  | Notes                         |
| -------------------- | ----------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/intake.test.mjs event-runtime/lib/api-intake.test.mjs event-runtime/lib/decision-effects.test.mjs --timeout 20000` | pass    | 64 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`         | pass    | 1962 pass, 10 skipped         |
| UX critique          | `factory-ux-critic`                                                                                         | not run | no user-facing surface        |

UX critique: skipped