### PR TITLE
fix(backend): resolve terminal chain failures

### DIFF
--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -22,6 +22,35 @@ import { tx } from "./db.mjs";
 export const CHAIN_SOURCE = "chain";
 
 /**
+ * How many passes a run may fail *transiently* (SQLITE_BUSY, disk I/O, an
+ * unexpected throw) before the resolver stops retrying it and records
+ * `chain_gave_up`. Deterministic failures never consume a pass: they resolve
+ * on first sight. Overridable per call via `maxTransientPasses`.
+ */
+export const CHAIN_MAX_TRANSIENT_PASSES = 5;
+
+/** `attempt_trace` markers (kind `lifecycle`) the resolver writes per run. */
+export const CHAIN_RESOLVED_NOTE = "chain_resolved";
+export const CHAIN_TRANSIENT_NOTE = "chain_transient_error";
+
+/**
+ * A failure that is a pure function of the persisted run/result/edges and
+ * would therefore recur identically on every later tick. Only these resolve
+ * the chain step on sight; anything else is treated as transient.
+ */
+export class ChainTerminalError extends Error {
+  constructor(message, reason = "invalid_chain_data") {
+    super(message);
+    this.name = "ChainTerminalError";
+    this.reason = reason;
+  }
+}
+
+function isTerminalError(err) {
+  return err instanceof ChainTerminalError || err instanceof SyntaxError;
+}
+
+/**
  * The only chain-provenance admission path. The source is assigned here after
  * the resolver has derived the edge; no envelope supplied by a caller can
  * select it through the public API.
@@ -40,16 +69,22 @@ function resolvePath(expr, context) {
   if (typeof expr !== "string" || !expr.startsWith("$.")) return expr; // literal
   const [root, ...segments] = expr.slice(2).split(".");
   if (!(root in context))
-    throw new Error(`chain input path "${expr}": unknown root "${root}"`);
+    throw new ChainTerminalError(
+      `chain input path "${expr}": unknown root "${root}"`,
+    );
   let value = context[root];
   for (const segment of segments) {
     if (value === null || typeof value !== "object" || !(segment in value)) {
-      throw new Error(`chain input path "${expr}" resolves to nothing`);
+      throw new ChainTerminalError(
+        `chain input path "${expr}" resolves to nothing`,
+      );
     }
     value = value[segment];
   }
   if (value === undefined)
-    throw new Error(`chain input path "${expr}" resolves to nothing`);
+    throw new ChainTerminalError(
+      `chain input path "${expr}" resolves to nothing`,
+    );
   return value;
 }
 
@@ -87,7 +122,7 @@ function chainCandidates(db, edges) {
   const placeholders = agents.map(() => "?").join(", ");
   return db
     .query(
-      `SELECT r.run_id, r.spec_json, res.result_json,
+      `SELECT r.run_id, r.attempts, r.spec_json, res.result_json,
               e.correlation_id, e.event_id AS origin_event_id, e.source AS origin_source
        FROM runs r
        JOIN results res ON res.run_id = r.run_id AND res.attempt = r.attempts
@@ -135,18 +170,35 @@ function existingChainEvents(db, edges) {
  * independent edges selected by non-empty artifact arrays (OPS-223, WM-119,
  * WM-430). Idempotent — derived event IDs dedup at intake, fully emitted sets
  * are zero-ops, and partially emitted sets resume with only missing siblings.
- * Invalid chain data and intake collisions are terminal too: reporting them
- * once is preferable to re-attempting a deterministic failure on every tick.
+ *
+ * Failure classification (#1458): a run's chain step is marked resolved only
+ * for *deterministic* outcomes — invalid chain data (`ChainTerminalError`,
+ * malformed spec/result JSON), intake refusals, and foreign-causation
+ * duplicates — because re-attempting those on every tick would only repeat
+ * the same report. Anything else (SQLITE_BUSY, disk I/O, an unexpected
+ * throw) leaves `chain_resolved_at` NULL so the run is retried on a later
+ * pass, with only the siblings that are still missing re-admitted; after
+ * `maxTransientPasses` such passes the run resolves with `chain_gave_up`.
+ * Every resolution writes an `attempt_trace` marker
+ * `{ note: "chain_resolved", reason, ... }` so an operator can see why no
+ * child event fired.
  *
  * @returns {{ emitted: number, skipped: number, errors: string[] }}
  */
