### PR TITLE
fix(web): enable keyboard list activation

### DIFF
--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -12,6 +12,7 @@ import {
   useMemo,
   useRef,
   useState,
+  type KeyboardEvent as ReactKeyboardEvent,
 } from "react";
 import { attrIcon } from "./attrIcons";
 export { GitBranchIcon, SourceIcon, RepoBadge, BranchBadge } from "./attrIcons";
@@ -850,6 +851,18 @@ export function Table({ className = "", ...props }: ComponentProps<"table">) {
       className={`text-sm [&_thead]:text-xs [&_thead]:uppercase [&_thead]:text-(--text-faint) [&_td.mono]:text-sm ${className}`}
     />
   );
+}
+
+/** Makes a focusable table row activate like a button without stealing child controls. */
+export function rowKeyHandler(onActivate: () => void) {
+  return (event: ReactKeyboardEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== "Enter" && event.key !== " " && event.key !== "Spacebar")
+      return;
+    event.preventDefault();
+    event.stopPropagation();
+    onActivate();
+  };
 }
 
 /** Pinned title, verb, and utility rows; the spec and payload scroll underneath (WM-209). */

--- a/event-runtime/web/src/views/Chains.test.tsx
+++ b/event-runtime/web/src/views/Chains.test.tsx
@@ -132,6 +132,28 @@ describe("Chains list (WM-537)", () => {
     });
   });
 
