### PR TITLE
fix(backend): pass dispatch identity to agents

### DIFF
--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -368,6 +368,13 @@ capabilities. Adapter support is a contract, not a hopeful command-line flag.
 Adapters execute only the registry-verified `promptText` snapshot and refuse
 definitions without it; `promptPath` is provenance, not executable prompt source.
 
+**Dispatch agent environment.** A worktree dispatch receives three
+RunSpec-derived identity variables: `FACTORY_RUN_ID` (the dispatch run ID),
+`FACTORY_TICKET` (the ticket identifier), and `FACTORY_REPO` (the configured
+repository name). They are set by the worker rather than inherited from its
+ambient environment, so a dispatch prompt can bind its PR handoff to the run
+that owns the worktree.
+
 **Artifact-view sidecar (`agents/<name>.view.json`, WM-454).** An optional
 `factory.artifact-view/v1` document beside the definition annotates pointers
 into the output schema with rendering hints ([event-runtime-artifact-views.md](event-runtime-artifact-views.md)

--- a/docs/event-runtime.md
+++ b/docs/event-runtime.md
@@ -368,12 +368,15 @@ capabilities. Adapter support is a contract, not a hopeful command-line flag.
 Adapters execute only the registry-verified `promptText` snapshot and refuse
 definitions without it; `promptPath` is provenance, not executable prompt source.
 
-**Dispatch agent environment.** A worktree dispatch receives three
-RunSpec-derived identity variables: `FACTORY_RUN_ID` (the dispatch run ID),
-`FACTORY_TICKET` (the ticket identifier), and `FACTORY_REPO` (the configured
-repository name). They are set by the worker rather than inherited from its
-ambient environment, so a dispatch prompt can bind its PR handoff to the run
-that owns the worktree.
+**Dispatch agent environment.** Any `dispatch@<version>` run receives up to
+three RunSpec-derived identity variables: `FACTORY_RUN_ID` (the dispatch run
+ID), `FACTORY_TICKET` (the ticket identifier), and `FACTORY_REPO` (the
+configured repository name). A key is omitted when the spec does not carry the
+value; it is never exported as the string `"null"`. They are set by the worker
+rather than inherited from its ambient environment, so a dispatch prompt can
+bind its PR handoff to the run that owns the worktree. The shared child-env
+builder re-asserts these keys after its credential and prefix strip loops, so
+an adapter's `extraStrip` or `stripPrefixes: ["FACTORY_"]` cannot remove them.
 
 **Artifact-view sidecar (`agents/<name>.view.json`, WM-454).** An optional
 `factory.artifact-view/v1` document beside the definition annotates pointers

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -99,6 +99,12 @@ export function safeChildEnvironment(
       delete childEnv[key];
     }
   }
+  // Dispatch identity is supplied explicitly by the worker from the RunSpec;
+  // re-assert it after the strip loops so an `extraStrip` entry or a
+  // `stripPrefixes: ["FACTORY_"]` adapter cannot silently remove it.
+  for (const key of DISPATCH_IDENTITY_ENV) {
+    if (env[key] !== undefined) childEnv[key] = env[key];
+  }
 
   return childEnv;
 }

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -22,6 +22,16 @@ export const RUNTIME_IDENTITY_ENV = [
   "FACTORY_EVENT_ENV",
 ];
 
