### PR TITLE
perf(backend): index run ticket subjects

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -307,8 +307,8 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
   const runs = new Set();
 
   // Keep only the small connected component for this ticket in memory. JSON
-  // LIKE is deliberately a broad SQL prefilter: objectNamesTicket below still
-  // checks the parsed, named fields so prose mentioning a ticket is excluded.
+  // LIKE is deliberately a broad prefilter for legacy event/proposal/result
+  // payloads; runs carry a normalized, indexed subject instead.
   const ticketLike = `%${ticket}%`;
   const eventRows = new Map();
   const proposalRows = new Map();
@@ -419,9 +419,7 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     (row) => row.id,
   );
   addRows(
-    db
-      .query(`SELECT * FROM runs WHERE UPPER(spec_json) LIKE ?`)
-      .all(ticketLike),
+    db.query(`SELECT * FROM runs WHERE subject = ?`).all(ticket),
     runRows,
     (row) => row.run_id,
   );
@@ -447,7 +445,7 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       proposals.add(row.id);
   }
   for (const row of runRows.values()) {
-    if (objectNamesTicket(parseObject(row.spec_json).input, ticket))
+    if (String(row.subject ?? "").toUpperCase() === ticket)
       runs.add(row.run_id);
   }
   for (const row of resultRows.values()) {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -589,8 +589,8 @@ describe("ticket journey join (WM-595)", () => {
         });
       s.db
         .query(
-          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+         VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)`,
         )
         .run(
           "run_ticket",
@@ -600,6 +600,7 @@ describe("ticket journey join (WM-595)", () => {
           "COMPLETED",
           "2026-01-01T10:00:00.000Z",
           "2026-01-01T10:10:00.000Z",
+          "WM-595",
         );
       s.db
         .query(
@@ -754,7 +755,7 @@ describe("ticket journey join (WM-595)", () => {
           schemaVersion: "factory.run-spec/v1",
           runId: "ignored",
           agent: "dispatch@1",
-          input: { repo: "factory", ticket },
+          input: { repo: "factory" },
         });
       for (const [runId, ticket] of [
         ["run-json-only", "WM-1328"],
@@ -762,8 +763,8 @@ describe("ticket journey join (WM-595)", () => {
       ]) {
         s.db
           .query(
-            `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-             VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+            `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+             VALUES (?, ?, ?, ?, ?, 1, ?, ?, ?)`,
           )
           .run(
             runId,
@@ -773,6 +774,7 @@ describe("ticket journey join (WM-595)", () => {
             "COMPLETED",
             "2026-01-01T10:00:00.000Z",
             "2026-01-01T10:01:00.000Z",
+            ticket,
           );
       }
       const guardedDb = {

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -146,6 +146,16 @@ CREATE INDEX IF NOT EXISTS idx_attempt_trace_run ON attempt_trace (run_id, seq);
 
 const SCHEMA = SCHEMA_V1;
 
+/** Return the normalized ticket subject carried by a run specification. */
+export function runSubject(spec) {
+  const candidates = [spec?.input?.ticket, spec?.subject];
+  for (const candidate of candidates) {
+    if (typeof candidate === "string" && candidate.trim())
+      return candidate.trim().toUpperCase();
+  }
+  return null;
+}
+
 /**
  * Ordered linear migrations list. Each migration runs sequentially inside a
  * transaction and advances PRAGMA user_version.
@@ -527,6 +537,38 @@ export const MIGRATIONS = [
       if (!columns.has("delivery_error")) {
         db.exec(`ALTER TABLE outbox ADD COLUMN delivery_error TEXT;`);
       }
+    },
+  },
+  {
+    version: 19,
+    name: "runs_subject",
+    up(db) {
+      const columns = new Set(
+        db
+          .query(`PRAGMA table_info(runs)`)
+          .all()
+          .map((row) => row.name),
+      );
+      if (!columns.has("subject")) {
+        db.exec(`ALTER TABLE runs ADD COLUMN subject TEXT;`);
+        const updateSubject = db.query(
+          `UPDATE runs SET subject = ? WHERE run_id = ?`,
+        );
+        for (const row of db
+          .query(`SELECT run_id, spec_json FROM runs`)
+          .all()) {
+          let spec = null;
+          try {
+            spec = JSON.parse(row.spec_json);
+          } catch {
+            // Preserve malformed legacy specifications as unclassified rows.
+          }
+          updateSubject.run(runSubject(spec), row.run_id);
+        }
+      }
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_runs_subject ON runs (subject);
+      `);
     },
   },
 ];

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -283,16 +283,22 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrated.close();
   });
 
-  test("tier escalation handoffs, inbox proposal IDs and lookup indexes reach schema 18 from a fresh and from a v14 database", () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(18);
+  test("tier escalation handoffs, inbox proposal IDs and lookup indexes reach schema 19 from a fresh and from a v14 database", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(19);
     const fresh = openDb(freshFile());
-    expect(getSchemaVersion(fresh)).toBe(18);
+    expect(getSchemaVersion(fresh)).toBe(19);
     expect(
       fresh
         .query(`PRAGMA table_info(outbox)`)
         .all()
         .map((row) => row.name),
     ).toEqual(expect.arrayContaining(["delivery_attempts", "delivery_error"]));
+    expect(
+      fresh
+        .query(`PRAGMA table_info(runs)`)
+        .all()
+        .map((row) => row.name),
+    ).toContain("subject");
     fresh.close();
 
     // #1230 (#1197) owns migration 14 and lands first; a database already at
@@ -303,15 +309,21 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrateDb(at14, { targetVersion: 13 });
     at14.exec("PRAGMA user_version = 14;");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(18);
+    expect(getSchemaVersion(at14)).toBe(19);
     expect(
       at14
         .query(`PRAGMA table_info(outbox)`)
         .all()
         .map((row) => row.name),
     ).toEqual(expect.arrayContaining(["delivery_attempts", "delivery_error"]));
+    expect(
+      at14
+        .query(`PRAGMA table_info(runs)`)
+        .all()
+        .map((row) => row.name),
+    ).toContain("subject");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(18);
+    expect(getSchemaVersion(at14)).toBe(19);
     expect(
       at14
         .query(
@@ -336,8 +348,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     migrateDb(db);
 
-    expect(CURRENT_SCHEMA_VERSION).toBe(18);
-    expect(getSchemaVersion(db)).toBe(18);
+    expect(CURRENT_SCHEMA_VERSION).toBe(19);
+    expect(getSchemaVersion(db)).toBe(19);
     expect(
       db
         .query(
@@ -379,7 +391,61 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
-  test("hot proposal and inbox lookup indexes upgrade an existing database", () => {
+  test("runs subject migration backfills populated v18 rows and indexes the column", () => {
+    const db = new Database(freshFile());
+    migrateDb(db, { targetVersion: 18 });
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
+    ).run(
+      "with-ticket",
+      "with-ticket-key",
+      JSON.stringify({ input: { ticket: " wm-1503 " } }),
+      "2026-08-30T00:00:00.000Z",
+      "2026-08-30T00:00:00.000Z",
+    );
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
+    ).run(
+      "with-subject",
+      "with-subject-key",
+      JSON.stringify({ subject: "ops-42" }),
+      "2026-08-30T00:00:00.000Z",
+      "2026-08-30T00:00:00.000Z",
+    );
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
+    ).run(
+      "without-ticket",
+      "without-ticket-key",
+      JSON.stringify({ input: { repo: "factory" } }),
+      "2026-08-30T00:00:00.000Z",
+      "2026-08-30T00:00:00.000Z",
+    );
+
+    migrateDb(db);
+
+    expect(getSchemaVersion(db)).toBe(19);
+    expect(
+      db.query(`SELECT run_id, subject FROM runs ORDER BY run_id`).all(),
+    ).toEqual([
+      { run_id: "with-subject", subject: "OPS-42" },
+      { run_id: "with-ticket", subject: "WM-1503" },
+      { run_id: "without-ticket", subject: null },
+    ]);
+    expect(
+      db
+        .query(
+          `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_runs_subject'`,
+        )
+        .get()?.sql,
+    ).toContain("runs (subject)");
+    db.close();
+  });
+
+  test("hot proposal, inbox and runs subject lookup indexes upgrade an existing database", () => {
     const file = freshFile();
     const db = new Database(file);
     // #1325 owns migration 16 (inbox_proposal_id); a database already at 16
@@ -390,9 +456,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
 
     const migrated = openDb(file);
-    expect(getSchemaVersion(migrated)).toBe(18);
+    expect(getSchemaVersion(migrated)).toBe(19);
     migrateDb(migrated);
-    expect(getSchemaVersion(migrated)).toBe(18);
+    expect(getSchemaVersion(migrated)).toBe(19);
     const plans = [
       [
         "metrics latest proposal",
@@ -416,6 +482,11 @@ describe("schema migration runner and assertions (OPS-415)", () => {
          WHERE e.correlation_id = 'inbox-1'
          ORDER BY p.created_at DESC, p.rowid DESC LIMIT 1`,
         "idx_events_correlation",
+      ],
+      [
+        "runs subject",
+        `SELECT run_id FROM runs WHERE subject = 'WM-1503'`,
+        "idx_runs_subject",
       ],
     ];
 

--- a/event-runtime/lib/lifecycle.mjs
+++ b/event-runtime/lib/lifecycle.mjs
@@ -6,7 +6,7 @@
  * that updates the run row. Illegal transitions are rejected, never repaired.
  */
 import { hashJson } from "./canonical.mjs";
-import { tx, txImmediate } from "./db.mjs";
+import { runSubject, tx, txImmediate } from "./db.mjs";
 
 export const STATES = [
   "PROPOSED",
@@ -130,9 +130,9 @@ export function createRun(
   const at = new Date(resolveNow(now)).toISOString();
   const result = txImmediate(db, () => {
     db.query(
-      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-       VALUES (?, ?, ?, ?, 'PROPOSED', 0, ?, ?)`,
-    ).run(runId, idempotencyKey, specJson, specHash, at, at);
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+       VALUES (?, ?, ?, ?, 'PROPOSED', 0, ?, ?, ?)`,
+    ).run(runId, idempotencyKey, specJson, specHash, at, at, runSubject(spec));
     appendJournal(db, {
       runId,
       from: null,

--- a/event-runtime/lib/lifecycle.test.mjs
+++ b/event-runtime/lib/lifecycle.test.mjs
@@ -29,6 +29,33 @@ function freshRun(db, key = `key-${Math.random()}`) {
 }
 
 describe("lifecycle", () => {
+  test("createRun persists a normalized ticket subject", () => {
+    const db = openDb(":memory:");
+    createRun(db, {
+      runId: "run_ticket_subject",
+      idempotencyKey: "ticket-subject-key",
+      spec: { input: { ticket: " wm-1503 " } },
+      specJson: '{"input":{"ticket":" wm-1503 "}}',
+      specHash: "sha256:ticket-subject",
+      actor: "test",
+    });
+    createRun(db, {
+      runId: "run_fallback_subject",
+      idempotencyKey: "fallback-subject-key",
+      spec: { subject: "ops-42" },
+      specJson: '{"subject":"ops-42"}',
+      specHash: "sha256:fallback-subject",
+      actor: "test",
+    });
+
+    expect(
+      db.query(`SELECT run_id, subject FROM runs ORDER BY run_id`).all(),
+    ).toEqual([
+      { run_id: "run_fallback_subject", subject: "OPS-42" },
+      { run_id: "run_ticket_subject", subject: "WM-1503" },
+    ]);
+  });
+
   test("happy path PROPOSED → … → COMPLETED, journaled with hashes", () => {
     const db = openDb(":memory:");
     const runId = freshRun(db);


### PR DESCRIPTION
Fixes watt-mind/factory#1503

Adds an indexed normalized run subject so ticket journeys avoid scanning run specs.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/db.test.mjs event-runtime/lib/lifecycle.test.mjs event-runtime/lib/api-runs.test.mjs --timeout 20000` | pass    | 83 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 1998 pass, emit/format clean |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped