### PR TITLE
fix(backend): clamp GitHub control-plane bodies

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1853,8 +1853,12 @@ export function githubControlPlane(options = {}) {
       const rawDetail = String(markdown).trim();
       const suffix = description.slice(current.length);
       const separator = suffix.slice(0, -rawDetail.length - 1);
+      // Byte budget, matching clampGithubBody (never smaller than chars).
       const available =
-        GITHUB_BODY_MAX_LENGTH - current.length - separator.length - 1;
+        GITHUB_BODY_MAX_LENGTH -
+        Buffer.byteLength(current, "utf8") -
+        Buffer.byteLength(separator, "utf8") -
+        1;
       if (available <= 0) return { appended: false, reason: "body_full" };
       const detail = clampGithubBody(rawDetail, { max: available });
       if (!detail) return { appended: false, reason: "body_full" };

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -24,7 +24,9 @@ import {
   AGENT_READY_LABEL,
   appendIssueDetail,
   BLOCKED_LABEL,
+  clampGithubBody,
   claimLabels,
+  GITHUB_BODY_MAX_LENGTH,
   IN_PROGRESS_LABEL,
   stampRun,
   validateLabels,
@@ -1420,14 +1422,14 @@ export function githubControlPlane(options = {}) {
     const pins = comments.filter((c) => parseReadyPin(c.body));
     if (pins.length === 0) {
       await call("POST", `repos/${repo}/issues/${number}/comments`, {
-        body: { body: stampRun(body) },
+        body: { body: clampGithubBody(stampRun(body)) },
       });
       return;
     }
     // Newest pin survives (updated in place); older duplicates are pruned.
     const newest = pins[pins.length - 1];
     await call("PATCH", `repos/${repo}/issues/comments/${newest.id}`, {
-      body: { body: stampRun(body) },
+      body: { body: clampGithubBody(stampRun(body)) },
     });
     for (const c of pins.slice(0, -1)) {
       try {
@@ -1740,7 +1742,7 @@ export function githubControlPlane(options = {}) {
       const { repo, number } = locate(identifier);
       await fetchIssue(repo, number);
       await call("POST", `repos/${repo}/issues/${number}/comments`, {
-        body: { body: stampRun(body) },
+        body: { body: clampGithubBody(stampRun(body)) },
       });
     },
 
@@ -1817,7 +1819,7 @@ export function githubControlPlane(options = {}) {
       const created = await call("POST", `repos/${repo}/issues`, {
         body: {
           title,
-          body: stampRun(body),
+          body: clampGithubBody(stampRun(body)),
           labels,
         },
       });
@@ -1847,8 +1849,17 @@ export function githubControlPlane(options = {}) {
         markdown,
       );
       if (!appended) return { appended: false };
+      const current = issue.body ?? "";
+      const rawDetail = String(markdown).trim();
+      const suffix = description.slice(current.length);
+      const separator = suffix.slice(0, -rawDetail.length - 1);
+      const available =
+        GITHUB_BODY_MAX_LENGTH - current.length - separator.length - 1;
+      if (available <= 0) return { appended: false, reason: "body_full" };
+      const detail = clampGithubBody(rawDetail, { max: available });
+      if (!detail) return { appended: false, reason: "body_full" };
       await call("PATCH", `repos/${repo}/issues/${number}`, {
-        body: { body: description },
+        body: { body: `${current}${separator}${detail}\n` },
       });
       return { appended: true };
     },

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -21,7 +21,12 @@ import path from "node:path";
 import { hashJson } from "../../event-runtime/lib/canonical.mjs";
 import { ControlPlaneError } from "./types.mjs";
 import { loadControlPlane } from "./index.mjs";
-import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
+import {
+  AGENT_READY_LABEL,
+  clampGithubBody,
+  GITHUB_BODY_MAX_LENGTH,
+  IN_PROGRESS_LABEL,
+} from "./labels.mjs";
 import {
   GITHUB_FACTORY_STATES,
   ghSpawn,
@@ -1029,6 +1034,75 @@ describe("control-plane contract: github", () => {
     await expect(cp.comment(`${REPO}#1`, "")).rejects.toThrow(
       ControlPlaneError,
     );
+  });
+
+  test("clamps long GitHub bodies while retaining the run trailer", async () => {
+    const { cp, seed } = makePlane();
+    const longBody = "x".repeat(70_000);
+    const previousAttribution = process.env.FACTORY_COMMENT_ATTRIBUTION;
+    const previousRunId = process.env.FACTORY_RUN_ID;
+    process.env.FACTORY_COMMENT_ATTRIBUTION = "1";
+    process.env.FACTORY_RUN_ID = "body-clamp-test";
+    try {
+      await cp.comment(`${REPO}#1`, longBody);
+      const comment = requireIssue(seed, REPO, 1).comments.at(-1).body;
+      expect(comment.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
+      expect(comment).toContain("… [truncated ");
+      expect(comment).toEndWith("run:body-clamp-test");
+
+      const created = await cp.file({
+        team: TEAM,
+        title: "long body",
+        body: longBody,
+      });
+      const createdNumber = Number(created.identifier.split("#")[1]);
+      const filed = requireIssue(seed, REPO, createdNumber).body;
+      expect(filed.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
+      expect(filed).toContain("… [truncated ");
+      expect(filed).toEndWith("run:body-clamp-test");
+
+      const appended = await cp.appendDetail(`${REPO}#1`, longBody);
+      expect(appended).toEqual({ appended: true });
+      const description = requireIssue(seed, REPO, 1).body;
+      expect(description.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
+      expect(description).toContain("… [truncated ");
+
+      await cp.setLabels(`${REPO}#1`, { add: [AGENT_READY_LABEL] });
+      const readyPin = requireIssue(seed, REPO, 1).comments.at(-1).body;
+      expect(readyPin.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
+      expect(readyPin).toEndWith("run:body-clamp-test");
+    } finally {
+      if (previousAttribution === undefined)
+        delete process.env.FACTORY_COMMENT_ATTRIBUTION;
+      else process.env.FACTORY_COMMENT_ATTRIBUTION = previousAttribution;
+      if (previousRunId === undefined) delete process.env.FACTORY_RUN_ID;
+      else process.env.FACTORY_RUN_ID = previousRunId;
+    }
+  });
+
+  test("clamping does not leave a truncation marker inside a fenced block", () => {
+    const body = `intro\n\`\`\`text\n${"x".repeat(70_000)}`;
+    const clamped = clampGithubBody(body);
+    expect(clamped.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
+    expect(clamped).toContain("… [truncated ");
+    expect(clamped).not.toContain("```text");
+  });
+
+  test("appendDetail reports body_full instead of patching a full issue", async () => {
+    const { api, cp, seed } = makePlane();
+    requireIssue(seed, REPO, 1).body = "x".repeat(GITHUB_BODY_MAX_LENGTH);
+    await expect(cp.appendDetail(`${REPO}#1`, "more detail")).resolves.toEqual({
+      appended: false,
+      reason: "body_full",
+    });
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "PATCH" &&
+          call.pathName === `repos/${REPO}/issues/1` &&
+          call.body?.body !== undefined,
+      ),
+    ).toBe(false);
   });
 
   test("setLabels keeps existing labels (complete-set, not a delta)", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1080,12 +1080,77 @@ describe("control-plane contract: github", () => {
     }
   });
 
-  test("clamping does not leave a truncation marker inside a fenced block", () => {
+  test("clamping keeps a fenced log and closes the fence before the marker", () => {
     const body = `intro\n\`\`\`text\n${"x".repeat(70_000)}`;
     const clamped = clampGithubBody(body);
-    expect(clamped.length).toBeLessThanOrEqual(GITHUB_BODY_MAX_LENGTH);
-    expect(clamped).toContain("… [truncated ");
-    expect(clamped).not.toContain("```text");
+    expect(Buffer.byteLength(clamped, "utf8")).toBeLessThanOrEqual(
+      GITHUB_BODY_MAX_LENGTH,
+    );
+    // The log survives up to the budget instead of being dropped wholesale.
+    expect(clamped.length).toBeGreaterThan(GITHUB_BODY_MAX_LENGTH - 100);
+    expect(clamped).toStartWith("intro\n```text\nxxxx");
+    expect(clamped).toMatch(/x\n```\n… \[truncated \d+ chars\]$/);
+    expect(clamped.split("```").length).toBe(3);
+
+    // A closed fence followed by prose truncates in the prose as before.
+    const closed = `\`\`\`\nlog\n\`\`\`\n${"p".repeat(70_000)}`;
+    expect(clampGithubBody(closed)).toMatch(
+      /^```\nlog\n```\np+\n\n… \[truncated/,
+    );
+
+    // A fence with no room for any content is dropped from its opening.
+    expect(clampGithubBody(`~~~~\n${"z".repeat(100)}`, { max: 30 })).toBe(
+      "… [truncated 105 chars]",
+    );
+    expect(clampGithubBody(`~~~~\nabc\n${"z".repeat(100)}`, { max: 60 })).toBe(
+      `~~~~\nabc\n${"z".repeat(21)}\n~~~~\n… [truncated 79 chars]`,
+    );
+  });
+
+  test("clamping budgets UTF-8 bytes and never splits a surrogate pair", () => {
+    const clamped = clampGithubBody("😀".repeat(40_000));
+    expect(Buffer.byteLength(clamped, "utf8")).toBeLessThanOrEqual(
+      GITHUB_BODY_MAX_LENGTH,
+    );
+    expect(clamped.isWellFormed()).toBe(true);
+    expect(clamped).toMatch(/^(😀)+\n\n… \[truncated \d+ chars\]$/);
+    // Unchanged when the byte length fits.
+    expect(clampGithubBody("é".repeat(100), { max: 200 })).toBe(
+      "é".repeat(100),
+    );
+    expect(clampGithubBody("é".repeat(100), { max: 199 })).toMatch(
+      /^é+\n\n… \[/,
+    );
+  });
+
+  test("clamping returns an empty string when the marker cannot fit", () => {
+    expect(clampGithubBody("hello world ".repeat(10), { max: 10 })).toBe("");
+    expect(clampGithubBody("hello world ".repeat(10), { max: 25 })).toBe(
+      "… [truncated 120 chars]",
+    );
+  });
+
+  test("the run trailer is only carved out when attribution is on", () => {
+    const previousAttribution = process.env.FACTORY_COMMENT_ATTRIBUTION;
+    const previousRunId = process.env.FACTORY_RUN_ID;
+    const body = `${"a".repeat(70_000)}\n\nrun:trailer-test`;
+    try {
+      delete process.env.FACTORY_COMMENT_ATTRIBUTION;
+      process.env.FACTORY_RUN_ID = "trailer-test";
+      expect(clampGithubBody(body)).not.toEndWith("run:trailer-test");
+      process.env.FACTORY_COMMENT_ATTRIBUTION = "1";
+      expect(clampGithubBody(body)).toMatch(
+        /^a+\n\n… \[truncated \d+ chars\]\n\nrun:trailer-test$/,
+      );
+      process.env.FACTORY_RUN_ID = "other";
+      expect(clampGithubBody(body)).not.toEndWith("run:trailer-test");
+    } finally {
+      if (previousAttribution === undefined)
+        delete process.env.FACTORY_COMMENT_ATTRIBUTION;
+      else process.env.FACTORY_COMMENT_ATTRIBUTION = previousAttribution;
+      if (previousRunId === undefined) delete process.env.FACTORY_RUN_ID;
+      else process.env.FACTORY_RUN_ID = previousRunId;
+    }
   });
 
   test("appendDetail reports body_full instead of patching a full issue", async () => {

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -26,73 +26,154 @@ export const AGENT_READY_LABEL = "ai:agent-ready";
 export const IN_PROGRESS_LABEL = "ai:in-progress";
 export const BLOCKED_LABEL = "ai:blocked";
 
-/** GitHub rejects issue and comment bodies above this many characters. */
+/**
+ * GitHub rejects issue and comment bodies above this many characters. The
+ * clamp budgets in UTF-8 bytes, which is never smaller than the character
+ * count, so a body that fits the byte budget fits GitHub either way.
+ */
 export const GITHUB_BODY_MAX_LENGTH = 65_536;
 
 const TRUNCATION_MARKER = (count) => `… [truncated ${count} chars]`;
 
+const byteLength = (text) => Buffer.byteLength(text, "utf8");
+
+const isHighSurrogate = (unit) => unit >= 0xd800 && unit <= 0xdbff;
+const isLowSurrogate = (unit) => unit >= 0xdc00 && unit <= 0xdfff;
+
+const utf8Size = (codePoint) =>
+  codePoint < 0x80 ? 1 : codePoint < 0x800 ? 2 : codePoint < 0x10000 ? 3 : 4;
+
 /**
- * Return the last safe character boundary at or before `limit`.
- *
- * A truncation marker must not be emitted inside a fenced code block: it
- * would turn the remainder of a report into code and hide the marker. When a
- * limit falls in a fence, discard that fence from its opening delimiter.
+ * The longest prefix of `text` that fits `budget` UTF-8 bytes, as a UTF-16
+ * index on a code-point boundary (a surrogate pair is never split).
  */
-function markdownFenceBoundary(text, limit) {
+function cutToBytes(text, budget) {
+  if (budget <= 0) return 0;
+  // Every code unit encodes to at least one byte, so `budget` code units is
+  // an upper bound; walk back one code point at a time from there.
+  let cut = Math.min(text.length, budget);
+  if (cut < text.length && isLowSurrogate(text.charCodeAt(cut))) cut -= 1;
+  let bytes = byteLength(text.slice(0, cut));
+  while (cut > 0 && bytes > budget) {
+    const previous =
+      cut >= 2 &&
+      isLowSurrogate(text.charCodeAt(cut - 1)) &&
+      isHighSurrogate(text.charCodeAt(cut - 2))
+        ? cut - 2
+        : cut - 1;
+    bytes -= utf8Size(text.codePointAt(previous));
+    cut = previous;
+  }
+  return cut;
+}
+
+/**
+ * The fenced code block still open at `limit`, or null when `limit` sits in
+ * prose. `openAt` is the offset of the opening delimiter, `contentStart` the
+ * first offset after the opening line, and `delimiter` the string that closes
+ * the fence (same character, same length).
+ */
+function openFenceAt(text, limit) {
   const beforeLimit = text.slice(0, limit);
   const fences = /(^|\n)[ \t]{0,3}(`{3,}|~{3,})[^\n]*/g;
-  let openAt = null;
-  let openChar = null;
-  let openLength = 0;
+  let open = null;
   let match;
   while ((match = fences.exec(beforeLimit))) {
     const marker = match[2];
     const markerStart = match.index + match[1].length;
-    if (openAt === null) {
-      openAt = markerStart;
-      openChar = marker[0];
-      openLength = marker.length;
-    } else if (marker[0] === openChar && marker.length >= openLength) {
-      openAt = null;
-      openChar = null;
-      openLength = 0;
+    if (open === null) {
+      open = {
+        openAt: markerStart,
+        contentStart: Math.min(limit, match.index + match[0].length + 1),
+        delimiter: marker,
+      };
+    } else if (
+      marker[0] === open.delimiter[0] &&
+      marker.length >= open.delimiter.length
+    ) {
+      open = null;
     }
   }
-  return openAt === null ? limit : openAt;
+  return open;
+}
+
+/**
+ * The run attribution trailer stampRun() appended to `text`, or "" when the
+ * attribution feature is off or the body does not end with this run's stamp.
+ * Anchoring on the feature keeps a report that merely ends in a `run:` line
+ * from being treated as attribution.
+ */
+function runTrailer(text) {
+  if (process.env.FACTORY_COMMENT_ATTRIBUTION !== "1") return "";
+  const id = process.env.FACTORY_RUN_ID;
+  if (!id) return "";
+  const trailer = `\n\nrun:${id}`;
+  return text.endsWith(trailer) ? trailer : "";
+}
+
+/**
+ * Build the clamped body for a cut at `cut` code units into `report`.
+ *
+ * A truncation marker must not land inside a fenced code block: it would turn
+ * the rest of the body into code and hide the marker. When the cut falls in a
+ * fence, keep the retained part of the fence and close it with the same
+ * delimiter before the marker. Only when none of the fence's content survives
+ * is the fence discarded from its opening delimiter.
+ */
+function buildClamped(report, cut, trailer) {
+  const fence = openFenceAt(report, cut);
+  let prefix;
+  let closer = "";
+  if (fence === null) {
+    prefix = report.slice(0, cut);
+  } else if (cut > fence.contentStart) {
+    prefix = report.slice(0, cut);
+    closer = `${prefix.endsWith("\n") ? "" : "\n"}${fence.delimiter}\n`;
+  } else {
+    prefix = report.slice(0, fence.openAt);
+  }
+  const separator = closer
+    ? ""
+    : prefix.length === 0
+      ? ""
+      : prefix.endsWith("\n")
+        ? "\n"
+        : "\n\n";
+  const marker = TRUNCATION_MARKER(report.length - prefix.length);
+  return `${prefix}${closer}${separator}${marker}${trailer}`;
 }
 
 /**
  * Clamp a Markdown body for GitHub without losing the optional run stamp.
  *
- * The marker's count is the number of source characters removed from the
- * report (the retained `run:` trailer is not counted). The helper deliberately
- * backs up to a fence opening rather than emitting an unterminated code fence.
+ * `max` is a UTF-8 byte budget and the cut never splits a surrogate pair. The
+ * marker's count is the number of source characters removed from the report
+ * (the retained `run:` trailer is not counted). A cut inside a fenced block
+ * closes the fence rather than dropping it, so a report that is mostly one
+ * long log keeps as much of the log as the budget allows.
+ *
+ * Returns "" when not even the bare marker fits `max`; callers with a
+ * deliberately tiny budget report that instead of posting a mangled marker.
  */
 export function clampGithubBody(body, { max = GITHUB_BODY_MAX_LENGTH } = {}) {
   const text = String(body ?? "");
-  if (text.length <= max) return text;
+  if (byteLength(text) <= max) return text;
 
-  // stampRun() appends this exact trailer. Keep it outside the truncatable
-  // report so long logs cannot erase the attribution that identifies a run.
-  const trailerMatch = /\n\nrun:[^\n]+$/.exec(text);
-  const trailer = trailerMatch?.[0] ?? "";
+  // Keep the attribution outside the truncatable report so long logs cannot
+  // erase the stamp that identifies a run.
+  const trailer = runTrailer(text);
   const report = trailer ? text.slice(0, -trailer.length) : text;
 
-  let cut = Math.min(report.length, max - trailer.length);
-  for (let attempt = 0; attempt < 4; attempt++) {
-    cut = markdownFenceBoundary(report, Math.max(0, cut));
-    const prefix = report.slice(0, cut);
-    const separator =
-      prefix.length === 0 ? "" : prefix.endsWith("\n") ? "\n" : "\n\n";
-    const marker = TRUNCATION_MARKER(report.length - cut);
-    const candidate = `${prefix}${separator}${marker}${trailer}`;
-    if (candidate.length <= max) return candidate;
-    cut -= candidate.length - max;
+  let cut = cutToBytes(report, max - byteLength(trailer));
+  for (let attempt = 0; attempt < 8 && cut > 0; attempt++) {
+    const candidate = buildClamped(report, cut, trailer);
+    const overage = byteLength(candidate) - max;
+    if (overage <= 0) return candidate;
+    cut = cutToBytes(report, byteLength(report.slice(0, cut)) - overage);
   }
 
-  // A normal GitHub-sized limit always accommodates the marker. This fallback
-  // keeps the helper total for callers that supply a deliberately tiny max.
-  return `${TRUNCATION_MARKER(report.length)}${trailer}`.slice(0, max);
+  const bare = `${TRUNCATION_MARKER(report.length)}${trailer}`;
+  return byteLength(bare) <= max ? bare : "";
 }
 
 /** Reject label typos before the tracker does, with a useful message. */

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -26,6 +26,75 @@ export const AGENT_READY_LABEL = "ai:agent-ready";
 export const IN_PROGRESS_LABEL = "ai:in-progress";
 export const BLOCKED_LABEL = "ai:blocked";
 
+/** GitHub rejects issue and comment bodies above this many characters. */
+export const GITHUB_BODY_MAX_LENGTH = 65_536;
+
+const TRUNCATION_MARKER = (count) => `… [truncated ${count} chars]`;
+
+/**
+ * Return the last safe character boundary at or before `limit`.
+ *
+ * A truncation marker must not be emitted inside a fenced code block: it
+ * would turn the remainder of a report into code and hide the marker. When a
+ * limit falls in a fence, discard that fence from its opening delimiter.
+ */
+function markdownFenceBoundary(text, limit) {
+  const beforeLimit = text.slice(0, limit);
+  const fences = /(^|\n)[ \t]{0,3}(`{3,}|~{3,})[^\n]*/g;
+  let openAt = null;
+  let openChar = null;
+  let openLength = 0;
+  let match;
+  while ((match = fences.exec(beforeLimit))) {
+    const marker = match[2];
+    const markerStart = match.index + match[1].length;
+    if (openAt === null) {
+      openAt = markerStart;
+      openChar = marker[0];
+      openLength = marker.length;
+    } else if (marker[0] === openChar && marker.length >= openLength) {
+      openAt = null;
+      openChar = null;
+      openLength = 0;
+    }
+  }
+  return openAt === null ? limit : openAt;
+}
+
+/**
+ * Clamp a Markdown body for GitHub without losing the optional run stamp.
+ *
+ * The marker's count is the number of source characters removed from the
+ * report (the retained `run:` trailer is not counted). The helper deliberately
+ * backs up to a fence opening rather than emitting an unterminated code fence.
+ */
+export function clampGithubBody(body, { max = GITHUB_BODY_MAX_LENGTH } = {}) {
+  const text = String(body ?? "");
+  if (text.length <= max) return text;
+
+  // stampRun() appends this exact trailer. Keep it outside the truncatable
+  // report so long logs cannot erase the attribution that identifies a run.
+  const trailerMatch = /\n\nrun:[^\n]+$/.exec(text);
+  const trailer = trailerMatch?.[0] ?? "";
+  const report = trailer ? text.slice(0, -trailer.length) : text;
+
+  let cut = Math.min(report.length, max - trailer.length);
+  for (let attempt = 0; attempt < 4; attempt++) {
+    cut = markdownFenceBoundary(report, Math.max(0, cut));
+    const prefix = report.slice(0, cut);
+    const separator =
+      prefix.length === 0 ? "" : prefix.endsWith("\n") ? "\n" : "\n\n";
+    const marker = TRUNCATION_MARKER(report.length - cut);
+    const candidate = `${prefix}${separator}${marker}${trailer}`;
+    if (candidate.length <= max) return candidate;
+    cut -= candidate.length - max;
+  }
+
+  // A normal GitHub-sized limit always accommodates the marker. This fallback
+  // keeps the helper total for callers that supply a deliberately tiny max.
+  return `${TRUNCATION_MARKER(report.length)}${trailer}`.slice(0, max);
+}
+
 /** Reject label typos before the tracker does, with a useful message. */
 export function validateLabels(names) {
   const bad = [];


### PR DESCRIPTION
Fixes watt-mind/factory#1482

Clamp GitHub control-plane report bodies before a 422 can discard the report.

## Validation

| Check                | Command                                                           | Result  | Notes                                |
| -------------------- | ----------------------------------------------------------------- | ------- | ------------------------------------ |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000`     | pass    | 105 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1993 pass, 10 skipped, emit/format clean |
| UX critique          | factory-ux-critic                                                 | skipped | backend control-plane; no user-facing surface |

UX critique: skipped

## Post-review

- `clampGithubBody` now cuts inside a fenced block and closes the fence with the same delimiter before the marker; the fence is only dropped when none of its content fits. A report that is mostly one long log keeps the log up to the budget (was: 72,061 chars → 75).
- Budget is measured in UTF-8 bytes (`Buffer.byteLength`) and the cut lands on a code-point boundary, never splitting a surrogate pair. `appendDetail` computes its remaining budget in bytes too.
- A `max` too small for the bare marker returns `""` instead of a mangled partial marker; `appendDetail` already reports `body_full` on that.
- The `run:` trailer is carved out only when `FACTORY_COMMENT_ATTRIBUTION=1` and the body ends with this run's exact stamp.
- Tests: fenced log survives truncated, closed fence + prose, fence dropped when nothing fits, byte budget / surrogate safety, empty result on tiny max, trailer anchoring.