### PR TITLE
test(work): make WM-213 reload deterministic

### DIFF
--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -15,6 +15,7 @@ import {
   CLI,
   DEAD_PORT,
   assertHealthyLiveServe,
+  awaitFile,
   editStampRoot,
   exitOf,
   killPool,
@@ -659,8 +660,11 @@ describe("work --reload-on-change (WM-213)", () => {
         // No commit — only a working-tree write. HEAD is unchanged (this tree has
         // no git at all), so a HEAD-only stamp would sit here forever.
         editStampRoot(stampRoot, "// v2\n");
-        const { code } = await exitOf(box.child);
-        expect(code).toBe(75);
+        const { code, signal } = await exitOf(box.child);
+        expect({ code, signal, tail: box.out.slice(-600) }).toMatchObject({
+          code: 75,
+          signal: null,
+        });
         expect(box.out).toContain("reloading worker (exit 75)");
         // The log names both stamps so the developer can see what moved.
         expect(box.out).toMatch(
@@ -696,8 +700,11 @@ describe("work --reload-on-change (WM-213)", () => {
           "// v2\n",
           "utf8",
         );
-        const { code } = await exitOf(box.child);
-        expect(code).toBe(75);
+        const { code, signal } = await exitOf(box.child);
+        expect({ code, signal, tail: box.out.slice(-600) }).toMatchObject({
+          code: 75,
+          signal: null,
+        });
         expect(box.out).toContain("reloading worker (exit 75)");
       } finally {
         box.child.kill("SIGKILL");
@@ -713,14 +720,18 @@ describe("work --reload-on-change (WM-213)", () => {
       const { openDb } = await import("../lib/db.mjs");
       const { createRun, transition } = await import("../lib/lifecycle.mjs");
       const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");
+      const { HOLD_PREFIX, holdMarkerFile } =
+        await import("../lib/adapters/fake.mjs");
 
       const home = tmpDir("evrt-reload-busy-");
       const stampRoot = makeStampRoot();
       const db = openDb(path.join(home, "runtime.db"));
 
-      // The fake adapter's "hang" mode occupies the worker for the whole spec
-      // timeout — the in-flight window this reload must not interrupt.
-      const input = { repos: ["hang"] };
+      // The fake adapter's hold mode keeps the run in flight until this file
+      // exists — the in-flight window is opened and closed by the test, not by
+      // the wall clock (gh-1423). The spec timeout is only a safety net.
+      const releaseFile = path.join(home, "release-run_reload_busy");
+      const input = { repos: [`${HOLD_PREFIX}${releaseFile}`] };
       const spec = {
         schemaVersion: "factory.run-spec/v1",
         runId: "run_reload_busy",
@@ -733,7 +744,7 @@ describe("work --reload-on-change (WM-213)", () => {
         policyVersion: WORKER_POLICY_VERSION,
         outputContract: "factory.status-report/v1",
         capabilities: ["linear:read"],
-        timeoutSeconds: 4,
+        timeoutSeconds: 120,
         maxAttempts: 1,
         idempotencyKey: "idem_reload_busy",
       };
@@ -767,6 +778,7 @@ describe("work --reload-on-change (WM-213)", () => {
         input: { repos: ["ok"] },
       });
 
+      const DEADLINE_MS = 30_000;
       const box = spawnWorker(
         ["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"],
         {
@@ -775,27 +787,48 @@ describe("work --reload-on-change (WM-213)", () => {
         },
       );
       try {
-        expect(await waitFor(box, "claimed run_reload_busy")).toBe(true);
+        expect(await waitFor(box, "claimed run_reload_busy", DEADLINE_MS)).toBe(
+          true,
+        );
+        // Proven in flight: the adapter has entered the hold, not merely been
+        // claimed — so the edit below lands strictly inside the run.
+        await awaitFile(holdMarkerFile(releaseFile), "hold marker", {
+          timeoutMs: DEADLINE_MS,
+        });
         editStampRoot(stampRoot, "// v2\n");
 
         expect(
-          await waitFor(box, "reload deferred until run_reload_busy finishes"),
+          await waitFor(
+            box,
+            "reload deferred until run_reload_busy finishes",
+            DEADLINE_MS,
+          ),
         ).toBe(true);
-        // Proven, not assumed: the deferral was logged while the run was still
-        // going, and the worker was still alive at that point.
+        // The deferral was logged while the run was still held open, and the
+        // worker was still alive at that point — asserted, not slept for.
         expect(box.out).not.toContain("run_reload_busy → ");
+        expect(box.out).not.toContain("reloading worker");
+        expect(box.out).not.toContain("worker stopped");
         expect(box.child.exitCode).toBe(null);
 
-        const { code } = await exitOf(box.child);
-        expect(code).toBe(75);
+        writeFileSync(releaseFile, "go\n", "utf8");
+        const { code, signal } = await exitOf(box.child, DEADLINE_MS);
+        expect({ code, signal, tail: box.out.slice(-600) }).toMatchObject({
+          code: 75,
+          signal: null,
+        });
         // Order is the guarantee: the run reached a terminal state BEFORE the reload.
-        expect(box.out.indexOf("run_reload_busy → ")).toBeGreaterThan(-1);
+        expect(box.out).toContain("run_reload_busy → COMPLETED");
         expect(box.out.indexOf("run_reload_busy → ")).toBeLessThan(
           box.out.indexOf("reloading worker"),
         );
         expect(box.out).not.toContain("claimed run_reload_waiting");
-        // And exactly one deferral line, however many intervals it spanned.
+        // Exactly one deferral line however many intervals it spanned, and
+        // exactly one exit — counted from the worker's own stop events.
         expect(box.out.split("reload deferred until").length - 1).toBe(1);
+        expect(box.out.split("reloading worker (exit 75)").length - 1).toBe(1);
+        expect(box.out.split("worker stopped (").length - 1).toBe(1);
+        expect(box.out).toContain("worker stopped (code_reload)");
       } finally {
         box.child.kill("SIGKILL");
         rmSync(stampRoot, { recursive: true, force: true });
@@ -805,10 +838,10 @@ describe("work --reload-on-change (WM-213)", () => {
       const row = verifyDb
         .query(`SELECT state FROM runs WHERE run_id = ?`)
         .get("run_reload_busy");
-      expect(["TIMED_OUT", "FAILED", "COMPLETED"]).toContain(row?.state);
+      expect(row?.state).toBe("COMPLETED");
       verifyDb.close();
     },
-    loadAdjustedTimeout(45_000),
+    loadAdjustedTimeout(90_000),
   );
 });
 

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -37,6 +37,27 @@ registerCliTmpCleanup();
 registerTestProcessCleanup(import.meta.url);
 
 const WORKER_POLICY_VERSION = policyVersion();
+const LIVE_STACK = path.resolve(import.meta.dir, "../../bin/live-stack.sh");
+
+/** Capture the shell supervisor's restart events, not just its worker's logs. */
+function spawnReloadSupervisor(args, env) {
+  const child = spawnTracked(
+    "bash",
+    [LIVE_STACK, "__supervise-worker", ...args],
+    {
+      env: { ...process.env, ...env },
+      stdio: ["ignore", "pipe", "pipe"],
+    },
+  );
+  const box = { out: "", child };
+  child.stdout.on("data", (b) => {
+    box.out += b;
+  });
+  child.stderr.on("data", (b) => {
+    box.out += b;
+  });
+  return box;
+}
 
 describe("work command", () => {
   test("work rejects an unsafe idle poll interval", () => {
@@ -715,7 +736,7 @@ describe("work --reload-on-change (WM-213)", () => {
   );
 
   test(
-    "a run in flight defers the reload; the worker restarts only once it is idle",
+    "a run in flight defers reload; its supervisor restarts only once it is idle",
     async () => {
       const { openDb } = await import("../lib/db.mjs");
       const { createRun, transition } = await import("../lib/lifecycle.mjs");
@@ -779,7 +800,7 @@ describe("work --reload-on-change (WM-213)", () => {
       });
 
       const DEADLINE_MS = 30_000;
-      const box = spawnWorker(
+      const box = spawnReloadSupervisor(
         ["--adapter-override", "fake", "--poll-ms", "50", "--reload-on-change"],
         {
           FACTORY_EVENT_HOME: home,
@@ -808,29 +829,41 @@ describe("work --reload-on-change (WM-213)", () => {
         // worker was still alive at that point — asserted, not slept for.
         expect(box.out).not.toContain("run_reload_busy → ");
         expect(box.out).not.toContain("reloading worker");
-        expect(box.out).not.toContain("worker stopped");
+        expect(box.out).not.toContain("[supervisor] worker reloaded");
         expect(box.child.exitCode).toBe(null);
 
         writeFileSync(releaseFile, "go\n", "utf8");
-        const { code, signal } = await exitOf(box.child, DEADLINE_MS);
-        expect({ code, signal, tail: box.out.slice(-600) }).toMatchObject({
-          code: 75,
-          signal: null,
-        });
-        // Order is the guarantee: the run reached a terminal state BEFORE the reload.
+        // Observe the handoff from the component that actually restarts the
+        // worker. The replacement then claims the queued run, proving it was
+        // re-execed only after the held lease was released.
+        expect(
+          await waitFor(
+            box,
+            "[supervisor] worker reloaded (exit 75) — restarting on new code",
+            DEADLINE_MS,
+          ),
+        ).toBe(true);
+        expect(
+          await waitFor(box, "claimed run_reload_waiting", DEADLINE_MS),
+        ).toBe(true);
+        expect(
+          await waitFor(box, "run_reload_waiting → COMPLETED", DEADLINE_MS),
+        ).toBe(true);
+        // Order is the guarantee: the held run reached a terminal state before
+        // the supervisor accepted the reload handoff.
         expect(box.out).toContain("run_reload_busy → COMPLETED");
         expect(box.out.indexOf("run_reload_busy → ")).toBeLessThan(
-          box.out.indexOf("reloading worker"),
+          box.out.indexOf("[supervisor] worker reloaded"),
         );
-        expect(box.out).not.toContain("claimed run_reload_waiting");
         // Exactly one deferral line however many intervals it spanned, and
-        // exactly one exit — counted from the worker's own stop events.
+        // exactly one reload recorded by the supervisor that owns restarts.
         expect(box.out.split("reload deferred until").length - 1).toBe(1);
-        expect(box.out.split("reloading worker (exit 75)").length - 1).toBe(1);
-        expect(box.out.split("worker stopped (").length - 1).toBe(1);
-        expect(box.out).toContain("worker stopped (code_reload)");
+        expect(box.out.split("[supervisor] worker reloaded").length - 1).toBe(
+          1,
+        );
       } finally {
-        box.child.kill("SIGKILL");
+        box.child.kill("SIGTERM");
+        await exitOf(box.child, DEADLINE_MS);
         rmSync(stampRoot, { recursive: true, force: true });
       }
 

--- a/event-runtime/lib/adapters/fake.mjs
+++ b/event-runtime/lib/adapters/fake.mjs
@@ -75,6 +75,49 @@ function ciDoctorArtifact(input) {
   };
 }
 
+/**
+ * `hold:<file>` (gh-1423) — the run stays in flight until <file> exists (the
+ * test's release signal), then completes normally. `<file>.held` is written
+ * the moment the adapter starts waiting, so a test can prove the run is
+ * inside the hold before acting, instead of guessing from wall-clock time.
+ * Abort resolves at once (like "hang"); the spec timeout still bounds it.
+ */
+export const HOLD_PREFIX = "hold:";
+export const HOLD_POLL_MS = 25;
+
+export const holdMarkerFile = (releaseFile) => `${releaseFile}.held`;
+
+/** Resolves "released" | "aborted" | "timed_out"; never throws on a lost race. */
+export async function holdUntilReleased({
+  releaseFile,
+  timeoutMs,
+  signal,
+  pollMs = HOLD_POLL_MS,
+}) {
+  if (!releaseFile)
+    throw new Error("fake: hold mode needs a release file path");
+  if (signal?.aborted) return "aborted";
+  writeFileSync(holdMarkerFile(releaseFile), `${Date.now()}\n`, "utf8");
+  const deadline = Date.now() + Math.max(0, Number(timeoutMs) || 0);
+  return new Promise((resolve) => {
+    let timer = null;
+    const done = (outcome) => {
+      clearTimeout(timer);
+      signal?.removeEventListener?.("abort", onAbort);
+      resolve(outcome);
+    };
+    const onAbort = () => done("aborted");
+    signal?.addEventListener?.("abort", onAbort, { once: true });
+    const tick = () => {
+      if (signal?.aborted) return done("aborted");
+      if (existsSync(releaseFile)) return done("released");
+      if (Date.now() >= deadline) return done("timed_out");
+      timer = setTimeout(tick, pollMs);
+    };
+    tick();
+  });
+}
+
 export const FAKE_PLAN_SHA = "c".repeat(40);
 
 export function mergeScanArtifact(repo) {
@@ -550,6 +593,25 @@ export async function execute({
   }
 
   const mode = spec.input?.repos?.[0];
+
+  if (typeof mode === "string" && mode.startsWith(HOLD_PREFIX)) {
+    // Held open until the test releases it — a deterministic in-flight
+    // window that does not depend on the spec timeout (gh-1423).
+    const outcome = await holdUntilReleased({
+      releaseFile: mode.slice(HOLD_PREFIX.length),
+      timeoutMs,
+      signal: abortSignal ?? signal,
+    });
+    if (outcome !== "released")
+      return { exitCode: null, timedOut: outcome === "timed_out" };
+    writeResult(workspaceDir, {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: { repos: [repoRow("hold")], recommendedAction: "wait" },
+      evidence: { queries: ["fake"], released: true },
+    });
+    return { exitCode: 0, timedOut: false };
+  }
 
   switch (mode) {
     case "with-artifact": {

--- a/event-runtime/lib/adapters/fake.test.mjs
+++ b/event-runtime/lib/adapters/fake.test.mjs
@@ -1,0 +1,110 @@
+import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-fake-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  HOLD_PREFIX,
+  execute,
+  holdMarkerFile,
+  holdUntilReleased,
+} from "./fake.mjs";
+import { until } from "../test-helpers-timing.mjs";
+
+const def = { ref: "factory-status-report@1" };
+const spec = (mode) => ({
+  agent: "factory-status-report@1",
+  outputContract: "factory.status-report/v1",
+  input: { repos: [mode] },
+});
+
+/** A pending promise's state, without racing a timer against it. */
+async function settled(promise) {
+  const marker = Symbol("pending");
+  const winner = await Promise.race([promise, Promise.resolve(marker)]);
+  return winner !== marker;
+}
+
+describe("fake adapter hold/release (gh-1423)", () => {
+  test("hold:<file> stays in flight until the release file exists, then completes", async () => {
+    const dir = tmpDir("evrt-fake-hold-");
+    const ws = tmpDir("evrt-fake-hold-ws-");
+    const releaseFile = path.join(dir, "release");
+    const run = execute({
+      spec: spec(`${HOLD_PREFIX}${releaseFile}`),
+      def,
+      workspaceDir: ws,
+      timeoutMs: 30_000,
+      env: {},
+    });
+
+    // The marker is the positive signal that the adapter is inside the hold.
+    await until("hold marker to appear", () =>
+      existsSync(holdMarkerFile(releaseFile)),
+    );
+    expect(await settled(run)).toBe(false);
+    expect(existsSync(path.join(ws, "result.json"))).toBe(false);
+
+    writeFileSync(releaseFile, "go\n", "utf8");
+    const outcome = await run;
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(
+      readFileSync(path.join(ws, "result.json"), "utf8"),
+    );
+    expect(result.terminalState).toBe("completed");
+    expect(result.artifact.repos[0].name).toBe("hold");
+  });
+
+  test("a held run times out when never released", async () => {
+    const dir = tmpDir("evrt-fake-hold-timeout-");
+    const ws = tmpDir("evrt-fake-hold-timeout-ws-");
+    const outcome = await execute({
+      spec: spec(`${HOLD_PREFIX}${path.join(dir, "never")}`),
+      def,
+      workspaceDir: ws,
+      timeoutMs: 60,
+      env: {},
+    });
+    expect(outcome).toEqual({ exitCode: null, timedOut: true });
+    expect(existsSync(path.join(ws, "result.json"))).toBe(false);
+  });
+
+  test("abort releases a held run immediately, and is not a timeout", async () => {
+    const dir = tmpDir("evrt-fake-hold-abort-");
+    const ws = tmpDir("evrt-fake-hold-abort-ws-");
+    const controller = new AbortController();
+    const run = execute({
+      spec: spec(`${HOLD_PREFIX}${path.join(dir, "never")}`),
+      def,
+      workspaceDir: ws,
+      timeoutMs: 30_000,
+      env: {},
+      abortSignal: controller.signal,
+    });
+    await until("hold marker to appear", () =>
+      existsSync(holdMarkerFile(path.join(dir, "never"))),
+    );
+    controller.abort();
+    expect(await run).toEqual({ exitCode: null, timedOut: false });
+  });
+
+  test("holdUntilReleased resolves aborted at once on an already-aborted signal", async () => {
+    const dir = tmpDir("evrt-fake-hold-preaborted-");
+    const releaseFile = path.join(dir, "release");
+    const controller = new AbortController();
+    controller.abort();
+    expect(
+      await holdUntilReleased({
+        releaseFile,
+        timeoutMs: 30_000,
+        signal: controller.signal,
+      }),
+    ).toBe("aborted");
+    expect(existsSync(holdMarkerFile(releaseFile))).toBe(false);
+  });
+
+  test("hold mode refuses an empty release path", async () => {
+    expect(
+      holdUntilReleased({ releaseFile: "", timeoutMs: 10 }),
+    ).rejects.toThrow("hold mode needs a release file path");
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1423

## Summary
- **fake adapter**: new `hold:<file>` mode keeps a run in flight until `<file>` exists, writes `<file>.held` the moment the wait starts, honours abort and the spec timeout (`event-runtime/lib/adapters/fake.mjs`), with focused coverage in the new `fake.test.mjs` (release, timeout, abort, pre-aborted, empty path).
- **work.test.mjs** (WM-213): the busy-reload test opens and closes the in-flight window with the release file instead of a 4 s `hang`; every wait is a ≥30 s deadline poll (`waitFor` / `awaitFile`); the run's terminal state is asserted as `COMPLETED` (deterministic, not `TIMED_OUT|FAILED|COMPLETED`).
- The restart-once assertion is observed through the shell supervisor (`bin/live-stack.sh __supervise-worker`): exactly one `[supervisor] worker reloaded (exit 75)` line, and the replacement worker goes on to claim/complete the queued run — the run reached its terminal state before the supervisor accepted the handoff.
- The two idle-reload tests now attach the worker output tail and signal to the exit assertion, so a future failure says what the worker was doing instead of `expected 75, received null`.

## Verification
- `bun test event-runtime/cli/work.test.mjs --timeout 60000` — 15 pass, 0 fail
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` — 1976 pass, 0 fail; emit/format/check green

## Handoff
- Under concurrent load (`bun test event-runtime/lib --timeout 20000` looping alongside, load avg 9–14): **30/30** consecutive green on the hold/release commit (33b9c6cc) and **10/10** green on the final head (4f40df95, supervisor-observed variant). The idle-reload case that stopped the previous attempt at 10/50 did not reproduce in 40 runs; its exit assertion now carries the output tail so it can be diagnosed if it recurs.
- The dispatch agent's earlier comment referenced "WM-1070" (a Linear id) for that flake — Linear is not this repo's control plane; nothing is filed there for this.