+  test("focuses rows and opens a chain with Enter or Space", async () => {
+    const onOpenChain = mock(() => {});
+    await withApi({ chains: async () => ({ chains: rows }) }, async () => {
+      const view = renderChains({ onOpenChain });
+      const row = await waitFor(() => {
+        const element = view.container.querySelector(
+          '[data-chain-id="corr-active"]',
+        ) as HTMLTableRowElement | null;
+        if (!element) throw new Error("row not rendered");
+        return element;
+      });
+
+      row.focus();
+      expect(document.activeElement).toBe(row);
+      fireEvent.keyDown(row, { key: "Enter" });
+      fireEvent.keyDown(row, { key: " " });
+
+      expect(onOpenChain).toHaveBeenCalledWith("corr-active");
+      expect(onOpenChain).toHaveBeenCalledTimes(2);
+    });
+  });
+
   test("supports state/is filters and repo operator context", async () => {
     await withApi({ chains: async () => ({ chains: rows }) }, async () => {
       const view = renderChains({ context: { kind: "repo", name: "factory" } });

--- a/event-runtime/web/src/views/Chains.tsx
+++ b/event-runtime/web/src/views/Chains.tsx
@@ -35,8 +35,10 @@ import {
   RepoBadge,
   STATE_HUES,
   SourceIcon,
+  Table,
   TableWindowFooter,
   Th,
+  rowKeyHandler,
   shortId,
 } from "../components/ui";
 
@@ -390,7 +392,11 @@ export function Chains({
           </>
         }
       >
-        <table className="w-full table-fixed border-separate border-spacing-0">
+        <Table
+          role="grid"
+          aria-label="Chains"
+          className="w-full table-fixed border-separate border-spacing-0"
+        >
           <colgroup>
             {cols.map((column) => (
               <col
@@ -406,8 +412,11 @@ export function Chains({
               />
             ))}
           </colgroup>
-          <thead>
-            <tr className="text-left text-[11px] text-(--text-faint)">
+          <thead role="rowgroup">
+            <tr
+              role="row"
+              className="text-left text-[11px] text-(--text-faint)"
+            >
               {cols.map((column) => {
                 const sort = CHAINS_DISPLAY.sorts.find(
                   (item) => item.column === column.key,
@@ -451,7 +460,7 @@ export function Chains({
               })}
             </tr>
           </thead>
-          <tbody>
+          <tbody role="rowgroup">
             {windowTokens.map((token) => {
               if (token.length === 2) {
                 const [section, sub] = token;
@@ -470,13 +479,17 @@ export function Chains({
               }
               const chain = token[0];
               const selected = chain.correlationId === selectedId;
+              const onActivate = () => onOpenChain(chain.correlationId);
               return (
                 <tr
                   key={chain.correlationId}
+                  role="row"
                   data-chain-id={chain.correlationId}
+                  tabIndex={0}
                   aria-selected={selected}
-                  onClick={() => onOpenChain(chain.correlationId)}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${selected ? "row-selected" : ""}`}
+                  onClick={onActivate}
+                  onKeyDown={rowKeyHandler(onActivate)}
+                  className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${selected ? "row-selected" : ""}`}
                 >
                   <td className="max-w-56 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap">
                     <div
@@ -580,7 +593,7 @@ export function Chains({
               />
             )}
           </tbody>
-        </table>
+        </Table>
       </ListPane>
     </div>
   );

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -649,6 +649,36 @@ describe("Runs component harness: selection & filter retention", () => {
     );
   });
 
+  test("focuses rows and selects a run with Enter or Space", async () => {
+    const onSelectRun = mock(() => {});
+    const r1 = stubListItem("run_keyboard_test", "RUNNING");
+    await withApi(
+      {
+        runs: async () => ({ runs: [r1] }),
+        run: async () => stubDetail(r1.runId, "RUNNING", []),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const { container } = renderRuns({ onSelectRun });
+        const row = await waitFor(() => {
+          const element = container
+            .querySelector(`td[title="${r1.runId}"]`)
+            ?.closest("tr");
+          if (!element) throw new Error("row not rendered");
+          return element;
+        });
+
+        row.focus();
+        expect(document.activeElement).toBe(row);
+        fireEvent.keyDown(row, { key: "Enter" });
+        fireEvent.keyDown(row, { key: " " });
+
+        expect(onSelectRun).toHaveBeenCalledWith(r1.runId);
+        expect(onSelectRun).toHaveBeenCalledTimes(2);
+      },
+    );
+  });
+
   test("focusRunId highlights the selected row and renders the detail pane", async () => {
     const r1 = stubListItem("run_selected_1", "RUNNING");
     const detail = stubDetail("run_selected_1", "RUNNING", [

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -88,6 +88,7 @@ import {
   VerbError,
   copyText,
   copyLink,
+  rowKeyHandler,
   shortId,
 } from "../components/ui";
 import { Button as PrimitiveButton } from "../components/ui";
@@ -1288,6 +1289,8 @@ export function Runs({
         }
       >
         <Table
+          role="grid"
+          aria-label="Runs"
           className="w-full table-fixed border-separate border-spacing-0"
           style={{
             minWidth: `${listCols.reduce(
@@ -1304,8 +1307,8 @@ export function Runs({
               />
             ))}
           </colgroup>
-          <thead>
-            <tr className="text-left">
+          <thead role="rowgroup">
+            <tr role="row" className="text-left">
               {listCols.map((c) => {
                 const sort = displayConfig.sorts.find(
                   (s) => s.column === c.key,
@@ -1340,14 +1343,17 @@ export function Runs({
               })}
             </tr>
           </thead>
-          <tbody>
+          <tbody role="rowgroup">
             {(() => {
               const renderRow = (r: RunListItem) => (
                 <tr
                   key={r.runId}
+                  role="row"
+                  tabIndex={0}
                   onClick={() => onSelectRun(r.runId)}
+                  onKeyDown={rowKeyHandler(() => onSelectRun(r.runId))}
                   aria-selected={r.runId === selectedId}
-                  className={`cursor-pointer hover:bg-(--surface-1) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
+                  className={`cursor-pointer hover:bg-(--surface-1) focus-visible:outline-2 focus-visible:-outline-offset-2 focus-visible:outline-(--accent) ${rowWash(r.state)} ${r.runId === selectedId ? "row-selected" : ""}`}
                 >
                   <td
                     className="mono max-w-28 overflow-hidden border-b border-(--border) px-3 py-1.5 whitespace-nowrap"


### PR DESCRIPTION
Fixes watt-mind/factory#1462

Keyboard users can focus and activate Runs and Chains list rows with Enter or Space.

## Validation

| Check                | Command                                                                          | Result   | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | -------- | ----------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Runs.test.tsx src/views/Chains.test.tsx` | pass     | 49 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass     | 1,994 pass, 10 skipped        |
| UX critique          | factory-ux-critic                                                                | required | SHIP; Runs and Chains exercised |

UX critique: required