### PR TITLE
fix(cli): settle dispatch watch outcomes

### DIFF
--- a/tools/dispatch.mjs
+++ b/tools/dispatch.mjs
@@ -18,6 +18,7 @@ export const DEFAULT_PORT = 7381;
 export const DEFAULT_TIMEOUT_MS = 30_000;
 export const DEFAULT_POLL_MS = 500;
 export const DEFAULT_WATCH_TIMEOUT_MS = 10_000;
+export const DEFAULT_WATCH_MAX_MS = 30 * 60_000;
 export const EXIT = {
   CONTROL_API_ERROR: 1,
   RUN_NOT_COMPLETED: 2,
@@ -59,11 +60,20 @@ export function resolveWatchTimeoutMs(env = process.env) {
   );
 }
 
+export function resolveWatchMaxMs(env = process.env) {
+  return positiveEnv(
+    env,
+    "FACTORY_DISPATCH_WATCH_MAX_MS",
+    DEFAULT_WATCH_MAX_MS,
+  );
+}
+
 const port = resolvePort();
 const BASE_URL = `http://127.0.0.1:${port}`;
 const timeoutMs = resolveTimeoutMs();
 const pollMs = resolvePollMs();
 const watchTimeoutMs = resolveWatchTimeoutMs();
+const watchMaxMs = resolveWatchMaxMs();
 
 const HELP = `factory dispatch — swift event-runtime task dispatcher
 
@@ -87,8 +97,10 @@ Options:
 Exit status:
   0                  Event run completed
   1                  Control API or command error
-  2                  Event run settled in a non-COMPLETED state
+  2                  Event run settled in a non-COMPLETED state, or --watch
+                     exceeded FACTORY_DISPATCH_WATCH_MAX_MS (default 30 min)
   3                  Event was admitted but the planner produced no run
+                     (NOOP, or a proposal still AWAITING_APPROVAL)
 `;
 
 function die(msg, code = 1) {
@@ -142,8 +154,17 @@ function progress(message, json) {
   (json ? console.error : console.log)(message);
 }
 
-function finalWatchResult({ eventId, runId, state, reasonCode }, json) {
-  const result = { eventId, runId, state, reasonCode: reasonCode ?? null };
+function finalWatchResult(
+  { eventId, runId, state, reasonCode, ...extra },
+  json,
+) {
+  const result = {
+    eventId,
+    runId,
+    state,
+    reasonCode: reasonCode ?? null,
+    ...extra,
+  };
   if (json) console.log(JSON.stringify(result));
   else {
     const subject = runId ? `Run ${runId}` : `Event ${eventId}`;
@@ -160,6 +181,7 @@ async function streamTrace(eventId, runId, json) {
     json,
   );
   let since = 0;
+  const startedAt = Date.now();
 
   while (true) {
     const trace = await api(
@@ -195,15 +217,24 @@ async function streamTrace(eventId, runId, json) {
       };
     }
 
+    if (Date.now() - startedAt >= watchMaxMs) {
+      const result = finalWatchResult(
+        { eventId, runId, state: "WATCH_TIMEOUT", reasonCode: "watch_timeout" },
+        json,
+      );
+      return { exitCode: EXIT.RUN_NOT_COMPLETED, result };
+    }
+
     await new Promise((r) => setTimeout(r, pollMs));
   }
 }
 
 async function findRunForEvent(source, eventId, maxWaitMs = watchTimeoutMs) {
   const start = Date.now();
+  let proposal = null;
   while (Date.now() - start < maxWaitMs) {
     const res = await api(`/proposals?status=all`);
-    const proposal = (res.proposals || []).find(
+    proposal = (res.proposals || []).find(
       (p) => p.eventSource === source && p.eventId === eventId,
     );
     if (proposal?.runId) {
@@ -211,13 +242,30 @@ async function findRunForEvent(source, eventId, maxWaitMs = watchTimeoutMs) {
     }
     await new Promise((r) => setTimeout(r, pollMs));
   }
+  // A live proposal without a run is waiting on approval (or approved but
+  // not yet started); noop/rejected/superseded/expired ones are a planner NOOP.
+  if (
+    proposal &&
+    proposal.decision !== "noop" &&
+    !proposal.expired &&
+    (proposal.status === "open" || proposal.status === "approved")
+  ) {
+    return {
+      runId: null,
+      state: "AWAITING_APPROVAL",
+      reasonCode: "awaiting_approval",
+      proposalId: proposal.id ?? null,
+      proposalStatus: proposal.status,
+    };
+  }
   const events = await api(`/events`);
   const event = (events.events || []).find(
     (entry) => entry.source === source && entry.eventId === eventId,
   );
   return {
     runId: null,
-    reasonCode: event?.lastPlanError || "no_proposal",
+    state: "NOOP",
+    reasonCode: event?.lastPlanError || proposal?.reason || "no_proposal",
   };
 }
 
@@ -320,19 +368,7 @@ async function main() {
       );
       process.exitCode = watched.exitCode;
     } else {
-      const result = finalWatchResult(
-        {
-          eventId: envelope.eventId,
-          runId: null,
-          state: "NOOP",
-          reasonCode: planned.reasonCode,
-        },
-        values.json,
-      );
-      if (!values.json)
-        console.log(
-          `Event admitted but planner produced no run: ${result.reasonCode}`,
-        );
+      finalWatchResult({ eventId: envelope.eventId, ...planned }, values.json);
       process.exitCode = EXIT.NO_PROPOSAL;
     }
   } else {

--- a/tools/dispatch.mjs
+++ b/tools/dispatch.mjs
@@ -16,6 +16,20 @@ import { unauthorizedMessage } from "../event-runtime/lib/client.mjs";
 
 export const DEFAULT_PORT = 7381;
 export const DEFAULT_TIMEOUT_MS = 30_000;
+export const DEFAULT_POLL_MS = 500;
+export const DEFAULT_WATCH_TIMEOUT_MS = 10_000;
+export const EXIT = {
+  CONTROL_API_ERROR: 1,
+  RUN_NOT_COMPLETED: 2,
+  NO_PROPOSAL: 3,
+};
+const TERMINAL_STATES = new Set([
+  "COMPLETED",
+  "FAILED",
+  "CANCELLED",
+  "REFUSED",
+  "TIMED_OUT",
+]);
 
 export function resolvePort(env = process.env) {
   return env.FACTORY_EVENT_PORT ? Number(env.FACTORY_EVENT_PORT) : DEFAULT_PORT;
@@ -28,9 +42,28 @@ export function resolveTimeoutMs(env = process.env) {
     : DEFAULT_TIMEOUT_MS;
 }
 
+function positiveEnv(env, name, fallback) {
+  const value = Number(env[name]);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
+}
+
+export function resolvePollMs(env = process.env) {
+  return positiveEnv(env, "FACTORY_DISPATCH_POLL_MS", DEFAULT_POLL_MS);
+}
+
+export function resolveWatchTimeoutMs(env = process.env) {
+  return positiveEnv(
+    env,
+    "FACTORY_DISPATCH_WATCH_TIMEOUT_MS",
+    DEFAULT_WATCH_TIMEOUT_MS,
+  );
+}
+
 const port = resolvePort();
 const BASE_URL = `http://127.0.0.1:${port}`;
 const timeoutMs = resolveTimeoutMs();
+const pollMs = resolvePollMs();
+const watchTimeoutMs = resolveWatchTimeoutMs();
 
 const HELP = `factory dispatch — swift event-runtime task dispatcher
 
@@ -50,6 +83,12 @@ Options:
   --watch, -w         Stream live run trace to stdout until completion
   --json              Output raw JSON response
   --help, -h          Show this help
+
+Exit status:
+  0                  Event run completed
+  1                  Control API or command error
+  2                  Event run settled in a non-COMPLETED state
+  3                  Event was admitted but the planner produced no run
 `;
 
 function die(msg, code = 1) {
@@ -99,14 +138,30 @@ async function api(path, options = {}) {
   }
 }
 
-async function streamTrace(runId) {
-  console.log(
+function progress(message, json) {
+  (json ? console.error : console.log)(message);
+}
+
+function finalWatchResult({ eventId, runId, state, reasonCode }, json) {
+  const result = { eventId, runId, state, reasonCode: reasonCode ?? null };
+  if (json) console.log(JSON.stringify(result));
+  else {
+    const subject = runId ? `Run ${runId}` : `Event ${eventId}`;
+    console.log(
+      `\n==> ${subject} settled: ${state} (${result.reasonCode || "ok"})`,
+    );
+  }
+  return result;
+}
+
+async function streamTrace(eventId, runId, json) {
+  progress(
     `\n==> Streaming live trace for run ${runId} (Ctrl+C to detach)...\n`,
+    json,
   );
   let since = 0;
-  let finished = false;
 
-  while (!finished) {
+  while (true) {
     const trace = await api(
       `/runs/${encodeURIComponent(runId)}/trace?since=${since}&limit=100`,
     );
@@ -124,40 +179,46 @@ async function streamTrace(runId) {
         else if (entry.data?.tool) detail = `[tool: ${entry.data.tool}]`;
         else detail = JSON.stringify(entry.data || {});
 
-        console.log(`[${time}] ${type.padEnd(14)} ${detail}`);
+        progress(`[${time}] ${type.padEnd(14)} ${detail}`, json);
       }
     }
 
     const run = await api(`/runs/${encodeURIComponent(runId)}`);
-    if (run && ["COMPLETED", "FAILED", "CANCELLED"].includes(run.state)) {
-      // Not `finished = true`: the `break` below exits the loop directly, so
-      // the while(!finished) condition is never re-evaluated after this branch.
-      console.log(
-        `\n==> Run ${runId} settled: ${run.state} (${run.reasonCode || "ok"})`,
+    if (run && TERMINAL_STATES.has(run.state)) {
+      const result = finalWatchResult(
+        { eventId, runId, state: run.state, reasonCode: run.reasonCode },
+        json,
       );
-      if (run.state !== "COMPLETED") {
-        process.exit(1);
-      }
-      break;
+      return {
+        exitCode: run.state === "COMPLETED" ? 0 : EXIT.RUN_NOT_COMPLETED,
+        result,
+      };
     }
 
-    await new Promise((r) => setTimeout(r, 1000));
+    await new Promise((r) => setTimeout(r, pollMs));
   }
 }
 
-async function findRunForEvent(source, eventId, maxWaitMs = 10000) {
+async function findRunForEvent(source, eventId, maxWaitMs = watchTimeoutMs) {
   const start = Date.now();
   while (Date.now() - start < maxWaitMs) {
-    const res = await api(`/proposals`);
+    const res = await api(`/proposals?status=all`);
     const proposal = (res.proposals || []).find(
       (p) => p.eventSource === source && p.eventId === eventId,
     );
     if (proposal?.runId) {
-      return proposal.runId;
+      return { runId: proposal.runId };
     }
-    await new Promise((r) => setTimeout(r, 500));
+    await new Promise((r) => setTimeout(r, pollMs));
   }
-  return null;
+  const events = await api(`/events`);
+  const event = (events.events || []).find(
+    (entry) => entry.source === source && entry.eventId === eventId,
+  );
+  return {
+    runId: null,
+    reasonCode: event?.lastPlanError || "no_proposal",
+  };
 }
 
 async function main() {
@@ -235,28 +296,50 @@ async function main() {
     body: JSON.stringify(envelope),
   });
 
-  if (values.json) {
+  if (values.json && !values.watch) {
     console.log(JSON.stringify(res, null, 2));
     return;
   }
 
-  console.log(`✓ Admitted event ${res.eventId} (type: ${eventType})`);
-  console.log(`  Source:  ${envelope.source}`);
-  console.log(`  Subject: ${envelope.subject}`);
-  console.log(`  Payload: ${JSON.stringify(payload)}`);
+  progress(`✓ Admitted event ${res.eventId} (type: ${eventType})`, values.json);
+  progress(`  Source:  ${envelope.source}`, values.json);
+  progress(`  Subject: ${envelope.subject}`, values.json);
+  progress(`  Payload: ${JSON.stringify(payload)}`, values.json);
 
   if (values.watch) {
-    console.log(`\nWaiting for planner to assign proposal and run...`);
-    const runId = await findRunForEvent(envelope.source, envelope.eventId);
-    if (runId) {
-      await streamTrace(runId);
-    } else {
-      console.log(
-        `Event admitted. Check status via: factory events ps or web UI http://127.0.0.1:${port}`,
+    progress(
+      `\nWaiting for planner to assign proposal and run...`,
+      values.json,
+    );
+    const planned = await findRunForEvent(envelope.source, envelope.eventId);
+    if (planned.runId) {
+      const watched = await streamTrace(
+        envelope.eventId,
+        planned.runId,
+        values.json,
       );
+      process.exitCode = watched.exitCode;
+    } else {
+      const result = finalWatchResult(
+        {
+          eventId: envelope.eventId,
+          runId: null,
+          state: "NOOP",
+          reasonCode: planned.reasonCode,
+        },
+        values.json,
+      );
+      if (!values.json)
+        console.log(
+          `Event admitted but planner produced no run: ${result.reasonCode}`,
+        );
+      process.exitCode = EXIT.NO_PROPOSAL;
     }
   } else {
-    console.log(`\nView live status: http://127.0.0.1:${port}/#/events`);
+    progress(
+      `\nView live status: http://127.0.0.1:${port}/#/events`,
+      values.json,
+    );
   }
 }
 

--- a/tools/dispatch.test.mjs
+++ b/tools/dispatch.test.mjs
@@ -43,6 +43,11 @@ function watchServer({ state, reasonCode = "needs_human" } = {}) {
         return Response.json({ admitted: true, eventId });
       }
       if (url.pathname === "/proposals") {
+        if (url.searchParams.get("status") !== "all")
+          return Response.json(
+            { error: "expected ?status=all" },
+            { status: 400 },
+          );
         return Response.json({
           proposals: [
             { eventSource: "factory-cli", eventId, runId: "run-watch-test" },
@@ -228,8 +233,14 @@ test("dispatch --watch reports a planner NOOP with the documented exit code", as
         eventId = event.eventId;
         return Response.json({ admitted: true, eventId });
       }
-      if (url.pathname === "/proposals")
+      if (url.pathname === "/proposals") {
+        if (url.searchParams.get("status") !== "all")
+          return Response.json(
+            { error: "expected ?status=all" },
+            { status: 400 },
+          );
         return Response.json({ proposals: [] });
+      }
       if (url.pathname === "/events")
         return Response.json({
           events: [
@@ -250,7 +261,80 @@ test("dispatch --watch reports a planner NOOP with the documented exit code", as
       "--watch",
     ]);
     expect(exitCode).toBe(3);
+    expect(stdout).toContain("settled: NOOP");
     expect(stdout).toContain("ticket_not_todo");
+    expect(stdout.match(/ticket_not_todo/g)).toHaveLength(1);
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("dispatch --watch reports AWAITING_APPROVAL when the proposal has no run yet", async () => {
+  let eventId = null;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "POST" && url.pathname === "/replay") {
+        const event = await request.json();
+        eventId = event.eventId;
+        return Response.json({ admitted: true, eventId });
+      }
+      if (url.pathname === "/proposals") {
+        if (url.searchParams.get("status") !== "all")
+          return Response.json(
+            { error: "expected ?status=all" },
+            { status: 400 },
+          );
+        return Response.json({
+          proposals: [
+            {
+              id: "prop-42",
+              eventSource: "factory-cli",
+              eventId,
+              status: "open",
+              runId: null,
+            },
+          ],
+        });
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const { exitCode, stdout } = await runDispatch(server, [
+      "status",
+      "--json",
+      "--watch",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(JSON.parse(stdout)).toMatchObject({
+      runId: null,
+      state: "AWAITING_APPROVAL",
+      reasonCode: "awaiting_approval",
+      proposalId: "prop-42",
+      proposalStatus: "open",
+    });
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("dispatch --watch exits 2 with WATCH_TIMEOUT when the run never settles", async () => {
+  const server = watchServer({ state: "RUNNING", reasonCode: null });
+  try {
+    const { exitCode, stdout } = await runDispatch(
+      server,
+      ["status", "--json", "--watch"],
+      { FACTORY_DISPATCH_WATCH_MAX_MS: "30" },
+    );
+    expect(exitCode).toBe(2);
+    expect(JSON.parse(stdout)).toMatchObject({
+      runId: "run-watch-test",
+      state: "WATCH_TIMEOUT",
+      reasonCode: "watch_timeout",
+    });
   } finally {
     server.stop(true);
   }

--- a/tools/dispatch.test.mjs
+++ b/tools/dispatch.test.mjs
@@ -9,6 +9,55 @@ import {
 
 const DISPATCH = path.join(import.meta.dir, "dispatch.mjs");
 
+async function runDispatch(server, args, extraEnv = {}) {
+  const child = Bun.spawn(["bun", DISPATCH, ...args], {
+    env: {
+      ...process.env,
+      FACTORY_EVENT_PORT: String(server.port),
+      FACTORY_CONTROL_API_TOKEN: "dispatch-test-token",
+      FACTORY_DISPATCH_POLL_MS: "1",
+      FACTORY_DISPATCH_WATCH_TIMEOUT_MS: "20",
+      ...extraEnv,
+    },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const [exitCode, stdout, stderr] = await Promise.all([
+    child.exited,
+    new Response(child.stdout).text(),
+    new Response(child.stderr).text(),
+  ]);
+  return { exitCode, stdout, stderr };
+}
+
+function watchServer({ state, reasonCode = "needs_human" } = {}) {
+  let eventId = null;
+  return Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "POST" && url.pathname === "/replay") {
+        const event = await request.json();
+        eventId = event.eventId;
+        return Response.json({ admitted: true, eventId });
+      }
+      if (url.pathname === "/proposals") {
+        return Response.json({
+          proposals: [
+            { eventSource: "factory-cli", eventId, runId: "run-watch-test" },
+          ],
+        });
+      }
+      if (url.pathname === "/runs/run-watch-test/trace")
+        return Response.json({ entries: [] });
+      if (url.pathname === "/runs/run-watch-test")
+        return Response.json({ state, reasonCode });
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
 test("defaults to the standard event-runtime port", () => {
   expect(DEFAULT_PORT).toBe(7381);
   expect(resolvePort({})).toBe(7381);
@@ -123,6 +172,85 @@ test("dispatch fails fast with the request path and configured timeout", async (
     expect(exitCode).toBe(1);
     expect(stderr).toMatch(/control API request to \/\S+ timed out after 50ms/);
     expect(`${stdout}${stderr}`).not.toContain("dispatch-secret-token");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test.each(["REFUSED", "TIMED_OUT"])(
+  "dispatch --watch settles on %s and exits as a failed run",
+  async (state) => {
+    const server = watchServer({ state, reasonCode: "typed_refusal" });
+    try {
+      const { exitCode, stdout } = await runDispatch(server, [
+        "status",
+        "--watch",
+      ]);
+      expect(exitCode).toBe(2);
+      expect(stdout).toContain(`settled: ${state}`);
+      expect(stdout).toContain("typed_refusal");
+    } finally {
+      server.stop(true);
+    }
+  },
+);
+
+test("dispatch --json --watch emits only its final settled object on stdout", async () => {
+  const server = watchServer({ state: "COMPLETED", reasonCode: "ok" });
+  try {
+    const { exitCode, stdout, stderr } = await runDispatch(server, [
+      "status",
+      "--json",
+      "--watch",
+    ]);
+    expect(exitCode).toBe(0);
+    expect(JSON.parse(stdout)).toMatchObject({
+      runId: "run-watch-test",
+      state: "COMPLETED",
+      reasonCode: "ok",
+    });
+    expect(stdout.trim().split("\n")).toHaveLength(1);
+    expect(stderr).toContain("Streaming live trace");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("dispatch --watch reports a planner NOOP with the documented exit code", async () => {
+  let eventId = null;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (request.method === "POST" && url.pathname === "/replay") {
+        const event = await request.json();
+        eventId = event.eventId;
+        return Response.json({ admitted: true, eventId });
+      }
+      if (url.pathname === "/proposals")
+        return Response.json({ proposals: [] });
+      if (url.pathname === "/events")
+        return Response.json({
+          events: [
+            {
+              source: "factory-cli",
+              eventId,
+              status: "noop",
+              lastPlanError: "ticket_not_todo",
+            },
+          ],
+        });
+      return new Response("not found", { status: 404 });
+    },
+  });
+  try {
+    const { exitCode, stdout } = await runDispatch(server, [
+      "status",
+      "--watch",
+    ]);
+    expect(exitCode).toBe(3);
+    expect(stdout).toContain("ticket_not_todo");
   } finally {
     server.stop(true);
   }


### PR DESCRIPTION
Fixes watt-mind/factory#1485

Review dispatch watch terminal exit handling and machine-readable watch output.

## Validation

| Check                | Command                                                                  | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------ | ------- | ----------------------------- |
| Verification Command | `bun test tools/dispatch.test.mjs --timeout 20000`                       | pass    | 11 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1994 pass, 10 skipped         |
| UX critique          | `factory-ux-critic`                                                      | not run | no user-facing surface        |

UX critique: skipped

## Post-review

Folded in the reviewer's in-scope nits (`tools/dispatch.mjs`, `tools/dispatch.test.mjs` only):

- `--watch` is now bounded: `FACTORY_DISPATCH_WATCH_MAX_MS` (default 30 min). When exceeded, dispatch settles with `state: "WATCH_TIMEOUT"` / `reasonCode: "watch_timeout"` and exits **2** (previously an unbounded watch could only end via Ctrl+C, i.e. exit 1 from the signal; a watch that hits the bound now exits 2 like any other non-COMPLETED settle).
- When a proposal exists but has no run after the 10 s planner wait (status `open`/`approved`, not `noop`/expired), the result is `state: "AWAITING_APPROVAL"` with `proposalId` and `proposalStatus`, exit 3, instead of a misleading `NOOP / no_proposal`.
- The NOOP reason is printed once (dropped the duplicated "planner produced no run" line).
- Test mocks reject `/proposals` calls without `?status=all`; added AWAITING_APPROVAL and WATCH_TIMEOUT tests.

Exit codes unchanged: 0 completed, 2 failed/refused/timed-out watch, 3 no run (NOOP or awaiting approval).
