### PR TITLE
fix(control-plane): paginate GitHub labels

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -120,7 +120,12 @@ const collaboratorAssociationCache = new Map();
 const PAGE_SIZE = 100;
 const MAX_PAGES = 50;
 
-/** Read a bounded GitHub REST collection in full. */
+/**
+ * Read a bounded GitHub REST collection in full. GitHub defaults to 30
+ * records, so callers that need the complete collection (comment history,
+ * repo labels) must opt into pagination rather than silently treating the
+ * first page as the entire collection.
+ */
 async function listAllPages(call, pathName, query = {}) {
   const items = [];
   for (let page = 1; page <= MAX_PAGES; page += 1) {
@@ -901,8 +906,16 @@ export function githubControlPlane(options = {}) {
   }
 
   async function repoLabels(repo) {
-    if (!repoLabelsCache.has(repo))
-      repoLabelsCache.set(repo, listAllPages(call, `repos/${repo}/labels`));
+    if (!repoLabelsCache.has(repo)) {
+      const promise = listAllPages(call, `repos/${repo}/labels`);
+      // A rejected read (403 mid token refresh, timeout, rate limit) must not
+      // be replayed to every later file()/claim()/setLabels() until restart:
+      // drop the memo so the next caller retries instead of inheriting it.
+      promise.catch(() => {
+        if (repoLabelsCache.get(repo) === promise) repoLabelsCache.delete(repo);
+      });
+      repoLabelsCache.set(repo, promise);
+    }
     return repoLabelsCache.get(repo);
   }
 
@@ -911,8 +924,15 @@ export function githubControlPlane(options = {}) {
     if (bad.length)
       throw new ControlPlaneError("invalid label(s):\n  " + bad.join("\n  "));
     if (!names.length) return;
-    const all = await repoLabels(repo);
-    const missing = names.filter((n) => !all.some((l) => l.name === n));
+    const findMissing = (all) =>
+      names.filter((n) => !all.some((l) => l.name === n));
+    let missing = findMissing(await repoLabels(repo));
+    if (missing.length) {
+      // The memo may predate `factory init` creating the label: re-read once
+      // before refusing so a fresh label takes effect without restarting serve.
+      repoLabelsCache.delete(repo);
+      missing = findMissing(await repoLabels(repo));
+    }
     if (missing.length)
       throw new ControlPlaneError(
         `label(s) do not exist in this workspace: ${missing.join(", ")}\n` +

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -120,6 +120,27 @@ const collaboratorAssociationCache = new Map();
 const PAGE_SIZE = 100;
 const MAX_PAGES = 50;
 
+/** Read a bounded GitHub REST collection in full. */
+async function listAllPages(call, pathName, query = {}) {
+  const items = [];
+  for (let page = 1; page <= MAX_PAGES; page += 1) {
+    const rows = await call("GET", pathName, {
+      query: {
+        ...query,
+        per_page: String(PAGE_SIZE),
+        page: String(page),
+      },
+    });
+    const pageItems = Array.isArray(rows) ? rows : [];
+    items.push(...pageItems);
+    if (pageItems.length < PAGE_SIZE) return items;
+  }
+  console.warn(
+    `GitHub pagination reached the ${MAX_PAGES}-page safety ceiling for ${pathName}; results may be incomplete`,
+  );
+  return items;
+}
+
 /**
  * WM-879 gate 1: who last edited the issue body. `UserContentEdit.editor`
  * carries no `authorAssociation` of its own (that field only exists on the
@@ -798,6 +819,7 @@ export function githubControlPlane(options = {}) {
   const api = apiOpt ?? makeGhApi(exec);
 
   let projectCache = null;
+  const repoLabelsCache = new Map();
   // Short-TTL memo of the Projects v2 board read (WM-1067). `projectItems`
   // re-paginates the whole board over GraphQL and is called synchronously on
   // the dispatch/queue path — every concurrent claim and status lookup used to
@@ -879,10 +901,9 @@ export function githubControlPlane(options = {}) {
   }
 
   async function repoLabels(repo) {
-    const rows = await call("GET", `repos/${repo}/labels`, {
-      query: { per_page: "100" },
-    });
-    return Array.isArray(rows) ? rows : [];
+    if (!repoLabelsCache.has(repo))
+      repoLabelsCache.set(repo, listAllPages(call, `repos/${repo}/labels`));
+    return repoLabelsCache.get(repo);
   }
 
   async function requireLabelsExist(repo, names) {
@@ -956,31 +977,6 @@ export function githubControlPlane(options = {}) {
         `no state "${stateName}" on team ${defaultRepo ?? project.title} — have: ${project.options.map((o) => o.name).join(", ")}`,
       );
     return target;
-  }
-
-  /**
-   * Read a bounded GitHub REST collection. GitHub defaults to 30 records, so
-   * callers that need complete comment history must opt into pagination rather
-   * than silently treating the first page as the entire collection.
-   */
-  async function listAllPages(pathName, query = {}) {
-    const items = [];
-    for (let page = 1; page <= MAX_PAGES; page += 1) {
-      const rows = await call("GET", pathName, {
-        query: {
-          ...query,
-          per_page: String(PAGE_SIZE),
-          page: String(page),
-        },
-      });
-      const pageItems = Array.isArray(rows) ? rows : [];
-      items.push(...pageItems);
-      if (pageItems.length < PAGE_SIZE) return items;
-    }
-    console.warn(
-      `GitHub pagination reached the ${MAX_PAGES}-page safety ceiling for ${pathName}; results may be incomplete`,
-    );
-    return items;
   }
 
   async function projectItems() {
@@ -1382,7 +1378,10 @@ export function githubControlPlane(options = {}) {
   async function fetchReadyPin(repo, number) {
     let rows;
     try {
-      rows = await listAllPages(`repos/${repo}/issues/${number}/comments`);
+      rows = await listAllPages(
+        call,
+        `repos/${repo}/issues/${number}/comments`,
+      );
     } catch {
       // Absence — including an unfetchable comment list — is not itself a
       // refusal (see the docstring above): only a mismatched pin is.
@@ -1413,6 +1412,7 @@ export function githubControlPlane(options = {}) {
     let comments = [];
     try {
       const rows = await listAllPages(
+        call,
         `repos/${repo}/issues/${number}/comments`,
       );
       comments = Array.isArray(rows) ? rows : [];
@@ -1493,6 +1493,7 @@ export function githubControlPlane(options = {}) {
       const { repo, number } = locate(identifier);
       await fetchIssue(repo, number);
       const rows = await listAllPages(
+        call,
         `repos/${repo}/issues/${number}/comments`,
       );
       return rows.map((c) => ({
@@ -1968,10 +1969,7 @@ export async function provisionGithubRepo(call, repo, opts = {}) {
 
   let existing;
   try {
-    const rows = await call("GET", `repos/${repo}/labels`, {
-      query: { per_page: "100" },
-    });
-    existing = Array.isArray(rows) ? rows : [];
+    existing = await listAllPages(call, `repos/${repo}/labels`);
   } catch (err) {
     throw scopeHint(err, repo, "repo");
   }

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -372,7 +372,11 @@ function fakeApi(seed) {
     if (pathOnly === "user" && method === "GET") return seed.viewer;
 
     const labelsMatch = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/labels$/);
-    if (labelsMatch && method === "GET") return seed.labels;
+    if (labelsMatch && method === "GET") {
+      const perPage = Number(q.per_page ?? 30);
+      const page = Number(q.page ?? 1);
+      return seed.labels.slice((page - 1) * perPage, page * perPage);
+    }
 
     const commentsMatch = pathOnly.match(
       /^repos\/([^/]+\/[^/]+)\/issues\/(\d+)\/comments$/,
@@ -1846,6 +1850,30 @@ describe("github label write is a complete set", () => {
       [AGENT_READY_LABEL, "type:bug"].sort(),
     );
   });
+
+  test("finds a page-two label and caches the paginated read across file calls", async () => {
+    const seed = contractSeed();
+    seed.labels = Array.from({ length: 149 }, (_, i) => ({
+      id: i + 1,
+      name: `label-${i + 1}`,
+    }));
+    seed.labels.push({ id: 150, name: "type:bug" });
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({ api, repo: REPO, teams: { WM: REPO } });
+
+    await expect(
+      cp.file({ team: "WM", title: "page two", labels: ["type:bug"] }),
+    ).resolves.toBeDefined();
+    await expect(
+      cp.file({ team: "WM", title: "cached", labels: ["type:bug"] }),
+    ).resolves.toBeDefined();
+
+    const labelReads = api.calls.filter(
+      (call) =>
+        call.method === "GET" && call.pathName === `repos/${REPO}/labels`,
+    );
+    expect(labelReads.map((call) => call.query.page)).toEqual(["1", "2"]);
+  });
 });
 
 // -------------------------------------------- init provisioning (WM-1009) ---
@@ -1858,11 +1886,15 @@ describe("provisionGithubRepo", () => {
   /** A gh api fake with a controllable label set and project. */
   function provApi({ labels = [], project = null, failList = null } = {}) {
     const state = { labels: [...labels], created: [], calls: [] };
-    const api = async (method, pathName, { body } = {}) => {
-      state.calls.push({ method, pathName, body });
+    const api = async (method, pathName, { body, query } = {}) => {
+      state.calls.push({ method, pathName, body, query });
       if (method === "GET" && pathName === `repos/${REPO2}/labels`) {
         if (failList) throw new ControlPlaneError("Forbidden", { status: 403 });
-        return state.labels.map((name) => ({ name }));
+        const perPage = Number(query?.per_page ?? 30);
+        const page = Number(query?.page ?? 1);
+        return state.labels
+          .slice((page - 1) * perPage, page * perPage)
+          .map((name) => ({ name }));
       }
       if (method === "POST" && pathName === `repos/${REPO2}/labels`) {
         if (state.labels.includes(body.name))
@@ -1972,6 +2004,28 @@ describe("provisionGithubRepo", () => {
     expect(report.existed.sort()).toEqual(["ai:agent-ready", "type:bug"]);
     expect(report.created).not.toContain("ai:agent-ready");
     expect(report.created).toContain("ai:in-progress");
+  });
+
+  test("does not recreate a protocol label found on page two", async () => {
+    const api = provApi({
+      labels: [
+        ...Array.from({ length: 149 }, (_, i) => `label-${i + 1}`),
+        "type:bug",
+      ],
+    });
+    const report = await provisionGithubRepo(api, REPO2);
+    expect(report.existed).toContain("type:bug");
+    expect(api.state.created.map((label) => label.name)).not.toContain(
+      "type:bug",
+    );
+    expect(
+      api.state.calls
+        .filter(
+          (call) =>
+            call.method === "GET" && call.pathName === `repos/${REPO2}/labels`,
+        )
+        .map((call) => call.query.page),
+    ).toEqual(["1", "2"]);
   });
 
   test("a concurrent creation (422) is success, not a failure", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1874,6 +1874,63 @@ describe("github label write is a complete set", () => {
     );
     expect(labelReads.map((call) => call.query.page)).toEqual(["1", "2"]);
   });
+
+  test("a rejected label read is not memoized: the next file() retries", async () => {
+    const seed = contractSeed();
+    const inner = fakeApi(seed);
+    let failOnce = true;
+    const api = (method, pathName, opts) => {
+      if (failOnce && method === "GET" && pathName === `repos/${REPO}/labels`) {
+        failOnce = false;
+        throw new ControlPlaneError("Forbidden", { status: 403 });
+      }
+      return inner(method, pathName, opts);
+    };
+    api.calls = inner.calls;
+    const cp = githubControlPlane({ api, repo: REPO, teams: { WM: REPO } });
+
+    await expect(
+      cp.file({ team: "WM", title: "first", labels: ["type:bug"] }),
+    ).rejects.toThrow(/Forbidden/);
+    await expect(
+      cp.file({ team: "WM", title: "retry", labels: ["type:bug"] }),
+    ).resolves.toBeDefined();
+
+    const labelReads = inner.calls.filter(
+      (call) =>
+        call.method === "GET" && call.pathName === `repos/${REPO}/labels`,
+    );
+    expect(labelReads).toHaveLength(1);
+  });
+
+  test("a label created after the memo (factory init) is found on a re-read before refusing", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({ api, repo: REPO, teams: { WM: REPO } });
+    const labelReads = () =>
+      api.calls.filter(
+        (call) =>
+          call.method === "GET" && call.pathName === `repos/${REPO}/labels`,
+      ).length;
+
+    await expect(
+      cp.file({ team: "WM", title: "warm", labels: ["type:bug"] }),
+    ).resolves.toBeDefined();
+    expect(labelReads()).toBe(1);
+
+    // Still missing: the miss triggers exactly one re-read, then refuses.
+    await expect(
+      cp.file({ team: "WM", title: "missing", labels: ["type:docs"] }),
+    ).rejects.toThrow(/label\(s\) do not exist/);
+    expect(labelReads()).toBe(2);
+
+    // `factory init` creates the label out of band; no restart required.
+    seed.labels.push({ id: 999, name: "type:docs" });
+    await expect(
+      cp.file({ team: "WM", title: "fresh", labels: ["type:docs"] }),
+    ).resolves.toBeDefined();
+    expect(labelReads()).toBe(3);
+  });
 });
 
 // -------------------------------------------- init provisioning (WM-1009) ---


### PR DESCRIPTION
Fixes watt-mind/factory#1484

Paginate and cache GitHub label reads so page-two labels can be used by ticket actions.

## Validation

| Check                | Command                                              | Result  | Notes                                  |
| -------------------- | ---------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000` | pass    | 110 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1996 pass, 10 skipped, emit and format clean |
| UX critique          | factory-ux-critic                                    | not run | backend-only control-plane change      |

UX critique: skipped — no user-facing surface


## Post-review

Reviewer verdict FIX, addressed in 3165f083:

1. `repoLabels(repo)`: a rejected `listAllPages` promise is evicted from `repoLabelsCache` (mirrors the `projectItems()` precedent), so a transient 403/timeout/rate-limit is no longer replayed to every later `file()`/`claim()`/`setLabels()` until restart. Test: label read throws once, second `file()` succeeds with a fresh read.
2. `requireLabelsExist`: on a computed miss, drop the memo and re-read once before refusing, so a label created by `factory init` takes effect without restarting serve. Test: miss triggers exactly one re-read; label added out of band is then found.
3. Restored the `listAllPages` docstring rationale (GitHub defaults to 30 records; callers must opt into pagination).
