### PR TITLE
fix(backend): preserve GitHub file retries (#1483)

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1848,13 +1848,23 @@ export function githubControlPlane(options = {}) {
         const terms = [`repo:${repo}`, "is:issue"];
         if (marker)
           terms.push(`in:body ${JSON.stringify(encodeURIComponent(key))}`);
+        // The key is percent-encoded (it is stored encoded in the marker).
+        // The title is searched as typed, so it is not encoded; instead any
+        // `"` / `\` is dropped from the term so it cannot close the quoted
+        // phrase and smuggle in qualifiers (e.g. a second `repo:`).  The
+        // exact-title and repository_url post-filters below make the probe
+        // strict again and ignore any hit from another repository.
         if (titleToMatch)
-          terms.push(`in:title ${JSON.stringify(titleToMatch)}`);
+          terms.push(
+            `in:title ${JSON.stringify(titleToMatch.replace(/["\\]/g, ""))}`,
+          );
         const found = await call("GET", "search/issues", {
           query: { q: terms.join(" "), per_page: "100" },
         });
         created = (Array.isArray(found?.items) ? found.items : []).find(
           (issue) =>
+            typeof issue?.repository_url === "string" &&
+            issue.repository_url.endsWith(`/${repo}`) &&
             (!marker || issue.body?.includes(marker)) &&
             (!titleToMatch || issue.title === titleToMatch),
         );
@@ -1890,7 +1900,7 @@ export function githubControlPlane(options = {}) {
         return {
           ...filed,
           warnings: [
-            `${filed.identifier} exists, but a follow-up write failed: ${err.message}`,
+            `${filed.identifier} exists, but a follow-up write failed: ${err?.message ?? String(err)}`,
           ],
         };
       }

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1804,6 +1804,14 @@ export function githubControlPlane(options = {}) {
       );
     },
 
+    /**
+     * `dedupeKey` is opt-in: it is stored in the created issue as an opaque
+     * HTML comment and probes for that exact marker before POSTing.  Callers
+     * which already have a stable exact title can instead opt into that probe
+     * with `matchTitle` (true uses `title`; a string names the title to find).
+     * Neither probe runs unless explicitly requested, so normal filing keeps
+     * its current duplicate-title behaviour.
+     */
     async file({
       team,
       title,
@@ -1811,34 +1819,82 @@ export function githubControlPlane(options = {}) {
       labels = [],
       state = "Triage",
       projectId: _projectId,
+      dedupeKey,
+      matchTitle = false,
     } = {}) {
       if (!team || !title)
         throw new ControlPlaneError("file requires team and title");
       const repo = repoForTeam(team);
       await requireLabelsExist(repo, labels);
-      const created = await call("POST", `repos/${repo}/issues`, {
-        body: {
-          title,
-          body: clampGithubBody(stampRun(body)),
-          labels,
-        },
-      });
+      const key =
+        typeof dedupeKey === "string" && dedupeKey.trim()
+          ? dedupeKey.trim()
+          : null;
+      const titleToMatch =
+        matchTitle === true
+          ? title
+          : typeof matchTitle === "string" && matchTitle.trim()
+            ? matchTitle.trim()
+            : null;
+      const marker = key
+        ? `<!-- factory:dedupe-key ${encodeURIComponent(key)} -->`
+        : null;
+      let created = null;
+
+      // This is one bounded search instead of listing the repository's whole
+      // issue history. It remains opt-in because even a cheap remote read is
+      // unnecessary for ordinary filing.
+      if (marker || titleToMatch) {
+        const terms = [`repo:${repo}`, "is:issue"];
+        if (marker)
+          terms.push(`in:body ${JSON.stringify(encodeURIComponent(key))}`);
+        if (titleToMatch)
+          terms.push(`in:title ${JSON.stringify(titleToMatch)}`);
+        const found = await call("GET", "search/issues", {
+          query: { q: terms.join(" "), per_page: "100" },
+        });
+        created = (Array.isArray(found?.items) ? found.items : []).find(
+          (issue) =>
+            (!marker || issue.body?.includes(marker)) &&
+            (!titleToMatch || issue.title === titleToMatch),
+        );
+      }
+      if (!created) {
+        const issueBody = marker ? `${marker}\n${body}` : body;
+        created = await call("POST", `repos/${repo}/issues`, {
+          body: {
+            title,
+            body: clampGithubBody(stampRun(issueBody)),
+            labels,
+          },
+        });
+      }
       if (!created?.number)
         throw new ControlPlaneError("issueCreate returned no issue");
-      await setStatus(
-        repo,
-        created.number,
-        created.node_id ?? String(created.id),
-        state,
-      );
-      if (state.toLowerCase() === "done")
-        await call("PATCH", `repos/${repo}/issues/${created.number}`, {
-          body: { state: "closed" },
-        });
-      return {
+      const filed = {
         identifier: issueIdentifier(repo, created.number),
         url: created.html_url ?? "",
       };
+      try {
+        await setStatus(
+          repo,
+          created.number,
+          created.node_id ?? String(created.id),
+          state,
+        );
+        if (state.toLowerCase() === "done")
+          await call("PATCH", `repos/${repo}/issues/${created.number}`, {
+            body: { state: "closed" },
+          });
+      } catch (err) {
+        return {
+          ...filed,
+          warnings: [
+            `${filed.identifier} exists, but a follow-up write failed: ${err.message}`,
+          ],
+        };
+      }
+      return filed;
     },
 
     async appendDetail(identifier, markdown) {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -372,12 +372,35 @@ function fakeApi(seed) {
     if (pathOnly === "user" && method === "GET") return seed.viewer;
 
     if (pathOnly === "search/issues" && method === "GET") {
-      const repo = /(?:^|\s)repo:([^\s]+)/.exec(String(q.q ?? ""))?.[1];
-      const rows = repo
-        ? (seed.repos[repo]?.issues ?? []).filter(
-            (issue) => !issue.pull_request,
+      // Honour the query the way GitHub search does: every `repo:` qualifier
+      // widens the scope (so a smuggled second qualifier would leak hits from
+      // another repository), and quoted `in:title` / `in:body` terms narrow
+      // it to issues containing that literal text.
+      const text = String(q.q ?? "");
+      const unquoted = text.replace(/"(?:[^"\\]|\\.)*"/g, '""');
+      const repos = [...unquoted.matchAll(/(?:^|\s)repo:([^\s"]+)/g)].map(
+        (m) => m[1],
+      );
+      if (repos.length === 0) fail(`search/issues without repo: ${text}`);
+      const quoted = (field) => {
+        const m = new RegExp(`in:${field} "((?:[^"\\\\]|\\\\.)*)"`).exec(text);
+        return m ? JSON.parse(`"${m[1]}"`) : null;
+      };
+      const wantTitle = quoted("title");
+      const wantBody = quoted("body");
+      const rows = repos.flatMap((repo) =>
+        (seed.repos[repo]?.issues ?? [])
+          .filter(
+            (issue) =>
+              !issue.pull_request &&
+              (wantTitle === null || issue.title.includes(wantTitle)) &&
+              (wantBody === null || issue.body.includes(wantBody)),
           )
-        : [];
+          .map((issue) => ({
+            ...issue,
+            repository_url: `https://api.github.com/repos/${repo}`,
+          })),
+      );
       return { items: rows.slice(0, Number(q.per_page ?? 30)) };
     }
 
@@ -1281,6 +1304,111 @@ describe("control-plane contract: github", () => {
           call.method === "POST" && call.pathName === `repos/${REPO}/issues`,
       ),
     ).toHaveLength(1);
+  });
+
+  test("file dedupe probe scopes search to the repo and quotes both terms", async () => {
+    const seed = contractSeed();
+    addIssue(seed, REPO, {
+      id: 301,
+      node_id: "I_301",
+      number: 7,
+      title: "exact title",
+      body: "<!-- factory:dedupe-key run%2Fa%20b -->\nearlier",
+      status: "Todo",
+    });
+    addIssue(seed, OTHER_REPO, {
+      id: 302,
+      node_id: "I_302",
+      number: 7,
+      title: "exact title",
+      body: "<!-- factory:dedupe-key run%2Fa%20b -->\nelsewhere",
+    });
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+    const reused = await cp.file({
+      team: TEAM,
+      title: "exact title",
+      dedupeKey: "run/a b",
+      matchTitle: true,
+    });
+    expect(reused.identifier).toBe(`${REPO}#7`);
+    const search = api.calls.find(
+      (call) => call.method === "GET" && call.pathName === "search/issues",
+    );
+    expect(search.query.q).toBe(
+      `repo:${REPO} is:issue in:body "run%2Fa%20b" in:title "exact title"`,
+    );
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "POST" && call.pathName === `repos/${REPO}/issues`,
+      ),
+    ).toBe(false);
+  });
+
+  test("file dedupe probe: a quote in the title cannot escape the quoted term", async () => {
+    const seed = contractSeed();
+    const hostile = `x" repo:${OTHER_REPO} "y`;
+    addIssue(seed, OTHER_REPO, {
+      id: 303,
+      node_id: "I_303",
+      number: 9,
+      title: hostile,
+      body: "unrelated issue in another repo",
+    });
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      api: (method, pathName, opts) => {
+        const res = api(method, pathName, opts);
+        // Even if search returned a hit from another repository, the
+        // repository_url post-filter must ignore it.
+        if (method === "GET" && pathName === "search/issues") {
+          const extra = seed.repos[OTHER_REPO].issues.find(
+            (i) => i.number === 9,
+          );
+          return {
+            items: [
+              {
+                ...extra,
+                repository_url: `https://api.github.com/repos/${OTHER_REPO}`,
+              },
+              ...res.items,
+            ],
+          };
+        }
+        return res;
+      },
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+    const filed = await cp.file({
+      team: TEAM,
+      title: hostile,
+      matchTitle: true,
+    });
+    expect(filed.identifier).toBe(`${REPO}#4`);
+    const search = api.calls.find(
+      (call) => call.method === "GET" && call.pathName === "search/issues",
+    );
+    expect(search.query.q).toBe(
+      `repo:${REPO} is:issue in:title "x repo:${OTHER_REPO} y"`,
+    );
+    expect(
+      search.query.q.replace(/"(?:[^"\\]|\\.)*"/g, '""').match(/repo:/g),
+    ).toHaveLength(1);
+    // Nothing was written to the other repository's issue.
+    expect(
+      api.calls.some((call) =>
+        call.pathName.startsWith(`repos/${OTHER_REPO}/`),
+      ),
+    ).toBe(false);
+    expect((await cp.getTicket(`${REPO}#4`)).title).toBe(hostile);
   });
 
   test("appendDetail is idempotent", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -371,6 +371,16 @@ function fakeApi(seed) {
 
     if (pathOnly === "user" && method === "GET") return seed.viewer;
 
+    if (pathOnly === "search/issues" && method === "GET") {
+      const repo = /(?:^|\s)repo:([^\s]+)/.exec(String(q.q ?? ""))?.[1];
+      const rows = repo
+        ? (seed.repos[repo]?.issues ?? []).filter(
+            (issue) => !issue.pull_request,
+          )
+        : [];
+      return { items: rows.slice(0, Number(q.per_page ?? 30)) };
+    }
+
     const labelsMatch = pathOnly.match(/^repos\/([^/]+\/[^/]+)\/labels$/);
     if (labelsMatch && method === "GET") return seed.labels;
 
@@ -1228,6 +1238,49 @@ describe("control-plane contract: github", () => {
       "type:feature",
     ]);
     await expect(cp.file({ team: TEAM })).rejects.toThrow(ControlPlaneError);
+  });
+
+  test("file preserves and reuses an issue when setting its status fails", async () => {
+    const seed = contractSeed();
+    const api = fakeApi(seed);
+    let failStatus = true;
+    const cp = githubControlPlane({
+      api(method, pathName, opts) {
+        if (failStatus && opts?.body?.query?.includes("SetProjectStatus"))
+          throw new ControlPlaneError("board unavailable");
+        return api(method, pathName, opts);
+      },
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+    const opts = {
+      team: TEAM,
+      title: "retry-safe finding",
+      dedupeKey: "run-1483",
+    };
+
+    const first = await cp.file(opts);
+    expect(first.identifier).toBe(`${REPO}#4`);
+    expect(first.warnings).toEqual([
+      expect.stringContaining("board unavailable"),
+    ]);
+    expect(
+      api.calls.some(
+        (call) => call.method === "GET" && call.pathName === "search/issues",
+      ),
+    ).toBe(true);
+
+    failStatus = false;
+    const retried = await cp.file(opts);
+    expect(retried.identifier).toBe(first.identifier);
+    expect(retried.warnings).toBeUndefined();
+    expect(
+      api.calls.filter(
+        (call) =>
+          call.method === "POST" && call.pathName === `repos/${REPO}/issues`,
+      ),
+    ).toHaveLength(1);
   });
 
   test("appendDetail is idempotent", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1483

Retries now reuse a recorded issue and surface board follow-up failures.

## Validation

| Check                | Command                                                                  | Result  | Notes                                |
| -------------------- | ------------------------------------------------------------------------ | ------- | ------------------------------------ |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000`            | pass    | 109 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2001 pass, 10 skipped; emit/format clean |
| UX critique          | factory-ux-critic                                                        | not run | backend control-plane change         |

UX critique: skipped — backend control-plane change has no user-facing surface

## Post-review

- Search term hardening: the `in:title` term now has `"` / `\` stripped before quoting, so a quote in a title cannot close the phrase and inject qualifiers (e.g. a second `repo:`). The reviewer suggested `encodeURIComponent` like the key; that is not used for the title because GitHub searches the literal title text and `exact%20title` would never match `exact title` (the key works encoded only because the marker is stored encoded). The exact-title post-filter keeps the probe strict.
- Search hits are additionally post-filtered on `issue.repository_url.endsWith("/" + repo)`, so a hit from another repository is never reused or written to.
- The follow-up-write warning uses `err?.message ?? String(err)`.
- Test fake `search/issues` now honours `repo:` and the quoted `in:title` / `in:body` terms; new tests assert the exact query shape and that a hostile title (`x" repo:acme/other "y`) still yields a single `repo:` qualifier, ignores an injected other-repo hit, and files a fresh issue in the right repo.
