### PR TITLE
perf: cache artifact catalogue projection

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -6,12 +6,7 @@ import {
   readSync,
   rmSync,
 } from "node:fs";
-import {
-  findArtifact,
-  hashFileAsync,
-  listArtifactPage,
-  pruneArtifacts,
-} from "./artifacts.mjs";
+import { findArtifact, hashFileAsync, pruneArtifacts } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { ApiParameterError, parseListLimit } from "./api-params.mjs";
 
@@ -64,6 +59,8 @@ export async function handleArtifactApiRoute({
   env,
   nowMs,
   clearStoreStats,
+  clearArtifactPage,
+  getArtifactPage,
 }) {
   if (route === "GET /artifacts") {
     const orphanParam = url.searchParams.get("orphan");
@@ -100,17 +97,20 @@ export async function handleArtifactApiRoute({
         return send(422, { error: "invalid before cursor" });
       }
     }
-    const page = listArtifactPage(db, artifactsRoot(env.home), {
-      orphan: orphanParam === null ? undefined : orphanParam === "true",
-      kind: url.searchParams.has("kind")
-        ? url.searchParams.get("kind")
-        : undefined,
-      search: url.searchParams.has("search")
-        ? url.searchParams.get("search")
-        : undefined,
-      limit,
-      before,
-    });
+    const page = getArtifactPage(
+      {
+        orphan: orphanParam === null ? undefined : orphanParam === "true",
+        kind: url.searchParams.has("kind")
+          ? url.searchParams.get("kind")
+          : undefined,
+        search: url.searchParams.has("search")
+          ? url.searchParams.get("search")
+          : undefined,
+        limit,
+        before,
+      },
+      nowMs,
+    );
     return send(200, page);
   }
 
@@ -136,7 +136,10 @@ export async function handleArtifactApiRoute({
       now: nowMs,
       dryRun: !apply,
     });
-    if (apply) clearStoreStats();
+    if (apply) {
+      clearStoreStats();
+      clearArtifactPage();
+    }
     return send(200, result);
   }
 

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -3,6 +3,7 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-artifacts-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { artifactReferenceIndex } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import {
   GH_SECRET,
@@ -45,6 +46,88 @@ const makeServer = async (...args) => {
 };
 
 describe("artifact store and agent registry surfacing (OPS-212)", () => {
+  test("GET /artifacts reuses its index until a new result arrives", async () => {
+    const home = tmpDir("evrt-artifact-page-cache-");
+    const store = path.join(home, "artifacts");
+    mkdirSync(store, { recursive: true });
+    const firstHash = "a".repeat(64);
+    const secondHash = "b".repeat(64);
+    writeFileSync(path.join(store, firstHash), "first", "utf8");
+
+    const db = openDb(path.join(home, "runtime.db"));
+    const createdAt = "2026-01-02T03:04:05.000Z";
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+       VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`,
+    ).run(
+      "run_first",
+      "idem-first",
+      JSON.stringify({ agent: "cache-agent@1" }),
+      "spec-hash",
+      createdAt,
+      createdAt,
+    );
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:result', '{}', '{}', ?)`,
+    ).run(
+      "run_first",
+      JSON.stringify({ artifacts: [{ kind: "report", sha256: firstHash }] }),
+      createdAt,
+    );
+
+    let indexBuilds = 0;
+    const server = startApi({
+      db,
+      registry,
+      secret: SECRET,
+      policyVersion: PV,
+      port: 0,
+      env: { name: "test", home, adapter: "fake" },
+      buildArtifactReferenceIndex(currentDb) {
+        indexBuilds += 1;
+        return artifactReferenceIndex(currentDb);
+      },
+    });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const base = `http://127.0.0.1:${server.address().port}`;
+    try {
+      await fetch(`${base}/artifacts`);
+      await fetch(`${base}/artifacts`);
+      expect(indexBuilds).toBe(1);
+
+      writeFileSync(path.join(store, secondHash), "second", "utf8");
+      db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+         VALUES (?, ?, ?, ?, 'COMPLETED', ?, ?)`,
+      ).run(
+        "run_second",
+        "idem-second",
+        JSON.stringify({ agent: "cache-agent@1" }),
+        "spec-hash",
+        createdAt,
+        createdAt,
+      );
+      db.query(
+        `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, 'sha256:result', '{}', '{}', ?)`,
+      ).run(
+        "run_second",
+        JSON.stringify({ artifacts: [{ kind: "report", sha256: secondHash }] }),
+        createdAt,
+      );
+
+      const refreshed = await (await fetch(`${base}/artifacts`)).json();
+      expect(indexBuilds).toBe(2);
+      expect(refreshed.artifacts.map((artifact) => artifact.sha256)).toContain(
+        secondHash,
+      );
+    } finally {
+      server.close();
+      db.close();
+    }
+  });
+
   test("GET /artifacts catalogues and filters metadata; POST /artifacts/prune dry-runs and applies", async () => {
     const home = tmpDir("evrt-artifacts-api-");
     const store = path.join(home, "artifacts");

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -34,7 +34,12 @@ import {
   repoNamesFromInput,
 } from "./api-runs.mjs";
 import { handleScheduleApiRoute } from "./api-schedules.mjs";
-import { storeStats } from "./artifacts.mjs";
+import {
+  artifactInventory,
+  artifactReferenceIndex,
+  listArtifactPage,
+  storeStats,
+} from "./artifacts.mjs";
 import {
   API_HOST,
   DEFAULT_PORT,
@@ -139,6 +144,9 @@ export function createApi({
   // fails closed when this is absent and requires the matching bearer when it
   // is present. Never logged.
   controlApiToken = process.env.FACTORY_CONTROL_API_TOKEN || null,
+  // Injectable only so API tests can count cache rebuilds.
+  buildArtifactReferenceIndex = artifactReferenceIndex,
+  buildArtifactInventory = artifactInventory,
 } = {}) {
   const actor = "operator";
   const registryLoadedAt = new Date(now()).toISOString();
@@ -147,6 +155,10 @@ export function createApi({
     inboxPlanner ?? decisionEffectPlanner(registry, { onEvent, policyVersion });
   let cachedStoreStats = null;
   let cachedStoreStatsAt = 0;
+  let cachedArtifactReferences = null;
+  let cachedArtifactResultsRowid = null;
+  let cachedArtifactInventory = null;
+  let cachedArtifactInventoryAt = 0;
 
   function getStoreStats(nowMs) {
     if (cachedStoreStats && nowMs - cachedStoreStatsAt < storeStatsTtlMs)
@@ -159,6 +171,37 @@ export function createApi({
   function clearStoreStats() {
     cachedStoreStats = null;
     cachedStoreStatsAt = 0;
+  }
+
+  function clearArtifactPage() {
+    cachedArtifactReferences = null;
+    cachedArtifactResultsRowid = null;
+    cachedArtifactInventory = null;
+    cachedArtifactInventoryAt = 0;
+  }
+
+  function getArtifactPage(options, nowMs) {
+    const storeRoot = artifactsRoot(env?.home);
+    const resultsRowid =
+      db.query(`SELECT MAX(rowid) AS rowid FROM results`).get().rowid ?? 0;
+    const resultsChanged = resultsRowid !== cachedArtifactResultsRowid;
+    if (resultsChanged) {
+      cachedArtifactReferences = buildArtifactReferenceIndex(db);
+      cachedArtifactResultsRowid = resultsRowid;
+    }
+    if (
+      resultsChanged ||
+      !cachedArtifactInventory ||
+      nowMs - cachedArtifactInventoryAt >= storeStatsTtlMs
+    ) {
+      cachedArtifactInventory = buildArtifactInventory(storeRoot);
+      cachedArtifactInventoryAt = nowMs;
+    }
+    return listArtifactPage(db, storeRoot, {
+      ...options,
+      references: cachedArtifactReferences,
+      inventory: cachedArtifactInventory,
+    });
   }
 
   return async function handle(req, res) {
@@ -402,6 +445,8 @@ export function createApi({
         const result = await handleArtifactApiRoute({
           ...common,
           clearStoreStats,
+          clearArtifactPage,
+          getArtifactPage,
         });
         if (result !== false) return result;
       }

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -356,14 +356,8 @@ export function listArtifacts(
   }).artifacts;
 }
 
-/** Newest-first cursor page for the artifact catalogue HTTP projection. */
-export function listArtifactPage(
-  db,
-  storeRoot,
-  { orphan, kind, search, limit = 100, before = null } = {},
-) {
-  if (!existsSync(storeRoot)) return { artifacts: [], nextBefore: null };
-
+/** Build the result-to-artifact reference index used by catalogue pages. */
+export function artifactReferenceIndex(db) {
   const references = new Map();
   const rows = db
     .query(
@@ -409,22 +403,55 @@ export function listArtifactPage(
       }
     }
   }
+  return references;
+}
 
-  const term = typeof search === "string" ? search.toLowerCase() : null;
+/** Snapshot the artifact files that are currently present in the store. */
+export function artifactInventory(storeRoot) {
+  if (!existsSync(storeRoot)) return [];
   const inventory = [];
   for (const sha256 of readdirSync(storeRoot).filter((name) =>
     HEX64.test(name),
   )) {
     const stat = statSync(path.join(storeRoot, sha256));
     if (!stat.isFile()) continue;
-    const refs = references.get(sha256) ?? [];
+    inventory.push({
+      sha256,
+      sizeBytes: stat.size,
+      mtime: stat.mtime.toISOString(),
+    });
+  }
+  return inventory;
+}
+
+/** Newest-first cursor page for the artifact catalogue HTTP projection. */
+export function listArtifactPage(
+  db,
+  storeRoot,
+  {
+    orphan,
+    kind,
+    search,
+    limit = 100,
+    before = null,
+    references = null,
+    inventory = null,
+  } = {},
+) {
+  const index = references ?? artifactReferenceIndex(db);
+  const files = inventory ?? artifactInventory(storeRoot);
+
+  const term = typeof search === "string" ? search.toLowerCase() : null;
+  const catalogue = [];
+  for (const file of files) {
+    const refs = index.get(file.sha256) ?? [];
     const referenced = refs.length > 0;
     if (orphan !== undefined && orphan === referenced) continue;
     if (kind !== undefined && !refs.some((ref) => ref.kind === kind)) continue;
     if (
       term &&
       ![
-        sha256,
+        file.sha256,
         ...refs.flatMap((ref) => [ref.runId, ref.kind, ref.agent, ref.state]),
       ].some((value) =>
         String(value ?? "")
@@ -433,25 +460,23 @@ export function listArtifactPage(
       )
     )
       continue;
-    inventory.push({
-      sha256,
-      sizeBytes: stat.size,
-      mtime: stat.mtime.toISOString(),
+    catalogue.push({
+      ...file,
       referenced,
       references: refs,
     });
   }
-  inventory.sort(
+  catalogue.sort(
     (a, b) =>
       b.mtime.localeCompare(a.mtime) || a.sha256.localeCompare(b.sha256),
   );
   const afterCursor = before
-    ? inventory.filter(
+    ? catalogue.filter(
         (item) =>
           item.mtime < before.mtime ||
           (item.mtime === before.mtime && item.sha256 > before.sha256),
       )
-    : inventory;
+    : catalogue;
   const page = afterCursor.slice(0, limit + 1);
   const hasNextPage = page.length > limit;
   const artifacts = hasNextPage ? page.slice(0, -1) : page;


### PR DESCRIPTION
Fixes #1416

Cache artifact-page references and inventory so polling avoids repeated full scans until results or pruning change them.

## Validation

| Check                | Command                                                                          | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/artifacts.test.mjs event-runtime/lib/api-artifacts.test.mjs --timeout 20000` | pass    | 31 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1960 pass, emit and format clean |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface        |

UX critique: skipped
