### PR TITLE
docs(repos): document validator-accepted config keys

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -3,26 +3,34 @@
 repos:
   # Factory can manage its own checkout. The home-relative paths are portable;
   # change them in config/repos.yaml if your checkout layout differs.
-  - name: factory
-    path: ~/Develop/factory
-    github: watt-mind/factory
-    icon: ph-robot
-    color: orange
-    team: WM
-    project: Factory
+  - name: factory # Stable registry name used by commands and dispatch.
+    path: ~/Develop/factory # Local checkout path; `~` expands to the current home.
+    github: watt-mind/factory # GitHub owner/repo used for promotion PRs.
+    icon: ph-robot # Optional UI icon metadata.
+    color: orange # Optional UI colour metadata.
+    team: WM # Optional tracker team identifier.
+    project: Factory # Optional tracker project name.
     # Which tracker holds this repo's tickets: linear | github | memory.
     # Omit to inherit config/policy.yaml's controlPlane.kind (itself defaulting
     # to linear). Setting it per repo is what lets one factory instance run
     # this repo on GitHub Issues while every other repo it manages stays on
     # Linear — without it the choice is global and moving one moves all.
     # control_plane: github
-    base: develop
-    deploy_branch: main
-    worktree_up: bin/worktree-up.sh
-    worktree_down: bin/worktree-down.sh
-    worktree_root: ~/Develop/.worktrees/factory
-    max_in_flight: 20
-    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check
+    base: develop # Base branch for promotion PRs; defaults to main.
+    deploy_branch: main # Optional human-reviewed release branch.
+    worktree_up: bin/worktree-up.sh # Script that creates an isolated ticket worktree.
+    worktree_down: bin/worktree-down.sh # Script that tears down an isolated worktree.
+    worktree_root: ~/Develop/.worktrees/factory # Optional root for ticket worktrees.
+    # worktree_warm: bin/worktree-warm.sh # Optional script that warms a worktree template.
+    max_in_flight: 20 # Optional positive per-repository dispatch cap.
+    verify: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check # Optional local verification command.
+    # smoke_workflow: smoke-prod.yml # Optional post-deploy GitHub Actions workflow.
+    # smoke_url: https://factory.example.com/healthz # Optional post-deploy smoke endpoint.
+    smoke_deadline_seconds: 420 # Optional positive deadline for smoke confirmation.
+    # deployment: # Optional allow-listed deployment identity for verification.
+    #   url: https://factory.example.com # Deployment URL shown to operators.
+    #   branch: main # Branch the deployment represents.
+    #   revision_field: revision # Field carrying the deployed revision.
     # Executables this repo's worktree script and verify command need, with the
     # semver range each must satisfy (WM-316, docs/event-runtime-repos.md §5).
     # Preflight resolves each one on the node and compares versions BEFORE a
@@ -52,13 +60,13 @@ repos:
     toolchain:
       bun: ">=1.3 <2"
       git: ">=2.30"
