### PR TITLE
fix(backend): bound poisoned outbox delivery

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -177,6 +177,7 @@ export async function tick({
           `result event ${e.type} (${e.eventId}) artifact ${e.payload?.artifactHash ?? "-"}`,
         ),
       now,
+      log: logLine,
     });
   });
 

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -102,10 +102,12 @@ CREATE TABLE IF NOT EXISTS results (
 );
 
 CREATE TABLE IF NOT EXISTS outbox (
-  seq           INTEGER PRIMARY KEY AUTOINCREMENT,
-  event_json    TEXT NOT NULL,
-  created_at    TEXT NOT NULL,
-  published_at  TEXT
+  seq               INTEGER PRIMARY KEY AUTOINCREMENT,
+  event_json        TEXT NOT NULL,
+  created_at        TEXT NOT NULL,
+  published_at      TEXT,
+  delivery_attempts INTEGER NOT NULL DEFAULT 0,
+  delivery_error    TEXT
 );
 
 CREATE TABLE IF NOT EXISTS workers (
@@ -505,6 +507,26 @@ export const MIGRATIONS = [
         CREATE INDEX IF NOT EXISTS idx_events_correlation
           ON events (correlation_id);
       `);
+    },
+  },
+  {
+    version: 18,
+    name: "outbox_delivery_failures",
+    up(db) {
+      const columns = new Set(
+        db
+          .query(`PRAGMA table_info(outbox)`)
+          .all()
+          .map((row) => row.name),
+      );
+      if (!columns.has("delivery_attempts")) {
+        db.exec(
+          `ALTER TABLE outbox ADD COLUMN delivery_attempts INTEGER NOT NULL DEFAULT 0;`,
+        );
+      }
+      if (!columns.has("delivery_error")) {
+        db.exec(`ALTER TABLE outbox ADD COLUMN delivery_error TEXT;`);
+      }
     },
   },
 ];

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -283,22 +283,35 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrated.close();
   });
 
-  test("tier escalation handoffs, inbox proposal IDs and lookup indexes reach schema 17 from a fresh and from a v14 database", () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(17);
+  test("tier escalation handoffs, inbox proposal IDs and lookup indexes reach schema 18 from a fresh and from a v14 database", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(18);
     const fresh = openDb(freshFile());
-    expect(getSchemaVersion(fresh)).toBe(17);
+    expect(getSchemaVersion(fresh)).toBe(18);
+    expect(
+      fresh
+        .query(`PRAGMA table_info(outbox)`)
+        .all()
+        .map((row) => row.name),
+    ).toEqual(expect.arrayContaining(["delivery_attempts", "delivery_error"]));
     fresh.close();
 
     // #1230 (#1197) owns migration 14 and lands first; a database already at
-    // 14 must pick up 15 alone, and the guarded DDL must survive re-running.
+    // 14 must pick up later migrations, and the guarded DDL must survive
+    // re-running.
     const file = freshFile();
     const at14 = new Database(file);
     migrateDb(at14, { targetVersion: 13 });
     at14.exec("PRAGMA user_version = 14;");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(17);
+    expect(getSchemaVersion(at14)).toBe(18);
+    expect(
+      at14
+        .query(`PRAGMA table_info(outbox)`)
+        .all()
+        .map((row) => row.name),
+    ).toEqual(expect.arrayContaining(["delivery_attempts", "delivery_error"]));
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(17);
+    expect(getSchemaVersion(at14)).toBe(18);
     expect(
       at14
         .query(

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -336,8 +336,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     migrateDb(db);
 
-    expect(CURRENT_SCHEMA_VERSION).toBe(17);
-    expect(getSchemaVersion(db)).toBe(17);
+    expect(CURRENT_SCHEMA_VERSION).toBe(18);
+    expect(getSchemaVersion(db)).toBe(18);
     expect(
       db
         .query(
@@ -383,15 +383,16 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     const file = freshFile();
     const db = new Database(file);
     // #1325 owns migration 16 (inbox_proposal_id); a database already at 16
-    // must pick up 17 alone, and the guarded DDL must survive re-running.
+    // must pick up later migrations, and the guarded DDL must survive
+    // re-running.
     migrateDb(db, { targetVersion: 16 });
     expect(getSchemaVersion(db)).toBe(16);
     db.close();
 
     const migrated = openDb(file);
-    expect(getSchemaVersion(migrated)).toBe(17);
+    expect(getSchemaVersion(migrated)).toBe(18);
     migrateDb(migrated);
-    expect(getSchemaVersion(migrated)).toBe(17);
+    expect(getSchemaVersion(migrated)).toBe(18);
     const plans = [
       [
         "metrics latest proposal",

--- a/event-runtime/lib/outbox.mjs
+++ b/event-runtime/lib/outbox.mjs
@@ -10,6 +10,8 @@
 import { tx } from "./db.mjs";
 
 export const DEFAULT_OUTBOX_RETENTION_DAYS = 14;
+export const DEFAULT_OUTBOX_BATCH_SIZE = 500;
+export const DEFAULT_OUTBOX_MAX_ATTEMPTS = 3;
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Delete published rows older than the configured retention window. */
@@ -34,14 +36,15 @@ export function sweepPublishedOutbox(
 }
 
 /**
- * Deliver every unpublished outbox event to `sink(envelope, row)` in insertion
- * order, stamping each row after a successful delivery. Stops at the first
- * sink failure (order preserved for the retry).
+ * Deliver one bounded batch of unpublished outbox events to
+ * `sink(envelope, row)` in insertion order. Each successful delivery is
+ * stamped. Failures retry in order until `maxAttempts`; the final failure is
+ * parked, logged, and allows the following row to proceed.
  *
  * Published rows are pruned only after delivery, retaining a configurable
  * bounded window. Unpublished rows are never eligible for pruning.
  *
- * @returns {number} rows delivered
+ * @returns {{ delivered: number, remaining: number }} rows delivered and still pending
  */
 export function publishOutbox(
   db,
@@ -49,24 +52,65 @@ export function publishOutbox(
     sink,
     now = Date.now(),
     retentionDays = DEFAULT_OUTBOX_RETENTION_DAYS,
+    batchSize = DEFAULT_OUTBOX_BATCH_SIZE,
+    maxAttempts = DEFAULT_OUTBOX_MAX_ATTEMPTS,
+    log = () => {},
   } = {},
 ) {
+  if (!Number.isInteger(batchSize) || batchSize <= 0) {
+    throw new Error("batchSize must be a positive integer");
+  }
+  if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
+    throw new Error("maxAttempts must be a positive integer");
+  }
+
   const rows = db
     .query(
-      `SELECT seq, event_json FROM outbox WHERE published_at IS NULL ORDER BY seq`,
+      `SELECT seq, event_json, delivery_attempts
+       FROM outbox
+       WHERE published_at IS NULL
+       ORDER BY seq
+       LIMIT ?`,
     )
-    .all();
+    .all(batchSize);
   let delivered = 0;
   for (const row of rows) {
-    sink(JSON.parse(row.event_json), row);
-    tx(db, () => {
-      db.query(`UPDATE outbox SET published_at = ? WHERE seq = ?`).run(
-        new Date(now).toISOString(),
-        row.seq,
-      );
-    });
-    delivered += 1;
+    try {
+      sink(JSON.parse(row.event_json), row);
+      tx(db, () => {
+        db.query(
+          `UPDATE outbox
+           SET published_at = ?, delivery_error = NULL
+           WHERE seq = ?`,
+        ).run(new Date(now).toISOString(), row.seq);
+      });
+      delivered += 1;
+    } catch (error) {
+      const attempts = row.delivery_attempts + 1;
+      const parked = attempts >= maxAttempts;
+      const message = String(error?.message ?? error);
+      tx(db, () => {
+        db.query(
+          `UPDATE outbox
+           SET delivery_attempts = ?,
+               delivery_error = ?,
+               published_at = CASE WHEN ? THEN ? ELSE published_at END
+           WHERE seq = ?`,
+        ).run(
+          attempts,
+          message,
+          parked ? 1 : 0,
+          new Date(now).toISOString(),
+          row.seq,
+        );
+      });
+      if (!parked) break;
+      log(`outbox poison seq=${row.seq}: ${message}`);
+    }
   }
   sweepPublishedOutbox(db, { retentionDays, now });
-  return delivered;
+  const remaining = db
+    .query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`)
+    .get().n;
+  return { delivered, remaining };
 }

