### PR TITLE
fix(workers): prune obsolete registry rows (#1502)

### DIFF
--- a/event-runtime/lib/reaper.test.mjs
+++ b/event-runtime/lib/reaper.test.mjs
@@ -335,24 +335,38 @@ describe("reaper (OPS-416)", () => {
     });
   });
 
-  test("prunes stale stopped workers during reap cycle (OPS-431)", () => {
+  test("prunes expired stopped and dead workers during reap cycle", () => {
     const db = openDb(":memory:");
-    // w1: stopped 30 hours ago (> 24h retention window)
-    registerWorker(db, { workerId: "w1", now: T0 - 48 * 60 * 60 * 1000 });
-    deregisterWorker(db, "w1", { now: T0 - 30 * 60 * 60 * 1000 });
-
-    // w2: active worker
+    const hour = 60 * 60 * 1000;
+    registerWorker(db, { workerId: "w1", now: T0 });
     registerWorker(db, { workerId: "w2", now: T0 });
+    registerWorker(db, { workerId: "w3", now: T0 });
+    registerWorker(db, { workerId: "w4", now: T0 });
+    registerWorker(db, { workerId: "w5", now: T0 });
 
-    // w3: stopped 2 hours ago (< 24h retention window)
-    registerWorker(db, { workerId: "w3", now: T0 - 5 * 60 * 60 * 1000 });
-    deregisterWorker(db, "w3", { now: T0 - 2 * 60 * 60 * 1000 });
-
-    expect(listWorkers(db, { now: T0 })).toHaveLength(3);
+    // w1: stopped 2 hours ago (> 1h retention window).
+    deregisterWorker(db, "w1", { now: T0 - 2 * hour });
+    // w3: stopped 30 minutes ago (< 1h retention window).
+    deregisterWorker(db, "w3", { now: T0 - 30 * 60 * 1000 });
+    // w4: dead for more than 6 hours without a lease.
+    // w5: stale, but still owns an active attempt and must remain visible.
+    for (const workerId of ["w4", "w5"]) {
+      db.query(`UPDATE workers SET last_seen = ? WHERE worker_id = ?`).run(
+        new Date(T0 - 7 * hour).toISOString(),
+        workerId,
+      );
+    }
+    const leased = makeSpec({ runId: "run-leased-worker", maxAttempts: 2 });
+    setupVerifyingRun(db, leased, { now: T0, expired: false });
+    db.query(`UPDATE attempts SET lease_owner = ? WHERE run_id = ?`).run(
+      "w5",
+      leased.runId,
+    );
+    expect(listWorkers(db, { now: T0 })).toHaveLength(5);
 
     reapExpiredLeases(db, { now: T0, policyVersion: "test" });
 
     const remaining = listWorkers(db, { now: T0 });
-    expect(remaining.map((w) => w.workerId).sort()).toEqual(["w2", "w3"]);
+    expect(remaining.map((w) => w.workerId).sort()).toEqual(["w2", "w3", "w5"]);
   });
 });

--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -21,30 +21,64 @@ import { reposRoot } from "./repos.mjs";
 /** A worker is considered gone if it has not checked in for this long. */
 export const HEARTBEAT_STALE_MS = 90_000;
 
+/** Keep clean shutdowns briefly, but remove them before they bury the fleet. */
+export const STOPPED_WORKER_RETENTION_MS = 60 * 60 * 1000;
+
+/** A non-stopped worker past this age is a dead process, not capacity. */
+export const INACTIVE_WORKER_RETENTION_MS = 6 * 60 * 60 * 1000;
+
 const iso = (now) => new Date(now).toISOString();
+
+const ACTIVE_ATTEMPT_STATES = "'LEASED', 'RUNNING', 'VERIFYING'";
+
+/** Do not discard a registry row while an in-flight attempt still names it. */
+const unleasedWorker = `NOT EXISTS (
+  SELECT 1
+  FROM attempts
+  JOIN runs ON runs.run_id = attempts.run_id
+  WHERE attempts.lease_owner = workers.worker_id
+    AND runs.state IN (${ACTIVE_ATTEMPT_STATES})
+)`;
+
+function pruneHostWorkers(db, { host, workerId, now }) {
+  const inactiveCutoff = iso(now - INACTIVE_WORKER_RETENTION_MS);
+  db.query(
+    `DELETE FROM workers
+     WHERE host = ?
+       AND worker_id != ?
+       AND (state = 'stopped' OR (state != 'stopped' AND last_seen < ?))
+       AND ${unleasedWorker}`,
+  ).run(host, workerId, inactiveCutoff);
+}
 
 export function registerWorker(
   db,
   { workerId, labels = {}, adapters = [], now = Date.now() },
 ) {
   const at = iso(now);
-  db.query(
-    `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state)
-     VALUES (?, ?, ?, ?, ?, ?, ?, 'idle')
-     ON CONFLICT(worker_id) DO UPDATE SET
-       host = excluded.host, pid = excluded.pid, labels_json = excluded.labels_json,
-       adapters = excluded.adapters, last_seen = excluded.last_seen,
-       state = 'idle', stopped_at = NULL`,
-  ).run(
-    workerId,
-    hostname(),
-    process.pid,
-    JSON.stringify(labels),
-    adapters.join(","),
-    at,
-    at,
-  );
-  return { workerId, host: hostname(), pid: process.pid, labels, adapters };
+  const host = hostname();
+  return tx(db, () => {
+    // A clean pool restart deregisters each local worker first. Remove those
+    // obsolete rows as the replacement starts, while retaining active leases.
+    pruneHostWorkers(db, { host, workerId, now });
+    db.query(
+      `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state)
+       VALUES (?, ?, ?, ?, ?, ?, ?, 'idle')
+       ON CONFLICT(worker_id) DO UPDATE SET
+         host = excluded.host, pid = excluded.pid, labels_json = excluded.labels_json,
+         adapters = excluded.adapters, last_seen = excluded.last_seen,
+         state = 'idle', stopped_at = NULL`,
+    ).run(
+      workerId,
+      host,
+      process.pid,
+      JSON.stringify(labels),
+      adapters.join(","),
+      at,
+      at,
+    );
+    return { workerId, host, pid: process.pid, labels, adapters };
+  });
 }
 
 /** Called every loop tick: proof of life, plus what the worker is doing. */