+// These are assigned from a dispatch RunSpec by the worker, rather than
+// inherited from the worker process. Keep the list explicit so adapters do
+// not accidentally strip the identity the dispatch prompt needs for its PR
+// handoff.
+export const DISPATCH_IDENTITY_ENV = [
+  "FACTORY_RUN_ID",
+  "FACTORY_TICKET",
+  "FACTORY_REPO",
+];
+
 export const PUSH_CREDENTIAL_ENV = [
   "SSH_AUTH_SOCK",
   "SSH_AGENT_PID",

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
+  DISPATCH_IDENTITY_ENV,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
@@ -28,6 +29,7 @@ describe("shared child environment", () => {
       [
         ...PUSH_CREDENTIAL_ENV,
         ...PROVIDER_CREDENTIAL_ENV,
+        ...DISPATCH_IDENTITY_ENV,
         "ANTIGRAVITY_AGENT",
         "ANTIGRAVITY_LS_ADDRESS",
         "CURSOR_API_ENDPOINT",
@@ -45,6 +47,9 @@ describe("shared child environment", () => {
     for (const output of Object.values(outputs)) {
       for (const key of [...PUSH_CREDENTIAL_ENV, ...PROVIDER_CREDENTIAL_ENV]) {
         expect(output[key]).toBeUndefined();
+      }
+      for (const key of DISPATCH_IDENTITY_ENV) {
+        expect(output[key]).toBe(`supplied-${key}`);
       }
     }
     expect(keySet(outputs.command)).toEqual(

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -64,6 +64,36 @@ describe("shared child environment", () => {
     expect(keySet(outputs.pi)).toEqual(keySet(outputs.claude));
   });
 
+  test("dispatch identity survives extraStrip and FACTORY_ prefix stripping", () => {
+    const supplied = Object.fromEntries(
+      [...DISPATCH_IDENTITY_ENV, "FACTORY_OTHER"].map((key) => [
+        key,
+        `supplied-${key}`,
+      ]),
+    );
+    const output = safeChildEnvironment(
+      supplied,
+      { mutating: false },
+      {
+        factoryRoot: "/factory-root",
+        extraStrip: [...DISPATCH_IDENTITY_ENV],
+        stripPrefixes: ["FACTORY_"],
+      },
+    );
+    for (const key of DISPATCH_IDENTITY_ENV) {
+      expect(output[key]).toBe(`supplied-${key}`);
+    }
+    expect(output.FACTORY_OTHER).toBeUndefined();
+    expect(output.FACTORY_ROOT).toBeUndefined();
+
+    const absent = safeChildEnvironment({}, false, {
+      stripPrefixes: ["FACTORY_"],
+    });
+    for (const key of DISPATCH_IDENTITY_ENV) {
+      expect(absent[key]).toBeUndefined();
+    }
+  });
+
   test("does not grant push credentials to non-boolean mutating values", () => {
     const supplied = Object.fromEntries(
       PUSH_CREDENTIAL_ENV.map((key) => [key, `supplied-${key}`]),

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3579,6 +3579,18 @@ export async function executeClaimed(
 
     let outcome;
     try {
+      // Dispatch identity comes from the immutable RunSpec, never the ambient
+      // worker environment. The adapter's child-environment builder preserves
+      // these values while continuing to strip credentials it does not need.
+      const adapterEnv =
+        spec.agent === "dispatch@1"
+          ? {
+              ...env,
+              FACTORY_RUN_ID: runId,
+              FACTORY_TICKET: String(ticketId),
+              FACTORY_REPO: String(repoName),
+            }
+          : env;
       outcome = await adapter.execute({
         spec,
         def,
@@ -3588,7 +3600,7 @@ export async function executeClaimed(
           spec,
           maxRunMinutes: policyMaxRunMinutes(policyRoot),
         }),
-        env,
+        env: adapterEnv,
         onTrace,
         onUsage,
         resume: created.resume ?? null,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -941,6 +941,30 @@ export function tierEscalationEligibility(spec, reasonCode) {
   return { eligible, rootRunId };
 }
 
+/**
+ * Layer the RunSpec-derived dispatch identity onto the adapter environment.
+ *
+ * Any `dispatch@<version>` agent qualifies. Identity keys are only emitted when
+ * the spec actually carries the value, so a spec without a ticket or repo never
+ * exports the literal string "null". Non-dispatch agents get `env` unchanged.
+ */
+export function dispatchIdentityEnv({
+  spec,
+  env = {},
+  runId = null,
+  ticketId = null,
+  repoName = null,
+}) {
+  if (!String(spec?.agent ?? "").startsWith("dispatch@")) return env;
+  const identity = {};
+  if (runId != null && runId !== "") identity.FACTORY_RUN_ID = String(runId);
+  if (ticketId != null && ticketId !== "")
+    identity.FACTORY_TICKET = String(ticketId);
+  if (repoName != null && repoName !== "")
+    identity.FACTORY_REPO = String(repoName);
+  return { ...env, ...identity };
+}
+
 function maxEnvironmentRetries(spec) {
   return Number.isInteger(spec.maxEnvironmentRetries) &&
     spec.maxEnvironmentRetries >= 0
@@ -3582,15 +3606,13 @@ export async function executeClaimed(
       // Dispatch identity comes from the immutable RunSpec, never the ambient
       // worker environment. The adapter's child-environment builder preserves
       // these values while continuing to strip credentials it does not need.
-      const adapterEnv =
-        spec.agent === "dispatch@1"
-          ? {
-              ...env,
-              FACTORY_RUN_ID: runId,
-              FACTORY_TICKET: String(ticketId),
-              FACTORY_REPO: String(repoName),
-            }
-          : env;
+      const adapterEnv = dispatchIdentityEnv({
+        spec,
+        env,
+        runId,
+        ticketId,
+        repoName,
+      });
       outcome = await adapter.execute({
         spec,
         def,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -61,6 +61,7 @@ import { computeDefHash } from "./receipts.mjs";
 import { getAgent, loadRegistry } from "./registry.mjs";
 import { transcriptSessionId } from "./transcripts.mjs";
 import {
+  dispatchIdentityEnv,
   acquireClaimLock,
   adapterExecuteTimeoutMs,
   cancelRun,
@@ -3915,6 +3916,49 @@ sh -c 'sleep 5 & wait'
       now: afterExpiry,
     });
     expect(w1Result.fenced).toBe(true);
+  });
+
+  test("dispatchIdentityEnv omits unset identity keys and gates on the dispatch@ prefix (#1497)", () => {
+    const env = { PATH: "/bin" };
+    const full = dispatchIdentityEnv({
+      spec: { agent: "dispatch@2" },
+      env,
+      runId: "run-1",
+      ticketId: 1497,
+      repoName: "factory",
+    });
+    expect(full).toEqual({
+      PATH: "/bin",
+      FACTORY_RUN_ID: "run-1",
+      FACTORY_TICKET: "1497",
+      FACTORY_REPO: "factory",
+    });
+
+    const partial = dispatchIdentityEnv({
+      spec: { agent: "dispatch@1" },
+      env,
+      runId: "run-2",
+      ticketId: null,
+      repoName: undefined,
+    });
+    expect(partial).toEqual({ PATH: "/bin", FACTORY_RUN_ID: "run-2" });
+    expect("FACTORY_TICKET" in partial).toBe(false);
+    expect("FACTORY_REPO" in partial).toBe(false);
+
+    for (const agent of [
+      "factory-status-report@1",
+      "dispatcher@1",
+      undefined,
+    ]) {
+      const untouched = dispatchIdentityEnv({
+        spec: { agent },
+        env,
+        runId: "run-3",
+        ticketId: "T-1",
+        repoName: "r",
+      });
+      expect(untouched).toBe(env);
+    }
   });
 
   test("worker preserves push credentials for mutating runs and strips them for non-mutating runs (WM-128)", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4000,6 +4000,9 @@ sh -c 'sleep 5 & wait'
     expect(capturedMutatingEnv.SSH_AUTH_SOCK).toBe("/tmp/worker-dispatch.sock");
     expect(capturedMutatingEnv.GITHUB_TOKEN).toBe("ghp_worker_dispatch_token");
     expect(capturedMutatingEnv.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(capturedMutatingEnv.FACTORY_RUN_ID).toBe(mutatingSpec.runId);
+    expect(capturedMutatingEnv.FACTORY_TICKET).toBe("WM-128");
+    expect(capturedMutatingEnv.FACTORY_REPO).toBe("bj29");
 
     // 2. Non-mutating run (factory-status-report@1 has mutating: false)
     const readOnlySpec = queueRun(


### PR DESCRIPTION
Fixes watt-mind/factory#1497

Dispatch agents now receive run, ticket, and repository identity for handoff trailers.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/child-env.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 101 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1998 pass, 10 environment skips    |
| UX critique          | `factory-ux-critic`                                                             | skipped | no user-facing backend surface     |

UX critique: skipped — no user-facing backend surface


## Post-review

Folded in after review (commit 6dee4857):

1. `worker.mjs`: new `dispatchIdentityEnv()` emits `FACTORY_TICKET` / `FACTORY_REPO` only when the spec carries the value — no more literal `"null"` exports.
2. `worker.mjs`: gate is `String(spec.agent ?? "").startsWith("dispatch@")` instead of the literal `dispatch@1`.
3. `adapters/child-env.mjs`: `DISPATCH_IDENTITY_ENV` keys are re-asserted after the credential / `extraStrip` / `stripPrefixes` loops, so `stripPrefixes: ["FACTORY_"]` can no longer delete them.

Tests added for all three (`worker.test.mjs`, `child-env.test.mjs`); `docs/event-runtime.md` updated.
