### PR TITLE
fix(worker): reconcile verified PR handoffs

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -887,6 +887,11 @@ function commandLine(label, obs) {
  */
 export function composeHandoffVerification(handoff) {
   const lines = [HANDOFF_COMMENT_HEADING];
+  if (Number.isInteger(handoff.prNumber) && handoff.prNumber > 0) {
+    lines.push(
+      `- PR: #${handoff.prNumber} (${handoff.prDraft === true ? "draft" : "ready"})`,
+    );
+  }
   const primary = handoff.verification;
   if (primary) {
     lines.push(commandLine("Verification", primary));

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -888,9 +888,16 @@ function commandLine(label, obs) {
 export function composeHandoffVerification(handoff) {
   const lines = [HANDOFF_COMMENT_HEADING];
   if (Number.isInteger(handoff.prNumber) && handoff.prNumber > 0) {
-    lines.push(
-      `- PR: #${handoff.prNumber} (${handoff.prDraft === true ? "draft" : "ready"})`,
-    );
+    // Only a boolean says anything about the PR's draft state: the
+    // pr_base_unreadable path never sets prDraft, and the same composer writes
+    // the failure comment before the worker drafts the PR.
+    const draftState =
+      typeof handoff.prDraft === "boolean"
+        ? handoff.prDraft
+          ? "draft"
+          : "ready"
+        : "draft state unknown";
+    lines.push(`- PR: #${handoff.prNumber} (${draftState})`);
   }
   const primary = handoff.verification;
   if (primary) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2049,6 +2049,24 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(isBunTestFile("a/b.mjs")).toBe(false);
   });
 
+  test("composeHandoffVerification only qualifies the PR draft state when it is known", () => {
+    const base = { verification: null, repoVerify: null, webBuild: null };
+    expect(
+      composeHandoffVerification({ ...base, prNumber: 7, prDraft: true }),
+    ).toContain("- PR: #7 (draft)");
+    expect(
+      composeHandoffVerification({ ...base, prNumber: 7, prDraft: false }),
+    ).toContain("- PR: #7 (ready)");
+    // pr_base_unreadable never sets prDraft; the worker drafts the PR after
+    // this comment is composed, so "ready" would be a lie.
+    expect(composeHandoffVerification({ ...base, prNumber: 7 })).toContain(
+      "- PR: #7 (draft state unknown)",
+    );
+    expect(
+      composeHandoffVerification({ ...base, prNumber: 7, prDraft: null }),
+    ).toContain("- PR: #7 (draft state unknown)");
+  });
+
   test("composeHandoffVerification is built from observation; the agent's claim is only agent-reported", () => {
     const body = composeHandoffVerification({
       prNumber: 42,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2051,6 +2051,8 @@ describe("handoff verification helpers (WM-718)", () => {
 
   test("composeHandoffVerification is built from observation; the agent's claim is only agent-reported", () => {
     const body = composeHandoffVerification({
+      prNumber: 42,
+      prDraft: true,
       verification: {
         source: "ticket",
         command: "bun test",
@@ -2081,7 +2083,8 @@ describe("handoff verification helpers (WM-718)", () => {
     });
     const lines = body.split("\n");
     expect(lines[0]).toBe("## Handoff verification (worker-observed)");
-    expect(lines[1]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
+    expect(lines[1]).toBe("- PR: #42 (draft)");
+    expect(lines[2]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
     expect(body).toContain("(fail) x > y");
     expect(body).toContain(
       "- Repo verify: `bun test event-runtime/lib` — exit 0 (pass)",

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2350,8 +2350,10 @@ export function defaultReconcileVerifiedHandoffTicket({
   repo,
   fetchTicket,
   runCli = runLinearCli,
+  mayMutate = () => true,
 }) {
   try {
+    if (!mayMutate()) return false;
     const cur =
       typeof fetchTicket === "function"
         ? fetchTicket(ticket, repo)
@@ -4192,6 +4194,7 @@ export async function executeClaimed(
             repo: repoName,
             ticket: ticketId,
             handoff: verified.handoff,
+            mayMutate: mayMutateClaimedTicket,
           }) === true;
       } catch (err) {
         console.error(

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2338,6 +2338,48 @@ export function defaultReturnHandoffTicket({
   }
 }
 
+/**
+ * A verified PR_OPEN must not remain dispatchable when its agent omitted the
+ * final ticket projection. This is deliberately a small, best-effort repair:
+ * the caller owns the claim/fencing guard, while this helper re-reads the
+ * ticket so an agent that already put it In Review receives no duplicate
+ * mutation.
+ */
+export function defaultReconcileVerifiedHandoffTicket({
+  ticket,
+  repo,
+  fetchTicket,
+  runCli = runLinearCli,
+}) {
+  try {
+    const cur =
+      typeof fetchTicket === "function"
+        ? fetchTicket(ticket, repo)
+        : defaultFetchTicket(ticket, repo);
+    if (!cur || cur.state?.name === "In Review") return false;
+    runCli(
+      [
+        "state",
+        ticket,
+        "In Review",
+        "--add",
+        "ai:needs-review",
+        "--remove",
+        "ai:in-progress",
+        "--remove",
+        "ai:agent-ready",
+      ],
+      { repo },
+    );
+    return true;
+  } catch (err) {
+    console.error(
+      `[worker] failed to reconcile verified handoff ticket ${ticket}: ${String(err?.message ?? err)}`,
+    );
+    return false;
+  }
+}
+
 /** Convert an already-opened PR to draft and say why, so nobody merges a red handoff. */
 function defaultHoldPullRequest({ github, prNumber, body }) {
   if (!github || !Number.isInteger(prNumber)) return false;
@@ -2365,7 +2407,7 @@ function defaultFetchHandoffPullRequest({ github, prNumber }) {
     throw new Error("handoff PR requires github and a numeric PR number");
   }
   return loadForge().prView(github, prNumber, {
-    fields: ["baseRefName"],
+    fields: ["baseRefName", "isDraft"],
     timeout: workerSubprocessTimeoutMs(),
   });
 }
@@ -2406,6 +2448,7 @@ function assertHandoffPullRequestBase({ handoff, base, fetchPullRequest }) {
   const actual =
     typeof pr?.baseRefName === "string" ? pr.baseRefName.trim() : "";
   handoff.prBase = { expected, actual: actual || null };
+  handoff.prDraft = pr?.isDraft === true;
   if (!actual) {
     throw new ContractViolation(
       [`pr_base_unreadable: PR #${prNumber} has no baseRefName`],
@@ -2603,6 +2646,7 @@ export async function executeClaimed(
       // handoff comment, PR hold, and ticket return.
       commentTicket: () => true,
       returnHandoffTicket: () => true,
+      reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
     };
   } else if (dispatchStubSelected) {
@@ -2615,6 +2659,7 @@ export async function executeClaimed(
     dispatchOpts = {
       commentTicket: () => true,
       returnHandoffTicket: () => true,
+      reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
       ...dispatchOpts,
     };
@@ -2651,6 +2696,13 @@ export async function executeClaimed(
     dispatchOpts?.returnHandoffTicket ??
     ((args) =>
       defaultReturnHandoffTicket({
+        ...args,
+        fetchTicket: dispatchOpts?.fetchTicket,
+      }));
+  const reconcileVerifiedHandoffTicketFn =
+    dispatchOpts?.reconcileVerifiedHandoffTicket ??
+    ((args) =>
+      defaultReconcileVerifiedHandoffTicket({
         ...args,
         fetchTicket: dispatchOpts?.fetchTicket,
       }));
@@ -4133,11 +4185,27 @@ export async function executeClaimed(
     // agent-reported. Best effort — a comment failure never fails a verified
     // run.
     if (verified.handoff && mayMutateClaimedTicket()) {
+      let stateReconciled = false;
+      try {
+        stateReconciled =
+          reconcileVerifiedHandoffTicketFn({
+            repo: repoName,
+            ticket: ticketId,
+            handoff: verified.handoff,
+          }) === true;
+      } catch (err) {
+        console.error(
+          `[worker] failed to reconcile verified handoff ticket ${ticketId}: ${String(err?.message ?? err)}`,
+        );
+      }
       try {
         commentTicketFn({
           repo: repoName,
           ticket: ticketId,
-          body: composeHandoffVerification(verified.handoff),
+          body: [
+            composeHandoffVerification(verified.handoff),
+            ...(stateReconciled ? ["- state reconciled by worker"] : []),
+          ].join("\n"),
           handoff: verified.handoff,
         });
       } catch {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2343,8 +2343,13 @@ export function defaultReturnHandoffTicket({
  * final ticket projection. This is deliberately a small, best-effort repair:
  * the caller owns the claim/fencing guard, while this helper re-reads the
  * ticket so an agent that already put it In Review receives no duplicate
- * mutation.
+ * mutation. Like defaultUnclaimTicket / defaultBlockBaselineTicket it only
+ * touches a ticket still in the dispatch states (Todo, In Progress): a human
+ * who moved it to Blocked / Done / Canceled mid-run keeps that decision, and
+ * a closed GitHub issue is never reopened by the worker.
  */
+const RECONCILABLE_HANDOFF_STATES = new Set(["Todo", "In Progress"]);
+
 export function defaultReconcileVerifiedHandoffTicket({
   ticket,
   repo,
@@ -2358,7 +2363,15 @@ export function defaultReconcileVerifiedHandoffTicket({
       typeof fetchTicket === "function"
         ? fetchTicket(ticket, repo)
         : defaultFetchTicket(ticket, repo);
-    if (!cur || cur.state?.name === "In Review") return false;
+    if (!cur) return false;
+    const stateName = cur.state?.name;
+    if (stateName === "In Review") return false;
+    if (!RECONCILABLE_HANDOFF_STATES.has(stateName)) {
+      console.error(
+        `[worker] not reconciling verified handoff ticket ${ticket}: state is ${JSON.stringify(stateName ?? null)}, left as-is`,
+      );
+      return false;
+    }
     runCli(
       [
         "state",
@@ -4193,7 +4206,6 @@ export async function executeClaimed(
           reconcileVerifiedHandoffTicketFn({
             repo: repoName,
             ticket: ticketId,
-            handoff: verified.handoff,
             mayMutate: mayMutateClaimedTicket,
           }) === true;
       } catch (err) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -74,6 +74,7 @@ import {
   createReloadWatcher,
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultLocksDir,
+  defaultReconcileVerifiedHandoffTicket,
   defaultProjectTierEscalation,
   defaultReturnHandoffTicket,
   defaultUnclaimTicket,
@@ -4028,5 +4029,65 @@ sh -c 'sleep 5 & wait'
     expect(capturedReadOnlyEnv.SSH_AUTH_SOCK).toBeUndefined();
     expect(capturedReadOnlyEnv.GITHUB_TOKEN).toBeUndefined();
     expect(capturedReadOnlyEnv.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  describe("defaultReconcileVerifiedHandoffTicket (#1498)", () => {
+    const STATE_ARGS = [
+      "state",
+      "WM-1498",
+      "In Review",
+      "--add",
+      "ai:needs-review",
+      "--remove",
+      "ai:in-progress",
+      "--remove",
+      "ai:agent-ready",
+    ];
+
+    test("moves a Todo handoff to In Review and fixes its dispatch labels", () => {
+      const calls = [];
+      const result = defaultReconcileVerifiedHandoffTicket({
+        repo: "factory",
+        ticket: "WM-1498",
+        fetchTicket: () => ({ state: { name: "Todo" } }),
+        runCli: (args, options) => (calls.push({ args, options }), ""),
+      });
+
+      expect(result).toBe(true);
+      expect(calls).toEqual([
+        { args: STATE_ARGS, options: { repo: "factory" } },
+      ]);
+    });
+
+    test("does not mutate a ticket the agent already put In Review", () => {
+      const calls = [];
+      const result = defaultReconcileVerifiedHandoffTicket({
+        repo: "factory",
+        ticket: "WM-1498",
+        fetchTicket: () => ({ state: { name: "In Review" } }),
+        runCli: (args) => (calls.push(args), ""),
+      });
+
+      expect(result).toBe(false);
+      expect(calls).toHaveLength(0);
+    });
+
+    test("a false mayMutateClaimedTicket guard makes no reconciliation calls", () => {
+      const calls = [];
+      const mayMutateClaimedTicket = () => false;
+      if (mayMutateClaimedTicket()) {
+        defaultReconcileVerifiedHandoffTicket({
+          repo: "factory",
+          ticket: "WM-1498",
+          fetchTicket: () => {
+            calls.push("fetch");
+            return { state: { name: "Todo" } };
+          },
+          runCli: (args) => (calls.push(args), ""),
+        });
+      }
+
+      expect(calls).toHaveLength(0);
+    });
   });
 });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4074,19 +4074,18 @@ sh -c 'sleep 5 & wait'
 
     test("a false mayMutateClaimedTicket guard makes no reconciliation calls", () => {
       const calls = [];
-      const mayMutateClaimedTicket = () => false;
-      if (mayMutateClaimedTicket()) {
-        defaultReconcileVerifiedHandoffTicket({
-          repo: "factory",
-          ticket: "WM-1498",
-          fetchTicket: () => {
-            calls.push("fetch");
-            return { state: { name: "Todo" } };
-          },
-          runCli: (args) => (calls.push(args), ""),
-        });
-      }
+      const result = defaultReconcileVerifiedHandoffTicket({
+        repo: "factory",
+        ticket: "WM-1498",
+        mayMutate: () => false,
+        fetchTicket: () => {
+          calls.push("fetch");
+          return { state: { name: "Todo" } };
+        },
+        runCli: (args) => (calls.push(args), ""),
+      });
 
+      expect(result).toBe(false);
       expect(calls).toHaveLength(0);
     });
   });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -4072,6 +4072,36 @@ sh -c 'sleep 5 & wait'
       expect(calls).toHaveLength(0);
     });
 
+    test("moves an In Progress handoff to In Review", () => {
+      const calls = [];
+      const result = defaultReconcileVerifiedHandoffTicket({
+        repo: "factory",
+        ticket: "WM-1498",
+        fetchTicket: () => ({ state: { name: "In Progress" } }),
+        runCli: (args, options) => (calls.push({ args, options }), ""),
+      });
+
+      expect(result).toBe(true);
+      expect(calls).toEqual([
+        { args: STATE_ARGS, options: { repo: "factory" } },
+      ]);
+    });
+
+    for (const state of ["Blocked", "Done", "Canceled"]) {
+      test(`leaves a ticket a human moved to ${state} mid-run untouched`, () => {
+        const calls = [];
+        const result = defaultReconcileVerifiedHandoffTicket({
+          repo: "factory",
+          ticket: "WM-1498",
+          fetchTicket: () => ({ state: { name: state } }),
+          runCli: (args) => (calls.push(args), ""),
+        });
+
+        expect(result).toBe(false);
+        expect(calls).toHaveLength(0);
+      });
+    }
+
     test("a false mayMutateClaimedTicket guard makes no reconciliation calls", () => {
       const calls = [];
       const result = defaultReconcileVerifiedHandoffTicket({


### PR DESCRIPTION
Fixes watt-mind/factory#1498

Reconciles verified PR handoffs that an agent leaves dispatchable into In Review with review labels.

## Validation

| Check                | Command                                                                                | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/verify.test.mjs --timeout 20000` | pass    | 165 tests, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2004 tests, emit and format checks clean   |
| UX critique          | factory-ux-critic                                                                      | not run | backend worker reconciliation only         |

UX critique: skipped — backend worker reconciliation only


## Post-review

Folded in the reviewer's two fixes (45206204):

- `defaultReconcileVerifiedHandoffTicket` now only reconciles tickets in Todo / In Progress (mirroring `defaultUnclaimTicket` / `defaultBlockBaselineTicket`); Blocked / Done / Canceled are logged and left untouched, so a human decision made mid-run is never overridden and a closed GitHub issue is never reopened. Tests: In Progress moved, Blocked / Done / Canceled untouched.
- `composeHandoffVerification` prints `draft` / `ready` only when `prDraft` is a boolean, otherwise `draft state unknown` (the `pr_base_unreadable` path never sets it). Test added.
- Dropped the unused `handoff` argument at the reconcile call site.
