### PR TITLE
perf(web): memoize run tab counts

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -9,7 +9,12 @@ import {
 } from "bun:test";
 import { act, cleanup, fireEvent, waitFor } from "@testing-library/react";
 import { useState } from "react";
-import { Runs, runDrilldownFilters, statesForRunTab } from "./Runs";
+import {
+  Runs,
+  countRunsByTab,
+  runDrilldownFilters,
+  statesForRunTab,
+} from "./Runs";
 import {
   changeInput,
   createAgentsFixture,
@@ -56,6 +61,26 @@ test("reads a complete metrics drill-down contract from the hash", () => {
     agent: undefined,
   });
   expect(runDrilldownFilters("#/runs?population=terminal")).toBeNull();
+});
+
+test("counts each run state into its tab badge exactly once", () => {
+  const counts = countRunsByTab([
+    stubListItem("run_queued", "QUEUED"),
+    stubListItem("run_running", "RUNNING"),
+    stubListItem("run_completed", "COMPLETED"),
+    stubListItem("run_failed", "FAILED"),
+    stubListItem("run_refused", "REFUSED"),
+    stubListItem("run_cancelled", "CANCELLED"),
+    stubListItem("run_proposed", "PROPOSED"),
+  ]);
+
+  expect(counts).toEqual({
+    ALL: 7,
+    ACTIVE: 2,
+    COMPLETED: 1,
+    FAILED: 2,
+    CANCELLED: 1,
+  });
 });
 
 function stubListItem(
@@ -694,8 +719,17 @@ describe("Runs component harness: selection & filter retention", () => {
 
   test("tab counts describe the filtered set instead of the unfiltered totals", async () => {
     const rows = [
+      stubListItem("run_match_queued", "QUEUED", { agent: "triage-scan" }),
       stubListItem("run_match_active", "RUNNING", { agent: "triage-scan" }),
       stubListItem("run_match_done", "COMPLETED", { agent: "triage-scan" }),
+      stubListItem("run_match_failed", "FAILED", { agent: "triage-scan" }),
+      stubListItem("run_match_refused", "REFUSED", { agent: "triage-scan" }),
+      stubListItem("run_match_cancelled", "CANCELLED", {
+        agent: "triage-scan",
+      }),
+      stubListItem("run_match_proposed", "PROPOSED", {
+        agent: "triage-scan",
+      }),
       stubListItem("run_other_failed", "FAILED", { agent: "review-scan" }),
     ];
 
@@ -717,10 +751,11 @@ describe("Runs component harness: selection & filter retention", () => {
           );
         });
 
-        expect(r.getByRole("tab", { name: /^All 2$/i })).toBeTruthy();
-        expect(r.getByRole("tab", { name: /^Active 1$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^All 7$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Active 2$/i })).toBeTruthy();
         expect(r.getByRole("tab", { name: /^Completed 1$/i })).toBeTruthy();
-        expect(r.getByRole("tab", { name: /^Failed$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Failed 2$/i })).toBeTruthy();
+        expect(r.getByRole("tab", { name: /^Cancelled 1$/i })).toBeTruthy();
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -179,6 +179,24 @@ export function tabForRunState(state: string): RunTab {
   return "ALL";
 }
 
+export function countRunsByTab(
+  runs: readonly Pick<RunListItem, "state">[],
+): Record<RunTab, number> {
+  const counts: Record<RunTab, number> = {
+    ALL: 0,
+    ACTIVE: 0,
+    COMPLETED: 0,
+    FAILED: 0,
+    CANCELLED: 0,
+  };
+  for (const run of runs) {
+    counts.ALL += 1;
+    const stateTab = tabForRunState(run.state);
+    if (stateTab !== "ALL") counts[stateTab] += 1;
+  }
+  return counts;
+}
+
 const RUN_DRILLDOWN_POPULATIONS = new Set<RunListFilters["population"]>([
   "created",
   "terminal",
@@ -935,37 +953,31 @@ export function Runs({
     },
   });
 
-  const byState = statusQ.data?.runs?.byState ?? {};
-  const tabCount = (t: RunTab) => {
+  const byState = statusQ.data?.runs?.byState;
+  const tabCounts = useMemo((): Record<RunTab, number> => {
     if (filter.trim()) {
-      return t === "ALL"
-        ? filteredScoped.length
-        : filteredScoped.filter((r) => matchesRunTab(r.state, t)).length;
+      return countRunsByTab(filteredScoped);
     }
     if (fetchAll) {
-      return t === "ALL"
-        ? scoped.length
-        : scoped.filter((r) => matchesRunTab(r.state, t)).length;
+      return countRunsByTab(scoped);
     }
-    if (t === "ALL")
-      return Object.values(byState).reduce((n, v) => n + (v ?? 0), 0);
-    if (t === "ACTIVE")
-      return (
-        (byState.QUEUED ?? 0) +
-        (byState.LEASED ?? 0) +
-        (byState.RUNNING ?? 0) +
-        (byState.VERIFYING ?? 0)
-      );
-    if (t === "FAILED")
-      return (
-        (byState.FAILED ?? 0) +
-        (byState.TIMED_OUT ?? 0) +
-        (byState.REFUSED ?? 0)
-      );
-    if (t === "COMPLETED") return byState.COMPLETED ?? 0;
-    if (t === "CANCELLED") return byState.CANCELLED ?? 0;
-    return 0;
-  };
+    const counts: Record<RunTab, number> = {
+      ALL: 0,
+      ACTIVE: 0,
+      COMPLETED: 0,
+      FAILED: 0,
+      CANCELLED: 0,
+    };
+    for (const [state, count] of Object.entries(byState ?? {})) {
+      const value = count ?? 0;
+      counts.ALL += value;
+      const stateTab = tabForRunState(state);
+      if (stateTab !== "ALL") counts[stateTab] += value;
+    }
+    return counts;
+  }, [byState, fetchAll, filter, filteredScoped, scoped]);
+
+  const tabCount = (t: RunTab) => tabCounts[t];
 
   const selectTab = (t: RunTab) => {
     setTab(t);


### PR DESCRIPTION
Fixes #1461

Memoizes Runs tab badge aggregation while preserving filtered, fetch-all, and server-summary totals.

## Validation

| Check                | Command                                                                              | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `cd event-runtime/web && bun test src/views/Runs.test.tsx`                           | pass    | 41 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,982 pass; emit and formatting clean      |
| UX critique          | factory-ux-critic                                                                    | skipped | no material user-facing flow change        |

UX critique: skipped