--- a/event-runtime/lib/outbox.test.mjs
+++ b/event-runtime/lib/outbox.test.mjs
@@ -20,30 +20,124 @@ describe("publishOutbox", () => {
     seedOutbox(db, "a");
     seedOutbox(db, "b");
     const seen = [];
-    expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toBe(2);
+    expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toEqual({
+      delivered: 2,
+      remaining: 0,
+    });
     expect(seen).toEqual(["a", "b"]);
-    expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toBe(0);
+    expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toEqual({
+      delivered: 0,
+      remaining: 0,
+    });
     expect(seen).toEqual(["a", "b"]);
   });
 
-  test("a sink failure leaves the row unpublished for redelivery", () => {
+  test("parks a poisoned row and delivers its successor", () => {
     const db = openDb(":memory:");
-    seedOutbox(db, "a");
-    expect(() =>
+    db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`).run(
+      "not JSON",
+      new Date(0).toISOString(),
+    );
+    seedOutbox(db, "successor");
+    const logs = [];
+
+    expect(
       publishOutbox(db, {
         sink: () => {
-          throw new Error("sink down");
+          throw new Error("should not receive malformed event");
         },
+        maxAttempts: 2,
+        log: (line) => logs.push(line),
       }),
-    ).toThrow("sink down");
+    ).toEqual({ delivered: 0, remaining: 2 });
     expect(
       db
-        .query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`)
-        .get().n,
-    ).toBe(1);
+        .query(
+          `SELECT delivery_attempts, delivery_error, published_at
+           FROM outbox WHERE seq = 1`,
+        )
+        .get(),
+    ).toEqual({
+      delivery_attempts: 1,
+      delivery_error: expect.stringContaining("JSON"),
+      published_at: null,
+    });
+
     const seen = [];
-    expect(publishOutbox(db, { sink: (e) => seen.push(e.eventId) })).toBe(1);
-    expect(seen).toEqual(["a"]);
+    expect(
+      publishOutbox(db, {
+        sink: (event) => seen.push(event.eventId),
+        maxAttempts: 2,
+        log: (line) => logs.push(line),
+      }),
+    ).toEqual({ delivered: 1, remaining: 0 });
+    expect(seen).toEqual(["successor"]);
+    expect(
+      db
+        .query(
+          `SELECT delivery_attempts, delivery_error, published_at
+           FROM outbox WHERE seq = 1`,
+        )
+        .get(),
+    ).toEqual({
+      delivery_attempts: 2,
+      delivery_error: expect.stringContaining("JSON"),
+      published_at: expect.any(String),
+    });
+    expect(logs).toEqual([expect.stringContaining("outbox poison seq=1")]);
+  });
+
+  test("caps each call at its batch size and reports pending rows", () => {
+    const db = openDb(":memory:");
+    seedOutbox(db, "a");
+    seedOutbox(db, "b");
+    seedOutbox(db, "c");
+    const seen = [];
+
+    expect(
+      publishOutbox(db, {
+        sink: (event) => seen.push(event.eventId),
+        batchSize: 2,
+      }),
+    ).toEqual({ delivered: 2, remaining: 1 });
+    expect(seen).toEqual(["a", "b"]);
+    expect(
+      publishOutbox(db, {
+        sink: (event) => seen.push(event.eventId),
+        batchSize: 2,
+      }),
+    ).toEqual({ delivered: 1, remaining: 0 });
+    expect(seen).toEqual(["a", "b", "c"]);
+  });
+
+  test("uses a default batch size of 500", () => {
+    const db = openDb(":memory:");
+    for (let i = 0; i < 501; i += 1) seedOutbox(db, String(i));
+
+    expect(publishOutbox(db, { sink: () => {} })).toEqual({
+      delivered: 500,
+      remaining: 1,
+    });
+  });
+
+  test("retries a transient sink failure before later rows", () => {
+    const db = openDb(":memory:");
+    seedOutbox(db, "a");
+    seedOutbox(db, "b");
+    const seen = [];
+    let fail = true;
+    const sink = (event) => {
+      if (fail) {
+        fail = false;
+        throw new Error("sink down");
+      }
+      seen.push(event.eventId);
+    };
+
+    expect(publishOutbox(db, { sink })).toEqual({ delivered: 0, remaining: 2 });
+    expect(seen).toEqual([]);
+    expect(publishOutbox(db, { sink })).toEqual({ delivered: 2, remaining: 0 });
+    expect(seen).toEqual(["a", "b"]);
   });
 });
 
@@ -101,7 +195,7 @@ describe("outbox retention and drain index", () => {
         sink: (event) => seen.push(event.eventId),
         now: 24 * 60 * 60 * 1000,
       }),
-    ).toBe(1);
+    ).toEqual({ delivered: 1, remaining: 0 });
     expect(seen).toEqual(["pending"]);
   });
 });


### PR DESCRIPTION
Fixes #1479

Outbox delivery now caps batches and parks poisoned rows without blocking later events.

## Validation

| Check                | Command                                                                          | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/outbox.test.mjs event-runtime/cli/serve.test.mjs --timeout 20000` | pass    | 20 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1997 pass, 10 skipped         |
| UX critique          | factory-ux-critic                                                               | not run | no user-facing backend surface |

UX critique: skipped