### PR TITLE
fix(config): validate security scan settings (#1464)

### DIFF
--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -13,7 +13,7 @@
  * report-only one, and where its worktrees live (OPS-299).
  */
 import { createHash } from "node:crypto";
-import { existsSync, readFileSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import {
   DEFAULT_MAX_IN_FLIGHT,
@@ -689,7 +689,8 @@ export async function repoDispatchPreflight(
  *                        mergeCi: {workflow: string, requiredChecks: string[]}|null,
  *                        escalatePaths: string[]|null, smokeWorkflow: string|null, smokeUrl: string|null,
  *                        deployment: {url: string|null, branch: string|null, revisionField: string|null}|null,
- *                        security: {pythonVersion: string|null}|null,
+ *                        security: {pythonVersion: string|number|null, semgrepArgs: string|null,
+ *                        gitleaksArgs: string|null}|null,
  *                        worktreeRoot: string|null, worktreeUp: string|null, worktreeDown: string|null,
  *                        worktreeWarm: string|null, verify: string|null,
  *                        toolchain: Array<{executable: string, constraint: string}>|null,
@@ -789,16 +790,7 @@ export function loadRepos({ root = reposRoot() } = {}) {
         revisionField: entry.deployment.revision_field ?? null,
       };
     }
-    let security = null;
-    if (entry.security !== undefined && entry.security !== null) {
-      if (typeof entry.security !== "object" || Array.isArray(entry.security)) {
-        throw new RepoError(
-          `${file}: repo ${entry.name} security must be an object`,
-        );
-      }
-      // Deliberate allow-list: never pass through credential-shaped additions.
-      security = { pythonVersion: entry.security.python_version ?? null };
-    }
+    const security = normalizeSecurity(entry.security, entry.name, file);
     // WM-1007: which tracker holds this repo's tickets. Absent means "inherit
     // config/policy.yaml", which is why the default is null and not "linear" —
     // a value here would state a choice this file never made, and would
@@ -853,6 +845,63 @@ export function loadRepos({ root = reposRoot() } = {}) {
     });
   }
   return repos;
+}
+
+function normalizeSecurity(raw, repoName, file) {
+  if (raw === undefined || raw === null) return null;
+  if (typeof raw !== "object" || Array.isArray(raw)) {
+    throw new RepoError(`${file}: repo ${repoName} security must be an object`);
+  }
+
+  const keys = ["python_version", "semgrep_args", "gitleaks_args"];
+  const unknown = Object.keys(raw).filter((key) => !keys.includes(key));
+  if (unknown.length) {
+    throw new RepoError(
+      `${file}: repo ${repoName} security has unknown keys (${unknown.join(", ")})`,
+    );
+  }
+
+  for (const field of ["semgrep_args", "gitleaks_args"]) {
+    if (raw[field] !== undefined && typeof raw[field] !== "string") {
+      throw new RepoError(
+        `${file}: repo ${repoName} security.${field} must be a string, got ${JSON.stringify(raw[field])}`,
+      );
+    }
+  }
+  if (
+    raw.python_version !== undefined &&
+    typeof raw.python_version !== "string" &&
+    typeof raw.python_version !== "number"
+  ) {
+    throw new RepoError(
+      `${file}: repo ${repoName} security.python_version must be a string or number, got ${JSON.stringify(raw.python_version)}`,
+    );
+  }
+
+  return {
+    pythonVersion: raw.python_version ?? null,
+    semgrepArgs: raw.semgrep_args ?? null,
+    gitleaksArgs: raw.gitleaks_args ?? null,
+  };
+}
+
+/**
+ * Resolve a filesystem target to its configured repo record. Worktrees live
+ * outside their configured checkout, so an origin remote is a deliberate
+ * fallback after the canonical realpath-prefix match.
+ */
+export function findRepoForPath(repos, target, { remote = null } = {}) {
+  for (const repo of repos.values()) {
+    let byPath = false;
+    try {
+      const repoPath = realpathSync(repo.path);
+      byPath = target === repoPath || target.startsWith(repoPath + path.sep);
+    } catch {
+      /* A missing optional checkout must not prevent a remote match. */
+    }
+    if (byPath || (remote && repo.github === remote)) return repo;
+  }
+  return null;
 }
 
 /**

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -1,6 +1,12 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-repos-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import semver from "semver";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
@@ -14,6 +20,7 @@ import {
   REPO_TOOLCHAIN_MISMATCH,
   REPO_TOOLCHAIN_MISSING,
   RepoError,
+  findRepoForPath,
   repoDispatchPreflight,
   repoReadiness,
   reposView,
@@ -90,7 +97,8 @@ const YAML = `repos:
         - Verify
     security:
       python_version: "3.12"
-      api_token: never-publish-security-token
+      semgrep_args: "--exclude-rule example.rule"
+      gitleaks_args: "--no-git"
     escalate_paths:
       - src/auth/**
 
@@ -124,7 +132,11 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
         branch: "master",
         revisionField: "revision",
       },
-      security: { pythonVersion: "3.12" },
+      security: {
+        pythonVersion: "3.12",
+        semgrepArgs: "--exclude-rule example.rule",
+        gitleaksArgs: "--no-git",
+      },
       mergeCi: {
         workflow: "CI",
         requiredChecks: ["Shadow runner fleet available", "Verify"],
@@ -193,6 +205,59 @@ describe("loadRepos reads the registry fields the operator surfaces need (OPS-29
     const empty = tmpDir("evrt-repos-empty-");
     scratch.push(empty);
     expect(() => loadRepos({ root: empty })).toThrow(RepoError);
+  });
+
+  test("security only accepts documented, typed scan settings", () => {
+    const valid = loadRepos({
+      root: factoryRoot(`repos:
+  - name: configured
+    path: /tmp/configured
+    security:
+      python_version: 3.12
+      semgrep_args: --exclude-rule example.rule
+      gitleaks_args: --no-git
+`),
+    }).get("configured");
+    expect(valid.security).toEqual({
+      pythonVersion: 3.12,
+      semgrepArgs: "--exclude-rule example.rule",
+      gitleaksArgs: "--no-git",
+    });
+
+    for (const [field, value, expected] of [
+      ["semgrep_args", "[--exclude-rule]", "security.semgrep_args"],
+      ["gitleaks_args", "{no_git: true}", "security.gitleaks_args"],
+      ["python_version", "true", "security.python_version"],
+      ["unexpected", "value", "security has unknown keys"],
+    ]) {
+      const root = factoryRoot(`repos:
+  - name: invalid
+    path: /tmp/invalid
+    security:
+      ${field}: ${value}
+`);
+      expect(() => loadRepos({ root })).toThrow(
+        new RegExp(`repo invalid ${expected}`),
+      );
+    }
+  });
+
+  test("findRepoForPath uses a realpath prefix before the worktree remote fallback", () => {
+    const repos = loadRepos({
+      root: factoryRoot(`repos:
+  - name: configured
+    path: ${process.cwd()}
+    github: watt-mind/configured
+`),
+    });
+    expect(findRepoForPath(repos, realpathSync(process.cwd()))?.name).toBe(
+      "configured",
+    );
+    expect(
+      findRepoForPath(repos, "/tmp/worktree", {
+        remote: "watt-mind/configured",
+      })?.name,
+    ).toBe("configured");
   });
 
   test("max_in_flight must be a positive number when present, or null when absent/null (OPS-347)", () => {
@@ -474,7 +539,11 @@ describe("reposView is what the control API serves", () => {
           baseline: "event-runtime/lib/registry.test.mjs",
         },
       },
-      security: { pythonVersion: "3.12" },
+      security: {
+        pythonVersion: "3.12",
+        semgrepArgs: "--exclude-rule example.rule",
+        gitleaksArgs: "--no-git",
+      },
     });
     expect(rows[1]).toMatchObject({ escalatePaths: null, security: null });
 

--- a/tools/security-env.mjs
+++ b/tools/security-env.mjs
@@ -13,9 +13,7 @@
  * factory checkout. (.gitleaks.toml stays in-repo: CI and git hooks need it.)
  */
 import { realpathSync } from "node:fs";