@@ -95,16 +129,28 @@ export function stalledWorkers(db, { now = Date.now() } = {}) {
   return listWorkers(db, { now }).filter((w) => w.stale && w.currentRun);
 }
 
-/** Drop long-stopped workers so the registry reflects the fleet, not history. */
+/** Drop obsolete registry rows while retaining workers that own active leases. */
 export function pruneWorkers(
   db,
-  { olderThanMs = 24 * 60 * 60 * 1000, now = Date.now() } = {},
+  {
+    stoppedOlderThanMs = STOPPED_WORKER_RETENTION_MS,
+    inactiveOlderThanMs = INACTIVE_WORKER_RETENTION_MS,
+    now = Date.now(),
+  } = {},
 ) {
   return tx(db, () => {
-    const cutoff = iso(now - olderThanMs);
+    const stoppedCutoff = iso(now - stoppedOlderThanMs);
+    const inactiveCutoff = iso(now - inactiveOlderThanMs);
     const { changes } = db
-      .query(`DELETE FROM workers WHERE state = 'stopped' AND stopped_at < ?`)
-      .run(cutoff);
+      .query(
+        `DELETE FROM workers
+         WHERE (
+           (state = 'stopped' AND stopped_at < ?)
+           OR (state != 'stopped' AND last_seen < ?)
+         )
+         AND ${unleasedWorker}`,
+      )
+      .run(stoppedCutoff, inactiveCutoff);
     return changes ?? 0;
   });
 }

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -219,14 +219,63 @@ describe("worker registry and heartbeats (OPS-233)", () => {
     });
   });
 
-  test("pruning drops long-stopped workers only", () => {
+  test("pruning keeps recent and leased workers while dropping expired rows", () => {
     const d = db();
-    const old = Date.now() - 48 * 60 * 60 * 1000;
-    registerWorker(d, { workerId: "old", now: old });
-    deregisterWorker(d, "old", { now: old });
-    registerWorker(d, { workerId: "live" });
-    expect(pruneWorkers(d)).toBe(1);
-    expect(listWorkers(d).map((w) => w.workerId)).toEqual(["live"]);
+    const now = Date.now();
+    const hour = 60 * 60 * 1000;
+
+    registerWorker(d, { workerId: "old-stopped", now });
+    registerWorker(d, { workerId: "fresh-stopped", now });
+    registerWorker(d, { workerId: "stale-dead", now });
+    registerWorker(d, { workerId: "stale-but-leased", now });
+    deregisterWorker(d, "old-stopped", { now: now - 2 * hour });
+    deregisterWorker(d, "fresh-stopped", { now: now - 30 * 60 * 1000 });
+    heartbeat(d, "stale-dead", { now: now - 7 * hour });
+    heartbeat(d, "stale-but-leased", { now: now - 7 * hour });
+    queueRun(d, { runId: "run_leased" });
+    claimNext(d, {
+      owner: "stale-but-leased",
+      policyVersion: PV,
+      now,
+    });
+
+    expect(pruneWorkers(d, { now })).toBe(2);
+    expect(
+      listWorkers(d, { now })
+        .map((w) => w.workerId)
+        .sort(),
+    ).toEqual(["fresh-stopped", "stale-but-leased"]);
+  });
+
+  test("registering a worker removes obsolete rows from its host", () => {
+    const d = db();
+    const now = Date.now();
+
+    registerWorker(d, { workerId: "previous-pool", now });
+    deregisterWorker(d, "previous-pool", { now });
+    registerWorker(d, { workerId: "new-pool", now: now + 1 });
+
+    expect(listWorkers(d, { now: now + 1 }).map((w) => w.workerId)).toEqual([
+      "new-pool",
+    ]);
+  });
+
+  test("pruning retention windows are configurable", () => {
+    const d = db();
+    const now = Date.now();
+
+    registerWorker(d, { workerId: "stopped", now });
+    registerWorker(d, { workerId: "inactive", now });
+    deregisterWorker(d, "stopped", { now: now - 30 * 60 * 1000 });
+    heartbeat(d, "inactive", { now: now - 2 * 60 * 60 * 1000 });
+
+    expect(
+      pruneWorkers(d, {
+        now,
+        stoppedOlderThanMs: 15 * 60 * 1000,
+        inactiveOlderThanMs: 60 * 60 * 1000,
+      }),
+    ).toBe(2);
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1502

Prune obsolete worker registry rows while preserving active lease owners.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/workers.test.mjs event-runtime/lib/reaper.test.mjs --timeout 20000` | pass    | 37 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1998 pass, 10 skipped; emit clean  |
| UX critique          | `factory-ux-critic`                                                            | not run | no user-facing surface             |

UX critique: skipped — backend worker registry maintenance; no user-facing surface