### PR TITLE
fix(stack): rotate daemon logs and back off web restarts

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -10,6 +10,7 @@
 #   factory down                 # cleanly stop live daemons (drains the pool first)
 #   factory tail                 # tail all live logs (serve.log, worker.log, web.log)
 #   factory tail worker          # tail a specific daemon log
+#   factory logs rotate          # rotate oversized daemon logs now
 #
 set -euo pipefail
 
@@ -139,6 +140,8 @@ HOME_DIR="${FACTORY_EVENT_HOME:-$HOME/.factory/event-runtime}"
 RUN_DIR="${FACTORY_RUN_DIR:-$HOME/.factory/run}"
 API_PORT="${FACTORY_EVENT_PORT:-7381}"
 WEB_PORT="${FACTORY_EVENT_WEB_PORT:-7382}"
+LOG_ROTATE_BYTES="${FACTORY_LOG_ROTATE_BYTES:-52428800}"
+LOG_KEEP="${FACTORY_LOG_KEEP:-3}"
 
 # `up` creates these itself once `--dry-run` has had its chance to exit: a dry
 # run must leave no trace on disk.
@@ -374,6 +377,11 @@ case "$ACTION" in
     fi
 
     mkdir -p "$RUN_DIR" "$HOME_DIR"
+    [[ "$LOG_ROTATE_BYTES" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_BYTES must be a non-negative integer"
+    [[ "$LOG_KEEP" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
+    # This happens before any daemon is spawned. Existing live owners keep
+    # their inode and are copy-truncated; stopped daemons get a cheap rename.
+    rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
     # Record what was already running before this invocation starts anything,
     # so a failed `up` can tell its own daemons from the operator's.
     snapshot_up_pidfiles
@@ -599,16 +607,35 @@ case "$ACTION" in
   __supervise-web)
     # The static server normally survives API restarts. If an unrelated
     # uncaught process error does terminate it, keep the UI reachable while the
-    # API daemon is still alive. A bounded one-second check avoids crash-looping
-    # while still recovering before the next operator pulse.
+    # API daemon is still alive. Fast failures back off rather than turning a
+    # port clash into a one-line-per-second log flood.
     WEB_DEV="${1:-0}"
     WEB_CHILD_PID=""
+    WEB_CHILD_STARTED=0
+    WEB_RESTART_DELAY=1
     # A replacement stays in this supervisor's process group rather than being
     # detached. `factory down` can therefore stop the whole group atomically,
     # including a child spawned just before SIGTERM reaches this shell.
     trap 'if [[ -n "$WEB_CHILD_PID" ]]; then kill -TERM "$WEB_CHILD_PID" 2>/dev/null || true; fi; exit 0' TERM INT
     while pid_alive "$RUN_DIR/serve.pid"; do
       if ! pid_alive "$RUN_DIR/web.pid"; then
+        WEB_NOW=$(date +%s)
+        if [[ "$WEB_CHILD_STARTED" -gt 0 ]]; then
+          WEB_AGE=$((WEB_NOW - WEB_CHILD_STARTED))
+          if [[ "$WEB_AGE" -ge 60 ]]; then
+            WEB_RESTART_DELAY=1
+          elif [[ "$WEB_AGE" -le 5 ]]; then
+            printf '%s [web-supervisor] web server failed after %ss; retrying in %ss\n' \
+              "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$WEB_AGE" "$WEB_RESTART_DELAY"
+            sleep "$WEB_RESTART_DELAY"
+            WEB_RESTART_DELAY=$((WEB_RESTART_DELAY * 2))
+            [[ "$WEB_RESTART_DELAY" -le 30 ]] || WEB_RESTART_DELAY=30
+          else
+            # It was not a rapid crash-loop. Keep the next retry prompt while
+            # retaining the explicit 60-second reset for long-lived children.
+            WEB_RESTART_DELAY=1
+          fi
+        fi
         printf '%s [web-supervisor] web server down; restarting\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
         if [[ "$WEB_DEV" -eq 1 ]]; then
           (
@@ -624,7 +651,10 @@ case "$ACTION" in
           ) >>"$RUN_DIR/web.log" 2>&1 &
         fi
         WEB_CHILD_PID=$!
+        WEB_CHILD_STARTED=$(date +%s)
         printf '%s\n' "$WEB_CHILD_PID" >"$RUN_DIR/web.pid"
+      elif [[ "$WEB_CHILD_STARTED" -gt 0 ]] && (( $(date +%s) - WEB_CHILD_STARTED >= 60 )); then
+        WEB_RESTART_DELAY=1
       fi
       sleep "${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
     done
@@ -737,7 +767,19 @@ case "$ACTION" in
     fi
     ;;
 
+  logs)
+    [[ "${1:-}" == "rotate" && $# -eq 1 ]] || die "usage: factory logs rotate"
+    [[ "$LOG_ROTATE_BYTES" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_BYTES must be a non-negative integer"
+    [[ "$LOG_KEEP" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
+    rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
+    printf 'total log bytes: %s\n' "$(run_log_total_bytes "$RUN_DIR")"
+    ;;
+
+  status)
+    printf 'total log bytes: %s\n' "$(run_log_total_bytes "$RUN_DIR")"
+    ;;
+
   *)
-    die "unknown action '$ACTION' (expected: up, down, tail)"
+    die "unknown action '$ACTION' (expected: up, down, tail, logs, status)"
     ;;
 esac

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -11,6 +11,16 @@
 #   factory tail                 # tail all live logs (serve.log, worker.log, web.log)
 #   factory tail worker          # tail a specific daemon log
 #   factory logs rotate          # rotate oversized daemon logs now
+#   factory status               # report total bytes held by daemon logs (+ archives)
+#
+# Log rotation knobs (read by `up`, `logs rotate`, and the web supervisor tick):
+#   FACTORY_LOG_ROTATE_BYTES     # rotate a daemon log once it exceeds this many
+#                                # bytes; default 52428800 (50 MiB), minimum
+#                                # 1048576 (1 MiB); 0 disables rotation entirely
+#   FACTORY_LOG_KEEP             # archived generations to retain per log
+#                                # (<log>.1 .. <log>.N); default 3, minimum 1
+#   FACTORY_LOG_ROTATE_INTERVAL  # seconds between size checks while the stack is
+#                                # up (web supervisor tick); default 300
 #
 set -euo pipefail
 
@@ -142,6 +152,28 @@ API_PORT="${FACTORY_EVENT_PORT:-7381}"
 WEB_PORT="${FACTORY_EVENT_WEB_PORT:-7382}"
 LOG_ROTATE_BYTES="${FACTORY_LOG_ROTATE_BYTES:-52428800}"
 LOG_KEEP="${FACTORY_LOG_KEEP:-3}"
+LOG_ROTATE_INTERVAL="${FACTORY_LOG_ROTATE_INTERVAL:-300}"
+LOG_ROTATE_MIN_BYTES=1048576
+
+# Reject knob values before anything touches a log. A threshold below 1 MiB
+# would rotate on nearly every tick (and lose the log's recent tail every time);
+# 0 is the explicit "off" switch rather than a threshold.
+validate_log_knobs() {
+  [[ "$LOG_ROTATE_BYTES" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_BYTES must be a non-negative integer"
+  [[ "$LOG_ROTATE_BYTES" -eq 0 || "$LOG_ROTATE_BYTES" -ge "$LOG_ROTATE_MIN_BYTES" ]] ||
+    die "FACTORY_LOG_ROTATE_BYTES must be 0 (disabled) or at least $LOG_ROTATE_MIN_BYTES bytes (1 MiB)"
+  [[ "$LOG_KEEP" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
+  [[ "$LOG_ROTATE_INTERVAL" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_INTERVAL must be a non-negative integer"
+}
+
+# Rotation entry point shared by `up`, `logs rotate`, and the supervisor tick.
+# FACTORY_LOG_ROTATE_BYTES=0 means "never rotate"; everything else defers to
+# rotate_run_logs (worktree-common.sh), which copy-truncates logs with a live
+# owner and renames the rest.
+rotate_stack_logs() {
+  [[ "$LOG_ROTATE_BYTES" -gt 0 ]] || return 0
+  rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
+}
 
 # `up` creates these itself once `--dry-run` has had its chance to exit: a dry
 # run must leave no trace on disk.
@@ -377,11 +409,12 @@ case "$ACTION" in
     fi
 
     mkdir -p "$RUN_DIR" "$HOME_DIR"
-    [[ "$LOG_ROTATE_BYTES" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_BYTES must be a non-negative integer"
-    [[ "$LOG_KEEP" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
+    validate_log_knobs
     # This happens before any daemon is spawned. Existing live owners keep
     # their inode and are copy-truncated; stopped daemons get a cheap rename.
-    rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
+    # The web supervisor repeats the check every LOG_ROTATE_INTERVAL seconds
+    # so a stack left up for days still rotates.
+    rotate_stack_logs
     # Record what was already running before this invocation starts anything,
     # so a failed `up` can tell its own daemons from the operator's.
     snapshot_up_pidfiles
@@ -613,6 +646,13 @@ case "$ACTION" in
     WEB_CHILD_PID=""
     WEB_CHILD_STARTED=0
     WEB_RESTART_DELAY=1
+    # This loop is the stack's only periodic tick, so it also owns in-flight log
+    # rotation: `up` rotates once at start, and a stack left running for days
+    # would otherwise grow its logs without bound. Live owners keep their inode
+    # (copy-truncate), so daemons never notice. Bad knobs stop the supervisor
+    # before it can spawn anything, just as they stop `up`.
+    validate_log_knobs
+    LOG_ROTATE_CHECKED=$(date +%s)
     # A replacement stays in this supervisor's process group rather than being
     # detached. `factory down` can therefore stop the whole group atomically,
     # including a child spawned just before SIGTERM reaches this shell.
@@ -655,6 +695,10 @@ case "$ACTION" in
         printf '%s\n' "$WEB_CHILD_PID" >"$RUN_DIR/web.pid"
       elif [[ "$WEB_CHILD_STARTED" -gt 0 ]] && (( $(date +%s) - WEB_CHILD_STARTED >= 60 )); then
         WEB_RESTART_DELAY=1
+      fi
+      if (( $(date +%s) - LOG_ROTATE_CHECKED >= LOG_ROTATE_INTERVAL )); then
+        rotate_stack_logs
+        LOG_ROTATE_CHECKED=$(date +%s)
       fi
       sleep "${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
     done
@@ -769,9 +813,11 @@ case "$ACTION" in
 
   logs)
     [[ "${1:-}" == "rotate" && $# -eq 1 ]] || die "usage: factory logs rotate"
-    [[ "$LOG_ROTATE_BYTES" =~ ^[0-9]+$ ]] || die "FACTORY_LOG_ROTATE_BYTES must be a non-negative integer"
-    [[ "$LOG_KEEP" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
-    rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
+    validate_log_knobs
+    if [[ "$LOG_ROTATE_BYTES" -eq 0 ]]; then
+      info "log rotation disabled (FACTORY_LOG_ROTATE_BYTES=0); nothing rotated"
+    fi
+    rotate_stack_logs
     printf 'total log bytes: %s\n' "$(run_log_total_bytes "$RUN_DIR")"
     ;;
 

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -39,6 +39,10 @@ info() { printf '==> %s\\n' "$*"; }
 warn() { printf 'warn: %s\\n' "$*" >&2; }
 die() { printf 'error: %s\\n' "$*" >&2; exit 1; }
 pid_alive() {
+  if [[ "\${FAKE_WEB_SUPERVISOR:-0}" == "1" ]]; then
+    [[ "$(basename "$1")" == "serve.pid" ]]
+    return
+  fi
   [[ "\${FAKE_ALIVE:-0}" == "1" ]] || return 1
   [[ -f "$1" ]] || return 1
   [[ -f "$1.terminated" ]] && return 1
@@ -61,6 +65,12 @@ term_daemon() {
   [[ "\${FAKE_IGNORES_TERM:-0}" == "1" ]] || touch "$1.terminated"
 }
 await_daemon() { printf 'AWAIT %s\\n' "$2" >>"$SPAWN_LOG"; }
+rotate_run_logs() {
+  if [[ -n "\${FAKE_ROTATION_LOG:-}" ]]; then
+    printf 'ROTATE bytes=%s keep=%s\\n' "$2" "$3" >>"$FAKE_ROTATION_LOG"
+  fi
+}
+run_log_total_bytes() { printf '%s' "\${FAKE_LOG_BYTES:-0}"; }
 `;
 
 /**
@@ -719,6 +729,68 @@ test("`up --bogus` is still rejected", () => {
     f.cleanup();
   }
 });
+
+test("`logs rotate` reports its total after requesting the configured retention", () => {
+  const f = makeFixture();
+  const rotationLog = path.join(f.root, "rotations.log");
+  try {
+    const r = runStack(f, ["logs", "rotate"], {
+      FACTORY_LOG_ROTATE_BYTES: "42",
+      FACTORY_LOG_KEEP: "2",
+      FAKE_ROTATION_LOG: rotationLog,
+      FAKE_LOG_BYTES: "321",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("total log bytes: 321");
+    expect(readFileSync(rotationLog, "utf8")).toBe("ROTATE bytes=42 keep=2\n");
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("web supervisor exponentially backs off rapid restarts", async () => {
+  const f = makeFixture();
+  const sleeps = path.join(f.root, "sleeps.log");
+  const counter = path.join(f.root, "sleep-count");
+  const sleep = path.join(f.root, "stubs", "sleep");
+  writeFileSync(
+    sleep,
+    `#!/bin/sh
+n=$(cat "$FAKE_SLEEP_COUNT" 2>/dev/null || printf 0)
+n=$((n + 1))
+printf '%s\\n' "$n" > "$FAKE_SLEEP_COUNT"
+printf '%s\\n' "$1" >> "$FAKE_SLEEP_LOG"
+if [ "$n" -ge 4 ]; then kill -TERM "$PPID"; fi
+`,
+    "utf8",
+  );
+  chmodSync(sleep, 0o755);
+  mkdirSync(f.runDir, { recursive: true });
+  writeFileSync(path.join(f.runDir, "serve.pid"), "1\n", "utf8");
+  const proc = Bun.spawn({
+    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-web"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${path.join(f.root, "stubs")}:${process.env.PATH}`,
+      FAKE_REPO: f.root,
+      FACTORY_RUN_DIR: f.runDir,
+      FACTORY_EVENT_HOME: path.join(f.root, "home"),
+      FAKE_WEB_SUPERVISOR: "1",
+      FAKE_SLEEP_LOG: sleeps,
+      FAKE_SLEEP_COUNT: counter,
+    },
+  });
+  try {
+    const status = await proc.exited;
+    expect(status).toBe(0);
+    const delays = readFileSync(sleeps, "utf8").trim().split("\n");
+    expect(delays).toEqual(["1", "1", "1", "2"]);
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
 
 // --- __supervise-worker ------------------------------------------------------
 

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -735,18 +735,117 @@ test("`logs rotate` reports its total after requesting the configured retention"
   const rotationLog = path.join(f.root, "rotations.log");
   try {
     const r = runStack(f, ["logs", "rotate"], {
-      FACTORY_LOG_ROTATE_BYTES: "42",
+      FACTORY_LOG_ROTATE_BYTES: "1048576",
       FACTORY_LOG_KEEP: "2",
       FAKE_ROTATION_LOG: rotationLog,
       FAKE_LOG_BYTES: "321",
     });
     expect(r.status).toBe(0);
     expect(r.stdout).toContain("total log bytes: 321");
-    expect(readFileSync(rotationLog, "utf8")).toBe("ROTATE bytes=42 keep=2\n");
+    expect(readFileSync(rotationLog, "utf8")).toBe(
+      "ROTATE bytes=1048576 keep=2\n",
+    );
   } finally {
     f.cleanup();
   }
 });
+
+test("`logs rotate` treats FACTORY_LOG_ROTATE_BYTES=0 as disabled", () => {
+  const f = makeFixture();
+  const rotationLog = path.join(f.root, "rotations.log");
+  try {
+    const r = runStack(f, ["logs", "rotate"], {
+      FACTORY_LOG_ROTATE_BYTES: "0",
+      FAKE_ROTATION_LOG: rotationLog,
+      FAKE_LOG_BYTES: "7",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("log rotation disabled");
+    expect(r.stdout).toContain("total log bytes: 7");
+    expect(existsSync(rotationLog)).toBe(false);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("log knobs below 1 MiB or malformed are rejected before anything rotates", () => {
+  const f = makeFixture();
+  const rotationLog = path.join(f.root, "rotations.log");
+  try {
+    for (const [env, message] of [
+      [{ FACTORY_LOG_ROTATE_BYTES: "42" }, "at least 1048576 bytes"],
+      [{ FACTORY_LOG_ROTATE_BYTES: "lots" }, "non-negative integer"],
+      [
+        { FACTORY_LOG_KEEP: "0" },
+        "FACTORY_LOG_KEEP must be a positive integer",
+      ],
+      [
+        { FACTORY_LOG_ROTATE_INTERVAL: "soon" },
+        "FACTORY_LOG_ROTATE_INTERVAL must be a non-negative integer",
+      ],
+    ]) {
+      const r = runStack(f, ["logs", "rotate"], {
+        ...env,
+        FAKE_ROTATION_LOG: rotationLog,
+      });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain(message);
+      expect(existsSync(rotationLog)).toBe(false);
+    }
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("web supervisor rotates logs on its tick while the stack stays up", async () => {
+  const f = makeFixture();
+  const rotationLog = path.join(f.root, "rotations.log");
+  const counter = path.join(f.root, "sleep-count");
+  const sleep = path.join(f.root, "stubs", "sleep");
+  writeFileSync(
+    sleep,
+    `#!/bin/sh
+n=$(cat "$FAKE_SLEEP_COUNT" 2>/dev/null || printf 0)
+n=$((n + 1))
+printf '%s\n' "$n" > "$FAKE_SLEEP_COUNT"
+if [ "$n" -ge 3 ]; then kill -TERM "$PPID"; fi
+`,
+    "utf8",
+  );
+  chmodSync(sleep, 0o755);
+  mkdirSync(f.runDir, { recursive: true });
+  writeFileSync(path.join(f.runDir, "serve.pid"), "1\n", "utf8");
+  const proc = Bun.spawn({
+    cmd: ["bash", path.join(f.root, "bin", "live-stack.sh"), "__supervise-web"],
+    stdout: "pipe",
+    stderr: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${path.join(f.root, "stubs")}:${process.env.PATH}`,
+      FAKE_REPO: f.root,
+      FACTORY_RUN_DIR: f.runDir,
+      FACTORY_EVENT_HOME: path.join(f.root, "home"),
+      FAKE_WEB_SUPERVISOR: "1",
+      FAKE_SLEEP_COUNT: counter,
+      FAKE_ROTATION_LOG: rotationLog,
+      FACTORY_LOG_ROTATE_BYTES: "2097152",
+      FACTORY_LOG_KEEP: "4",
+      // Every tick is a rotation check; the real default is 300 s.
+      FACTORY_LOG_ROTATE_INTERVAL: "0",
+    },
+  });
+  try {
+    const status = await proc.exited;
+    expect(status).toBe(0);
+    const rotations = readFileSync(rotationLog, "utf8").trim().split("\n");
+    expect(rotations.length).toBeGreaterThanOrEqual(2);
+    expect(new Set(rotations)).toEqual(
+      new Set(["ROTATE bytes=2097152 keep=4"]),
+    );
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
 
 test("web supervisor exponentially backs off rapid restarts", async () => {
   const f = makeFixture();

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -478,6 +478,70 @@ spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
   fi
 }
 
+# The live stack keeps its logs alongside pidfiles.  Rotate a file in place
+# when one of its owners is still alive: a rename would leave that daemon
+# writing to the old inode forever, defeating the point of rotation.
+run_log_has_live_owner() { # <logfile>
+  local logfile="$1" run_dir stem pidfile
+  run_dir="$(dirname "$logfile")"
+  stem="$(basename "${logfile%.log}")"
+  # web.log is shared by web.pid and web-supervisor.pid; the prefix also
+  # covers worker-N.log / worker-N.pid pool slots.
+  for pidfile in "$run_dir/$stem".pid "$run_dir/$stem"-*.pid; do
+    pid_alive "$pidfile" && return 0
+  done
+  return 1
+}
+
+run_log_size_bytes() { # <logfile>
+  [[ -f "$1" ]] || { printf '0'; return; }
+  wc -c <"$1" | tr -d '[:space:]'
+}
+
+rotate_run_log() { # <logfile> <max-bytes> <keep>
+  local logfile="$1" max_bytes="$2" keep="$3" size i mode
+  [[ -f "$logfile" ]] || return 0
+  size="$(run_log_size_bytes "$logfile")"
+  [[ "$size" =~ ^[0-9]+$ ]] && ((size > max_bytes)) || return 0
+
+  # Keep .1 newest and discard only the oldest retained generation.
+  rm -f "$logfile.$keep"
+  for ((i = keep; i > 1; i--)); do
+    [[ -f "$logfile.$((i - 1))" ]] && mv -f "$logfile.$((i - 1))" "$logfile.$i"
+  done
+
+  if run_log_has_live_owner "$logfile"; then
+    cp -f "$logfile" "$logfile.1"
+    : >"$logfile"
+    mode="copy-truncated live log"
+  else
+    mv -f "$logfile" "$logfile.1"
+    : >"$logfile"
+    mode="moved stopped log"
+  fi
+  info "rotated $logfile (${size} bytes; $mode -> ${logfile}.1)"
+}
+
+rotate_run_logs() { # <run-dir> <max-bytes> <keep>
+  local run_dir="$1" max_bytes="$2" keep="$3" logfile
+  [[ -d "$run_dir" ]] || return 0
+  for logfile in "$run_dir"/*.log; do
+    [[ -f "$logfile" ]] || continue
+    rotate_run_log "$logfile" "$max_bytes" "$keep"
+  done
+}
+
+run_log_total_bytes() { # <run-dir>
+  local run_dir="$1" logfile total=0 size
+  [[ -d "$run_dir" ]] || { printf '0'; return; }
+  for logfile in "$run_dir"/*.log "$run_dir"/*.log.[0-9]*; do
+    [[ -f "$logfile" ]] || continue
+    size="$(run_log_size_bytes "$logfile")"
+    [[ "$size" =~ ^[0-9]+$ ]] && total=$((total + size))
+  done
+  printf '%s' "$total"
+}
+
 # Persist / restore the ports this checkout actually bound (OPS-460).
 read_ports() { # <worktree> → prints "api web"
   local f api="" web="" k v

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -499,22 +499,34 @@ run_log_size_bytes() { # <logfile>
 }
 
 rotate_run_log() { # <logfile> <max-bytes> <keep>
-  local logfile="$1" max_bytes="$2" keep="$3" size i mode
+  local logfile="$1" max_bytes="$2" keep="$3" size i mode old suffix
   [[ -f "$logfile" ]] || return 0
   size="$(run_log_size_bytes "$logfile")"
   [[ "$size" =~ ^[0-9]+$ ]] && ((size > max_bytes)) || return 0
 
-  # Keep .1 newest and discard only the oldest retained generation.
-  rm -f "$logfile.$keep"
+  # Keep .1 newest. Prune every generation past <keep>, not just .<keep>: a
+  # lowered FACTORY_LOG_KEEP must not strand .4/.5 archives forever.
+  for old in "$logfile".[0-9]*; do
+    [[ -f "$old" ]] || continue
+    suffix="${old##*.}"
+    [[ "$suffix" =~ ^[0-9]+$ ]] || continue
+    ((suffix >= keep)) && rm -f "$old"
+  done
   for ((i = keep; i > 1; i--)); do
     [[ -f "$logfile.$((i - 1))" ]] && mv -f "$logfile.$((i - 1))" "$logfile.$i"
   done
 
   if run_log_has_live_owner "$logfile"; then
+    # Copy-truncate: the daemon keeps appending to the same inode. Lines written
+    # between the cp and the truncate are lost — acceptable for a diagnostic log.
     cp -f "$logfile" "$logfile.1"
     : >"$logfile"
     mode="copy-truncated live log"
   else
+    # Rename is only safe with no live owner (checked above): a process still
+    # holding the old inode would keep writing to <log>.1 and the fresh <log>
+    # would stay empty. Ownership is inferred from pidfiles, so a daemon that
+    # outlived (or never had) its pidfile is invisible here and gets renamed.
     mv -f "$logfile" "$logfile.1"
     : >"$logfile"
     mode="moved stopped log"

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -109,6 +109,31 @@ function command(cmd, cwd, extraEnv = {}) {
   };
 }
 
+test("run log rotation retains bounded generations and copy-truncates a live owner", () => {
+  const r = sh(`
+    dir="$(mktemp -d)"
+    trap 'rm -rf "$dir"' EXIT
+    log="$dir/worker.log"
+    printf 'new' > "$log"
+    printf 'one' > "$log.1"
+    printf 'two' > "$log.2"
+    printf 'three' > "$log.3"
+    rotate_run_log "$log" 1 3 >/dev/null
+    printf 'generations=%s/%s/%s current=%s\\n' "$(cat "$log.1")" "$(cat "$log.2")" "$(cat "$log.3")" "$(wc -c < "$log" | tr -d '[:space:]')"
+
+    exec 9>> "$log"
+    printf 'before' >&9
+    printf '%s\\n' $$ > "$dir/worker.pid"
+    rotate_run_log "$log" 1 3 >/dev/null
+    printf 'after' >&9
+    exec 9>&-
+    printf 'live-current=%s archive=%s\\n' "$(cat "$log")" "$(cat "$log.1")"
+  `);
+  expect(r.status).toBe(0);
+  expect(r.stdout).toContain("generations=new/one/two current=0");
+  expect(r.stdout).toContain("live-current=after archive=before");
+});
+
 function git(cwd, ...args) {
   const result = command(["git", ...args], cwd);
   if (result.status !== 0) {

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -118,8 +118,10 @@ test("run log rotation retains bounded generations and copy-truncates a live own
     printf 'one' > "$log.1"
     printf 'two' > "$log.2"
     printf 'three' > "$log.3"
+    printf 'stale' > "$log.4"
+    printf 'staler' > "$log.7"
     rotate_run_log "$log" 1 3 >/dev/null
-    printf 'generations=%s/%s/%s current=%s\\n' "$(cat "$log.1")" "$(cat "$log.2")" "$(cat "$log.3")" "$(wc -c < "$log" | tr -d '[:space:]')"
+    printf 'generations=%s/%s/%s current=%s stale=%s\\n' "$(cat "$log.1")" "$(cat "$log.2")" "$(cat "$log.3")" "$(wc -c < "$log" | tr -d '[:space:]')" "$(ls "$dir" | grep -c 'worker\\.log\\.[4-9]' || true)"
 
     exec 9>> "$log"
     printf 'before' >&9
@@ -130,7 +132,7 @@ test("run log rotation retains bounded generations and copy-truncates a live own
     printf 'live-current=%s archive=%s\\n' "$(cat "$log")" "$(cat "$log.1")"
   `);
   expect(r.status).toBe(0);
-  expect(r.stdout).toContain("generations=new/one/two current=0");
+  expect(r.stdout).toContain("generations=new/one/two current=0 stale=0");
   expect(r.stdout).toContain("live-current=after archive=before");
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1438

Rotates bounded live-stack logs and backs off rapid web-server restart loops.

## Validation

| Check                | Command                                                                      | Result | Notes                         |
| -------------------- | ---------------------------------------------------------------------------- | ------ | ----------------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs bin/worktree-common.test.mjs --timeout 20000` | pass   | 74 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 1985 pass, 0 failures         |
| UX critique          | factory-ux-critic                                                            | not run | no user-facing surface        |

UX critique: skipped


## Post-review

Folded in from the merge review (f818304):

- **Rotation while up** — the web supervisor tick (the stack's only periodic loop, always spawned by `up`) now re-checks log sizes every `FACTORY_LOG_ROTATE_INTERVAL` seconds (default 300), so a stack left up for days rotates; live owners are copy-truncated, so daemons keep their inode.
- **Prune every stale generation** — `rotate_run_log` removes every `<log>.N` with `N >= FACTORY_LOG_KEEP` before shifting, not just `.<keep>`; a lowered keep no longer strands `.4`/`.7` archives.
- **Knob validation** — `FACTORY_LOG_ROTATE_BYTES=0` explicitly disables rotation; any other value must be `>= 1048576` (1 MiB). `FACTORY_LOG_KEEP` must be `>= 1`, `FACTORY_LOG_ROTATE_INTERVAL` a non-negative integer. Validated in `up`, `logs rotate`, and the supervisor.
- Comment on the mv-branch caveat (rename is only safe with no live owner; ownership is inferred from pidfiles).
- Header usage block documents `factory status` and all three env knobs.
- Tests: pruning of stale generations, `0` = disabled, sub-1 MiB / malformed knobs rejected before anything rotates, supervisor rotates on tick.

Note: routing `factory logs rotate` / `factory status` through `bin/factory` is outside this PR's Owned Paths and tracked by #1487.