-export function resolveChains(db, registry, { now = Date.now() } = {}) {
+export function resolveChains(
+  db,
+  registry,
+  { now = Date.now(), maxTransientPasses = CHAIN_MAX_TRANSIENT_PASSES } = {},
+) {
   const edges = registry.edges ?? {};
   const outcome = { emitted: 0, skipped: 0, errors: [] };
   const candidates = chainCandidates(db, edges);
   if (candidates.length === 0) return outcome;
   const existingByRun = existingChainEvents(db, edges);
-  const resolvedRunIds = [];
+  /** @type {Array<{ row: object, reason: string, detail?: object }>} */
+  const resolved = [];
+  /** @type {Array<{ row: object, error: string }>} */
+  const transient = [];
   const resolvedAt = new Date(now).toISOString();
 
   for (const row of candidates) {
@@ -165,7 +217,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
             );
             if (items == null) return false;
             if (!Array.isArray(items)) {
-              throw new Error(
+              throw new ChainTerminalError(
                 `independent chain selector "${candidate.whenItemsField}" is not an array`,
               );
             }
@@ -179,7 +231,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
               !Array.isArray(additionalKeys) ||
               additionalKeys.some((key) => typeof key !== "string")
             ) {
-              throw new Error(
+              throw new ChainTerminalError(
                 `chain edge "${recommendation}" also must be an array of edge keys`,
               );
             }
@@ -187,7 +239,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
               .map((key) => {
                 const candidate = rule.edges[key];
                 if (candidate === undefined) {
-                  throw new Error(
+                  throw new ChainTerminalError(
                     `chain edge "${recommendation}" references unknown sibling "${key}"`,
                   );
                 }
@@ -209,7 +261,7 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
         // is a legitimate terminal — record nothing, chain nothing, and do
         // not re-parse the same accepted result on every later tick.
         outcome.skipped += 1;
-        resolvedRunIds.push(row.run_id);
+        resolved.push({ row, reason: "no_edge_selected" });
         continue;
       }
 
@@ -263,7 +315,9 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
               itemKeyVal === null ||
               String(itemKeyVal).trim() === ""
             ) {
-              throw new Error(`multi-emit chain item missing key "${itemKey}"`);
+              throw new ChainTerminalError(
+                `multi-emit chain item missing key "${itemKey}"`,
+              );
             }
             const itemContext = {
               input: spec.input,
@@ -328,7 +382,9 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
 
       const ids = envelopes.map((envelope) => envelope.eventId);
       if (new Set(ids).size !== ids.length) {
-        throw new Error(`chain event IDs are not unique: ${ids.join(", ")}`);
+        throw new ChainTerminalError(
+          `chain event IDs are not unique: ${ids.join(", ")}`,
+        );
       }
 
       // A prior process may have stopped after admitting only part of a mixed
@@ -337,15 +393,31 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       // marker, not permission to backfill stale actions under today's edges.
       const existingIds = existingByRun.get(row.run_id) ?? new Set();
       if ([...existingIds].some((eventId) => !ids.includes(eventId))) {
-        resolvedRunIds.push(row.run_id);
+        resolved.push({
+          row,
+          reason: "stale_children",
+          detail: { existing: [...existingIds], expected: ids },
+        });
         continue;
       }
       const pending = envelopes.filter(
         (envelope) => !existingIds.has(envelope.eventId),
       );
-      let terminalFailure = false;
+      // Admit each missing sibling independently: a deterministic refusal
+      // resolves the run, but a transient throw on one sibling must neither
+      // resolve the run nor abandon the siblings that are still pending —
+      // the next pass re-admits exactly the ones that did not land.
+      const terminalErrors = [];
+      const transientErrors = [];
       for (const envelope of pending) {
-        const admitted = admitChainEvent(db, registry, envelope, { now });
+        let admitted;
+        try {
+          admitted = admitChainEvent(db, registry, envelope, { now });
+        } catch (err) {
+          if (isTerminalError(err)) throw err;
+          transientErrors.push(`${envelope.eventId}: ${err.message}`);
+          continue;
+        }
         if (admitted.admitted) {
           outcome.emitted += 1;
           existingIds.add(envelope.eventId);
@@ -354,38 +426,102 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
             outcome.skipped += 1;
             existingIds.add(envelope.eventId);
           } else {
-            terminalFailure = true;
-            outcome.errors.push(
+            terminalErrors.push(
               `${envelope.eventId}: duplicate chain event belongs to ${admitted.event?.causation_id ?? "an unknown run"}`,
             );
           }
         } else {
-          terminalFailure = true;
-          outcome.errors.push(
+          terminalErrors.push(
             `${envelope.eventId}: ${admitted.errors.join("; ")}`,
           );
         }
       }
-      if (
-        terminalFailure ||
+      outcome.errors.push(...terminalErrors, ...transientErrors);
+      if (terminalErrors.length > 0) {
+        resolved.push({
+          row,
+          reason: "intake_refused",
+          detail: { errors: terminalErrors },
+        });
+      } else if (transientErrors.length > 0) {
+        transient.push({ row, error: transientErrors.join("; ") });
+      } else if (
         envelopes.every((envelope) => existingIds.has(envelope.eventId))
       ) {
-        resolvedRunIds.push(row.run_id);
+        resolved.push({ row, reason: "emitted", detail: { events: ids } });
       }
     } catch (err) {
       outcome.errors.push(`chain-${row.run_id}: ${err.message}`);
-      resolvedRunIds.push(row.run_id);
+      if (isTerminalError(err)) {
+        resolved.push({
+          row,
+          reason: err.reason ?? "invalid_chain_data",
+          detail: { error: err.message },
+        });
+      } else {
+        transient.push({ row, error: err.message });
+      }
     }
   }
-  if (resolvedRunIds.length > 0) {
-    const markResolved = db.query(
-      `UPDATE runs
-          SET chain_resolved_at = ?
-        WHERE run_id = ? AND chain_resolved_at IS NULL`,
+
+  if (resolved.length === 0 && transient.length === 0) return outcome;
+  const markResolved = db.query(
+    `UPDATE runs
+        SET chain_resolved_at = ?
+      WHERE run_id = ? AND chain_resolved_at IS NULL`,
+  );
+  const insertMarker = db.query(
+    `INSERT INTO attempt_trace (run_id, attempt, ts, kind, payload_json)
+     VALUES (?, ?, ?, 'lifecycle', ?)`,
+  );
+  const countTransient = db.query(
+    `SELECT COUNT(*) AS n FROM attempt_trace
+      WHERE run_id = ? AND kind = 'lifecycle'
+        AND json_extract(payload_json, '$.note') = ?`,
+  );
+  const record = (row, note, payload) =>
+    insertMarker.run(
+      row.run_id,
+      row.attempts,
+      resolvedAt,
+      JSON.stringify({ note, ...payload }),
     );
-    tx(db, () => {
-      for (const runId of resolvedRunIds) markResolved.run(resolvedAt, runId);
-    });
-  }
+  tx(db, () => {
+    for (const { row, error } of transient) {
+      const passes = countTransient.get(row.run_id, CHAIN_TRANSIENT_NOTE).n + 1;
+      record(row, CHAIN_TRANSIENT_NOTE, { pass: passes, error });
+      if (passes >= maxTransientPasses) {
+        outcome.errors.push(
+          `chain-${row.run_id}: gave up after ${passes} transient failure(s)`,
+        );
+        resolved.push({
+          row,
+          reason: "chain_gave_up",
+          detail: { passes, error },
+        });
+      }
+    }
+    for (const { row, reason, detail } of resolved) {
+      markResolved.run(resolvedAt, row.run_id);
+      record(row, CHAIN_RESOLVED_NOTE, { reason, ...detail });
+    }
+  });
   return outcome;
+}
+
+/**
+ * The persisted `{ note: "chain_resolved", reason, ... }` marker for a run,
+ * or null while the chain step is still open. Operator-facing: answers "why
+ * did no child event fire for this run".
+ */
+export function chainResolution(db, runId) {
+  const row = db
+    .query(
+      `SELECT payload_json FROM attempt_trace
+        WHERE run_id = ? AND kind = 'lifecycle'
+          AND json_extract(payload_json, '$.note') = ?
+        ORDER BY seq DESC LIMIT 1`,
+    )
+    .get(runId, CHAIN_RESOLVED_NOTE);
+  return row ? JSON.parse(row.payload_json) : null;
 }

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -135,6 +135,8 @@ function existingChainEvents(db, edges) {
  * independent edges selected by non-empty artifact arrays (OPS-223, WM-119,
  * WM-430). Idempotent — derived event IDs dedup at intake, fully emitted sets
  * are zero-ops, and partially emitted sets resume with only missing siblings.
+ * Invalid chain data and intake collisions are terminal too: reporting them
+ * once is preferable to re-attempting a deterministic failure on every tick.
  *
  * @returns {{ emitted: number, skipped: number, errors: string[] }}
  */
@@ -148,10 +150,10 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
   const resolvedAt = new Date(now).toISOString();
 
   for (const row of candidates) {
-    const spec = JSON.parse(row.spec_json);
-    const result = JSON.parse(row.result_json);
-    const rule = edges[spec.agent];
     try {
+      const spec = JSON.parse(row.spec_json);
+      const result = JSON.parse(row.result_json);
+      const rule = edges[spec.agent];
       const recommendation = result.artifact?.[rule.recommendationField];
       const artifact = result.artifact ?? {};
       const selectionContext = { input: spec.input, artifact };
@@ -341,27 +343,38 @@ export function resolveChains(db, registry, { now = Date.now() } = {}) {
       const pending = envelopes.filter(
         (envelope) => !existingIds.has(envelope.eventId),
       );
+      let terminalFailure = false;
       for (const envelope of pending) {
         const admitted = admitChainEvent(db, registry, envelope, { now });
         if (admitted.admitted) {
           outcome.emitted += 1;
           existingIds.add(envelope.eventId);
         } else if (admitted.duplicate) {
-          outcome.skipped += 1;
           if (admitted.event?.causation_id === row.run_id) {
+            outcome.skipped += 1;
             existingIds.add(envelope.eventId);
+          } else {
+            terminalFailure = true;
+            outcome.errors.push(
+              `${envelope.eventId}: duplicate chain event belongs to ${admitted.event?.causation_id ?? "an unknown run"}`,
+            );
           }
         } else {
+          terminalFailure = true;
           outcome.errors.push(
             `${envelope.eventId}: ${admitted.errors.join("; ")}`,
           );
         }
       }
-      if (envelopes.every((envelope) => existingIds.has(envelope.eventId))) {
+      if (
+        terminalFailure ||
+        envelopes.every((envelope) => existingIds.has(envelope.eventId))
+      ) {
         resolvedRunIds.push(row.run_id);
       }
     } catch (err) {
       outcome.errors.push(`chain-${row.run_id}: ${err.message}`);
+      resolvedRunIds.push(row.run_id);
     }
   }
   if (resolvedRunIds.length > 0) {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -4,7 +4,12 @@ import { cpSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { memoryForge } from "../../lib/forge/memory.mjs";
 import * as fake from "./adapters/fake.mjs";
-import { admitChainEvent, buildChainInput, resolveChains } from "./chain.mjs";
+import {
+  admitChainEvent,
+  buildChainInput,
+  chainResolution,
+  resolveChains,
+} from "./chain.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { createRun, transition } from "./lifecycle.mjs";
@@ -722,6 +727,10 @@ describe("multi-emit chain resolution (WM-119)", () => {
         .query(`SELECT chain_resolved_at FROM runs WHERE run_id = 'run-err-1'`)
         .get().chain_resolved_at,
     ).not.toBeNull();
+    expect(chainResolution(db, "run-err-1")).toMatchObject({
+      note: "chain_resolved",
+      reason: "invalid_chain_data",
+    });
     expect(resolveChains(db, registry)).toEqual({
       emitted: 0,
       skipped: 0,
@@ -837,11 +846,189 @@ describe("multi-emit chain resolution (WM-119)", () => {
     expect(outcome.errors).toEqual([
       "chain-run-intake-conflict: eventId: already admitted with a different payload",
     ]);
+    expect(
+      db
+        .query(
+          `SELECT chain_resolved_at FROM runs WHERE run_id = 'run-intake-conflict'`,
+        )
+        .get().chain_resolved_at,
+    ).not.toBeNull();
+    expect(chainResolution(db, "run-intake-conflict")).toMatchObject({
+      reason: "intake_refused",
+      errors: [
+        "chain-run-intake-conflict: eventId: already admitted with a different payload",
+      ],
+    });
     expect(resolveChains(db, conflictRegistry, { now })).toEqual({
       emitted: 0,
       skipped: 0,
       errors: [],
     });
+  });
+
+  /** Make intake of one chain child fail like a busy/corrupt database would. */
+  function failInsertOf(db, eventId) {
+    db.exec(
+      `CREATE TRIGGER IF NOT EXISTS fail_${eventId.replace(/[^a-z0-9]/gi, "_")}
+         BEFORE INSERT ON events
+         WHEN NEW.event_id = '${eventId}'
+       BEGIN SELECT RAISE(ABORT, 'database is locked'); END;`,
+    );
+    return () =>
+      db.exec(
+        `DROP TRIGGER IF EXISTS fail_${eventId.replace(/[^a-z0-9]/gi, "_")}`,
+      );
+  }
+
+  function resolvedAtOf(db, runId) {
+    return db
+      .query(`SELECT chain_resolved_at FROM runs WHERE run_id = ?`)
+      .get(runId).chain_resolved_at;
+  }
+
+  test("a transient intake throw leaves the chain step open and lands on a later pass (#1458)", () => {
+    const db = openDb(":memory:");
+    seedCompletedRun(db, {
+      runId: "run-transient",
+      agent: "work-scan@1",
+      input: { repo: "wm/transient" },
+      artifact: {
+        recommendation: "DISPATCH",
+        repo: "wm/transient",
+        plan: [{ ticket: "WM-401" }],
+      },
+    });
+    const heal = failInsertOf(db, "chain-run-transient-WM-401");
+
+    const first = resolveChains(db, registry);
+    expect(first.emitted).toBe(0);
+    expect(first.errors).toHaveLength(1);
+    expect(first.errors[0]).toContain("database is locked");
+    expect(resolvedAtOf(db, "run-transient")).toBeNull();
+    expect(chainResolution(db, "run-transient")).toBeNull();
+
+    heal();
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 1,
+      skipped: 0,
+      errors: [],
+    });
+    expect(resolvedAtOf(db, "run-transient")).not.toBeNull();
+    expect(chainResolution(db, "run-transient")).toMatchObject({
+      reason: "emitted",
+      events: ["chain-run-transient-WM-401"],
+    });
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  test("persistent transient failures give up after the bounded pass count with a recorded reason (#1458)", () => {
+    const db = openDb(":memory:");
+    seedCompletedRun(db, {
+      runId: "run-stuck",
+      agent: "work-scan@1",
+      input: { repo: "wm/stuck" },
+      artifact: {
+        recommendation: "DISPATCH",
+        repo: "wm/stuck",
+        plan: [{ ticket: "WM-402" }],
+      },
+    });
+    failInsertOf(db, "chain-run-stuck-WM-402");
+
+    for (let pass = 1; pass < 3; pass += 1) {
+      const outcome = resolveChains(db, registry, { maxTransientPasses: 3 });
+      expect(outcome.emitted).toBe(0);
+      expect(outcome.errors).toHaveLength(1);
+      expect(resolvedAtOf(db, "run-stuck")).toBeNull();
+    }
+    const last = resolveChains(db, registry, { maxTransientPasses: 3 });
+    expect(last.emitted).toBe(0);
+    expect(last.errors).toHaveLength(2);
+    expect(last.errors[1]).toBe(
+      "chain-run-stuck: gave up after 3 transient failure(s)",
+    );
+    expect(resolvedAtOf(db, "run-stuck")).not.toBeNull();
+    expect(chainResolution(db, "run-stuck")).toMatchObject({
+      reason: "chain_gave_up",
+      passes: 3,
+    });
+    expect(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM attempt_trace
+            WHERE run_id = 'run-stuck'
+              AND json_extract(payload_json, '$.note') = 'chain_transient_error'`,
+        )
+        .get().n,
+    ).toBe(3);
+    expect(resolveChains(db, registry, { maxTransientPasses: 3 })).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  test("a transient failure on one sibling keeps the fan-out open and retries only that sibling (#1458)", () => {
+    const db = openDb(":memory:");
+    seedCompletedRun(db, {
+      runId: "run-partial-transient",
+      agent: "work-scan@1",
+      input: { repo: "wm/partial-transient" },
+      artifact: {
+        recommendation: "DISPATCH",
+        repo: "wm/partial-transient",
+        plan: [
+          { ticket: "WM-501" },
+          { ticket: "WM-502" },
+          { ticket: "WM-503" },
+        ],
+      },
+    });
+    const heal = failInsertOf(db, "chain-run-partial-transient-WM-502");
+
+    const first = resolveChains(db, registry);
+    expect(first.emitted).toBe(2);
+    expect(first.skipped).toBe(0);
+    expect(first.errors).toEqual([
+      expect.stringContaining(
+        "chain-run-partial-transient-WM-502: database is locked",
+      ),
+    ]);
+    expect(resolvedAtOf(db, "run-partial-transient")).toBeNull();
+    expect(
+      db
+        .query(
+          `SELECT event_id FROM events
+            WHERE causation_id = 'run-partial-transient' ORDER BY event_id`,
+        )
+        .all()
+        .map((row) => row.event_id),
+    ).toEqual([
+      "chain-run-partial-transient-WM-501",
+      "chain-run-partial-transient-WM-503",
+    ]);
+
+    heal();
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 1,
+      skipped: 0,
+      errors: [],
+    });
+    expect(resolvedAtOf(db, "run-partial-transient")).not.toBeNull();
+    expect(chainResolution(db, "run-partial-transient")).toMatchObject({
+      reason: "emitted",
+    });
+    expect(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM events WHERE causation_id = 'run-partial-transient'`,
+        )
+        .get().n,
+    ).toBe(3);
   });
 
   test("triage-apply outcome edges route to the correct follow-up", () => {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -717,6 +717,131 @@ describe("multi-emit chain resolution (WM-119)", () => {
     expect(outcome.emitted).toBe(0);
     expect(outcome.errors).toHaveLength(1);
     expect(outcome.errors[0]).toContain('missing key "ticket"');
+    expect(
+      db
+        .query(`SELECT chain_resolved_at FROM runs WHERE run_id = 'run-err-1'`)
+        .get().chain_resolved_at,
+    ).not.toBeNull();
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  test("foreign chain-event duplicates resolve and report their collision once", () => {
+    const db = openDb(":memory:");
+    const collisionRegistry = {
+      ...registry,
+      edges: {
+        "collision-edge@1": {
+          recommendationField: "recommendation",
+          edges: {
+            NEXT: {
+              eventType: "factory.work.requested",
+              input: { repo: "$.input.repo" },
+            },
+          },
+        },
+      },
+    };
+    const now = Date.parse("2026-08-30T00:00:00.000Z");
+    seedCompletedRun(db, {
+      runId: "run-foreign-duplicate",
+      agent: "collision-edge@1",
+      input: { repo: "wm/collision" },
+      artifact: { recommendation: "NEXT" },
+    });
+    expect(
+      admitChainEvent(
+        db,
+        collisionRegistry,
+        {
+          schemaVersion: "factory.event/v1",
+          eventId: "chain-run-foreign-duplicate",
+          type: "factory.work.requested",
+          subject: "collision-edge@1",
+          occurredAt: new Date(now).toISOString(),
+          correlationId: "corr-run-foreign-duplicate",
+          causationId: "run-other",
+          payload: { repo: "wm/collision" },
+        },
+        { now },
+      ).admitted,
+    ).toBe(true);
+
+    const outcome = resolveChains(db, collisionRegistry, { now });
+    expect(outcome.emitted).toBe(0);
+    expect(outcome.skipped).toBe(0);
+    expect(outcome.errors).toEqual([
+      "chain-run-foreign-duplicate: duplicate chain event belongs to run-other",
+    ]);
+    expect(
+      db
+        .query(
+          `SELECT chain_resolved_at FROM runs WHERE run_id = 'run-foreign-duplicate'`,
+        )
+        .get().chain_resolved_at,
+    ).not.toBeNull();
+    expect(resolveChains(db, collisionRegistry, { now })).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  test("intake conflicts resolve and report their refusal once", () => {
+    const db = openDb(":memory:");
+    const conflictRegistry = {
+      ...registry,
+      edges: {
+        "conflict-edge@1": {
+          recommendationField: "recommendation",
+          edges: {
+            NEXT: {
+              eventType: "factory.work.requested",
+              input: { repo: "$.input.repo" },
+            },
+          },
+        },
+      },
+    };
+    const now = Date.parse("2026-08-30T00:00:00.000Z");
+    seedCompletedRun(db, {
+      runId: "run-intake-conflict",
+      agent: "conflict-edge@1",
+      input: { repo: "wm/expected" },
+      artifact: { recommendation: "NEXT" },
+    });
+    expect(
+      admitChainEvent(
+        db,
+        conflictRegistry,
+        {
+          schemaVersion: "factory.event/v1",
+          eventId: "chain-run-intake-conflict",
+          type: "factory.work.requested",
+          subject: "conflict-edge@1",
+          occurredAt: new Date(now).toISOString(),
+          correlationId: "corr-run-intake-conflict",
+          causationId: "run-other",
+          payload: { repo: "wm/conflicting" },
+        },
+        { now },
+      ).admitted,
+    ).toBe(true);
+
+    const outcome = resolveChains(db, conflictRegistry, { now });
+    expect(outcome.emitted).toBe(0);
+    expect(outcome.skipped).toBe(0);
+    expect(outcome.errors).toEqual([
+      "chain-run-intake-conflict: eventId: already admitted with a different payload",
+    ]);
+    expect(resolveChains(db, conflictRegistry, { now })).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
   });
 
   test("triage-apply outcome edges route to the correct follow-up", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1458

Resolve malformed, refused, conflicting, and foreign-duplicate chain candidates once instead of reprocessing them every tick.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | \`bun test event-runtime/lib/chain.test.mjs event-runtime/cli/serve.test.mjs --timeout 20000\` | pass | 37 tests, 0 failures |
| Repo verify | \`bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check\` | pass | 1983 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | backend chain resolver has no user-facing surface |

UX critique: skipped — backend chain resolver has no user-facing surface

## Post-review (ceeb9ff)

- **Failure classification**: only deterministic failures resolve the chain step — `ChainTerminalError` (unknown sibling, `also` not an array, missing item key, non-array selector, non-unique IDs, missing input path), malformed spec/result JSON, intake refusals and foreign-causation duplicates. Any other throw (SQLITE_BUSY, disk I/O, unexpected) leaves `chain_resolved_at` NULL and is retried on later passes.
- **Bounded retry**: each transient pass writes an `attempt_trace` `lifecycle` marker `{ note: "chain_transient_error", pass, error }`; after `maxTransientPasses` (default `CHAIN_MAX_TRANSIENT_PASSES = 5`) the run resolves with reason `chain_gave_up`. No schema migration needed — the counter is the marker count.
- **Partial fan-out**: siblings are admitted independently; a transient throw on one sibling neither resolves the run nor abandons the rest, and the next pass re-admits only the missing siblings.
- **Resolution reason persisted**: every resolution writes `{ note: "chain_resolved", reason, ... }` (`emitted`, `no_edge_selected`, `stale_children`, `intake_refused`, `invalid_chain_data`, `chain_gave_up`) to `attempt_trace`; `chainResolution(db, runId)` reads it back.
- **Tests**: transient throw stays unresolved then lands; persistent transient gives up after N passes with the recorded reason; one-sibling transient failure keeps the fan-out open and retries only that sibling; existing intake-conflict / missing-key tests assert the persisted reason.