-    owned_paths_policy:
-      direct:
+    owned_paths_policy: # Optional closure rules for ticket Owned Paths.
+      direct: # Source-glob changes require their generated/output paths.
         - source: shared/**
           requires:
             - dist/**
             - plugins/core/**
-      pin_manifests:
+      pin_manifests: # Pin manifests that must accompany matching path changes.
         - event-runtime/agents/*.json
       # Registry inputs change the tracked zero-pack digest baseline.
       registry_digest:
@@ -69,11 +77,16 @@ repos:
           - event-runtime/schedules.json
         baseline: event-runtime/lib/registry.test.mjs
     merge_ci:
+      # Fallback workflow when GitHub branch protection returns no contexts.
       workflow: CI
+      # Unique checks required from that fallback workflow.
       required_checks:
         - Shadow runner fleet available
         - Verify
-    escalate_paths: []
+    escalate_paths: [] # Paths that require human escalation; empty means none.
+    security: # Optional allow-listed settings for the security audit.
+      python_version: "3.12" # Optional Python version for the security audit.
+
 
   # Add product repositories only to your ignored config/repos.yaml. Start in
   # report-only mode until their isolated worktree lifecycle is proven.
@@ -82,5 +95,5 @@ repos:
   #   github: your-org/example
   #   team: EXAMPLE
   #   base: main
-  #   report_only: true
+  #   report_only: true # Disable ticket dispatch until worktree lifecycle is proven.
   #   verify: bun test

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -222,7 +222,7 @@ auto-approval path above is what stops the inbox escalation.
 ## 3. Capacity: one budget, checked at plan and again at execute
 
 **Decision.** One per-repo in-flight cap, shared by both paths: the repo's
-`max_in_flight` in `config/repos.yaml`, falling back to
+[`max_in_flight` in the repository config reference](event-runtime-repos.md#config-reference), falling back to
 `concurrency.max_in_flight_per_repo` in `config/policy.yaml`. The ledger that
 counts against it is the existing one — `lib/worker-leases.mjs`: files under
 `~/.factory/worker-leases/` that independent supervisors already share, live
@@ -341,7 +341,7 @@ collided with a dev server.
 
 Consequences, all inherited from the dispatcher's rules rather than invented:
 
-- **`report_only` repos are never tier-2 targets.** A repo without the
+- **[`report_only` repos](event-runtime-repos.md#config-reference) are never tier-2 targets.** A repo without the
   scripts has a safe concurrency of one human; `tick.mjs` refuses to
   dispatch there and the planner refuses to propose there
   (`repo_report_only`), for the same reason.
@@ -442,7 +442,7 @@ event-runtime-workers.md §5), with one permanent exception:
 - **The develop-targeting merge chain may eventually earn `auto`.** This is
   autonomy the orchestrator path already has — `policy.yaml`'s
   `auto_merge_base: [develop]` with green CI — so the runtime earning it is
-  parity on a track record, not new ground. Escalation rules
+  parity on a track record, not new ground. [Escalation rules](event-runtime-repos.md#config-reference)
   (`escalate_paths`, the judgment list) apply identically; an escalated PR
   is `human_needed`, never `auto`.
 - **The ship chain's deploy-branch merge is PERMANENTLY `watched`.** That
@@ -479,7 +479,7 @@ remain in force.
 Dispatch is re-read immediately before approval: it must still be Todo,
 unassigned, `ai:agent-ready`, inside its lease cap, and disjoint from active
 Owned Paths. `ai:escalated`, security classification, and a ticket path that
-intersects the repo's `escalate_paths` leave the proposal open with a typed
+intersects the repo's [`escalate_paths`](event-runtime-repos.md#config-reference) leave the proposal open with a typed
 reason. Triage apply additionally revalidates its schema and closed action
 registry. Proposal/run-spec mismatches and expired proposals fail closed.
 

--- a/docs/event-runtime-repos.md
+++ b/docs/event-runtime-repos.md
@@ -53,6 +53,49 @@ substitute for reviewing the generated local files.
 
 ---
 
+## Config reference
+
+`config/repos.yaml` is a `repos:` list. This table is the contract implemented
+by `loadRepos` in `event-runtime/lib/repos.mjs`; it is also the reference for
+values shown by the runtime UI and used by dispatch. A value without a type
+check is retained as supplied, so use the documented type rather than relying
+on downstream coercion.
+
+| Key                                  | Type                                                           | Default                                  | Invalid value / behaviour                                                                                                           |
+| :----------------------------------- | :------------------------------------------------------------- | :--------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                               | non-empty repository identifier                                | required                                 | Missing or falsy values fail config load.                                                                                           |
+| `path`                               | local path string                                              | required                                 | Missing or falsy values fail config load; a leading `~` expands.                                                                    |
+| `github`                             | GitHub `owner/repo` string                                     | `null`                                   | Retained as supplied; promotion later fails without a non-empty string.                                                             |
+| `base`                               | branch string                                                  | `main`                                   | Retained as supplied; no load-time branch validation.                                                                               |
+| `deploy_branch`                      | branch string                                                  | `null`                                   | Retained as supplied; no load-time branch validation.                                                                               |
+| `team`                               | tracker team identifier                                        | `null`                                   | Retained as supplied.                                                                                                               |
+| `project`                            | tracker project name                                           | `null`                                   | Retained as supplied.                                                                                                               |
+| `icon`                               | UI icon identifier                                             | none                                     | Accepted as registry metadata; the repos reader does not project it.                                                                |
+| `color`                              | UI colour identifier                                           | none                                     | Accepted as registry metadata; the repos reader does not project it.                                                                |
+| `control_plane`                      | `linear`, `memory`, or `github`                                | `null` (inherit policy)                  | Any other value fails config load.                                                                                                  |
+| `report_only`                        | boolean                                                        | `false`                                  | Only literal `true` enables report-only mode; every other value is `false`.                                                         |
+| `max_in_flight`                      | positive finite number                                         | `null` (dispatcher policy fallback)      | A non-number, zero, negative, or non-finite value fails config load.                                                                |
+| `smoke_deadline_seconds`             | positive finite number                                         | `null`                                   | May be top-level or under `deployment`; invalid values fail config load.                                                            |
+| `smoke_workflow`                     | workflow filename/string                                       | `null`                                   | Retained as supplied.                                                                                                               |
+| `smoke_url`                          | URL string                                                     | `null`                                   | Retained as supplied.                                                                                                               |
+| `deployment`                         | object                                                         | `null`                                   | A non-object or array fails config load. `url`, `branch`, and `revision_field` are allow-listed and otherwise retained as supplied. |
+| `worktree_up`                        | repository script path                                         | `null`                                   | Retained as supplied; promotion requires a non-empty string.                                                                        |
+| `worktree_down`                      | repository script path                                         | `null`                                   | Retained as supplied.                                                                                                               |
+| `worktree_root`                      | local directory path                                           | `null`                                   | Retained as supplied, with a leading `~` expanded.                                                                                  |
+| `worktree_warm`                      | repository script path                                         | `null`                                   | Retained as supplied.                                                                                                               |
+| `verify`                             | shell command string                                           | `null`                                   | Retained as supplied.                                                                                                               |
+| `toolchain`                          | executable-to-semver map, or `{ executable, constraint }` list | `null` (no preflight)                    | Invalid structure, executable, duplicate, or non-canonical semver range fails config load; `*` is the only unrestricted range.      |
+| `owned_paths_policy`                 | object                                                         | empty `direct` and `pin_manifests` lists | Unknown keys and malformed `direct`, `pin_manifests`, or `registry_digest` members fail config load.                                |
+| `owned_paths_policy.direct`          | list of `{ source, requires }`                                 | `[]`                                     | Each source and each non-empty requires-list entry must be a non-empty string.                                                      |
+| `owned_paths_policy.pin_manifests`   | list of path globs                                             | `[]`                                     | Each entry must be a non-empty string.                                                                                              |
+| `owned_paths_policy.registry_digest` | `{ inputs, baseline }` object                                  | absent                                   | Unknown keys, an empty/non-string inputs list, or an empty/non-string baseline fails config load.                                   |
+| `merge_ci`                           | `{ workflow, required_checks }` object                         | `null`                                   | Requires a non-empty workflow and unique, non-empty check names; otherwise config load fails.                                       |
+| `escalate_paths`                     | list of non-empty path globs                                   | `null`                                   | Malformed values deliberately load as `null` and are treated as absent at plan time.                                                |
+| `security`                           | object                                                         | `null`                                   | A non-object or array fails config load; only the fields below are projected.                                                       |
+| `security.python_version`            | Python version string                                          | `null`                                   | Retained as supplied; other `security` keys are deliberately not exposed.                                                           |
+
+---
+
 ## 1. The gap, precisely
 
 `config/repos.yaml` is the routing registry, but its `path:` values currently
@@ -98,7 +141,7 @@ repos:
     path: ~/Develop/factory # local default, not a fleet-wide path
     github: watt-mind/factory
     base: develop
-    # worktree_up/down/root, verify, toolchain, etc.
+    # See “Config reference” above for worktree, verify, toolchain, and policy keys.
 ```
 
 A remote worker node extends its existing SSH inventory entry with a managed

--- a/docs/event-runtime-webui.md
+++ b/docs/event-runtime-webui.md
@@ -1381,7 +1381,9 @@ worktrees a repo owns.
   `#/projects/:name` is shareable per §10.8, and the empty state names the
   file that is empty (`config/repos.yaml`) rather than saying "no results".
 - **Detail panel.** Repository settings are grouped by what they govern, and
-  every group names `config/repos.yaml` as its source. **Dispatch** shows the
+  every group names `config/repos.yaml` as its source; field semantics live in
+  the [repository config reference](event-runtime-repos.md#config-reference).
+  **Dispatch** shows the
   dispatchable/report-only mode, effective max in flight and whether it came
   from the repo or the planner default, base branch, worktree root and script
   capabilities, and the verify command verbatim. **Merge gate** shows the
@@ -1390,8 +1392,8 @@ worktrees a repo owns.
   empty list says so. **Owned paths policy** shows direct source/required-path
   rules and pin manifests, or the default. **Deploy & smoke** shows deploy
   branch, the allow-listed deployment URL/branch/revision field, smoke
-  workflow/URL/deadline. **Security** currently allow-lists only
-  `python_version`, or states that defaults apply. Long path/check lists are
+  workflow/URL/deadline. **Security** shows the allow-listed
+  [`security.python_version`](event-runtime-repos.md#config-reference), or states that defaults apply. Long path/check lists are
   untruncated monospace chips inside their own scrolling containers, and all
   other absent values use the shared empty-value placeholder.
 - **Janitor, Dry before Apply (OPS-362).** `POST /repos/:name/janitor` — §2's


### PR DESCRIPTION
Fixes watt-mind/factory#1465

Operators can now look up every repos.yaml field, default, and validation outcome in one place.

## Validation

| Check                | Command                                                                                             | Result  | Notes                              |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs --timeout 20000`                                        | pass    | 60 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1981 pass, 10 skipped, 0 failures |
| UX critique          | factory-ux-critic                                                                                   | not run | no user-facing surface             |

UX critique: skipped