### PR TITLE
fix(api): return 413 for oversized bodies

### DIFF
--- a/event-runtime/lib/api-http.mjs
+++ b/event-runtime/lib/api-http.mjs
@@ -2,17 +2,35 @@
 import { createHash } from "node:crypto";
 
 /** §14 size limit: a control-plane payload has no business being megabytes. */
-const MAX_BODY_BYTES = 1024 * 1024;
+export const MAX_BODY_BYTES = 1024 * 1024;
+
+export class PayloadTooLargeError extends Error {
+  constructor(limitBytes = MAX_BODY_BYTES) {
+    super("payload_too_large");
+    this.name = "PayloadTooLargeError";
+    this.code = "payload_too_large";
+    this.status = 413;
+    this.limitBytes = limitBytes;
+  }
+}
 
 export function readBody(req) {
   return new Promise((resolve, reject) => {
+    const contentLength = req.headers?.["content-length"];
+    if (Number(contentLength) > MAX_BODY_BYTES) {
+      reject(new PayloadTooLargeError());
+      return;
+    }
+
     const chunks = [];
     let size = 0;
+    let tooLarge = false;
     req.on("data", (chunk) => {
+      if (tooLarge) return;
       size += chunk.length;
       if (size > MAX_BODY_BYTES) {
-        reject(new Error("payload_too_large"));
-        req.destroy();
+        tooLarge = true;
+        reject(new PayloadTooLargeError());
         return;
       }
       chunks.push(chunk);

--- a/event-runtime/lib/api-http.test.mjs
+++ b/event-runtime/lib/api-http.test.mjs
@@ -1,5 +1,8 @@
 import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-http-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { Readable } from "node:stream";
+import { MAX_BODY_BYTES, PayloadTooLargeError, readBody } from "./api-http.mjs";
 import {
   GH_SECRET,
   PV,
@@ -40,6 +43,29 @@ const makeServer = async (...args) => {
   trackTmpDir(path.dirname(result.db.filename));
   return result;
 };
+
+describe("request body limits", () => {
+  test("readBody rejects streamed oversized bodies with a typed error", async () => {
+    const err = await rejection(
+      readBody(Readable.from([Buffer.alloc(MAX_BODY_BYTES + 1)])),
+    );
+
+    expect(err).toBeInstanceOf(PayloadTooLargeError);
+    expect(err).toMatchObject({
+      code: "payload_too_large",
+      status: 413,
+      limitBytes: MAX_BODY_BYTES,
+    });
+  });
+
+  test("readBody refuses an oversized Content-Length before subscribing", async () => {
+    const req = new EventEmitter();
+    req.headers = { "content-length": String(MAX_BODY_BYTES + 1) };
+
+    await expect(readBody(req)).rejects.toBeInstanceOf(PayloadTooLargeError);
+    expect(req.listenerCount("data")).toBe(0);
+  });
+});
 
 describe("Host and Origin header security confinement (OPS-408)", () => {
   let s;

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -19,6 +19,7 @@ import {
   isLoopbackHost,
   isLoopbackOrigin,
   parseJson,
+  PayloadTooLargeError,
   readBody,
   send as sendJson,
 } from "./api-http.mjs";
@@ -97,6 +98,11 @@ const BEARER_EXEMPT_ROUTES = new Set([
   // exempt too — an external GitHub sender cannot present a bearer (WM-1150).
   "POST /webhooks/github",
 ]);
+
+function payloadTooLargeBody(err) {
+  if (!(err instanceof PayloadTooLargeError)) return null;
+  return { error: err.code, limitBytes: err.limitBytes };
+}
 
 /**
  * Constant-time bearer check (WM-1152). Returns true only for a well-formed
@@ -264,7 +270,7 @@ export function createApi({
           "POST /replay",
         ].includes(route)
       ) {
-        return handleIntakeApiRoute(common);
+        return await handleIntakeApiRoute(common);
       }
       if (url.pathname === "/inbox" || url.pathname.startsWith("/inbox/")) {
         const detailMatch = url.pathname.match(/^\/inbox\/([^/]+)$/);
@@ -315,6 +321,8 @@ export function createApi({
             }
             return send(200, result);
           } catch (err) {
+            const body = payloadTooLargeBody(err);
+            if (body) return send(413, body);
             const status = Number(err?.status) || 400;
             return send(status, {
               error: err?.code ?? "invalid_response",
@@ -451,9 +459,12 @@ export function createApi({
         if (result !== false) return result;
       }
       return send(404, { error: `no route: ${route}` });
-    } catch {
+    } catch (err) {
       // Never leak a stack trace across the API boundary.
-      if (!res.headersSent) sendJson(res, 500, { error: "internal_error" });
+      const body = payloadTooLargeBody(err);
+      if (!res.headersSent && body) sendJson(res, 413, body);
+      else if (!res.headersSent)
+        sendJson(res, 500, { error: "internal_error" });
       else res.end();
     }
   };

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -682,6 +682,44 @@ describe("bearer-token auth on the control API (WM-1152)", () => {
     }
   });
 
+  test("POST /events rejects an oversized declared body before reading it", async () => {
+    const s = await makeServer({ autoAuthorize: false });
+    try {
+      const res = await new Promise((resolve, reject) => {
+        const req = http.request({
+          host: "127.0.0.1",
+          port: s.port,
+          path: "/events",
+          method: "POST",
+          headers: {
+            "content-length": String(1024 * 1024 + 1),
+            "x-factory-timestamp": String(Date.now()),
+            "x-factory-signature": "sha256=not-checked-before-body-limit",
+          },
+        });
+        req.on("response", (response) => {
+          const chunks = [];
+          response.on("data", (chunk) => chunks.push(chunk));
+          response.on("end", () =>
+            resolve({
+              status: response.statusCode,
+              body: JSON.parse(Buffer.concat(chunks).toString("utf8")),
+            }),
+          );
+        });
+        req.on("error", reject);
+        req.end();
+      });
+      expect(res.status).toBe(413);
+      expect(res.body).toEqual({
+        error: "payload_too_large",
+        limitBytes: 1024 * 1024,
+      });
+    } finally {
+      s.close();
+    }
+  });
+
   test("token unset: every privileged mutation fails closed before side effects", async () => {
     const s = await makeServer({ controlApiToken: null });
     try {


### PR DESCRIPTION
Fixes watt-mind/factory#1460

Oversized API payloads now return a retry-safe 413 response before body processing.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-http.test.mjs event-runtime/lib/api.test.mjs --timeout 20000` | pass    | 33 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1,985 tests; emit and format clean |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface             |

UX critique: skipped