### PR TITLE
fix(web): paginate inbox replay lookup and prevent duplicates

### DIFF
--- a/event-runtime/web/src/components/InboxActions.test.tsx
+++ b/event-runtime/web/src/components/InboxActions.test.tsx
@@ -208,6 +208,115 @@ test("Replay, Rerun CI, and Ship use their existing API request shapes and refet
   expect(changed).toHaveBeenCalledTimes(3);
 });
 
+test("Replay finds a referenced human-needed event beyond the first 200 events", async () => {
+  const replay = mock(async (_envelope: unknown) => ({
+    admitted: true,
+    duplicate: false,
+    eventId: "new",
+  }));
+  const newerEvents = Array.from({ length: 200 }, (_, index) => ({
+    ...event,
+    eventId: `newer-${index}`,
+    envelope: { ...event.envelope, eventId: `newer-${index}` },
+  }));
+  const olderEvents = Array.from({ length: 49 }, (_, index) => ({
+    ...event,
+    eventId: `older-${index}`,
+    envelope: { ...event.envelope, eventId: `older-${index}` },
+  }));
+  const apiCalls = {
+    events: mock(
+      async (
+        _status?: string,
+        page: { limit?: number; before?: string } = {},
+      ) =>
+        page.before === "cursor-1"
+          ? { events: [...olderEvents, event], nextBefore: null }
+          : { events: newerEvents, nextBefore: "cursor-1" },
+    ),
+    replay,
+    triggerSchedule: mock(async (_loop: string) => ({}) as never),
+    repos: mock(async () => ({ repos: [] }) as never),
+    schedules: mock(async () => ({ schedules: [] }) as never),
+  };
+  const view = render(
+    <InboxActions
+      item={item({
+        kind: "human_needed",
+        refs: { eventSource: "github", eventId: "failed-1" },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+    />,
+  );
+
+  fireEvent.click(view.getByRole("button", { name: "Replay" }));
+  await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+  expect(apiCalls.events).toHaveBeenNthCalledWith(1, "human_needed", {
+    limit: 200,
+    before: undefined,
+  });
+  expect(apiCalls.events).toHaveBeenNthCalledWith(2, "human_needed", {
+    limit: 200,
+    before: "cursor-1",
+  });
+});
+
+test("a successful Replay stays completed and cannot be submitted twice", async () => {
+  const replay = mock(async (_envelope: unknown) => ({
+    admitted: true,
+    duplicate: false,
+    eventId: "new",
+  }));
+  const apiCalls = {
+    events: mock(async () => ({ events: [event] })),
+    replay,
+    triggerSchedule: mock(async (_loop: string) => ({}) as never),
+    repos: mock(async () => ({ repos: [] }) as never),
+    schedules: mock(async () => ({ schedules: [] }) as never),
+  };
+  const view = render(
+    <InboxActions
+      item={item({
+        kind: "human_needed",
+        refs: { eventSource: "github", eventId: "failed-1" },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+    />,
+  );
+
+  fireEvent.click(view.getByRole("button", { name: "Replay" }));
+  await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+  const button = view.getByRole("button", { name: "Replayed" });
+  expect(button.hasAttribute("disabled")).toBe(true);
+  fireEvent.click(button);
+  expect(replay).toHaveBeenCalledTimes(1);
+
+  view.rerender(
+    <InboxActions
+      item={item({
+        kind: "human_needed",
+        title: "Changed action",
+        refs: { eventSource: "github", eventId: "failed-1" },
+      })}
+      connected
+      onResolve={() => {}}
+      onItemChange={() => {}}
+      apiCalls={apiCalls}
+    />,
+  );
+  await waitFor(() =>
+    expect(
+      view.getByRole("button", { name: "Replay" }).hasAttribute("disabled"),
+    ).toBe(false),
+  );
+});
+
 test("an item already correlated to a proposal replaces its mutating action", () => {
   const apiCalls = {
     events: mock(async () => ({ events: [] })),

--- a/event-runtime/web/src/components/InboxActions.tsx
+++ b/event-runtime/web/src/components/InboxActions.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { api } from "../api";
 import type { AdmittedEvent, InboxItem } from "../types";
 import { Button, JumpLink, VerbError } from "./ui";
@@ -16,6 +16,9 @@ const PLAIN_ACTION_KINDS = new Set([
   "SMOKE RED",
   "CIRCUIT BREAKER",
 ]);
+
+const REFERENCED_EVENT_PAGE_LIMIT = 200;
+const REFERENCED_EVENT_MAX_PAGES = 5;
 
 // Jump chips read as links, not stray mono text: pill border + underline on hover.
 const CHIP_CLASS =
@@ -128,6 +131,14 @@ export function InboxActions({
   const [pending, setPending] = useState<string | null>(null);
   const [completed, setCompleted] = useState<string | null>(null);
   const [error, setError] = useState<unknown>(null);
+  const itemSnapshot = JSON.stringify(item);
+  const previousItemSnapshot = useRef(itemSnapshot);
+
+  useEffect(() => {
+    if (previousItemSnapshot.current === itemSnapshot) return;
+    previousItemSnapshot.current = itemSnapshot;
+    setCompleted(null);
+  }, [itemSnapshot]);
 
   const run = async (label: string, action: () => Promise<unknown>) => {
     setPending(label);
@@ -144,14 +155,28 @@ export function InboxActions({
   };
 
   const loadReferencedEvent = async () => {
-    const { events } = await apiCalls.events();
-    return referencedEvent(events, item);
+    const status = item.kind === "human_needed" ? "human_needed" : undefined;
+    let before: string | undefined;
+    for (let page = 0; page < REFERENCED_EVENT_MAX_PAGES; page += 1) {
+      const response = await apiCalls.events(status, {
+        limit: REFERENCED_EVENT_PAGE_LIMIT,
+        before,
+      });
+      const event = referencedEvent(response.events, item);
+      if (event) return event;
+      if (!response.nextBefore) break;
+      before = response.nextBefore;
+    }
+    return null;
   };
 
   const replay = () =>
     run("Replay", async () => {
       const event = await loadReferencedEvent();
-      if (!event) throw new Error("Referenced event is no longer available");
+      if (!event)
+        throw new Error(
+          `Referenced event was not found within the ${REFERENCED_EVENT_MAX_PAGES}-page lookup bound`,
+        );
       await apiCalls.replay(replayEnvelope(item, event, now()));
     });
 
@@ -221,10 +246,14 @@ export function InboxActions({
         )}
         {item.kind === "human_needed" && (
           <Button
-            disabled={!connected || pending !== null}
+            disabled={!connected || pending !== null || completed === "Replay"}
             onClick={() => void replay()}
           >
-            {pending === "Replay" ? "Replaying…" : "Replay"}
+            {pending === "Replay"
+              ? "Replaying…"
+              : completed === "Replay"
+                ? "Replayed"
+                : "Replay"}
           </Button>
         )}
         {item.kind === "CI RED" && !proposalCreated && (


### PR DESCRIPTION
Fixes watt-mind/factory#1435

Review the draft: Replay is covered locally, but the seeded Inbox lacks a human_needed item for UX approval.

## Validation

| Check                | Command                                                                  | Result       | Notes                                      |
| -------------------- | ------------------------------------------------------------------------ | ------------ | ------------------------------------------ |
| Verification Command | `cd event-runtime/web && bun test src/components/InboxActions.test.tsx` | pass         | 7 tests, 0 failures                        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1959 pass, emit and format checks clean |
| UX critique          | factory-ux-critic                                                        | NOT-ASSESSED | seeded Inbox has no human_needed item      |

UX critique: required — NOT-ASSESSED
