### PR TITLE
fix(backend): replay latest missed slot for last catch-up

### DIFF
--- a/docs/event-runtime-schedules.md
+++ b/docs/event-runtime-schedules.md
@@ -84,16 +84,18 @@ approved tick and a replayed one converge on the same run.
 A laptop asleep from 22:00 to 04:00 misses six hourly slots. There is no
 universally right answer, so each loop declares one:
 
-| `catchUp`        | Behaviour                                                       | Use for                                                                                    |
-| :--------------- | :-------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
-| `none` (default) | Fire only the current slot; missed ones are recorded as skipped | Idempotent maintenance — running the reaper once now is equivalent to running it six times |
-| `last`           | Fire the most recent missed slot, then resume                   | Loops where one late run still has value                                                   |
-| `all`            | Fire every missed slot in order                                 | Anything that accumulates per-interval work; rare, and expensive by construction           |
+| `catchUp`        | Behaviour                                                                           | Use for                                                                                    |
+| :--------------- | :---------------------------------------------------------------------------------- | :----------------------------------------------------------------------------------------- |
+| `none` (default) | Fire only the current slot; missed ones are recorded as skipped                     | Idempotent maintenance — running the reaper once now is equivalent to running it six times |
+| `last`           | Fire the most recent missed slot (the slot immediately before current), then resume | Loops where one late run still has value                                                   |
+| `all`            | Fire every missed slot in order                                                     | Anything that accumulates per-interval work; rare, and expensive by construction           |
 
 The count of skipped slots travels on the tick that did fire
-(`payload.skippedSlots`), and `serve` logs it — so a six-hour gap reads as one
-run standing for six slots rather than as silence. There is no separate journal
-record per skipped slot.
+(`payload.skippedSlots`), and `serve` logs it. For `last`, this counts the
+older missed slots: the newest missed slot fires, while the current slot fires
+on the following tick; if there are no missed slots, `last` fires the current
+slot with `skippedSlots: 0`. There is no separate journal record per skipped
+slot.
 
 ## 5. Overlap: a loop is a singleton by default
 

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -91,8 +91,18 @@ export function dueSlots({
     return { slots, skipped };
   }
 
-  // "none" and "last" both fire exactly one tick here; they differ only in
-  // which slot it claims to be, and therefore in what a replay would mean.
+  if (catchUp === "last" && totalMissed > 1) {
+    // The current slot is not missed yet. Emit its immediate predecessor —
+    // the newest missed slot — and leave the current one for the next tick.
+    return {
+      slots: [new Date(Date.parse(current) - period).toISOString()],
+      skipped: totalMissed - 2,
+    };
+  }
+
+  // `none`, and `last` when the previous slot is already the last admitted
+  // one, fire the current slot. There is no missed slot to replay in that
+  // `last` case.
   const slots = [current];
   return { slots, skipped: Math.max(0, totalMissed - 1) };
 }

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -148,7 +148,24 @@ describe("dueSlots — catch-up policy (§4)", () => {
       cadenceSeconds: hour,
       catchUp: "last",
     });
-    expect(outcome.slots).toEqual(["2026-08-14T04:00:00.000Z"]);
+    expect(outcome).toEqual({
+      slots: ["2026-08-14T03:00:00.000Z"],
+      skipped: 4,
+    });
+  });
+
+  test("last: with no missed slots, fires the current slot like none", () => {
+    expect(
+      dueSlots({
+        lastSlot: "2026-08-14T03:00:00.000Z",
+        nowMs: now,
+        cadenceSeconds: hour,
+        catchUp: "last",
+      }),
+    ).toEqual({
+      slots: ["2026-08-14T04:00:00.000Z"],
+      skipped: 0,
+    });
   });
 
   test("all: every missed slot fires, in order, nothing skipped", () => {
@@ -243,6 +260,32 @@ describe("emitDueTicks (§3)", () => {
       tickEventId("reaper", "2026-08-14T04:00:00.000Z"),
     );
     expect(envelope.source).toBe("schedule");
+  });
+
+  test("a last catch-up tick binds its payload slot to its event ID and auto-approves", () => {
+    const d = db();
+    const registry = withLoop({ catchUp: "last", approval: "auto" });
+    emitDueTicks(d, registry, { now: at("2026-08-13T22:00:00Z") });
+    emitDueTicks(d, registry, { now: at("2026-08-14T04:00:00Z") });
+
+    const row = d
+      .query(
+        `SELECT event_id, envelope_json FROM events ORDER BY event_id DESC LIMIT 1`,
+      )
+      .get();
+    const envelope = JSON.parse(row.envelope_json);
+    expect(envelope.payload).toMatchObject({
+      loop: "reaper",
+      slot: "2026-08-14T03:00:00.000Z",
+      skippedSlots: 4,
+    });
+    expect(row.event_id).toBe(tickEventId("reaper", envelope.payload.slot));
+
+    planAdmittedEvents(d, registry, { policyVersion: PV });
+    expect(
+      autoApproveScheduled(d, registry, approveProposal, { policyVersion: PV })
+        .approved,
+    ).toHaveLength(2);
   });
 
   test("a static payload rides on the tick and the planner proposes the routed run (WM-72)", () => {


### PR DESCRIPTION
Fixes #1480

Review the documented `last` catch-up replay semantics before merging.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/schedules.test.mjs --timeout 20000` | pass | 33 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 1,995 pass, 0 failures; emit and format clean |
| UX critique          | factory-ux-critic                | skipped | backend and docs only |

UX critique: skipped
