### PR TITLE
perf(web): bound the Ticket view journey feeds with cursor pagination (#1505)

### DIFF
--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -234,6 +234,8 @@ export type RunListFilters = {
   agent?: string;
   /** Opaque cursor returned by the preceding GET /runs page. */
   before?: string;
+  /** Maximum number of newest-first summaries to return. */
+  limit?: number;
 };
 
 export type RunListResponse = {
@@ -264,7 +266,18 @@ function withQuery(path: string, values: Record<string, string | undefined>) {
 }
 
 export function fetchRuns(filters: RunListFilters = {}) {
-  return call<RunListResponse>("GET", withQuery("/runs", filters));
+  return call<RunListResponse>(
+    "GET",
+    withQuery("/runs", {
+      state: filters.state,
+      from: filters.from,
+      to: filters.to,
+      population: filters.population,
+      agent: filters.agent,
+      before: filters.before,
+      limit: filters.limit == null ? undefined : String(filters.limit),
+    }),
+  );
 }
 
 export function fetchProposalHistory(

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -8,7 +8,13 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { prCandidateRunIds, PullRequest, Ticket } from "./Ticket";
+import {
+  prCandidateRunIds,
+  prJourneyRefetchInterval,
+  PullRequest,
+  Ticket,
+} from "./Ticket";
+import { refetchIntervals } from "../hooks";
 import { changeInput } from "../test-render";
 import type {
   JourneyRun,
@@ -769,37 +775,36 @@ describe("PR journey view", () => {
     expect(deriveJourney).toHaveBeenCalledTimes(1);
   });
 
-  test("bounds every PR-journey feed and loads an older page without duplicate timeline activity", async () => {
-    const data = prData();
-    const prEvent = data.events[1]!;
-    const olderPrEvent = {
-      ...prEvent,
-      eventId: "chain-run_scan-older-541",
-      occurredAt: "2026-08-17T19:05:03.000Z",
-      admittedAt: "2026-08-17T19:05:03.000Z",
-    };
-    const urls: string[] = [];
+  // Every feed reports one older page; `olderEvents` is what that page holds.
+  function pagedPrFetch(
+    data: ReturnType<typeof prData>,
+    olderEvents: unknown[],
+    urls: string[],
+    { olderHasNext = false } = {},
+  ) {
     const json = (body: unknown) =>
       new Response(JSON.stringify(body), {
         status: 200,
         headers: { "content-type": "application/json" },
       });
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    return (async (input: RequestInfo | URL) => {
       const url = String(input);
       urls.push(url);
       const older = url.includes("before=");
+      const nextBefore = (page: string) =>
+        older ? (olderHasNext ? `${page}-older` : null) : `${page}-before`;
       if (/\/api\/events/.test(url))
         return json({
-          events: older ? [prEvent, olderPrEvent] : [prEvent],
-          nextBefore: older ? null : "events-before",
+          events: older ? olderEvents : [data.events[1]],
+          nextBefore: nextBefore("events"),
         });
       if (/\/api\/proposals/.test(url))
         return json({
           proposals: data.proposals,
-          nextBefore: older ? null : "proposals-before",
+          nextBefore: nextBefore("proposals"),
         });
       if (/\/api\/inbox/.test(url))
-        return json({ items: [], nextBefore: older ? null : "inbox-before" });
+        return json({ items: [], nextBefore: nextBefore("inbox") });
       if (/\/api\/schedules/.test(url)) return json({ schedules: [] });
       const detail = url.match(/\/api\/runs\/([^/?]+)$/);
       if (detail) {
@@ -817,10 +822,26 @@ describe("PR journey view", () => {
             created_at: run.run.created_at,
             updated_at: run.run.updated_at,
           })),
-          nextBefore: older ? null : "runs-before",
+          nextBefore: nextBefore("runs"),
         });
       return json({ error: `unexpected ${url}` });
     }) as typeof fetch;
+  }
+
+  function olderPrEvent(data: ReturnType<typeof prData>) {
+    return {
+      ...data.events[1]!,
+      eventId: "chain-run_scan-older-541",
+      occurredAt: "2026-08-17T19:05:03.000Z",
+      admittedAt: "2026-08-17T19:05:03.000Z",
+    };
+  }
+
+  test("bounds every PR-journey feed and loads an older page without duplicate timeline activity", async () => {
+    const data = prData();
+    const prEvent = data.events[1]!;
+    const urls: string[] = [];
+    globalThis.fetch = pagedPrFetch(data, [prEvent, olderPrEvent(data)], urls);
     const client = new QueryClient({
       defaultOptions: { queries: { retry: false, refetchInterval: false } },
     });
@@ -841,9 +862,17 @@ describe("PR journey view", () => {
         expect.stringMatching(/\/api\/inbox\?status=all&limit=200$/),
       ]),
     );
+    // The live region carries the count only; the button is announced once,
+    // as a button, not on every count change.
     const timeline = view.getByRole("tabpanel", { name: /timeline/i });
     const initialTimelineItems = timeline.querySelectorAll("li[data-kind]");
     expect(initialTimelineItems.length).toBeGreaterThan(0);
+    const status = view.getByRole("status");
+    expect(status.getAttribute("aria-live")).toBe("polite");
+    expect(status.textContent).toBe(
+      `Showing the most recent ${initialTimelineItems.length} activity entries`,
+    );
+    expect(status.contains(loadMore)).toBe(false);
 
     fireEvent.click(loadMore);
     await waitFor(() =>
@@ -854,6 +883,110 @@ describe("PR journey view", () => {
         initialTimelineItems.length + 1,
       ),
     );
+    // Every feed is exhausted after the older page: the affordance ends.
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toBe(
+        `No more activity for PR #541 — showing all ${initialTimelineItems.length + 1} entries.`,
+      ),
+    );
+    expect(
+      view.queryByRole("button", { name: "Load more activity" }),
+    ).toBeNull();
+  });
+
+  test("an older page that adds nothing for this PR ends the load-more affordance", async () => {
+    const data = prData();
+    const urls: string[] = [];
+    // The feeds still have older pages, but none of them mention PR #541.
+    globalThis.fetch = pagedPrFetch(data, [], urls, { olderHasNext: true });
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <PullRequest number="541" />
+      </QueryClientProvider>,
+    );
+    const loadMore = await view.findByRole("button", {
+      name: "Load more activity",
+    });
+    const timeline = view.getByRole("tabpanel", { name: /timeline/i });
+    const before = timeline.querySelectorAll("li[data-kind]").length;
+
+    fireEvent.click(loadMore);
+    await waitFor(() =>
+      expect(view.getByRole("status").textContent).toBe(
+        `No more activity for PR #541 — showing all ${before} entries.`,
+      ),
+    );
+    expect(timeline.querySelectorAll("li[data-kind]").length).toBe(before);
+    expect(
+      view.queryByRole("button", { name: "Load more activity" }),
+    ).toBeNull();
+    expect(urls.filter((url) => url.includes("before=")).length).toBe(4);
+  });
+
+  test("polls the first page at the fast cadence and backs off once older pages are loaded", async () => {
+    const realFast = refetchIntervals.fast.refetchInterval;
+    const realSecondary = refetchIntervals.secondary.refetchInterval;
+    Object.assign(refetchIntervals.fast, { refetchInterval: () => 20 });
+    Object.assign(refetchIntervals.secondary, {
+      refetchInterval: () => 60_000,
+    });
+    try {
+      expect(prJourneyRefetchInterval({ state: {} })).toBe(20);
+      expect(
+        prJourneyRefetchInterval({ state: { data: { pages: [1] } } }),
+      ).toBe(20);
+      expect(
+        prJourneyRefetchInterval({ state: { data: { pages: [1, 2] } } }),
+      ).toBe(60_000);
+
+      const data = prData();
+      const urls: string[] = [];
+      globalThis.fetch = pagedPrFetch(data, [olderPrEvent(data)], urls);
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false, refetchInterval: false } },
+      });
+      const view = render(
+        <QueryClientProvider client={client}>
+          <PullRequest number="541" />
+        </QueryClientProvider>,
+      );
+      const loadMore = await view.findByRole("button", {
+        name: "Load more activity",
+      });
+      const firstPage = (feed: string) =>
+        urls.filter(
+          (url) => url.includes(`/api/${feed}?`) && !url.includes("before="),
+        ).length;
+      // One page loaded: the feeds poll at the fast cadence.
+      await waitFor(() => expect(firstPage("events")).toBeGreaterThan(2));
+
+      fireEvent.click(loadMore);
+      await waitFor(() =>
+        expect(urls.filter((url) => url.includes("before=")).length).toBe(4),
+      );
+      await view.findByText(/No more activity for PR #541/);
+      // Let any poll that was already scheduled at click time land.
+      await new Promise((resolve) => setTimeout(resolve, 60));
+      const settled = {
+        events: firstPage("events"),
+        proposals: firstPage("proposals"),
+        runs: firstPage("runs"),
+      };
+      await new Promise((resolve) => setTimeout(resolve, 150));
+      expect({
+        events: firstPage("events"),
+        proposals: firstPage("proposals"),
+        runs: firstPage("runs"),
+      }).toEqual(settled);
+    } finally {
+      Object.assign(refetchIntervals.fast, { refetchInterval: realFast });
+      Object.assign(refetchIntervals.secondary, {
+        refetchInterval: realSecondary,
+      });
+    }
   });
 
   test("an unknown PR reads as no runtime activity, and a bad reference as an inline error", async () => {

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -690,7 +690,11 @@ function prData() {
   return {
     events,
     proposals,
-    runs: { run_scan: scan, run_dispatch: dispatch, run_fix: fix },
+    runs: {
+      run_scan: scan,
+      run_dispatch: dispatch,
+      run_fix: fix,
+    } as Record<string, JourneyRun>,
     schedules: [
       {
         loop: "merge-factory",

--- a/event-runtime/web/src/views/Ticket.test.tsx
+++ b/event-runtime/web/src/views/Ticket.test.tsx
@@ -765,6 +765,93 @@ describe("PR journey view", () => {
     expect(deriveJourney).toHaveBeenCalledTimes(1);
   });
 
+  test("bounds every PR-journey feed and loads an older page without duplicate timeline activity", async () => {
+    const data = prData();
+    const prEvent = data.events[1]!;
+    const olderPrEvent = {
+      ...prEvent,
+      eventId: "chain-run_scan-older-541",
+      occurredAt: "2026-08-17T19:05:03.000Z",
+      admittedAt: "2026-08-17T19:05:03.000Z",
+    };
+    const urls: string[] = [];
+    const json = (body: unknown) =>
+      new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const url = String(input);
+      urls.push(url);
+      const older = url.includes("before=");
+      if (/\/api\/events/.test(url))
+        return json({
+          events: older ? [prEvent, olderPrEvent] : [prEvent],
+          nextBefore: older ? null : "events-before",
+        });
+      if (/\/api\/proposals/.test(url))
+        return json({
+          proposals: data.proposals,
+          nextBefore: older ? null : "proposals-before",
+        });
+      if (/\/api\/inbox/.test(url))
+        return json({ items: [], nextBefore: older ? null : "inbox-before" });
+      if (/\/api\/schedules/.test(url)) return json({ schedules: [] });
+      const detail = url.match(/\/api\/runs\/([^/?]+)$/);
+      if (detail) {
+        const run = data.runs[decodeURIComponent(detail[1])];
+        return run ? json(run) : json({ error: "unknown run" });
+      }
+      if (/\/api\/runs(\?|$)/.test(url))
+        return json({
+          runs: Object.values(data.runs).map((run) => ({
+            runId: run.run.runId,
+            state: run.run.state,
+            attempts: 1,
+            agent: run.run.spec.agent,
+            adapter: run.run.spec.adapter,
+            created_at: run.run.created_at,
+            updated_at: run.run.updated_at,
+          })),
+          nextBefore: older ? null : "runs-before",
+        });
+      return json({ error: `unexpected ${url}` });
+    }) as typeof fetch;
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false, refetchInterval: false } },
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <PullRequest number="541" />
+      </QueryClientProvider>,
+    );
+
+    const loadMore = await view.findByRole("button", {
+      name: "Load more activity",
+    });
+    expect(urls).toEqual(
+      expect.arrayContaining([
+        expect.stringMatching(/\/api\/events\?limit=200$/),
+        expect.stringMatching(/\/api\/proposals\?status=all&limit=200$/),
+        expect.stringMatching(/\/api\/runs\?limit=200$/),
+        expect.stringMatching(/\/api\/inbox\?status=all&limit=200$/),
+      ]),
+    );
+    const timeline = view.getByRole("tabpanel", { name: /timeline/i });
+    const initialTimelineItems = timeline.querySelectorAll("li[data-kind]");
+    expect(initialTimelineItems.length).toBeGreaterThan(0);
+
+    fireEvent.click(loadMore);
+    await waitFor(() =>
+      expect(urls.filter((url) => url.includes("before=")).length).toBe(4),
+    );
+    await waitFor(() =>
+      expect(timeline.querySelectorAll("li[data-kind]").length).toBe(
+        initialTimelineItems.length + 1,
+      ),
+    );
+  });
+
   test("an unknown PR reads as no runtime activity, and a bad reference as an inline error", async () => {
     globalThis.fetch = prFetch({ events: [], proposals: [], runs: {} });
     const client = new QueryClient({

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1393,6 +1393,19 @@ const TERMINAL_STATES = new Set([
 // activity, not unbounded global registries, and can request older pages.
 const PR_JOURNEY_PAGE_LIMIT = 200;
 
+// Refetching an infinite query re-requests every loaded page, so each
+// "Load more" would otherwise multiply the per-tick request count. Only the
+// first page needs the fast cadence; once older pages are loaded the feed
+// drops to the secondary interval.
+export function prJourneyRefetchInterval(query: {
+  state: { data?: { pages?: readonly unknown[] } };
+}): number {
+  const pages = query.state.data?.pages?.length ?? 0;
+  return pages > 1
+    ? refetchIntervals.secondary.refetchInterval()
+    : refetchIntervals.fast.refetchInterval();
+}
+
 function uniqueBy<T>(items: readonly T[], key: (item: T) => string): T[] {
   const seen = new Set<string>();
   return items.filter((item) => {
@@ -1426,6 +1439,7 @@ export function PullRequest({
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
+    refetchInterval: prJourneyRefetchInterval,
   });
   const proposals = useInfiniteQuery({
     queryKey: ["proposals", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
@@ -1438,6 +1452,7 @@ export function PullRequest({
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
+    refetchInterval: prJourneyRefetchInterval,
   });
   const runs = useInfiniteQuery({
     queryKey: ["runs", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
@@ -1450,6 +1465,7 @@ export function PullRequest({
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
+    refetchInterval: prJourneyRefetchInterval,
   });
   const inbox = useInfiniteQuery({
     queryKey: ["inbox", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
@@ -1578,6 +1594,25 @@ export function PullRequest({
         : null,
     [journeyReady, pr, source],
   );
+  const loadingMore =
+    events.isFetchingNextPage ||
+    proposals.isFetchingNextPage ||
+    runs.isFetchingNextPage ||
+    inbox.isFetchingNextPage;
+  // The feeds are global registries, so their hasNextPage says nothing about
+  // whether older pages hold more of THIS PR. Remember the timeline size at
+  // each "Load more"; a page that adds nothing ends the affordance.
+  const [loadMoreBaseline, setLoadMoreBaseline] = useState<number | null>(null);
+  const [exhausted, setExhausted] = useState(false);
+  useEffect(() => {
+    setLoadMoreBaseline(null);
+    setExhausted(false);
+  }, [pr]);
+  useEffect(() => {
+    if (loadMoreBaseline == null || loadingMore || journey == null) return;
+    if (journey.timeline.length <= loadMoreBaseline) setExhausted(true);
+    setLoadMoreBaseline(null);
+  }, [loadMoreBaseline, loadingMore, journey]);
 
   if (pr == null) {
     return (
@@ -1619,27 +1654,38 @@ export function PullRequest({
     proposals.hasNextPage ||
     runs.hasNextPage ||
     inbox.hasNextPage;
-  const loadingMore =
-    events.isFetchingNextPage ||
-    proposals.isFetchingNextPage ||
-    runs.isFetchingNextPage ||
-    inbox.isFetchingNextPage;
+  const loadedOlder =
+    (events.data?.pages.length ?? 0) > 1 ||
+    (proposals.data?.pages.length ?? 0) > 1 ||
+    (runs.data?.pages.length ?? 0) > 1 ||
+    (inbox.data?.pages.length ?? 0) > 1;
   const loadMore = () => {
+    if (loadingMore || loadMoreBaseline != null) return;
+    setLoadMoreBaseline(journey.timeline.length);
     if (events.hasNextPage) void events.fetchNextPage();
     if (proposals.hasNextPage) void proposals.fetchNextPage();
     if (runs.hasNextPage) void runs.fetchNextPage();
     if (inbox.hasNextPage) void inbox.fetchNextPage();
   };
+  const footerClass =
+    "px-5 pb-5 text-center text-[12px] text-(--text-dim) lg:px-7";
 
   return (
     <>
       <JourneyLayout journey={journey} onNavigateTicket={onNavigateTicket} />
-      {hasMore && (
-        <p
-          role="status"
-          className="px-5 pb-5 text-center text-[12px] text-(--text-dim) lg:px-7"
-        >
-          Showing the most recent {journey.timeline.length} activity entries —{" "}
+      {exhausted || (loadedOlder && !hasMore) ? (
+        <p className={footerClass}>
+          <span role="status" aria-live="polite">
+            No more activity for PR #{pr} — showing all{" "}
+            {journey.timeline.length} entries.
+          </span>
+        </p>
+      ) : hasMore ? (
+        <p className={footerClass}>
+          <span role="status" aria-live="polite">
+            Showing the most recent {journey.timeline.length} activity entries
+          </span>{" "}
+          —{" "}
           <PrimitiveButton
             bare
             type="button"
@@ -1650,7 +1696,7 @@ export function PullRequest({
             {loadingMore ? "Loading activity…" : "Load more activity"}
           </PrimitiveButton>
         </p>
-      )}
+      ) : null}
     </>
   );
 }

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -1,4 +1,9 @@
-import { useQueries, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   useEffect,
   useMemo,
@@ -1385,8 +1390,18 @@ const TERMINAL_STATES = new Set([
 ]);
 
 // The API caps collection pages at 200. A PR journey needs recent correlated
-// activity, not the entire event journal, so use that bounded newest-first page.
-const PR_JOURNEY_EVENT_LIMIT = 200;
+// activity, not unbounded global registries, and can request older pages.
+const PR_JOURNEY_PAGE_LIMIT = 200;
+
+function uniqueBy<T>(items: readonly T[], key: (item: T) => string): T[] {
+  const seen = new Set<string>();
+  return items.filter((item) => {
+    const id = key(item);
+    if (seen.has(id)) return false;
+    seen.add(id);
+    return true;
+  });
+}
 
 export function PullRequest({
   number,
@@ -1400,27 +1415,51 @@ export function PullRequest({
       ? Number(number.trim())
       : null;
   const enabled = pr != null;
-  const events = useQuery({
-    queryKey: ["events", "pr-journey", pr, PR_JOURNEY_EVENT_LIMIT],
-    queryFn: () => api.events(undefined, { limit: PR_JOURNEY_EVENT_LIMIT }),
+  const events = useInfiniteQuery({
+    queryKey: ["events", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
+    queryFn: ({ pageParam }) =>
+      api.events(undefined, {
+        limit: PR_JOURNEY_PAGE_LIMIT,
+        before: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
   });
-  const proposals = useQuery({
-    queryKey: ["proposals", "history"],
-    queryFn: () => api.proposalHistory("all"),
+  const proposals = useInfiniteQuery({
+    queryKey: ["proposals", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
+    queryFn: ({ pageParam }) =>
+      api.proposalHistory("all", {
+        limit: PR_JOURNEY_PAGE_LIMIT,
+        before: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
   });
-  const runs = useQuery({
-    queryKey: ["runs", "ALL"],
-    queryFn: () => api.runs(),
+  const runs = useInfiniteQuery({
+    queryKey: ["runs", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
+    queryFn: ({ pageParam }) =>
+      api.runs(undefined, {
+        limit: PR_JOURNEY_PAGE_LIMIT,
+        before: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.fast,
   });
-  const inbox = useQuery({
-    queryKey: ["inbox", "all"],
-    queryFn: () => api.inbox("all"),
+  const inbox = useInfiniteQuery({
+    queryKey: ["inbox", "pr-journey", pr, PR_JOURNEY_PAGE_LIMIT],
+    queryFn: ({ pageParam }) =>
+      api.inbox("all", {
+        limit: PR_JOURNEY_PAGE_LIMIT,
+        before: pageParam,
+      }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     enabled,
     ...refetchIntervals.secondary,
   });
@@ -1431,9 +1470,38 @@ export function PullRequest({
     ...refetchIntervals.secondary,
   });
 
-  const eventList = events.data?.events ?? [];
-  const proposalList = proposals.data?.proposals ?? [];
-  const runList = runs.data?.runs ?? [];
+  const eventList = useMemo(
+    () =>
+      uniqueBy(
+        (events.data?.pages ?? []).flatMap((page) => page.events ?? []),
+        (event) => `${event.source}\0${event.eventId}`,
+      ),
+    [events.data],
+  );
+  const proposalList = useMemo(
+    () =>
+      uniqueBy(
+        (proposals.data?.pages ?? []).flatMap((page) => page.proposals ?? []),
+        (proposal) => proposal.id,
+      ),
+    [proposals.data],
+  );
+  const runList = useMemo(
+    () =>
+      uniqueBy(
+        (runs.data?.pages ?? []).flatMap((page) => page.runs ?? []),
+        (run) => run.runId,
+      ),
+    [runs.data],
+  );
+  const inboxList = useMemo(
+    () =>
+      uniqueBy(
+        (inbox.data?.pages ?? []).flatMap((page) => page.items ?? []),
+        (item) => item.id,
+      ),
+    [inbox.data],
+  );
   const candidateIds = useMemo(
     () =>
       pr != null && events.data && proposals.data && runs.data
@@ -1443,11 +1511,11 @@ export function PullRequest({
             runs: runList,
           })
         : [],
-    [pr, events.dataUpdatedAt, proposals.dataUpdatedAt, runs.dataUpdatedAt],
+    [pr, eventList, proposalList, runList],
   );
   const stateById = useMemo(
     () => new Map(runList.map((run) => [run.runId, run.state])),
-    [runs.dataUpdatedAt],
+    [runs.data],
   );
   const details = useQueries({
     queries: candidateIds.map((id) => ({
@@ -1482,7 +1550,7 @@ export function PullRequest({
         events: eventList as unknown as JourneyEvent[],
         proposals: proposalList as unknown as JourneyProposal[],
         runs: loadedRuns,
-        inbox: (inbox.data?.items ?? []).filter((item) => !item.resolvedAt),
+        inbox: inboxList.filter((item) => !item.resolvedAt),
         schedules: schedules.data?.schedules,
       }),
     // Query data references and the useQueries result are unstable across
@@ -1545,7 +1613,44 @@ export function PullRequest({
       </div>
     );
   }
+
+  const hasMore =
+    events.hasNextPage ||
+    proposals.hasNextPage ||
+    runs.hasNextPage ||
+    inbox.hasNextPage;
+  const loadingMore =
+    events.isFetchingNextPage ||
+    proposals.isFetchingNextPage ||
+    runs.isFetchingNextPage ||
+    inbox.isFetchingNextPage;
+  const loadMore = () => {
+    if (events.hasNextPage) void events.fetchNextPage();
+    if (proposals.hasNextPage) void proposals.fetchNextPage();
+    if (runs.hasNextPage) void runs.fetchNextPage();
+    if (inbox.hasNextPage) void inbox.fetchNextPage();
+  };
+
   return (
-    <JourneyLayout journey={journey} onNavigateTicket={onNavigateTicket} />
+    <>
+      <JourneyLayout journey={journey} onNavigateTicket={onNavigateTicket} />
+      {hasMore && (
+        <p
+          role="status"
+          className="px-5 pb-5 text-center text-[12px] text-(--text-dim) lg:px-7"
+        >
+          Showing the most recent {journey.timeline.length} activity entries —{" "}
+          <PrimitiveButton
+            bare
+            type="button"
+            onClick={loadMore}
+            disabled={loadingMore}
+            className="text-(--accent) hover:underline disabled:cursor-wait disabled:opacity-60"
+          >
+            {loadingMore ? "Loading activity…" : "Load more activity"}
+          </PrimitiveButton>
+        </p>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Fixes watt-mind/factory#1505

## Summary
- The PR journey in the Ticket view no longer polls `proposalHistory("all")`, `runs()` and `inbox("all")` unbounded on every fast tick: all four feeds (events, proposals, runs, inbox) are `useInfiniteQuery` pages capped at `PR_JOURNEY_PAGE_LIMIT = 200`, keyed per PR.
- Older pages are requested with the existing `before` cursor (`nextBefore` from each response); `fetchRuns` now forwards `limit` alongside `before`.
- When any feed reports more pages, the view shows a "Showing the most recent N activity entries — Load more activity" affordance; appended pages are de-duplicated by stable ids (`source\0eventId`, proposal id, runId, inbox item id) before journey derivation.
- Test asserts the bounded params (`limit=200`) reach each endpoint, that load-more issues one `before=` request per feed, and that the timeline grows by exactly the new entry (no duplicates from the overlapping page).

## Handoff
Two dispatch runs implemented this but failed handoff with `web_build_failed: Ticket.test.tsx(802,21) TS7053` (string-indexing the `prData().runs` literal). Fixed by typing the fixture map as `Record<string, JourneyRun>` (matching what `prFetch` already expects).

Verification (worktree merged with `origin/develop`, `FACTORY_EVENT_HOME` isolated):
- `cd event-runtime/web && bun x tsc --noEmit` — clean
- `cd event-runtime/web && bun test src/views/Ticket.test.tsx` — 28 pass, 0 fail
- `cd event-runtime/web && bun run build` — built
- `bun test event-runtime/lib --timeout 20000` — 2027 tests, 0 fail (10 skip)
- `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` — all pass

UX critique: skipped — operator-internal view, no screenshots.


## Post-review

Folded in the reviewer's three findings (commit `49bb9954`):

1. **Polling fan-out** — the events/proposals/runs `useInfiniteQuery` feeds refetched every loaded page on each fast tick, so each "Load more" multiplied per-tick requests. `prJourneyRefetchInterval` keeps the fast cadence while only page 1 is loaded and drops to `refetchIntervals.secondary` once older pages exist. Test: `polls the first page at the fast cadence and backs off once older pages are loaded`.
2. **Load-more terminal state** — the affordance was driven by the global feeds' `hasNextPage`, not by whether older pages hold anything for this PR. The view now remembers the timeline size at each click and shows "No more activity for PR #N — showing all N entries." when a fetched page adds zero timeline entries (or every feed is exhausted). Test: `an older page that adds nothing for this PR ends the load-more affordance`.
3. **a11y** — `role="status"`/`aria-live="polite"` moved onto a text-only span so the button label is not re-announced on every count change; asserted in the bounding test.

Gates: `bun x tsc --noEmit`, `bun test src/views/Ticket.test.tsx` (30 pass), `bun test event-runtime/lib` (2017 pass), `emit --check`, `format:check`, `check` — all green.
