### PR TITLE
chore(evals): reuse canonical process termination

### DIFF
--- a/evals/lib/grader.mjs
+++ b/evals/lib/grader.mjs
@@ -15,12 +15,13 @@
  * reaches the CLI's own children, SIGTERM then SIGKILL after a grace period,
  * `--strict-mcp-config` with no config so no MCP server is loaded, and
  * ANTHROPIC_API_KEY stripped so the CLI uses subscription auth rather than
- * billing per token (docs/architecture.md §2.9). They are re-implemented
- * rather than imported because that adapter pulls in the whole event-runtime
- * registry graph, and `node evals/run.mjs` must stand alone.
+ * billing per token (docs/architecture.md §2.9). The process-group termination
+ * primitive is shared with the runtime adapters so its TERM→KILL deduplication
+ * and close-time cancellation stay canonical.
  */
 import { spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
+import { killProcessGroup } from "../../event-runtime/lib/adapters/child-process.mjs";
 import { DEFAULT_MODEL } from "./policy.mjs";
 
 export const KILL_GRACE_MS = 30_000;
@@ -161,16 +162,9 @@ export function callClaude({
     });
 
     let timedOut = false;
-    let killTimer = null;
+    let cancelTermination = null;
     const escalate = () => {
-      killProcessGroup(child, "SIGTERM");
-      if (!killTimer) {
-        killTimer = setTimeout(
-          () => killProcessGroup(child, "SIGKILL"),
-          killGraceMs,
-        );
-        killTimer.unref?.();
-      }
+      cancelTermination ??= killProcessGroup(child, { killGraceMs });
     };
     const termTimer = setTimeout(() => {
       timedOut = true;
@@ -185,7 +179,7 @@ export function callClaude({
 
     const finish = (exitCode, error) => {
       clearTimeout(termTimer);
-      if (killTimer) clearTimeout(killTimer);
+      cancelTermination?.();
       signal?.removeEventListener?.("abort", onAbort);
       const parsed = parseCliJson(stdout);
       resolve({
@@ -204,25 +198,6 @@ export function callClaude({
     child.on("error", (error) => finish(null, String(error?.message ?? error)));
     child.on("close", (exitCode) => finish(exitCode, null));
   });
-}
-
-/** Terminate the CLI and everything it started (the adapter's WM-263 rule). */
-export function killProcessGroup(
-  child,
-  signal = "SIGTERM",
-  kill = process.kill,
-) {
-  const pid = child?.pid;
-  if (!pid) return;
-  try {
-    kill(-pid, signal);
-  } catch {
-    try {
-      child.kill(signal);
-    } catch {
-      // already gone
-    }
-  }
 }
 
 /**

--- a/evals/lib/grader.mjs
+++ b/evals/lib/grader.mjs
@@ -119,6 +119,7 @@ export function callClaude({
   allowedTools = [],
   disallowedTools = [],
   killGraceMs = KILL_GRACE_MS,
+  killFn = process.kill,
   spawnFn = spawn,
   env = process.env,
   signal,
@@ -164,7 +165,10 @@ export function callClaude({
     let timedOut = false;
     let cancelTermination = null;
     const escalate = () => {
-      cancelTermination ??= killProcessGroup(child, { killGraceMs });
+      cancelTermination ??= killProcessGroup(child, {
+        killGraceMs,
+        kill: killFn,
+      });
     };
     const termTimer = setTimeout(() => {
       timedOut = true;

--- a/evals/lib/grader.test.mjs
+++ b/evals/lib/grader.test.mjs
@@ -10,9 +10,17 @@ function fakeChild() {
   child.stdout.setEncoding = () => {};
   child.stderr.setEncoding = () => {};
   child.signals = [];
-  child.kill = (signal) => {
+  // Records every process-group signal instead of letting the shared helper
+  // reach process.kill(-pid, …) — a fake pid must never signal a live group.
+  child.killFn = (pid, signal) => {
+    expect(pid).toBe(-child.pid);
     child.signals.push(signal);
     child.emit("signal", signal);
+  };
+  child.kill = (signal) => {
+    throw new Error(
+      `child.kill(${signal}) must not be reached: killFn was injected`,
+    );
   };
   return child;
 }
@@ -34,6 +42,7 @@ function graderCall(child, options = {}) {
     timeoutMs: 10,
     budgetUsd: 1,
     killGraceMs: 10,
+    killFn: child.killFn,
     spawnFn: () => child,
     ...options,
   });
@@ -58,7 +67,9 @@ describe("grader process termination", () => {
     controller.abort();
 
     await waitForSignal(child, "SIGKILL");
+    // Abort and timeout both escalate, yet exactly one TERM and one KILL land.
     expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+    expect(child.signals).toHaveLength(2);
 
     child.emit("close", 1);
     await pending;

--- a/evals/lib/grader.test.mjs
+++ b/evals/lib/grader.test.mjs
@@ -1,0 +1,66 @@
+import { describe, expect, test } from "bun:test";
+import { EventEmitter } from "node:events";
+import { callClaude } from "./grader.mjs";
+
+function fakeChild() {
+  const child = new EventEmitter();
+  child.pid = 999_999;
+  child.stdout = new EventEmitter();
+  child.stderr = new EventEmitter();
+  child.stdout.setEncoding = () => {};
+  child.stderr.setEncoding = () => {};
+  child.signals = [];
+  child.kill = (signal) => {
+    child.signals.push(signal);
+    child.emit("signal", signal);
+  };
+  return child;
+}
+
+function waitForSignal(child, signal) {
+  if (child.signals.includes(signal)) return Promise.resolve();
+  return new Promise((resolve) => {
+    child.on("signal", (received) => {
+      if (received === signal) resolve();
+    });
+  });
+}
+
+function graderCall(child, options = {}) {
+  return callClaude({
+    prompt: "grade this",
+    model: "test-model",
+    cwd: process.cwd(),
+    timeoutMs: 10,
+    budgetUsd: 1,
+    killGraceMs: 10,
+    spawnFn: () => child,
+    ...options,
+  });
+}
+
+describe("grader process termination", () => {
+  test("sends TERM then KILL after the configured grace period", async () => {
+    const child = fakeChild();
+    const pending = graderCall(child);
+
+    await waitForSignal(child, "SIGKILL");
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+
+    child.emit("close", 1);
+    await pending;
+  });
+
+  test("deduplicates abort and timeout termination", async () => {
+    const child = fakeChild();
+    const controller = new AbortController();
+    const pending = graderCall(child, { signal: controller.signal });
+    controller.abort();
+
+    await waitForSignal(child, "SIGKILL");
+    expect(child.signals).toEqual(["SIGTERM", "SIGKILL"]);
+
+    child.emit("close", 1);
+    await pending;
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1463

Grader now shares the runtime TERM→KILL lifecycle and covers racing termination paths.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test evals/lib/grader.test.mjs evals/run.test.mjs --timeout 20000` | pass | 38 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1,982 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

## Post-review

Review (FIX): `grader.test.mjs` used `fakeChild().pid = 999_999` without injecting `kill`, so the shared `killProcessGroup` called the real `process.kill(-999999, …)` on the runner.

- `callClaude` now accepts `killFn = process.kill` and passes it to `killProcessGroup(child, { killGraceMs, kill: killFn })`.
- Both tests inject a recording fake that asserts the group pid (`-child.pid`) and records the signal; `child.kill` throws if reached. The abort+timeout case asserts exactly one TERM then one KILL (two calls total).
- Re-verified: `bun test evals/lib/grader.test.mjs evals/run.test.mjs` (38 pass), `bun run format:check`, `bun run check`, `bun test event-runtime/lib` (1992 pass, 0 fail), `bun build/emit.mjs --check`.
