### PR TITLE
perf(web): memoize artifact previews

### DIFF
--- a/event-runtime/web/src/views/ArtifactFull.tsx
+++ b/event-runtime/web/src/views/ArtifactFull.tsx
@@ -78,15 +78,24 @@ export function ArtifactFull({
     staleTime: 30_000,
   });
 
-  const selectedKinds = selected ? kindsOf(selected) : [];
+  const selectedKinds = useMemo(
+    () => (selected ? kindsOf(selected) : []),
+    [selected],
+  );
   const selectedName = digest ? downloadName(digest, selectedKinds) : "";
   const shortDigest = digest.slice(0, 12);
 
-  const binary = contentQ.data !== undefined && looksBinary(contentQ.data);
-  const preview =
-    contentQ.data === undefined || binary
-      ? null
-      : formattedContent(contentQ.data, selectedKinds);
+  const binary = useMemo(
+    () => contentQ.data !== undefined && looksBinary(contentQ.data),
+    [contentQ.data],
+  );
+  const preview = useMemo(
+    () =>
+      contentQ.data === undefined || binary
+        ? null
+        : formattedContent(contentQ.data, selectedKinds),
+    [contentQ.data, binary, selectedKinds],
+  );
 
   const parsedArtifact = useMemo(
     () => (contentQ.data === undefined ? null : parsedObject(contentQ.data)),
@@ -123,11 +132,13 @@ export function ArtifactFull({
     [preview],
   );
 
-  const matchCount = contentSearch.trim()
-    ? previewLines.filter((line) =>
-        line.toLowerCase().includes(contentSearch.trim().toLowerCase()),
-      ).length
-    : null;
+  const matchCount = useMemo(() => {
+    const search = contentSearch.trim().toLowerCase();
+    return search
+      ? previewLines.filter((line) => line.toLowerCase().includes(search))
+          .length
+      : null;
+  }, [contentSearch, previewLines]);
 
   const toggleRaw = useCallback(() => {
     setArtifactRaw((prev) => {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -1,5 +1,5 @@
 import "../test-dom";
-import { afterEach, describe, expect, mock, test } from "bun:test";
+import { afterEach, describe, expect, jest, mock, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
   act,
@@ -13,7 +13,12 @@ import { readFileSync } from "node:fs";
 import path from "node:path";
 import { useState } from "react";
 import type { ArtifactInventoryItem } from "../types";
-import { Artifacts, formatBytes, type ArtifactFilters } from "./Artifacts";
+import {
+  Artifacts,
+  formatBytes,
+  formattedContent,
+  type ArtifactFilters,
+} from "./Artifacts";
 import { ARTIFACT_RAW_KEY } from "../components/ArtifactView";
 import { handleRunArtifactClick } from "./Runs";
 
@@ -80,6 +85,7 @@ function renderArtifacts(
     items?: ArtifactInventoryItem[];
     agents?: unknown[];
     nextBefore?: string | null;
+    formatContent?: typeof formattedContent;
   } = {},
   onOpenFull = mock(() => {}),
 ) {
@@ -144,6 +150,7 @@ function renderArtifacts(
           onFiltersChange={setFilters}
           onJumpRun={onJumpRun}
           onOpenFull={onOpenFull}
+          formatContent={seed.formatContent}
         />
       </QueryClientProvider>
     );
@@ -443,6 +450,46 @@ describe("Artifacts inventory (WM-207)", () => {
     fireEvent.click(view.getByRole("button", { name: "Copy SHA-256" }));
     expect(writeText).toHaveBeenNthCalledWith(1, raw);
     expect(writeText).toHaveBeenNthCalledWith(2, "a".repeat(64));
+  });
+
+  test("formats a large artifact once across a useNow tick", async () => {
+    const raw = JSON.stringify({
+      entries: Array.from({ length: 10_000 }, (_, index) => ({
+        index,
+        message: `artifact line ${index}`,
+      })),
+    });
+    const intervalSpy = jest.spyOn(globalThis, "setInterval");
+    let tick: (() => void) | undefined;
+    intervalSpy.mockImplementation((callback, delay, ...args) => {
+      if (delay === 1_000 && typeof callback === "function")
+        tick = () => callback(...args);
+      return 0 as unknown as ReturnType<typeof setInterval>;
+    });
+    const formatContent = mock(formattedContent);
+    globalThis.fetch = mock(
+      async () => new Response(raw, { status: 200 }),
+    ) as unknown as typeof fetch;
+    window.location.hash = `#/artifacts/${"a".repeat(64)}`;
+
+    try {
+      const view = renderArtifacts(undefined, undefined, { formatContent });
+      await view.findByRole("region", { name: "Artifact content" });
+      expect(formatContent).toHaveBeenCalledTimes(1);
+
+      expect(typeof tick).toBe("function");
+      const realDateNow = Date.now;
+      Date.now = () => realDateNow() + 1_000;
+      try {
+        act(() => (tick as () => void)());
+      } finally {
+        Date.now = realDateNow;
+      }
+
+      expect(formatContent).toHaveBeenCalledTimes(1);
+    } finally {
+      intervalSpy.mockRestore();
+    }
   });
 
   test("selects a row into the inspector and routes run artifact links to the same deep link", async () => {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -459,13 +459,8 @@ describe("Artifacts inventory (WM-207)", () => {
         message: `artifact line ${index}`,
       })),
     });
-    const intervalSpy = jest.spyOn(globalThis, "setInterval");
-    let tick: (() => void) | undefined;
-    intervalSpy.mockImplementation((callback, delay, ...args) => {
-      if (delay === 1_000 && typeof callback === "function")
-        tick = () => callback(...args);
-      return 0 as unknown as ReturnType<typeof setInterval>;
-    });
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date("2026-08-30T00:00:00.000Z"));
     const formatContent = mock(formattedContent);
     globalThis.fetch = mock(
       async () => new Response(raw, { status: 200 }),
@@ -477,18 +472,12 @@ describe("Artifacts inventory (WM-207)", () => {
       await view.findByRole("region", { name: "Artifact content" });
       expect(formatContent).toHaveBeenCalledTimes(1);
 
-      expect(typeof tick).toBe("function");
-      const realDateNow = Date.now;
-      Date.now = () => realDateNow() + 1_000;
-      try {
-        act(() => (tick as () => void)());
-      } finally {
-        Date.now = realDateNow;
-      }
+      act(() => jest.advanceTimersByTime(1_000));
 
       expect(formatContent).toHaveBeenCalledTimes(1);
     } finally {
-      intervalSpy.mockRestore();
+      cleanup();
+      jest.useRealTimers();
     }
   });
 

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -270,12 +270,15 @@ export function Artifacts({
   onFiltersChange,
   onJumpRun,
   onOpenFull,
+  formatContent = formattedContent,
 }: {
   metrics?: StatusView["artifacts"];
   filters: ArtifactFilters;
   onFiltersChange: (filters: ArtifactFilters) => void;
   onJumpRun: (runId: string) => void;
   onOpenFull?: (digest: string) => void;
+  /** Injectable formatter keeps the expensive preview derivation testable. */
+  formatContent?: typeof formattedContent;
 }) {
   const now = useNow();
   const artifactsQ = useQuery({
@@ -403,15 +406,24 @@ export function Artifacts({
       ),
     [linkedEvents, producerRunIds],
   );
-  const selectedKinds = selected ? kindsOf(selected) : [];
+  const selectedKinds = useMemo(
+    () => (selected ? kindsOf(selected) : []),
+    [selected],
+  );
   const selectedName = selectedSha
     ? downloadName(selectedSha, selectedKinds)
     : "";
-  const binary = contentQ.data !== undefined && looksBinary(contentQ.data);
-  const preview =
-    contentQ.data === undefined || binary
-      ? null
-      : formattedContent(contentQ.data, selectedKinds);
+  const binary = useMemo(
+    () => contentQ.data !== undefined && looksBinary(contentQ.data),
+    [contentQ.data],
+  );
+  const preview = useMemo(
+    () =>
+      contentQ.data === undefined || binary
+        ? null
+        : formatContent(contentQ.data, selectedKinds),
+    [contentQ.data, binary, selectedKinds, formatContent],
+  );
   const parsedArtifact = useMemo(
     () => (contentQ.data === undefined ? null : parsedObject(contentQ.data)),
     [contentQ.data],
@@ -438,12 +450,14 @@ export function Artifacts({
     parsedArtifact !== null &&
     viewApplies(producerAgent?.outputView, parsedArtifact) &&
     !artifactRaw;
-  const previewLines = preview?.split("\n") ?? [];
-  const matchCount = contentSearch.trim()
-    ? previewLines.filter((line) =>
-        line.toLowerCase().includes(contentSearch.trim().toLowerCase()),
-      ).length
-    : null;
+  const previewLines = useMemo(() => preview?.split("\n") ?? [], [preview]);
+  const matchCount = useMemo(() => {
+    const search = contentSearch.trim().toLowerCase();
+    return search
+      ? previewLines.filter((line) => line.toLowerCase().includes(search))
+          .length
+      : null;
+  }, [contentSearch, previewLines]);
 
   const selectArtifact = (sha256: string) => {
     setContentSearch("");


### PR DESCRIPTION
Fixes watt-mind/factory#1418

Review that unchanged artifact content is formatted only once across clock-driven rerenders.

## Validation

| Check                | Command                                                                                         | Result  | Notes                              |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Artifacts.test.tsx src/views/ArtifactFull.test.tsx` | pass    | 39 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1976 pass, 10 skipped, 0 failures |
| UX critique          | `factory-ux-critic`                                                                              | not run | no user-facing flow changed        |

UX critique: skipped — no user-facing flow changed