-import { homedir } from "node:os";
-import path from "node:path";
-import { loadConfigYaml } from "../lib/schedule.mjs";
+import { findRepoForPath, loadRepos } from "../event-runtime/lib/repos.mjs";
 
 export const USAGE = "usage: bun tools/security-env.mjs [PATH]";
 
@@ -41,11 +39,8 @@ export function run(argv = process.argv.slice(2)) {
     throw new UsageError(USAGE);
   }
 
-  const cfg = loadConfigYaml("repos");
-  const expand = (p) => realpathSync(p.replace(/^~(?=\/|$)/, homedir()));
-
-  // Worktrees live outside the configured path, so also match by origin remote
-  // (normalized to owner/repo).
+  // Worktrees live outside the configured path, so preserve the normalized
+  // origin remote as a fallback after the registry's canonical path match.
   const remote = (() => {
     const r = Bun.spawnSync([
       "git",
@@ -63,26 +58,18 @@ export function run(argv = process.argv.slice(2)) {
     return m ? m[1] : null;
   })();
 
-  for (const repo of cfg.repos || []) {
-    let byPath = false;
-    try {
-      const repoPath = expand(repo.path);
-      byPath = target === repoPath || target.startsWith(repoPath + path.sep);
-    } catch {
-      /* intentionally ignored */
-    }
-    if (!byPath && !(remote && repo.github === remote)) continue;
-    const sec = repo.security || {};
-    if (sec.semgrep_args)
-      console.log(`export SEMGREP_ARGS=${JSON.stringify(sec.semgrep_args)}`);
-    if (sec.gitleaks_args)
-      console.log(`export GITLEAKS_ARGS=${JSON.stringify(sec.gitleaks_args)}`);
-    if (sec.python_version)
-      console.log(
-        `export PYTHON_VERSION=${JSON.stringify(String(sec.python_version))}`,
-      );
-    break;
-  }
+  const repo = findRepoForPath(loadRepos(), target, { remote });
+  const security = repo?.security;
+  if (security?.semgrepArgs)
+    console.log(`export SEMGREP_ARGS=${JSON.stringify(security.semgrepArgs)}`);
+  if (security?.gitleaksArgs)
+    console.log(
+      `export GITLEAKS_ARGS=${JSON.stringify(security.gitleaksArgs)}`,
+    );
+  if (security?.pythonVersion)
+    console.log(
+      `export PYTHON_VERSION=${JSON.stringify(String(security.pythonVersion))}`,
+    );
 }
 
 if (import.meta.main) {

--- a/tools/security-env.test.mjs
+++ b/tools/security-env.test.mjs
@@ -1,9 +1,11 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { expect, test } from "bun:test";
 
 const ROOT = path.resolve(import.meta.dir, "..");
 
-function run(args) {
+function run(args, { env = process.env } = {}) {
   return Bun.spawnSync({
     cmd: [
       process.execPath,
@@ -11,10 +13,39 @@ function run(args) {
       ...args,
     ],
     cwd: ROOT,
+    env,
     stdout: "pipe",
     stderr: "pipe",
   });
 }
+
+test("security-env emits the validated registry settings byte-for-byte", () => {
+  const factoryRoot = mkdtempSync(path.join(tmpdir(), "security-env-"));
+  try {
+    mkdirSync(path.join(factoryRoot, "config"));
+    writeFileSync(
+      path.join(factoryRoot, "config", "repos.yaml"),
+      `repos:
+  - name: fixture
+    path: ${ROOT}
+    security:
+      semgrep_args: --exclude-rule example.rule
+      gitleaks_args: --no-git
+      python_version: 3.12
+`,
+    );
+    const proc = run([ROOT], {
+      env: { ...process.env, FACTORY_REPOS_ROOT: factoryRoot },
+    });
+    expect(proc.exitCode).toBe(0);
+    expect(proc.stdout.toString()).toBe(
+      'export SEMGREP_ARGS="--exclude-rule example.rule"\nexport GITLEAKS_ARGS="--no-git"\nexport PYTHON_VERSION="3.12"\n',
+    );
+    expect(output(proc, "stderr")).toBe("");
+  } finally {
+    rmSync(factoryRoot, { recursive: true, force: true });
+  }
+});
 
 function output(proc, stream) {
   return proc[stream]?.toString().trim() ?? "";


### PR DESCRIPTION
Fixes #1464

Validate scan settings in the shared repository registry so security tooling uses typed configuration.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs tools/security-env.test.mjs --timeout 20000` | pass | 64 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1987 pass, 10 skipped |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped