### PR TITLE
fix(web): show in-flight run health

### DIFF
--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -8,6 +8,7 @@ import {
   createEventFixture,
   createRunDetailFixture,
   createRunListItemFixture,
+  createWorkerFixture,
   renderWithClient,
   restoreApi,
   withApi,
@@ -80,6 +81,103 @@ describe("RunFull layout (WM-194)", () => {
 });
 
 describe("RunFull header (WM-193)", () => {
+  test("shows elapsed time, lease remaining, and a fresh worker heartbeat for an in-flight run", async () => {
+    const runId = "run_inflight_fresh";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+      attempts: [
+        {
+          run_id: runId,
+          attempt: 1,
+          lease_owner: "worker_fresh",
+          lease_expires_at: new Date(Date.now() + 3 * 60_000).toISOString(),
+          started_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+          finished_at: null,
+          terminal_state: null,
+          reason_code: null,
+          workspace_path: null,
+        },
+      ],
+    });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "RUNNING" })],
+        }),
+        workers: async () => ({
+          workers: [
+            createWorkerFixture({
+              workerId: "worker_fresh",
+              currentRun: runId,
+              state: "busy",
+              lastSeen: new Date(Date.now() - 10_000).toISOString(),
+            }),
+          ],
+        }),
+      },
+      async () => {
+        const view = renderRunFull(runId);
+        const status = await waitFor(() =>
+          view.getByLabelText("In-flight run status"),
+        );
+        expect(status.textContent).toContain("Elapsed 2m");
+        expect(status.textContent).toContain("lease 3m");
+        expect(status.textContent).toContain("worker_fresh");
+        expect(status.textContent).toMatch(/heartbeat \d+s ago/);
+        expect(status.textContent).not.toContain("stale");
+      },
+    );
+  });
+
+  test("marks an in-flight worker with a stale heartbeat", async () => {
+    const runId = "run_inflight_stale";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "VERIFYING" } as RunDetail["run"],
+      attempts: [
+        {
+          run_id: runId,
+          attempt: 1,
+          lease_owner: "worker_stale",
+          lease_expires_at: new Date(Date.now() + 3 * 60_000).toISOString(),
+          started_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+          finished_at: null,
+          terminal_state: null,
+          reason_code: null,
+          workspace_path: null,
+        },
+      ],
+    });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "VERIFYING" })],
+        }),
+        workers: async () => ({
+          workers: [
+            createWorkerFixture({
+              workerId: "worker_stale",
+              currentRun: runId,
+              state: "busy",
+              stale: true,
+              lastSeen: new Date(Date.now() - 5 * 60_000).toISOString(),
+            }),
+          ],
+        }),
+      },
+      async () => {
+        const view = renderRunFull(runId);
+        const status = await waitFor(() =>
+          view.getByLabelText("In-flight run status"),
+        );
+        expect(status.textContent).toContain("worker_stale");
+        expect(status.textContent).toMatch(/heartbeat [45]m ago/);
+        expect(status.textContent).toContain("stale");
+      },
+    );
+  });
+
   test("keeps run identity and actions without duplicating sidebar metadata", async () => {
     const runId = "run_clean_header";
     const detail = createRunDetailFixture({

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -178,6 +178,28 @@ describe("RunFull header (WM-193)", () => {
     );
   });
 
+  test("omits the in-flight status span when elapsed, lease, and worker are all unknown", async () => {
+    const runId = "run_inflight_empty";
+    const detail = createRunDetailFixture({
+      run: { runId, state: "RUNNING" } as RunDetail["run"],
+      attempts: [],
+    });
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({
+          runs: [createRunListItemFixture({ runId, state: "RUNNING" })],
+        }),
+        workers: async () => ({ workers: [] }),
+      },
+      async () => {
+        const view = renderRunFull(runId);
+        await waitFor(() => view.getByText(/Remaining/));
+        expect(view.queryByLabelText("In-flight run status")).toBeNull();
+      },
+    );
+  });
+
   test("keeps run identity and actions without duplicating sidebar metadata", async () => {
     const runId = "run_clean_header";
     const detail = createRunDetailFixture({

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -27,6 +27,8 @@ import { handleRunArtifactClick, toggleRunPin } from "./Runs";
 import { AgentHoverCard } from "../components/AgentHoverCard";
 import { TicketText } from "../components/TicketHoverCard";
 import type { RunSummary } from "../types";
+import { formatDuration, formatRelative } from "../format";
+import { leaseRemaining } from "./Runs";
 
 /**
  * Full-page run view (`#/run/:id`, webui doc §10.11) — the trace at a
@@ -84,6 +86,11 @@ export function RunFull({
     queryKey: ["events", "ALL"],
     queryFn: () => api.events(),
     ...refetchIntervals.secondary,
+  });
+  const workersQ = useQuery({
+    queryKey: ["workers"],
+    queryFn: api.workers,
+    ...refetchIntervals.primary,
   });
   const listRow: RunSummary | null = useMemo(
     () => (listQ.data?.runs ?? []).find((r) => r.runId === runId) ?? null,
@@ -380,6 +387,19 @@ export function RunFull({
   ]);
 
   const inflight = Boolean(d && ["RUNNING", "VERIFYING"].includes(d.run.state));
+  const activeAttempt = d?.attempts.at(-1) ?? null;
+  const worker = useMemo(() => {
+    const workers = workersQ.data?.workers ?? [];
+    return (
+      workers.find((row) => row.workerId === activeAttempt?.lease_owner) ??
+      workers.find((row) => row.currentRun === d?.run.runId) ??
+      null
+    );
+  }, [activeAttempt?.lease_owner, d?.run.runId, workersQ.data]);
+  const elapsed = activeAttempt?.started_at
+    ? formatDuration((now - Date.parse(activeAttempt.started_at)) / 1000)
+    : null;
+  const lease = leaseRemaining(activeAttempt?.lease_expires_at, now);
   const showVerbRow =
     Boolean(canApprove && selProposal) ||
     Boolean(d && isCancellable(d.run.state)) ||
@@ -508,6 +528,30 @@ export function RunFull({
             )}
             {inflight && d && (
               <>
+                <span
+                  aria-label="In-flight run status"
+                  className="mr-1 inline-flex flex-wrap items-center gap-1 text-[12px] text-(--text-dim) tabular-nums"
+                >
+                  {elapsed && <span>Elapsed {elapsed}</span>}
+                  {elapsed && (lease || worker) && <span>·</span>}
+                  {lease && <span>{lease}</span>}
+                  {lease && worker && <span>·</span>}
+                  {worker && (
+                    <>
+                      <span>{worker.workerId}</span>
+                      <span>·</span>
+                      <span>
+                        heartbeat {formatRelative(worker.lastSeen, now)}
+                      </span>
+                      {worker.stale && (
+                        <StateBadge
+                          state="stale"
+                          hues={{ stale: "var(--hue-err)" }}
+                        />
+                      )}
+                    </>
+                  )}
+                </span>
                 <span
                   className="mr-1 text-[12px] text-(--text-dim) tabular-nums"
                   title="Current execution deadline. The sidebar budget meter preserves the original approved RunSpec; its lease clock reflects extensions."

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -528,30 +528,32 @@ export function RunFull({
             )}
             {inflight && d && (
               <>
-                <span
-                  aria-label="In-flight run status"
-                  className="mr-1 inline-flex flex-wrap items-center gap-1 text-[12px] text-(--text-dim) tabular-nums"
-                >
-                  {elapsed && <span>Elapsed {elapsed}</span>}
-                  {elapsed && (lease || worker) && <span>·</span>}
-                  {lease && <span>{lease}</span>}
-                  {lease && worker && <span>·</span>}
-                  {worker && (
-                    <>
-                      <span>{worker.workerId}</span>
-                      <span>·</span>
-                      <span>
-                        heartbeat {formatRelative(worker.lastSeen, now)}
-                      </span>
-                      {worker.stale && (
-                        <StateBadge
-                          state="stale"
-                          hues={{ stale: "var(--hue-err)" }}
-                        />
-                      )}
-                    </>
-                  )}
-                </span>
+                {(elapsed || lease || worker) && (
+                  <span
+                    aria-label="In-flight run status"
+                    className="mr-1 inline-flex flex-wrap items-center gap-1 text-[12px] text-(--text-dim) tabular-nums"
+                  >
+                    {elapsed && <span>Elapsed {elapsed}</span>}
+                    {elapsed && (lease || worker) && <span>·</span>}
+                    {lease && <span>{lease}</span>}
+                    {lease && worker && <span>·</span>}
+                    {worker && (
+                      <>
+                        <span>{worker.workerId}</span>
+                        <span>·</span>
+                        <span>
+                          heartbeat {formatRelative(worker.lastSeen, now)}
+                        </span>
+                        {worker.stale && (
+                          <StateBadge
+                            state="stale"
+                            hues={{ stale: "var(--hue-err)" }}
+                          />
+                        )}
+                      </>
+                    )}
+                  </span>
+                )}
                 <span
                   className="mr-1 text-[12px] text-(--text-dim) tabular-nums"
                   title="Current execution deadline. The sidebar budget meter preserves the original approved RunSpec; its lease clock reflects extensions."

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -411,6 +411,20 @@ function leasePart(
   };
 }
 
+/** The compact lease label shared by the list and the full run view. */
+export function leaseRemaining(
+  leaseExpiresAt: string | null | undefined,
+  now: number,
+) {
+  if (!leaseExpiresAt) return null;
+  const lease = leasePart(
+    clockTo(leaseExpiresAt, 0, now),
+    null,
+    leaseExpiresAt,
+  );
+  return lease?.text ?? null;
+}
+
 /**
  * The one place a row says how long an in-flight attempt has left (WM-725).
  * Budget and lease share this single line: stacking a second line of clocks

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -269,6 +269,52 @@ describe("Ticket journey view", () => {
     expect(current.textContent).toContain("stale · 5m");
   });
 
+  test("prefers the lease owner over a worker whose stale currentRun still points at the run", async () => {
+    const runId = "run_ticket_lease_owner";
+    const data = source();
+    const live = run(runId, new Date(Date.now() - 2 * 60_000).toISOString());
+    live.run.state = "RUNNING";
+    live.lifecycle[1] = { ...live.lifecycle[1], to_state: "RUNNING" };
+    (live as JourneyRun & { attempts: unknown[] }).attempts = [
+      {
+        started_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+        lease_owner: "worker_lease_owner",
+      },
+    ];
+    data.runs = [live];
+    const base = {
+      host: "test",
+      pid: 1,
+      labels: {},
+      adapters: [],
+      state: "busy" as const,
+      startedAt: new Date().toISOString(),
+      stoppedAt: null,
+    };
+    const view = renderTicket(data, undefined, [
+      {
+        ...base,
+        workerId: "worker_stale_claim",
+        currentRun: runId,
+        lastSeen: new Date(Date.now() - 5 * 60_000).toISOString(),
+        stale: true,
+      },
+      {
+        ...base,
+        workerId: "worker_lease_owner",
+        currentRun: runId,
+        lastSeen: new Date(Date.now() - 10_000).toISOString(),
+        stale: false,
+      },
+    ]);
+    await view.findByRole("heading", { name: "WM-542" });
+    const current = view.getByText("Current run / worker")
+      .nextElementSibling as HTMLElement;
+    expect(current.textContent).toContain("worker_lease_owner");
+    expect(current.textContent).not.toContain("worker_stale_claim");
+    expect(current.textContent).toMatch(/heartbeat 1?0s ago/);
+  });
+
   test("renders a two-run journey, PR, aggregates, timeline sources, and current-state block", async () => {
     const view = renderTicket(source());
     await view.findByRole("heading", { name: "WM-542" });

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -16,6 +16,7 @@ import type {
   TicketTrackerDetail,
 } from "../subjectJourney";
 import * as subjectJourneyModel from "../subjectJourney";
+import type { Worker } from "../types";
 
 const realFetch = globalThis.fetch;
 
@@ -148,6 +149,7 @@ function journeyFetch(
   data: TicketJourneySource,
   detail?: TicketTrackerDetail | null,
   detailStatus = 200,
+  workers: Worker[] = [],
 ) {
   return (async (input: RequestInfo | URL) => {
     const url = String(input);
@@ -165,6 +167,9 @@ function journeyFetch(
     if (/\/api\/schedules/.test(url)) {
       return new Response(JSON.stringify({ schedules: [] }), { status: 200 });
     }
+    if (/\/api\/workers/.test(url)) {
+      return new Response(JSON.stringify({ workers }), { status: 200 });
+    }
     return new Response(JSON.stringify(data), { status: 200 });
   }) as unknown as typeof fetch;
 }
@@ -172,8 +177,9 @@ function journeyFetch(
 function renderTicket(
   data: TicketJourneySource,
   detail?: TicketTrackerDetail | null,
+  workers: Worker[] = [],
 ) {
-  globalThis.fetch = journeyFetch(data, detail);
+  globalThis.fetch = journeyFetch(data, detail, 200, workers);
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, refetchInterval: false } },
   });
@@ -191,6 +197,78 @@ afterEach(() => {
 });
 
 describe("Ticket journey view", () => {
+  test("adds elapsed time and a fresh heartbeat next to the current run", async () => {
+    const runId = "run_ticket_fresh";
+    const data = source();
+    const live = run(runId, new Date(Date.now() - 2 * 60_000).toISOString());
+    live.run.state = "RUNNING";
+    live.lifecycle[1] = { ...live.lifecycle[1], to_state: "RUNNING" };
+    (live as JourneyRun & { attempts: unknown[] }).attempts = [
+      {
+        started_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+        lease_owner: "worker_ticket_fresh",
+      },
+    ];
+    data.runs = [live];
+    const view = renderTicket(data, undefined, [
+      {
+        workerId: "worker_ticket_fresh",
+        host: "test",
+        pid: 1,
+        labels: {},
+        adapters: [],
+        state: "busy",
+        currentRun: runId,
+        lastSeen: new Date(Date.now() - 10_000).toISOString(),
+        stale: false,
+        startedAt: new Date().toISOString(),
+        stoppedAt: null,
+      },
+    ]);
+    await view.findByRole("heading", { name: "WM-542" });
+    const current = view.getByText("Current run / worker")
+      .nextElementSibling as HTMLElement;
+    expect(current.textContent).toContain(`${runId} · elapsed 2m`);
+    expect(current.textContent).toContain("worker_ticket_fresh");
+    expect(current.textContent).toMatch(/heartbeat 1?0s ago/);
+  });
+
+  test("shows stale heartbeat age next to the current run", async () => {
+    const runId = "run_ticket_stale";
+    const data = source();
+    const live = run(runId, new Date(Date.now() - 2 * 60_000).toISOString());
+    live.run.state = "RUNNING";
+    live.lifecycle[1] = { ...live.lifecycle[1], to_state: "RUNNING" };
+    (live as JourneyRun & { attempts: unknown[] }).attempts = [
+      {
+        started_at: new Date(Date.now() - 2 * 60_000).toISOString(),
+        lease_owner: "worker_ticket_stale",
+      },
+    ];
+    data.runs = [live];
+    const view = renderTicket(data, undefined, [
+      {
+        workerId: "worker_ticket_stale",
+        host: "test",
+        pid: 1,
+        labels: {},
+        adapters: [],
+        state: "busy",
+        currentRun: runId,
+        lastSeen: new Date(Date.now() - 5 * 60_000).toISOString(),
+        stale: true,
+        startedAt: new Date().toISOString(),
+        stoppedAt: null,
+      },
+    ]);
+    await view.findByRole("heading", { name: "WM-542" });
+    const current = view.getByText("Current run / worker")
+      .nextElementSibling as HTMLElement;
+    expect(current.textContent).toContain(`${runId} · elapsed 2m`);
+    expect(current.textContent).toContain("worker_ticket_stale");
+    expect(current.textContent).toContain("stale · 5m");
+  });
+
   test("renders a two-run journey, PR, aggregates, timeline sources, and current-state block", async () => {
     const view = renderTicket(source());
     await view.findByRole("heading", { name: "WM-542" });

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1281,12 +1281,18 @@ export function Ticket({
     (query.data.runs.find(
       (run) => run.run.runId === journey.currentRun?.runId,
     ) as TicketRunWithAttempts | undefined) ?? null;
+  const workers = workersQuery.data?.workers ?? [];
+  const leaseOwner = currentRunDetail?.attempts?.at(-1)?.lease_owner ?? null;
   const currentWorker =
-    (workersQuery.data?.workers ?? []).find(
+    (leaseOwner
+      ? workers.find((worker) => worker.workerId === leaseOwner)
+      : undefined) ??
+    workers.find(
       (worker) =>
-        worker.workerId === currentRunDetail?.attempts?.at(-1)?.lease_owner ||
-        worker.currentRun === journey.currentRun?.runId,
-    ) ?? null;
+        journey.currentRun?.runId != null &&
+        worker.currentRun === journey.currentRun.runId,
+    ) ??
+    null;
   return (
     <JourneyLayout
       journey={journey}

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -58,7 +58,12 @@ import type {
   RunDetail,
   RunListItem,
   TicketSummary,
+  Worker,
 } from "../types";
+
+type TicketRunWithAttempts = JourneyRun & {
+  attempts?: Array<{ started_at: string | null; lease_owner: string | null }>;
+};
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
@@ -837,14 +842,19 @@ function JourneyLayout({
   detail = null,
   detailPending = false,
   detailError = null,
+  currentRunDetail = null,
+  currentWorker = null,
 }: {
   journey: SubjectJourney;
   onNavigateTicket?: (ticketId: string) => void;
   detail?: TicketTrackerDetail | null;
   detailPending?: boolean;
   detailError?: string | null;
+  currentRunDetail?: TicketRunWithAttempts | null;
+  currentWorker?: Worker | null;
 }) {
   const [tab, setTab] = useState<JourneyTab>("timeline");
+  const now = useNow();
   const cost =
     journey.totalCost == null ? "—" : `$${journey.totalCost.toFixed(2)}`;
   const tokens =
@@ -1078,9 +1088,20 @@ function JourneyLayout({
                 <div>
                   <dt className="text-(--text-faint)">Current run / worker</dt>
                   <dd className="mono mt-1 break-words text-(--text-dim)">
-                    {journey.currentRun
-                      ? `${journey.currentRun.runId}${journey.currentRun.actor ? ` · ${journey.currentRun.actor}` : ""}`
-                      : "—"}
+                    {journey.currentRun ? (
+                      <>
+                        {journey.currentRun.runId}
+                        {currentRunDetail?.attempts?.at(-1)?.started_at &&
+                          ` · elapsed ${formatDuration(now - Date.parse(currentRunDetail.attempts.at(-1)!.started_at!))}`}
+                        {currentWorker &&
+                          ` · ${currentWorker.workerId} · ${currentWorker.stale ? `stale · ${formatDuration(now - Date.parse(currentWorker.lastSeen))}` : `heartbeat ${formatDuration(now - Date.parse(currentWorker.lastSeen))} ago`}`}
+                        {!currentWorker &&
+                          journey.currentRun.actor &&
+                          ` · ${journey.currentRun.actor}`}
+                      </>
+                    ) : (
+                      "—"
+                    )}
                   </dd>
                 </div>
                 <div>
@@ -1151,6 +1172,12 @@ export function Ticket({
     enabled: valid,
     staleTime: 15_000,
     ...pollingOptions(30_000),
+  });
+  const workersQuery = useQuery({
+    queryKey: ["workers"],
+    queryFn: api.workers,
+    enabled: valid,
+    ...refetchIntervals.primary,
   });
 
   if (!ticketId || ticketId.trim() === "")
@@ -1250,6 +1277,16 @@ export function Ticket({
     }),
     detailQuery.data,
   );
+  const currentRunDetail =
+    (query.data.runs.find(
+      (run) => run.run.runId === journey.currentRun?.runId,
+    ) as TicketRunWithAttempts | undefined) ?? null;
+  const currentWorker =
+    (workersQuery.data?.workers ?? []).find(
+      (worker) =>
+        worker.workerId === currentRunDetail?.attempts?.at(-1)?.lease_owner ||
+        worker.currentRun === journey.currentRun?.runId,
+    ) ?? null;
   return (
     <JourneyLayout
       journey={journey}
@@ -1260,6 +1297,8 @@ export function Ticket({
           ? ((detailQuery.error as Error)?.message ?? "unavailable")
           : null
       }
+      currentRunDetail={currentRunDetail}
+      currentWorker={currentWorker}
     />
   );
 }


### PR DESCRIPTION
Fixes watt-mind/factory#1501

Operators can assess in-flight run timing and worker heartbeat health without leaving the run or ticket view.

## Validation

| Check                | Command                                                               | Result | Notes                                      |
| -------------------- | --------------------------------------------------------------------- | ------ | ------------------------------------------ |
| Verification Command | `cd event-runtime/web && bun test src/views/RunFull.test.tsx src/views/Ticket.test.tsx` | pass   | 45 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 1,996 pass; emit and format clean          |
| UX critique          | factory-ux-critic                                                     | pass   | required — SHIP; `/tmp/factory-1501-runs-active.png` |

UX critique: required

## Post-review

Reviewer verdict FIX, addressed in b74bfb67 (after merging `origin/develop`):

- `Ticket.tsx`: `currentWorker` now resolves the attempt's lease owner first and only falls back to a `currentRun` match, mirroring `RunFull.tsx`; previously a single `find` ORed both conditions and could name a worker whose stale `currentRun` still pointed at the run. New test covers two workers where the stale claimant precedes the lease owner.
- `RunFull.tsx`: the `In-flight run status` span is no longer rendered when elapsed, lease, and worker are all unknown. New test asserts the span is absent.
- Removed the unexpanded `run:$FACTORY_RUN_ID` trailer from this body.

Verification: `bun test src/views/RunFull.test.tsx src/views/Ticket.test.tsx` 48 pass; `bunx tsc --noEmit` clean; `bun test event-runtime/lib` 2005 pass; `emit --check`, `format:check`, `bun run check` clean.
