### PR TITLE
fix(worker): refuse closed tier continuations (#1499)

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1151,6 +1151,7 @@ export function worktreeDispatchAutoEligibility(
   {
     fetchTicket = fetchTicketDefault,
     fetchViewer = fetchViewerDefault,
+    fetchPullRequest = fetchPullRequestDefault,
     fetchInFlight = fetchInFlightDefault,
     countLeases = (repoName) => liveWorkerLeases(repoName).length,
     hasTicketLease = (repoName, ticket) =>
@@ -1311,6 +1312,30 @@ export function worktreeDispatchAutoEligibility(
       "noop",
       `tier_escalation_check_failed:${failedEscalationCheck}`,
     );
+  }
+
+  const failedPrNumber = escalatedContinuation?.failedRunArtifact?.prNumber;
+  if (canResumeEscalation && Number.isInteger(failedPrNumber)) {
+    let failedPullRequest;
+    try {
+      failedPullRequest = fetchPullRequest({
+        github: repo.github,
+        pr: failedPrNumber,
+      });
+    } catch (err) {
+      return refusal(
+        "ticket_escalation_pr_read_failed",
+        evidence,
+        "noop",
+        err?.message ?? String(err),
+      );
+    }
+    evidence.escalatedPullRequest = failedPullRequest;
+    evidence.checks.ticket_escalation_pr_read = true;
+    if (["MERGED", "CLOSED"].includes(failedPullRequest?.state)) {
+      return refusal("ticket_escalation_pr_closed", evidence);
+    }
+    evidence.checks.ticket_escalation_pr_active = true;
   }
 
   // A lease-loss retry is the one exception to the ordinary Todo/unassigned

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -22,6 +22,7 @@ import {
   policyMergeBatchSize,
   wrapLinearReads,
   worktreeDispatchAutoEligibility,
+  worktreeDispatchGate,
   worktreeMergeFixEligibility,
 } from "./planner.mjs";
 import {
@@ -1301,6 +1302,47 @@ describe("planEvent worktree gate (WM-108)", () => {
         ticket_claim_escalation: true,
       });
       expect(viewerRepos).toEqual(["tiered"]);
+
+      const closedEscalation = {
+        failedRunId: base.runId,
+        continuationRunId: continuation.runId,
+        rootRunId: base.runId,
+        repo: "tiered",
+        ticket: "WM-694",
+        projectionState: "applied",
+        failedRunArtifact: { prNumber: 1499 },
+      };
+      for (const state of ["MERGED", "CLOSED"]) {
+        expect(
+          worktreeDispatchGate(continuation.input, {
+            ...dispatch,
+            escalatedContinuation: closedEscalation,
+            fetchPullRequest: ({ pr }) => ({ state, number: pr }),
+          }),
+        ).toEqual({ decision: "noop", reason: "ticket_escalation_pr_closed" });
+      }
+      expect(
+        worktreeDispatchAutoEligibility(continuation.input, {
+          ...dispatch,
+          escalatedContinuation: closedEscalation,
+          fetchPullRequest: () => ({ state: "OPEN" }),
+        }).ok,
+      ).toBe(true);
+      let readPullRequest = false;
+      expect(
+        worktreeDispatchAutoEligibility(continuation.input, {
+          ...dispatch,
+          escalatedContinuation: {
+            ...closedEscalation,
+            failedRunArtifact: {},
+          },
+          fetchPullRequest: () => {
+            readPullRequest = true;
+            return { state: "CLOSED" };
+          },
+        }).ok,
+      ).toBe(true);
+      expect(readPullRequest).toBe(false);
 
       assigned.assignee = { id: "someone-else", name: "Other" };
       const foreign = worktreeDispatchAutoEligibility(continuation.input, {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1321,6 +1321,24 @@ describe("planEvent worktree gate (WM-108)", () => {
           }),
         ).toEqual({ decision: "noop", reason: "ticket_escalation_pr_closed" });
       }
+      // A transient forge failure is reported under its own reason so the
+      // worker can requeue it instead of refusing the continuation for good.
+      const unreadable = worktreeDispatchAutoEligibility(continuation.input, {
+        ...dispatch,
+        escalatedContinuation: closedEscalation,
+        fetchPullRequest: () => {
+          throw new Error("github_read_failed: x");
+        },
+      });
+      expect(unreadable.ok).toBe(false);
+      expect(unreadable.refusal).toMatchObject({
+        reason: "ticket_escalation_pr_read_failed",
+        decision: "noop",
+        detail: "github_read_failed: x",
+      });
+      expect(unreadable.evidence.checks.ticket_escalation_pr_read).toBe(
+        undefined,
+      );
       expect(
         worktreeDispatchAutoEligibility(continuation.input, {
           ...dispatch,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3271,12 +3271,30 @@ export async function executeClaimed(
         ) {
           return deferTransientGate("owned_paths_unknown");
         }
+        // A forge read failure while checking the failed run's PR is as
+        // transient as a Linear read failure: requeue with backoff instead
+        // of permanently killing the escalation continuation. Only when the
+        // retries are exhausted does the continuation refuse terminally, and
+        // then the tier_escalations row must leave 'applied' with it.
+        if (
+          gate === "dispatch" &&
+          gateRefusal.reason === "ticket_escalation_pr_read_failed" &&
+          worktreeHandoff
+        ) {
+          const deferred = deferTransientGate(gateRefusal.reason);
+          if (deferred?.terminalState === "REFUSED") {
+            refuseTierEscalationClaim(db, worktreeHandoff, gateRefusal.reason);
+          }
+          return deferred;
+        }
         releaseClaimLock(lockFile);
         if (
           gate === "dispatch" &&
-          ["ticket_claimed_by_other", "ticket_escalation_pr_closed"].includes(
-            gateRefusal.reason,
-          ) &&
+          [
+            "ticket_claimed_by_other",
+            "ticket_escalation_pr_closed",
+            "ticket_escalation_pr_read_failed",
+          ].includes(gateRefusal.reason) &&
           worktreeHandoff
         ) {
           refuseTierEscalationClaim(db, worktreeHandoff, gateRefusal.reason);

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1174,6 +1174,20 @@ function originatingEvent(db, runId) {
   );
 }
 
+function resultArtifactForRun(db, runId) {
+  const row = db
+    .query(
+      `SELECT result_json FROM results WHERE run_id = ? ORDER BY attempt DESC LIMIT 1`,
+    )
+    .get(runId);
+  if (!row?.result_json) return null;
+  try {
+    return JSON.parse(row.result_json)?.artifact ?? null;
+  } catch {
+    return null;
+  }
+}
+
 function tierEscalationForContinuation(db, runId) {
   const row = db
     .query(`SELECT * FROM tier_escalations WHERE continuation_run_id = ?`)
@@ -1188,6 +1202,7 @@ function tierEscalationForContinuation(db, runId) {
     workspacePath: row.workspace_path,
     sourceWorkspacePath: row.source_workspace_path,
     projectionState: row.projection_state,
+    failedRunArtifact: resultArtifactForRun(db, row.failed_run_id),
   };
 }
 
@@ -3259,7 +3274,9 @@ export async function executeClaimed(
         releaseClaimLock(lockFile);
         if (
           gate === "dispatch" &&
-          gateRefusal.reason === "ticket_claimed_by_other" &&
+          ["ticket_claimed_by_other", "ticket_escalation_pr_closed"].includes(
+            gateRefusal.reason,
+          ) &&
           worktreeHandoff
         ) {
           refuseTierEscalationClaim(db, worktreeHandoff, gateRefusal.reason);

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2642,6 +2642,99 @@ sh -c 'sleep 5 & wait'
     db.close();
   });
 
+  test("tier escalation refuses a continuation when its failed run PR is closed", async () => {
+    const db = openDb(":memory:");
+    const failedRunId = "run_tier_closed_failed";
+    const continuationRunId = "run_tier_closed_continuation";
+    queueRun(
+      db,
+      makeSpec({
+        runId: continuationRunId,
+        agent: "dispatch@1",
+        input: {
+          repo: "factory",
+          ticket: "watt-mind/factory#1499",
+          modelTier: "strong",
+        },
+        workspace: { type: "worktree", checkoutDir: "repo" },
+        outputContract: "factory.dispatch-result/v1",
+        modelTier: "strong",
+      }),
+    );
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:test', '{}', '{}', ?)`,
+    ).run(
+      failedRunId,
+      JSON.stringify({ artifact: { prNumber: 1499 } }),
+      new Date(T0).toISOString(),
+    );
+    db.query(
+      `INSERT INTO tier_escalations
+         (root_run_id, failed_run_id, continuation_run_id, repo, ticket,
+          workspace_path, source_workspace_path, projection_state, created_at)
+       VALUES (?, ?, ?, 'factory', 'watt-mind/factory#1499', '/tmp/checkout', '/tmp/wrapper', 'applied', ?)`,
+    ).run(
+      failedRunId,
+      failedRunId,
+      continuationRunId,
+      new Date(T0).toISOString(),
+    );
+
+    const locksDir = tmpDir("tier-closed-locks-");
+    const leasesDir = tmpDir("tier-closed-leases-");
+    let claims = 0;
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        dispatch: {
+          locksDir,
+          leasesDir,
+          fetchTicket: () => ({
+            identifier: "watt-mind/factory#1499",
+            state: { name: "In Progress" },
+            assignee: { id: "factory-owner", name: "Factory" },
+            labels: {
+              nodes: [{ name: "ai:in-progress" }, { name: "tier:strong" }],
+            },
+            description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
+          }),
+          fetchViewer: () => ({ id: "factory-owner", name: "Factory" }),
+          fetchPullRequest: ({ github, pr }) => {
+            expect(github).toBe("watt-mind/factory");
+            expect(pr).toBe(1499);
+            return { state: "MERGED" };
+          },
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          claimTicket: () => ((claims += 1), { ok: true }),
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      runId: continuationRunId,
+      terminalState: "REFUSED",
+      reasonCode: "ticket_escalation_pr_closed",
+    });
+    expect(claims).toBe(0);
+    expect(existsSync(dispatchLockPath("factory", locksDir))).toBe(false);
+    expect(
+      db
+        .query(
+          `SELECT projection_state, projection_error FROM tier_escalations WHERE continuation_run_id = ?`,
+        )
+        .get(continuationRunId),
+    ).toEqual({
+      projection_state: "refused",
+      projection_error: "ticket_escalation_pr_closed",
+    });
+    db.close();
+  });
+
   test("tier escalation projection replaces every tier label and comments both run ids idempotently", () => {
     const calls = [];
     const runCli = (args) => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2735,6 +2735,133 @@ sh -c 'sleep 5 & wait'
     db.close();
   });
 
+  test("tier escalation requeues a continuation when its failed run PR read fails transiently", async () => {
+    const seedEscalation = (db, failedRunId, continuationRunId) => {
+      queueRun(
+        db,
+        makeSpec({
+          runId: continuationRunId,
+          agent: "dispatch@1",
+          input: {
+            repo: "factory",
+            ticket: "watt-mind/factory#1499",
+            modelTier: "strong",
+          },
+          workspace: { type: "worktree", checkoutDir: "repo" },
+          outputContract: "factory.dispatch-result/v1",
+          modelTier: "strong",
+        }),
+      );
+      db.query(
+        `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, 'sha256:test', '{}', '{}', ?)`,
+      ).run(
+        failedRunId,
+        JSON.stringify({ artifact: { prNumber: 1499 } }),
+        new Date(T0).toISOString(),
+      );
+      db.query(
+        `INSERT INTO tier_escalations
+           (root_run_id, failed_run_id, continuation_run_id, repo, ticket,
+            workspace_path, source_workspace_path, projection_state, created_at)
+         VALUES (?, ?, ?, 'factory', 'watt-mind/factory#1499', '/tmp/checkout', '/tmp/wrapper', 'applied', ?)`,
+      ).run(
+        failedRunId,
+        failedRunId,
+        continuationRunId,
+        new Date(T0).toISOString(),
+      );
+    };
+    const escalationRow = (db, continuationRunId) =>
+      db
+        .query(
+          `SELECT projection_state, projection_error FROM tier_escalations WHERE continuation_run_id = ?`,
+        )
+        .get(continuationRunId);
+    const dispatchOpts = (locksDir, leasesDir, claims) => ({
+      locksDir,
+      leasesDir,
+      fetchTicket: () => ({
+        identifier: "watt-mind/factory#1499",
+        state: { name: "In Progress" },
+        assignee: { id: "factory-owner", name: "Factory" },
+        labels: {
+          nodes: [{ name: "ai:in-progress" }, { name: "tier:strong" }],
+        },
+        description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
+      }),
+      fetchViewer: () => ({ id: "factory-owner", name: "Factory" }),
+      fetchPullRequest: () => {
+        throw new Error("github_read_failed: rate limited");
+      },
+      fetchInFlight: () => [],
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      claimTicket: () => ((claims.count += 1), { ok: true }),
+    });
+
+    {
+      const db = openDb(":memory:");
+      const continuationRunId = "run_tier_unreadable_continuation";
+      seedEscalation(db, "run_tier_unreadable_failed", continuationRunId);
+      const locksDir = tmpDir("tier-unreadable-locks-");
+      const leasesDir = tmpDir("tier-unreadable-leases-");
+      const claims = { count: 0 };
+      const summary = await runOnce(
+        db,
+        registry,
+        adapters,
+        opts({ dispatch: dispatchOpts(locksDir, leasesDir, claims) }),
+      );
+      expect(summary).toMatchObject({
+        runId: continuationRunId,
+        terminalState: "QUEUED",
+        reasonCode: "ticket_escalation_pr_read_failed",
+      });
+      expect(summary.requeueAfterMs).toBeGreaterThan(0);
+      expect(claims.count).toBe(0);
+      expect(existsSync(dispatchLockPath("factory", locksDir))).toBe(false);
+      expect(runState(db, continuationRunId)).toBe("QUEUED");
+      expect(escalationRow(db, continuationRunId)).toEqual({
+        projection_state: "applied",
+        projection_error: null,
+      });
+      db.close();
+    }
+
+    {
+      const db = openDb(":memory:");
+      const continuationRunId = "run_tier_exhausted_continuation";
+      seedEscalation(db, "run_tier_exhausted_failed", continuationRunId);
+      const locksDir = tmpDir("tier-exhausted-locks-");
+      const leasesDir = tmpDir("tier-exhausted-leases-");
+      const claims = { count: 0 };
+      const summary = await runOnce(
+        db,
+        registry,
+        adapters,
+        opts({
+          dispatch: {
+            ...dispatchOpts(locksDir, leasesDir, claims),
+            maxTransientGateRequeues: 0,
+          },
+        }),
+      );
+      expect(summary).toMatchObject({
+        runId: continuationRunId,
+        terminalState: "REFUSED",
+        reasonCode: "ticket_escalation_pr_read_failed",
+      });
+      expect(claims.count).toBe(0);
+      expect(existsSync(dispatchLockPath("factory", locksDir))).toBe(false);
+      expect(escalationRow(db, continuationRunId)).toEqual({
+        projection_state: "refused",
+        projection_error: "ticket_escalation_pr_read_failed",
+      });
+      db.close();
+    }
+  });
+
   test("tier escalation projection replaces every tier label and comments both run ids idempotently", () => {
     const calls = [];
     const runCli = (args) => {


### PR DESCRIPTION
Fixes watt-mind/factory#1499

Stop tier-escalation continuations when the original PR is already merged or closed.

## Validation

| Check                | Command                                                                          | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 191 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1997 pass, emit and format clean       |
| UX critique          | factory-ux-critic                                                                | not run | backend runtime gate; no user surface  |

UX critique: skipped — backend runtime gate with no user-facing surface

## Post-review

- Transient `github_read_failed:` from the failed-run PR check (`ticket_escalation_pr_read_failed`) now requeues via `deferTransientGate`, mirroring `linear_read_failed`; on retry exhaustion the continuation refuses and the `tier_escalations` row is marked `refused` (reason also added to the `refuseTierEscalationClaim` list).
- Tests: planner case asserting the transient refusal shape; worker case covering QUEUED-with-backoff and exhausted REFUSED + row state.
