### PR TITLE
fix(linear): abort retrying cursor walks (#1428)

### DIFF
--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -28,13 +28,16 @@ import {
 // on a `blocks` node the blocker is `node.issue` (plain `relations` would
 // give what X blocks — the wrong direction). State `type`, not name: workflow
 // names are per-team config, the types are Linear's own enum.
-const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } }`;
+const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } pageInfo{ hasNextPage endCursor } }`;
 const PAGE_CAP = 2_000;
-const DEFAULT_REQUEST_TIMEOUT_MS = 30_000;
+// Five retried responses can wait 1+2+4+8 seconds. Leave that retry budget
+// outside the original 30-second request allowance rather than timing out a
+// healthy response midway through its documented backoff schedule.
+const DEFAULT_REQUEST_TIMEOUT_MS = 45_000;
 const ISSUE_FIELDS = `id identifier title url description createdAt startedAt updatedAt priority
   state{ id name type } assignee{ id name }
   team{ key } project{ name }
-  labels(first:30){ nodes{ id name } }
+  labels(first:30){ nodes{ id name } pageInfo{ hasNextPage endCursor } }
   comments(last:1){ nodes{ createdAt } }
   ${BLOCKERS}`;
 
@@ -90,7 +93,7 @@ function openBlockerIdentifiers(issue) {
 }
 
 /**
- * @param {{ gql?: (query: string, variables?: object) => Promise<object>, timeoutMs?: number }} [options]
+ * @param {{ gql?: (query: string, variables?: object, signal?: AbortSignal) => Promise<object>, timeoutMs?: number }} [options]
  * @returns {import("./types.mjs").ControlPlane}
  */
 export function linearControlPlane({
@@ -99,21 +102,27 @@ export function linearControlPlane({
 } = {}) {
   const requestTimeout = requestTimeoutMs(timeoutMs);
 
+  /**
+   * Bound one GraphQL operation and cancel the underlying fetch/backoff.
+   *
+   * `gql` retries transient failures. A failed mutation is therefore an
+   * unknown outcome: it may have committed before its response was lost, so
+   * callers must not blindly replay non-idempotent creates or comments.
+   */
   async function call(query, variables = {}) {
     let timer;
+    const controller = new AbortController();
+    const timeoutError = new ControlPlaneError(
+      `linear graphql timed out after ${requestTimeout}ms`,
+    );
     try {
       return await Promise.race([
-        Promise.resolve().then(() => gql(query, variables)),
+        Promise.resolve().then(() => gql(query, variables, controller.signal)),
         new Promise((_, reject) => {
-          timer = setTimeout(
-            () =>
-              reject(
-                new ControlPlaneError(
-                  `linear graphql timed out after ${requestTimeout}ms`,
-                ),
-              ),
-            requestTimeout,
-          );
+          timer = setTimeout(() => {
+            controller.abort(timeoutError);
+            reject(timeoutError);
+          }, requestTimeout);
         }),
       ]);
     } catch (cause) {
@@ -127,10 +136,27 @@ export function linearControlPlane({
     }
   }
 
-  async function collectPages(query, variables, connectionFor, name) {
-    const nodes = [];
-    let after = null;
-    for (;;) {
+  async function collectPages(
+    query,
+    variables,
+    connectionFor,
+    name,
+    initialConnection,
+  ) {
+    const nodes = [...(initialConnection?.nodes ?? [])];
+    if (nodes.length > PAGE_CAP)
+      throw new ControlPlaneError(
+        `linear ${name} pagination exceeded ${PAGE_CAP} rows`,
+      );
+    let after = initialConnection?.pageInfo?.endCursor ?? null;
+    let hasNextPage = initialConnection
+      ? Boolean(initialConnection.pageInfo?.hasNextPage)
+      : true;
+    while (hasNextPage) {
+      if (after === null && initialConnection)
+        throw new ControlPlaneError(
+          `linear ${name} pagination has next page without an end cursor`,
+        );
       const d = await call(query, { ...variables, after });
       const connection = connectionFor(d);
       const page = connection?.nodes ?? [];
@@ -139,13 +165,45 @@ export function linearControlPlane({
           `linear ${name} pagination exceeded ${PAGE_CAP} rows`,
         );
       nodes.push(...page);
-      if (!connection?.pageInfo?.hasNextPage) return nodes;
+      hasNextPage = Boolean(connection?.pageInfo?.hasNextPage);
+      if (!hasNextPage) return nodes;
       after = connection.pageInfo.endCursor;
       if (!after)
         throw new ControlPlaneError(
           `linear ${name} pagination has next page without an end cursor`,
         );
     }
+    return nodes;
+  }
+
+  async function paginateIssueConnections(issue) {
+    if (!issue?.id) return issue;
+    const paged = { ...issue };
+    if (issue.labels?.pageInfo?.hasNextPage) {
+      paged.labels = {
+        ...issue.labels,
+        nodes: await collectPages(
+          `query TicketLabelsPage($id:String!,$after:String){ issue(id:$id){ labels(first:30,after:$after){ nodes{ id name } pageInfo{ hasNextPage endCursor } } } }`,
+          { id: issue.id },
+          (d) => d?.issue?.labels,
+          "ticket labels",
+          issue.labels,
+        ),
+      };
+    }
+    if (issue.inverseRelations?.pageInfo?.hasNextPage) {
+      paged.inverseRelations = {
+        ...issue.inverseRelations,
+        nodes: await collectPages(
+          `query TicketRelationsPage($id:String!,$after:String){ issue(id:$id){ inverseRelations(first:250,after:$after){ nodes{ type issue{ identifier state{ type } } } pageInfo{ hasNextPage endCursor } } } }`,
+          { id: issue.id },
+          (d) => d?.issue?.inverseRelations,
+          "ticket inverse relations",
+          issue.inverseRelations,
+        ),
+      };
+    }
+    return paged;
   }
 
   async function issueByKey(key) {
@@ -153,19 +211,28 @@ export function linearControlPlane({
       `query($k:String!){ issue(id:$k){ ${ISSUE_FIELDS} } }`,
       { k: key },
     );
-    const issue = normalizeTicket(d?.issue);
+    const issue = normalizeTicket(await paginateIssueConnections(d?.issue));
     if (!issue) throw new ControlPlaneError(`no such issue: ${key}`);
     return issue;
   }
 
   async function statesFor(teamKey) {
     const d = await call(
-      `query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } } } } }`,
+      `query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } pageInfo{ hasNextPage endCursor } } } } }`,
       { t: teamKey },
     );
     const team = d?.teams?.nodes?.[0];
     if (!team) throw new ControlPlaneError(`no such team: ${teamKey}`);
-    return { teamId: team.id, states: team.states?.nodes ?? [] };
+    return {
+      teamId: team.id,
+      states: await collectPages(
+        `query TeamStatesPage($id:String!,$after:String){ team(id:$id){ states(first:50,after:$after){ nodes{ id name } pageInfo{ hasNextPage endCursor } } } }`,
+        { id: team.id },
+        (d) => d?.team?.states,
+        "states",
+        team.states,
+      ),
+    };
   }
 
   async function allLabels() {
@@ -236,12 +303,22 @@ export function linearControlPlane({
           : `state:{ type:{ nin:["completed","canceled"] } }`;
       const stateClause = stateFilter ? `${stateFilter},` : "";
       const decl = states?.length ? ", $s:[String!]" : "";
-      const vars = { t: team, ...(project ? { p: project } : {}) };
+      const vars = {
+        t: team,
+        orderBy: "createdAt",
+        ...(project ? { p: project } : {}),
+      };
       if (states?.length) vars.s = states;
       const query = project
-        ? `query($t:String!,$p:String!${decl},$after:String){ issues(first:250,after:$after, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`
-        : `query($t:String!${decl},$after:String){ issues(first:250,after:$after, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`;
-      return (await collectPages(query, vars, (d) => d?.issues, "issues"))
+        ? `query($t:String!,$p:String!${decl},$after:String,$orderBy:IssueOrderByInput){ issues(first:250,after:$after,orderBy:$orderBy, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`
+        : `query($t:String!${decl},$after:String,$orderBy:IssueOrderByInput){ issues(first:250,after:$after,orderBy:$orderBy, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`;
+      return (
+        await Promise.all(
+          (await collectPages(query, vars, (d) => d?.issues, "issues")).map(
+            paginateIssueConnections,
+          ),
+        )
+      )
         .map(normalizeTicket)
         .sort(byQueueOrder);
     },

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -43,6 +43,155 @@ describe("Linear ControlPlane pagination (GH-1393)", () => {
       "cursor-1",
     ]);
     expect(calls[0].query).toContain("pageInfo{ hasNextPage endCursor }");
+    expect(calls[0].variables.orderBy).toBe("createdAt");
+  });
+
+  test("passes an abort signal to gql and aborts it on the request timeout", async () => {
+    let observed;
+    const cp = linearControlPlane({
+      gql: (_query, _variables, signal) => {
+        observed = signal;
+        return new Promise((_, reject) =>
+          signal?.addEventListener("abort", () => reject(signal.reason)),
+        );
+      },
+      timeoutMs: 1,
+    });
+
+    await expect(cp.raw("query { ping }")).rejects.toBeInstanceOf(
+      ControlPlaneError,
+    );
+    expect(observed).toBeDefined();
+    expect(observed.aborted).toBe(true);
+  });
+
+  test("paginates ticket labels and inverse relations only when needed", async () => {
+    const cursors = [];
+    const ticket = {
+      id: "issue-1",
+      identifier: "WM-1",
+      title: "Issue",
+      state: { id: "todo", name: "Todo", type: "started" },
+      assignee: null,
+      team: { key: "WM" },
+      project: null,
+      comments: { nodes: [] },
+      labels: {
+        nodes: [{ id: "first", name: "first" }],
+        pageInfo: { hasNextPage: true, endCursor: "labels-1" },
+      },
+      inverseRelations: {
+        nodes: [
+          {
+            type: "blocks",
+            issue: {
+              identifier: "WM-2",
+              state: { type: "started" },
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: true, endCursor: "relations-1" },
+      },
+    };
+    const cp = linearControlPlane({
+      gql: async (query, variables) => {
+        if (query.includes("issue(id:$k)")) return { issue: ticket };
+        if (query.includes("TicketLabelsPage")) {
+          cursors.push(["labels", variables.after]);
+          return {
+            issue: {
+              labels: {
+                nodes: [{ id: "second", name: "second" }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          };
+        }
+        if (query.includes("TicketRelationsPage")) {
+          cursors.push(["relations", variables.after]);
+          return {
+            issue: {
+              inverseRelations: {
+                nodes: [
+                  {
+                    type: "blocks",
+                    issue: {
+                      identifier: "WM-3",
+                      state: { type: "started" },
+                    },
+                  },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          };
+        }
+        throw new Error(`unexpected query: ${query}`);
+      },
+    });
+
+    await expect(cp.getTicket("WM-1")).resolves.toMatchObject({
+      labels: [{ name: "first" }, { name: "second" }],
+      blockedBy: ["WM-2", "WM-3"],
+    });
+    expect(cursors).toEqual([
+      ["labels", "labels-1"],
+      ["relations", "relations-1"],
+    ]);
+  });
+
+  test("paginates workflow states after the first page", async () => {
+    let update;
+    const ticket = {
+      id: "issue-1",
+      identifier: "WM-1",
+      title: "Issue",
+      state: { id: "todo", name: "Todo", type: "started" },
+      assignee: null,
+      team: { key: "WM" },
+      project: null,
+      labels: { nodes: [] },
+      comments: { nodes: [] },
+      inverseRelations: { nodes: [] },
+    };
+    const cp = linearControlPlane({
+      gql: async (query, variables) => {
+        if (query.includes("issue(id:$k)")) return { issue: ticket };
+        if (query.includes("teams(filter"))
+          return {
+            teams: {
+              nodes: [
+                {
+                  id: "team-1",
+                  states: {
+                    nodes: [{ id: "todo", name: "Todo" }],
+                    pageInfo: { hasNextPage: true, endCursor: "states-1" },
+                  },
+                },
+              ],
+            },
+          };
+        if (query.includes("TeamStatesPage")) {
+          expect(variables.after).toBe("states-1");
+          return {
+            team: {
+              states: {
+                nodes: [{ id: "review", name: "In Review" }],
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            },
+          };
+        }
+        if (query.includes("issueUpdate")) {
+          update = variables.in;
+          return { issueUpdate: { success: true } };
+        }
+        throw new Error(`unexpected query: ${query}`);
+      },
+    });
+
+    await cp.transition("WM-1", "In Review");
+    expect(update).toEqual({ stateId: "review" });
   });
 
   test("setLabels resolves a label from the second cursor page", async () => {

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -148,7 +148,52 @@ export function getApiKey() {
   return key;
 }
 
-export async function gql(query, variables = {}, retries = 5) {
+function abortReason(signal) {
+  return signal?.reason instanceof Error
+    ? signal.reason
+    : new Error("Linear request aborted");
+}
+
+function throwIfAborted(signal) {
+  if (signal?.aborted) throw abortReason(signal);
+}
+
+function retryDelay(ms, signal) {
+  if (!signal) return new Promise((resolve) => setTimeout(resolve, ms));
+  throwIfAborted(signal);
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(done, ms);
+    const onAbort = () => done(abortReason(signal));
+    function done(error) {
+      clearTimeout(timer);
+      signal.removeEventListener("abort", onAbort);
+      if (error) reject(error);
+      else resolve();
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
+/**
+ * Send a Linear GraphQL request, retrying transient responses unless cancelled.
+ *
+ * A failed or timed-out mutation has an unknown server outcome: Linear may have
+ * committed a non-idempotent create/comment before this client observes the
+ * failure. Callers must inspect the resulting resource instead of replaying it.
+ */
+export async function gql(
+  query,
+  variables = {},
+  retriesOrOptions = 5,
+  legacySignal,
+) {
+  const options =
+    typeof retriesOrOptions === "number"
+      ? { retries: retriesOrOptions, signal: legacySignal }
+      : retriesOrOptions instanceof AbortSignal
+        ? { retries: 5, signal: retriesOrOptions }
+        : (retriesOrOptions ?? {});
+  const { retries = 5, signal } = options;
   const apiKey = getApiKey();
   const headers = {
     "Content-Type": "application/json",
@@ -159,10 +204,12 @@ export async function gql(query, variables = {}, retries = 5) {
 
   for (let attempt = 0; attempt < retries; attempt++) {
     try {
+      throwIfAborted(signal);
       const res = await fetch(LINEAR_API_URL, {
         method: "POST",
         headers,
         body,
+        signal,
       });
 
       if (!res.ok) {
@@ -170,7 +217,7 @@ export async function gql(query, variables = {}, retries = 5) {
           [429, 500, 502, 503, 504].includes(res.status) &&
           attempt < retries - 1
         ) {
-          await new Promise((r) => setTimeout(r, delay));
+          await retryDelay(delay, signal);
           delay *= 2;
           continue;
         }
@@ -185,7 +232,7 @@ export async function gql(query, variables = {}, retries = 5) {
           msg.toUpperCase().includes("RATELIMITED") &&
           attempt < retries - 1
         ) {
-          await new Promise((r) => setTimeout(r, delay));
+          await retryDelay(delay, signal);
           delay *= 2;
           continue;
         }
@@ -194,11 +241,12 @@ export async function gql(query, variables = {}, retries = 5) {
 
       return data.data || {};
     } catch (err) {
+      if (signal?.aborted) throw abortReason(signal);
       if (
         attempt < retries - 1 &&
         !(err.message && err.message.startsWith("HTTP 4"))
       ) {
-        await new Promise((r) => setTimeout(r, delay));
+        await retryDelay(delay, signal);
         delay *= 2;
         continue;
       }

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -6,7 +6,45 @@ import {
   parseTs,
   HEARTBEAT_LABEL,
   AGENT_LABEL_PREFIX,
+  gql,
 } from "./reaper.mjs";
+
+describe("Linear GraphQL cancellation", () => {
+  test("forwards an AbortSignal to fetch and stops retrying when aborted", async () => {
+    const previousFetch = globalThis.fetch;
+    const previousKey = process.env.LINEAR_API_KEY;
+    const controller = new AbortController();
+    let observed;
+    process.env.LINEAR_API_KEY = "test-key";
+    globalThis.fetch = (_url, options) => {
+      observed = options.signal;
+      return new Promise((_, reject) =>
+        controller.signal.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        ),
+      );
+    };
+
+    try {
+      const request = gql(
+        "query { ping }",
+        {},
+        {
+          retries: 1,
+          signal: controller.signal,
+        },
+      );
+      controller.abort(new Error("timeout"));
+      await expect(request).rejects.toThrow("timeout");
+      expect(observed).toBe(controller.signal);
+      expect(observed.aborted).toBe(true);
+    } finally {
+      globalThis.fetch = previousFetch;
+      if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousKey;
+    }
+  });
+});
 
 describe("reaper argument parser", () => {
   test("default arguments", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1428

Abort timed-out Linear retries while preserving complete, stable cursor walks.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test lib/control-plane/linear.test.mjs orchestrator/reaper.test.mjs --timeout 20000` | pass | 54 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1,959 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped