### PR TITLE
fix(supervise): back off crash-looping pool slots

### DIFF
--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -122,7 +122,13 @@ export function getPoolLines(pool, s) {
       ? `live (pid ${sup.pid})`
       : `DEAD (stale pid ${sup.pid})`;
   const draining = pool.slots.filter((sl) => sl.alive && sl.draining).length;
-  const line = `${pad("pool", 11)}supervisor ${supText}   workers ${pool.size}${draining > 0 ? ` (${draining} draining)` : ""}`;
+  const crashLoops = pool.slots.filter((sl) => sl.crashLoops > 0);
+  const crashText = crashLoops.length
+    ? `   crashLoops ${crashLoops
+        .map((sl) => `slot ${sl.n}: ${sl.crashLoops}`)
+        .join(", ")}`
+    : "";
+  const line = `${pad("pool", 11)}supervisor ${supText}   workers ${pool.size}${draining > 0 ? ` (${draining} draining)` : ""}${crashText}`;
 
   // §13's shape of anomaly: work waiting with nothing left that can grow the
   // pool. The queue is not stuck yet — the live workers may still drain it —

--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -112,8 +112,12 @@ export function getAnomalyLines(s) {
  */
 export function getPoolLines(pool, s) {
   const started = pool?.supervisor !== null && pool?.supervisor !== undefined;
-  if (!started && (pool?.slots?.length ?? 0) === 0)
-    return { line: null, anomalies: [] };
+  // A leftover `fastExits: 0` crash-loop file (kept across restarts as the
+  // durable backoff counter) is not a slot worth a pool line on its own.
+  const liveSlots = (pool?.slots ?? []).filter(
+    (sl) => sl.hasPidFile || sl.crashLoops > 0,
+  );
+  if (!started && liveSlots.length === 0) return { line: null, anomalies: [] };
 
   const sup = pool.supervisor;
   const supText = !sup

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -203,6 +203,35 @@ describe("pool visibility in status/doctor (WM-226)", () => {
     }
   });
 
+  test("a leftover fastExits: 0 crash-loop file after a clean stop prints no pool line", async () => {
+    const { getPoolLines, readPool } = await import("../cli.mjs");
+    const dir = tmpDir("evrt-pool-leftover-");
+    try {
+      // A clean pool stop removes the pidfiles but keeps the durable backoff
+      // counter; on its own that must not fabricate a "supervisor absent" line.
+      writeFileSync(
+        path.join(dir, "worker-1.crash-loop.json"),
+        JSON.stringify({ fastExits: 0, nextAttemptAt: null }),
+      );
+      const view = getPoolLines(readPool(dir), {
+        runs: { byState: { QUEUED: 3 } },
+      });
+      expect(view.line).toBeNull();
+      expect(view.anomalies).toEqual([]);
+
+      // A real backoff counter is still worth showing.
+      writeFileSync(
+        path.join(dir, "worker-1.crash-loop.json"),
+        JSON.stringify({ fastExits: 2, nextAttemptAt: null }),
+      );
+      expect(getPoolLines(readPool(dir), {}).line).toContain(
+        "crashLoops slot 1: 2",
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
   test("a live supervisor reports its pool size; a dead one with a queue is an anomaly", async () => {
     const { getPoolLines, readPool } = await import("../cli.mjs");
     const dir = tmpDir("evrt-pool-view-");

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -222,6 +222,14 @@ describe("pool visibility in status/doctor (WM-226)", () => {
       writeFileSync(path.join(dir, "worker-1.drain"), "scale-down\n");
       expect(getPoolLines(readPool(dir), {}).line).toContain("(1 draining)");
 
+      writeFileSync(
+        path.join(dir, "worker-1.crash-loop.json"),
+        JSON.stringify({ fastExits: 3, nextAttemptAt: Date.now() + 2_000 }),
+      );
+      expect(getPoolLines(readPool(dir), {}).line).toContain(
+        "crashLoops slot 1: 3",
+      );
+
       // A queue with waiting runs and a dead supervisor is the §13 anomaly:
       // nothing is left that can grow the pool behind the workers still up.
       writeFileSync(path.join(dir, "supervisor.pid"), "2147483646\n");

--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -68,7 +68,7 @@ function writeCrashLoop(file, state) {
   writeFileSync(file, `${JSON.stringify(state)}\n`);
 }
 
-function backoffMs(fastExits) {
+export function crashBackoffMs(fastExits) {
   return Math.min(
     CRASH_BACKOFF_MS * 2 ** (fastExits - CRASH_LOOP_LIMIT),
     CRASH_BACKOFF_MAX_MS,
@@ -304,7 +304,7 @@ export default async function supervise(args) {
 
     const fastExits = (state?.fastExits ?? 0) + 1;
     const nextAttemptAt =
-      fastExits >= CRASH_LOOP_LIMIT ? now + backoffMs(fastExits) : null;
+      fastExits >= CRASH_LOOP_LIMIT ? now + crashBackoffMs(fastExits) : null;
     writeCrashLoop(files.crashLoop, {
       fastExits,
       spawnedAt: null,

--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -6,6 +6,7 @@ import {
   openSync,
   readdirSync,
   readFileSync,
+  renameSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -65,7 +66,11 @@ function readCrashLoop(file) {
 }
 
 function writeCrashLoop(file, state) {
-  writeFileSync(file, `${JSON.stringify(state)}\n`);
+  // tmp + rename: a concurrent `status` reads either the previous complete
+  // state or the new one, never a torn file.
+  const tmp = `${file}.${process.pid}.tmp`;
+  writeFileSync(tmp, `${JSON.stringify(state)}\n`);
+  renameSync(tmp, file);
 }
 
 export function crashBackoffMs(fastExits) {

--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -39,7 +39,44 @@ export function slotFiles(dir, n) {
     drain: path.join(dir, `worker-${n}.drain`),
     log: path.join(dir, `worker-${n}.log`),
     id: path.join(dir, `worker-${n}.id`),
+    crashLoop: path.join(dir, `worker-${n}.crash-loop.json`),
   };
+}
+
+const CRASH_LOOP_LIMIT = 3;
+const CRASH_BACKOFF_MS = 2_000;
+const CRASH_BACKOFF_MAX_MS = 60_000;
+
+function readCrashLoop(file) {
+  try {
+    const parsed = JSON.parse(readFileSync(file, "utf8"));
+    return {
+      fastExits: Math.max(0, Number(parsed.fastExits) || 0),
+      spawnedAt: Number(parsed.spawnedAt) || null,
+      lastExitedAt: Number(parsed.lastExitedAt) || null,
+      lastExitDurationMs: Number(parsed.lastExitDurationMs) || null,
+      workerId: typeof parsed.workerId === "string" ? parsed.workerId : null,
+      nextAttemptAt: Number(parsed.nextAttemptAt) || null,
+      loggedRetryAt: Number(parsed.loggedRetryAt) || null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function writeCrashLoop(file, state) {
+  writeFileSync(file, `${JSON.stringify(state)}\n`);
+}
+
+function backoffMs(fastExits) {
+  return Math.min(
+    CRASH_BACKOFF_MS * 2 ** (fastExits - CRASH_LOOP_LIMIT),
+    CRASH_BACKOFF_MAX_MS,
+  );
+}
+
+function remainingSeconds(at, now) {
+  return Math.max(1, Math.ceil((at - now) / 1000));
 }
 
 /** Signal 0 probes without delivering: EPERM still proves the process exists. */
@@ -80,19 +117,26 @@ export function readPool(dir = runDir()) {
   } catch {
     /* dir missing or unreadable: names stays [] from the initializer */
   }
-  const slots = [];
+  const slotNumbers = new Set();
   for (const name of names) {
-    const m = /^worker-(\d+)\.pid$/.exec(name);
+    const m = /^worker-(\d+)\.(?:pid|crash-loop\.json)$/.exec(name);
     if (!m) continue;
-    const n = Number(m[1]);
+    slotNumbers.add(Number(m[1]));
+  }
+  const slots = [];
+  for (const n of slotNumbers) {
     const files = slotFiles(dir, n);
     const pid = readPidFile(files.pid);
+    const crashLoop = readCrashLoop(files.crashLoop);
     slots.push({
       n,
       pid,
+      hasPidFile: existsSync(files.pid),
       alive: pidAlive(pid),
       draining: existsSync(files.drain),
       workerId: readFileTrimmed(files.id),
+      crashLoops: crashLoop?.fastExits ?? 0,
+      nextAttemptAt: crashLoop?.nextAttemptAt ?? null,
     });
   }
   slots.sort((a, b) => a.n - b.n);
@@ -208,6 +252,71 @@ export default async function supervise(args) {
     spawnedAt.delete(n);
   }
 
+  function resetCrashLoop(n, state) {
+    if (state.fastExits === 0 && state.nextAttemptAt === null) return;
+    writeCrashLoop(slotFiles(dir, n).crashLoop, {
+      ...state,
+      fastExits: 0,
+      nextAttemptAt: null,
+      loggedRetryAt: null,
+    });
+    log(`slot ${n} registered past spawn grace — crash-loop counter reset`);
+  }
+
+  function resetRegisteredSlots(now) {
+    for (const slot of readPool(dir).slots) {
+      if (!slot.alive || !slot.workerId) continue;
+      const files = slotFiles(dir, slot.n);
+      const state = readCrashLoop(files.crashLoop);
+      if (
+        !state ||
+        state.fastExits === 0 ||
+        state.workerId !== slot.workerId ||
+        now - (state.spawnedAt ?? now) < spawnGraceMs
+      )
+        continue;
+      const worker = db
+        .query(`SELECT started_at FROM workers WHERE worker_id = ?`)
+        .get(slot.workerId);
+      if (
+        worker &&
+        Number.isFinite(Date.parse(worker.started_at)) &&
+        now - Date.parse(worker.started_at) >= spawnGraceMs
+      )
+        resetCrashLoop(slot.n, state);
+    }
+  }
+
+  function recordExit(slot, now) {
+    const files = slotFiles(dir, slot.n);
+    const state = readCrashLoop(files.crashLoop);
+    const startedAt = spawnedAt.get(slot.n) ?? state?.spawnedAt;
+    const fastExit =
+      !slot.draining &&
+      Number.isFinite(startedAt) &&
+      now - startedAt < spawnGraceMs;
+    releaseSlot(slot.n);
+
+    if (!fastExit) {
+      rmSync(files.crashLoop, { force: true });
+      return null;
+    }
+
+    const fastExits = (state?.fastExits ?? 0) + 1;
+    const nextAttemptAt =
+      fastExits >= CRASH_LOOP_LIMIT ? now + backoffMs(fastExits) : null;
+    writeCrashLoop(files.crashLoop, {
+      fastExits,
+      spawnedAt: null,
+      lastExitedAt: now,
+      lastExitDurationMs: now - startedAt,
+      workerId: slot.workerId ?? state?.workerId ?? null,
+      nextAttemptAt,
+      loggedRetryAt: null,
+    });
+    return { fastExits, nextAttemptAt };
+  }
+
   function spawnSlot(n) {
     const files = slotFiles(dir, n);
     // Never inherit the previous tenant's drain flag: a fresh worker that finds
@@ -237,7 +346,18 @@ export default async function supervise(args) {
     closeSync(out);
     writeFileSync(files.pid, `${child.pid}\n`);
     writeFileSync(files.id, `${workerId}\n`);
-    spawnedAt.set(n, Date.now());
+    const startedAt = Date.now();
+    spawnedAt.set(n, startedAt);
+    const previous = readCrashLoop(files.crashLoop);
+    writeCrashLoop(files.crashLoop, {
+      fastExits: previous?.fastExits ?? 0,
+      spawnedAt: startedAt,
+      lastExitedAt: previous?.lastExitedAt ?? null,
+      lastExitDurationMs: previous?.lastExitDurationMs ?? null,
+      workerId,
+      nextAttemptAt: null,
+      loggedRetryAt: null,
+    });
     return { pid: child.pid, workerId, log: files.log };
   }
 
@@ -261,18 +381,27 @@ export default async function supervise(args) {
   function tick() {
     const now = Date.now();
     for (const s of readPool(dir).slots) {
-      if (s.alive) continue;
+      // A crash-loop state intentionally remains after its pidfile is removed
+      // so status can expose the held slot. It is not a second exit.
+      if (s.alive || !s.hasPidFile) continue;
       log(
         `slot ${s.n} (worker ${s.workerId ?? "?"}, pid ${s.pid ?? "?"}) exited — slot released`,
       );
-      releaseSlot(s.n);
+      recordExit(s, now);
     }
+
+    // A registered worker which survives the boot window is healthy enough to
+    // forget previous fast exits. Check the registry as well as its pid: a
+    // process that never registered has not recovered the pool.
+    resetRegisteredSlots(now);
 
     const alive = readPool(dir).slots.filter((s) => s.alive);
     const observed = poolCounts(db, { now });
-    const pending = alive.filter(
-      (s) => now - (spawnedAt.get(s.n) ?? 0) < spawnGraceMs,
-    ).length;
+    const pending = alive.filter((s) => {
+      const state = readCrashLoop(slotFiles(dir, s.n).crashLoop);
+      const startedAt = spawnedAt.get(s.n) ?? state?.spawnedAt ?? 0;
+      return now - startedAt < spawnGraceMs;
+    }).length;
     const draining = alive.filter((s) => s.draining).length;
     const decision = poolDecision({
       queued: observed.queued,
@@ -291,6 +420,20 @@ export default async function supervise(args) {
       while (taken.has(slot)) slot += 1;
       if (slot > bounds.max) {
         log(`hold — no free slot below max ${bounds.max} [${counts}]`);
+        return decision;
+      }
+      const files = slotFiles(dir, slot);
+      const crashLoop = readCrashLoop(files.crashLoop);
+      if (crashLoop?.nextAttemptAt && crashLoop.nextAttemptAt > now) {
+        if (crashLoop.loggedRetryAt !== crashLoop.nextAttemptAt) {
+          log(
+            `crash-loop slot ${slot}: ${crashLoop.fastExits} fast exits, next attempt in ${remainingSeconds(crashLoop.nextAttemptAt, now)}s [${counts}]`,
+          );
+          writeCrashLoop(files.crashLoop, {
+            ...crashLoop,
+            loggedRetryAt: crashLoop.nextAttemptAt,
+          });
+        }
         return decision;
       }
       const { pid, workerId, log: logFile } = spawnSlot(slot);

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -10,7 +10,7 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
-import { workerPassthroughArgs } from "./supervise.mjs";
+import { readPool, workerPassthroughArgs } from "./supervise.mjs";
 import {
   CLI,
   DEAD_PORT,
@@ -160,6 +160,89 @@ describe("supervise (WM-226)", () => {
     }
   }, 60_000);
 
+  test("fast-exit slots back off exponentially instead of respawning every tick", async () => {
+    const home = tmpDir("evrt-pool-crash-loop-");
+    const dir = tmpDir("evrt-pool-crash-loop-run-");
+    const box = spawnSupervisor(
+      [
+        "--workers",
+        "1:1",
+        "--interval-ms",
+        "100",
+        "--spawn-grace-ms",
+        "500",
+        "--adapter-override",
+        "does-not-exist",
+      ],
+      { FACTORY_EVENT_HOME: home, FACTORY_RUN_DIR: dir },
+    );
+    try {
+      expect(
+        await waitFor(
+          box,
+          "crash-loop slot 1: 3 fast exits, next attempt in 2s",
+          15_000,
+        ),
+      ).toBe(true);
+      expect(
+        await waitFor(
+          box,
+          "crash-loop slot 1: 4 fast exits, next attempt in 4s",
+          15_000,
+        ),
+      ).toBe(true);
+      expect(readPool(dir).slots[0].crashLoops).toBeGreaterThanOrEqual(4);
+    } finally {
+      await killPool(box, dir);
+      rmSync(home, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 45_000);
+
+  test("a registered worker that survives grace resets its crash-loop counter", async () => {
+    const home = tmpDir("evrt-pool-crash-reset-");
+    const dir = tmpDir("evrt-pool-crash-reset-run-");
+    writeFileSync(
+      path.join(dir, "worker-1.crash-loop.json"),
+      JSON.stringify({
+        fastExits: 2,
+        spawnedAt: Date.now() - 1_000,
+        workerId: "old-worker",
+        nextAttemptAt: null,
+        loggedRetryAt: null,
+      }),
+    );
+    const box = spawnSupervisor(
+      [
+        "--workers",
+        "1:1",
+        "--interval-ms",
+        "100",
+        "--spawn-grace-ms",
+        "500",
+        "--adapter-override",
+        "fake",
+        "--poll-ms",
+        "50",
+      ],
+      { FACTORY_EVENT_HOME: home, FACTORY_RUN_DIR: dir },
+    );
+    try {
+      expect(
+        await waitFor(
+          box,
+          "slot 1 registered past spawn grace — crash-loop counter reset",
+          10_000,
+        ),
+      ).toBe(true);
+      expect(readPool(dir).slots[0].crashLoops).toBe(0);
+    } finally {
+      await killPool(box, dir);
+      rmSync(home, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  }, 30_000);
+
   test("surplus idle workers drain back to workers.min, and the pool is not respawned past target", async () => {
     const home = tmpDir("evrt-pool-down-");
     const dir = tmpDir("evrt-pool-down-run-");
@@ -191,6 +274,18 @@ describe("supervise (WM-226)", () => {
     );
     try {
       expect(await waitFor(box, "spawn slot 2", 30_000)).toBe(true);
+      // A stale backoff for an unavailable slot must not turn a scale-down
+      // decision into a retry hold; draining live capacity remains safe.
+      writeFileSync(
+        path.join(dir, "worker-3.crash-loop.json"),
+        JSON.stringify({
+          fastExits: 3,
+          spawnedAt: null,
+          workerId: "previous-worker",
+          nextAttemptAt: Date.now() + 60_000,
+          loggedRetryAt: null,
+        }),
+      );
       expect(await waitFor(box, "drain slot", 30_000)).toBe(true);
       expect(box.out).toMatch(
         /drain slot \d+ \(worker \S+\): \d+ idle worker\(s\) and no queued runs, pool 2 above workers.min 1/,

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -10,7 +10,12 @@ import {
 } from "node:fs";
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
-import { readPool, workerPassthroughArgs } from "./supervise.mjs";
+import { registerWorker } from "../lib/workers.mjs";
+import {
+  crashBackoffMs,
+  readPool,
+  workerPassthroughArgs,
+} from "./supervise.mjs";
 import {
   CLI,
   DEAD_PORT,
@@ -192,12 +197,45 @@ describe("supervise (WM-226)", () => {
         ),
       ).toBe(true);
       expect(readPool(dir).slots[0].crashLoops).toBeGreaterThanOrEqual(4);
+      expect(crashBackoffMs(3)).toBe(2_000);
+      expect(crashBackoffMs(4)).toBe(4_000);
+      expect(crashBackoffMs(8)).toBe(60_000);
     } finally {
       await killPool(box, dir);
       rmSync(home, { recursive: true, force: true });
       rmSync(dir, { recursive: true, force: true });
     }
   }, 45_000);
+
+  test("--once reports a persisted crash-loop hold without respawning", () => {
+    const home = tmpDir("evrt-pool-crash-once-");
+    const dir = tmpDir("evrt-pool-crash-once-run-");
+    try {
+      writeFileSync(
+        path.join(dir, "worker-1.crash-loop.json"),
+        JSON.stringify({
+          fastExits: 3,
+          spawnedAt: null,
+          workerId: "failed-worker",
+          nextAttemptAt: Date.now() + 16_000,
+          loggedRetryAt: null,
+        }),
+      );
+      const result = runCli(["supervise", "--workers", "1:1", "--once"], {
+        FACTORY_EVENT_HOME: home,
+        FACTORY_RUN_DIR: dir,
+      });
+      expect(result.status).toBe(0);
+      expect(result.all).toMatch(
+        /crash-loop slot 1: 3 fast exits, next attempt in \d+s/,
+      );
+      expect(readPool(dir).slots[0].crashLoops).toBe(3);
+      expect(existsSync(path.join(dir, "worker-1.pid"))).toBe(false);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   test("a registered worker that survives grace resets its crash-loop counter", async () => {
     const home = tmpDir("evrt-pool-crash-reset-");
@@ -246,34 +284,27 @@ describe("supervise (WM-226)", () => {
   test("surplus idle workers drain back to workers.min, and the pool is not respawned past target", async () => {
     const home = tmpDir("evrt-pool-down-");
     const dir = tmpDir("evrt-pool-down-run-");
-    // Two short hangs: long enough to force a second worker, short enough that
-    // both go idle while the supervisor is still watching.
-    for (const runId of ["run_drain_a", "run_drain_b"]) {
-      await seedRun(home, {
-        runId,
-        input: { repos: ["hang"] },
-        timeoutSeconds: 3,
-      });
-    }
-    const box = spawnSupervisor(
-      [
-        "--workers",
-        "1:2",
-        "--interval-ms",
-        "150",
-        "--spawn-grace-ms",
-        "150",
-        "--adapter-override",
-        "fake",
-        "--poll-ms",
-        "50",
-        "--drain-timeout",
-        "1",
-      ],
-      { FACTORY_EVENT_HOME: home, FACTORY_RUN_DIR: dir },
-    );
+    const children = [];
+    let box = null;
     try {
-      expect(await waitFor(box, "spawn slot 2", 30_000)).toBe(true);
+      // Adopt two known-idle processes instead of waiting on timed fake runs.
+      // That keeps this a supervisor decision test even on a loaded worker,
+      // where run timeouts can otherwise leave transient busy registry rows.
+      const db = openDb(path.join(home, "runtime.db"));
+      for (const n of [1, 2]) {
+        const workerId = `worker_drain_${n}`;
+        registerWorker(db, { workerId });
+        const child = spawn(
+          process.execPath,
+          ["-e", "setInterval(() => {}, 60_000)"],
+          { stdio: "ignore" },
+        );
+        children.push(child);
+        writeFileSync(path.join(dir, `worker-${n}.pid`), `${child.pid}\n`);
+        writeFileSync(path.join(dir, `worker-${n}.id`), `${workerId}\n`);
+      }
+      db.close();
+
       // A stale backoff for an unavailable slot must not turn a scale-down
       // decision into a retry hold; draining live capacity remains safe.
       writeFileSync(
@@ -286,7 +317,12 @@ describe("supervise (WM-226)", () => {
           loggedRetryAt: null,
         }),
       );
-      expect(await waitFor(box, "drain slot", 30_000)).toBe(true);
+
+      box = spawnSupervisor(["--workers", "1:2", "--interval-ms", "100"], {
+        FACTORY_EVENT_HOME: home,
+        FACTORY_RUN_DIR: dir,
+      });
+      expect(await waitFor(box, "drain slot", 10_000)).toBe(true);
       expect(box.out).toMatch(
         /drain slot \d+ \(worker \S+\): \d+ idle worker\(s\) and no queued runs, pool 2 above workers.min 1/,
       );
@@ -294,19 +330,22 @@ describe("supervise (WM-226)", () => {
       expect(box.out).toContain(
         "it exits at its next idle poll boundary, never mid-run",
       );
-      expect(await waitFor(box, "slot released", 30_000)).toBe(true);
+      const drainedSlot = Number(/drain slot (\d+)/.exec(box.out)?.[1]);
+      expect(drainedSlot).toBeGreaterThanOrEqual(1);
+      children[drainedSlot - 1].kill("SIGKILL");
+      await exitOf(children[drainedSlot - 1]);
+      expect(await waitFor(box, "slot released", 10_000)).toBe(true);
+      expect(await waitFor(box, "steady: 0 queued", 10_000)).toBe(true);
 
-      // Converged at min and stayed there — a drain that is immediately undone
-      // by the next tick's spawn is a busy loop, not a scale-down.
-      const deadline = Date.now() + 3_000;
-      while (Date.now() < deadline) {
-        expect(await poolSize(dir)).toBeLessThanOrEqual(2);
-        await Bun.sleep(200);
-      }
+      // Converged at min and did not immediately undo the drain.
       expect(await poolSize(dir)).toBe(1);
-      expect(box.out.split("spawn slot").length - 1).toBe(2); // slots 1 and 2, no third
+      expect(box.out).not.toContain("spawn slot");
     } finally {
-      await killPool(box, dir);
+      if (box) await killPool(box, dir);
+      for (const child of children) {
+        if (child.exitCode == null && child.signalCode == null)
+          child.kill("SIGKILL");
+      }
       rmSync(home, { recursive: true, force: true });
       rmSync(dir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Fixes watt-mind/factory#1437

Review the durable per-slot crash-loop backoff and deterministic recovery coverage.

## Validation

| Check                | Command                                                                                                  | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/cli/supervise.test.mjs --timeout 20000`                                          | pass    | 8 tests, 0 failures                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`        | pass    | 1982 pass, emit and format clean       |
| UX critique          | factory-ux-critic                                                                                        | not run | backend supervisor has no user surface |

UX critique: skipped

## Handoff

- Post-review (1eeab2c5): `getPoolLines` now ignores slots that have neither a pidfile nor a non-zero crash-loop counter, so a leftover `worker-N.crash-loop.json` with `fastExits: 0` after a clean pool stop no longer fabricates a `pool supervisor absent workers 0` line on stacks that never ran a pool. The durable backoff file is still kept across restarts. New status.test case covers the leftover-file case and confirms a real counter (`fastExits: 2`) still prints `crashLoops slot 1: 2`.
- Post-review (polish): `writeCrashLoop` writes tmp + `renameSync`, so a concurrent `status` never reads a torn crash-loop file.
- Verified: `bun test event-runtime/cli/supervise.test.mjs event-runtime/cli/status.test.mjs` (17 pass), `bun test event-runtime/lib` (1992 pass), `bun build/emit.mjs --check`, `format:check`, `bun run check` all green.
