### PR TITLE
fix(inbox): reject whitespace-only required text (#1433)

### DIFF
--- a/event-runtime/lib/decision.mjs
+++ b/event-runtime/lib/decision.mjs
@@ -278,7 +278,7 @@ function validateFieldValue(field, value, path, errors) {
       return;
     }
     const maximum = field.maxLength ?? TEXT_DEFAULT_MAX_LENGTH;
-    if (field.required === true && value.length === 0)
+    if (field.required === true && value.trim().length === 0)
       errors.push(`${path}: required text must not be empty`);
     if (value.length > maximum)
       errors.push(`${path}: longer than maxLength ${maximum}`);

--- a/event-runtime/lib/decision.test.mjs
+++ b/event-runtime/lib/decision.test.mjs
@@ -722,6 +722,30 @@ describe("validateDecisionResponse", () => {
     });
   });
 
+  test("rejects whitespace-only required text without trimming its stored value", () => {
+    for (const value of ["   ", "\n\t"]) {
+      const response = validResponse();
+      response.fields.note = value;
+      expect(validateDecisionResponse(response, RESPONSE_REQUEST)).toEqual({
+        valid: false,
+        errors: ["$.fields.note: required text must not be empty"],
+      });
+    }
+
+    const optionalRequest = dismissRequest({
+      fields: [{ id: "note", kind: "text", label: "Note" }],
+    });
+    const optionalResponse = {
+      ...validResponse(),
+      requestHash: decisionRequestHash(optionalRequest),
+      optionId: "dismiss",
+      fields: { note: "   " },
+    };
+    expect(validateDecisionResponse(optionalResponse, optionalRequest)).toEqual(
+      { valid: true, errors: [] },
+    );
+  });
+
   test("validates text type and maxLength", () => {
     expectInvalidResponse((response) => {
       response.fields.note = 3;

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -418,6 +418,43 @@ describe("human inbox ledger (WM-285)", () => {
     expect(() => retryInboxDecision(db, item.id)).toThrow("already applied");
   });
 
+  test("whitespace-only required text is rejected before a response is recorded", () => {
+    const db = openDb(":memory:");
+    const request = decision([
+      { id: "answer", label: "Answer", effect: "answer" },
+    ]);
+    request.fields = [
+      { id: "reply", kind: "text", label: "Reply", required: true },
+    ];
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "answer",
+        refs: { issue: "WM-1" },
+        decision: request,
+      },
+      { id: "whitespace_response" },
+    );
+
+    try {
+      decideInboxItem(db, "whitespace_response", {
+        schemaVersion: "factory.decision-response/v1",
+        requestHash: decisionRequestHash(request),
+        optionId: "answer",
+        fields: { reply: " \n " },
+      });
+      throw new Error("expected invalid response");
+    } catch (error) {
+      expect(error).toMatchObject({
+        code: "invalid_response",
+        status: 400,
+        errors: ["$.fields.reply: required text must not be empty"],
+      });
+    }
+    expect(getInboxItem(db, "whitespace_response").response).toBeNull();
+  });
+
   test("each failed retry advances a durable attempt token", () => {
     const db = openDb(":memory:");
     const request = decision([

--- a/event-runtime/web/src/lib/decisionForm.test.ts
+++ b/event-runtime/web/src/lib/decisionForm.test.ts
@@ -80,6 +80,19 @@ describe("decision form helpers", () => {
     expect(fieldErrors(request, "go", values)).toEqual({});
   });
 
+  test("treats whitespace-only required text as empty", () => {
+    const requiredTextRequest: DecisionRequest = {
+      ...request,
+      fields: [{ id: "note", kind: "text", label: "Note", required: true }],
+    };
+    expect(fieldErrors(requiredTextRequest, "go", { note: " \n\t " })).toEqual({
+      note: "Note is required.",
+    });
+    expect(fieldErrors(requiredTextRequest, "go", { note: " note " })).toEqual(
+      {},
+    );
+  });
+
   test("enforces number bounds and integer values", () => {
     const values = initialValues(request);
     values.count = 1;

--- a/event-runtime/web/src/lib/decisionForm.ts
+++ b/event-runtime/web/src/lib/decisionForm.ts
@@ -41,7 +41,7 @@ export function fieldErrors(
     const value = values[field.id];
     if (field.kind === "text") {
       if (typeof value !== "string") errors[field.id] = "Enter text.";
-      else if (field.required && value.length === 0)
+      else if (field.required && value.trim().length === 0)
         errors[field.id] = `${field.label} is required.`;
       else if (value.length > (field.maxLength ?? 2000))
         errors[field.id] =


### PR DESCRIPTION
Fixes watt-mind/factory#1433

Reject whitespace-only required decision text before any response is stored.

## Validation

| Check                | Command                                                                                                    | Result | Notes                                  |
| -------------------- | ---------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/decision.test.mjs event-runtime/lib/inbox.test.mjs --timeout 20000 && cd event-runtime/web && bun test src/lib/decisionForm.test.ts` | pass   | 65 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`        | pass   | 1,961 pass; emit and format clean      |
| UX critique          | `factory-ux-critic`                                                                                       | pass   | required; FIX-FIRST: missing hint      |

UX critique: required


Note: AC-4 (visible whitespace-only hint in the web form) is split out to #1452 / #1454; this PR covers the server/validator rejection only.