### PR TITLE
fix(intake): return conflicts for GitHub and schedules

### DIFF
--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -349,6 +349,10 @@ function planAfterResponse(onEvent, kind = "admitted") {
   });
 }
 
+export function sendPayloadMismatch(send, eventId) {
+  return send(409, { error: "payload_mismatch", eventId });
+}
+
 function admit(
   db,
   registry,
@@ -365,10 +369,7 @@ function admit(
     now: nowMs,
   });
   if (outcome.conflict) {
-    return send(409, {
-      error: "payload_mismatch",
-      eventId: parsed.value.eventId,
-    });
+    return sendPayloadMismatch(send, parsed.value.eventId);
   }
   if (!outcome.admitted && !outcome.duplicate)
     return send(422, { errors: outcome.errors });
@@ -481,6 +482,8 @@ export async function handleIntakeApiRoute({
     const outcome = admitExternalEvent(db, registry, translated.envelope, {
       now: nowMs,
     });
+    if (outcome.conflict)
+      return sendPayloadMismatch(send, translated.envelope.eventId);
     if (!outcome.admitted && !outcome.duplicate)
       return send(422, { errors: outcome.errors });
     // Ack GitHub immediately; plan off the response path (WM-1162).

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -874,6 +874,29 @@ describe("GitHub full event-set mapping (WM-1150)", () => {
         eventId: "d-tunnel-alias",
       });
 
+      // A changed redelivery is a conflict, not a validation error. The
+      // /github and tunnel-alias routes share this response behavior.
+      const changedPayload = {
+        ...payload,
+        pull_request: { ...payload.pull_request, number: 701 },
+      };
+      const changedBody = JSON.stringify(changedPayload);
+      const conflict = await fetch(s.url("/github"), {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          "x-github-event": "pull_request",
+          "x-github-delivery": "d-tunnel-alias",
+          "x-hub-signature-256": ghSign(changedBody),
+        },
+        body: changedBody,
+      });
+      expect(conflict.status).toBe(409);
+      expect(await conflict.json()).toEqual({
+        error: "payload_mismatch",
+        eventId: "d-tunnel-alias",
+      });
+
       // A bad signature still 401s before parsing on the alias path.
       const forged = await fetch(s.url("/webhooks/github"), {
         method: "POST",

--- a/event-runtime/lib/api-schedules.mjs
+++ b/event-runtime/lib/api-schedules.mjs
@@ -1,5 +1,6 @@
 /** Schedule listing and ad-hoc trigger endpoints. */
 import { admitEvent } from "./intake.mjs";
+import { sendPayloadMismatch } from "./api-intake.mjs";
 import { planEvent } from "./planner.mjs";
 import { parseCadence, scheduleView } from "./schedules.mjs";
 
@@ -16,6 +17,7 @@ export async function handleScheduleApiRoute({
   actor,
   policyVersion,
   onEvent,
+  admit = admitEvent,
 }) {
   if (route === "GET /schedules") {
     const schedules = scheduleView(db, registry, { now: nowMs }).map((item) => {
@@ -126,7 +128,8 @@ export async function handleScheduleApiRoute({
         ...(prNumbers ? { prNumbers } : {}),
       },
     };
-    const outcome = admitEvent(db, registry, envelope, { now: nowMs });
+    const outcome = admit(db, registry, envelope, { now: nowMs });
+    if (outcome.conflict) return sendPayloadMismatch(send, eventId);
     if (!outcome.admitted && !outcome.duplicate)
       return send(422, { errors: outcome.errors });
     if (outcome.admitted) onEvent("admitted");

--- a/event-runtime/lib/api-schedules.test.mjs
+++ b/event-runtime/lib/api-schedules.test.mjs
@@ -1,5 +1,6 @@
 import { trackTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-schedules-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { handleScheduleApiRoute } from "./api-schedules.mjs";
 import {
   GH_SECRET,
   PV,
@@ -123,6 +124,34 @@ describe("POST /schedules/:loop/run (OPS-401)", () => {
     expect(body.admitted).toBe(true);
     expect(body.loop).toBe("reaper");
     expect(body.decision).toBe("run");
+  });
+
+  test("returns the shared payload mismatch response when admission conflicts", async () => {
+    const response = await handleScheduleApiRoute({
+      route: "POST /schedules/reaper/run",
+      url: new URL("http://127.0.0.1/schedules/reaper/run"),
+      req: { method: "POST" },
+      db: { query: () => ({ get: () => undefined }) },
+      registry: overlayFreeRegistry,
+      send: (status, body) => ({ status, body }),
+      readBody: async () => Buffer.alloc(0),
+      parseJson: () => ({ value: {} }),
+      nowMs: Date.parse("2026-01-01T00:00:00.000Z"),
+      actor: "operator",
+      policyVersion: PV,
+      onEvent: () => {
+        throw new Error("conflicting events must not be planned");
+      },
+      admit: () => ({ admitted: false, duplicate: false, conflict: true }),
+    });
+
+    expect(response).toEqual({
+      status: 409,
+      body: {
+        error: "payload_mismatch",
+        eventId: "manual:reaper:2026-01-01T00:00:00.000Z",
+      },
+    });
   });
 
   test("rejects manual fire when the configured cadence is invalid", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1459

GitHub webhooks and schedule runs now return a typed 409 payload conflict response.

## Validation

| Check                | Command                                                                                              | Result  | Notes                                  |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-intake.test.mjs event-runtime/lib/api-schedules.test.mjs --timeout 20000` | pass    | 53 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1983 tests, 0 failures; emit/format clean |
| UX critique          | factory-ux-critic                                                                                    | skipped | backend API; no user-facing surface    |

UX critique: skipped — backend API change; no user-facing surface
