### PR TITLE
fix(handoff): mount fd links and alternatives

### DIFF
--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -19,6 +19,22 @@ The forced-command server rejects unknown fields, malformed IDs, unconfigured re
 
 `handoff` is reserved provenance. Unsigned intake still fails, `/replay` rejects both `handoff` and `chain`, and only authenticated signed `/events` may admit `handoff`. A handoff is unattended, not operator authorization: sensitive/escalated and `escalate_paths` bypasses remain false.
 
+## Worker verification sandbox
+
+Before a handoff result is accepted, its ticket verification command runs in a
+user, mount, PID, and network namespace followed by a chroot. The guest mounts
+the worktree, `/usr`, declared package runners, `proc`, an ephemeral `/tmp`, and
+the four basic device nodes. `/usr`, the worktree, and package runners are
+read-only where the check does not need to write; `/dev` is a tmpfs with only
+`null`, `zero`, `random`, `urandom`, and standard `/dev/fd`, `stdin`, `stdout`,
+and `stderr` links into the guest's `/proc/self/fd`.
+
+Some host executables are managed through `/etc/alternatives`. When that
+directory exists, it alone is bind-mounted read-only so those commands remain
+usable. No other host `/etc` path is mounted: credentials, host identity, and
+machine configuration remain outside the guest. Hosts without
+`/etc/alternatives` omit that optional mount and still create the sandbox.
+
 ## Client SSH alias
 
 Create a dedicated key for this purpose; do not reuse an interactive-login key. No key is committed to Factory. Configure an alias on the client:

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -314,6 +314,12 @@ done
 mount --rbind /usr "$root/usr"
 mount --make-rslave "$root/usr"
 mount -o remount,bind,ro "$root/usr"
+if [ -d /etc/alternatives ]; then
+  mkdir -p "$root/etc/alternatives"
+  mount --rbind /etc/alternatives "$root/etc/alternatives"
+  mount --make-rslave "$root/etc/alternatives"
+  mount -o remount,bind,ro "$root/etc/alternatives"
+fi
 mount --rbind "$workspace" "$root/workspace"
 mount --make-rslave "$root/workspace"
 mount -t tmpfs -o mode=1777,size="${"$"}{tmpfs_mb}m" tmpfs "$root/tmp"
@@ -322,6 +328,10 @@ for dev in null zero random urandom; do
   touch "$root/dev/$dev"
   mount --bind "/dev/$dev" "$root/dev/$dev"
 done
+ln -s /proc/self/fd "$root/dev/fd"
+ln -s /proc/self/fd/0 "$root/dev/stdin"
+ln -s /proc/self/fd/1 "$root/dev/stdout"
+ln -s /proc/self/fd/2 "$root/dev/stderr"
 if command -v ip >/dev/null 2>&1; then
   ip link set lo up || echo "handoff-sandbox: loopback stayed down" >&2
 elif command -v ifconfig >/dev/null 2>&1; then

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1815,6 +1815,51 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(obs.output.trim().split("\n").pop().trim()).toBe("1");
   });
 
+  test("the sandbox supplies standard fd links for Bash process substitution", () => {
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
+    const worktree = realpathSync(tmpDir("evrt-handoff-fd-"));
+    const obs = runHandoffCommand({
+      command:
+        "bash -c 'cat <(echo ok)' && readlink /dev/fd && readlink /dev/stdin && readlink /dev/stdout && readlink /dev/stderr && find /dev -mindepth 1 -maxdepth 1 -printf '%f\\n' | sort",
+      cwd: worktree,
+      worktreePath: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.passed).toBe(true);
+    expect(obs.output).toContain("ok\n/proc/self/fd\n/proc/self/fd/0");
+    expect(obs.output).toContain("/proc/self/fd/1\n/proc/self/fd/2");
+    expect(obs.output.trim().split("\n").slice(-8)).toEqual([
+      "fd",
+      "null",
+      "random",
+      "stderr",
+      "stdin",
+      "stdout",
+      "urandom",
+      "zero",
+    ]);
+  });
+
+  test("the sandbox exposes only read-only host alternatives under /etc", () => {
+    if (insideHandoffSandbox()) return;
+    if (!handoffSandboxAvailable({ cache: false, nested: false })) return;
+    const worktree = realpathSync(tmpDir("evrt-handoff-alternatives-"));
+    const hostHasAlternatives = existsSync("/etc/alternatives");
+    const obs = runHandoffCommand({
+      command:
+        "test ! -e /etc/hostname && test ! -e /etc/passwd && if [ -d /etc/alternatives ]; then awk 'BEGIN { print 1 }'; test -r /etc/alternatives; ! touch /etc/alternatives/.factory-write-probe 2>/dev/null; else test ! -e /etc/alternatives; fi",
+      cwd: worktree,
+      worktreePath: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 60_000,
+    });
+    expect(obs.passed).toBe(true);
+    if (hostHasAlternatives) expect(obs.output.trim()).toBe("1");
+    else expect(obs.output.trim()).toBe("");
+  });
+
   test("the PID-namespace init reaps a forked grandchild", () => {
     if (insideHandoffSandbox()) return;
     if (!handoffSandboxAvailable({ cache: false, nested: false })) return;


### PR DESCRIPTION
Fixes watt-mind/factory#1425

Handoff verification now supports Bash process substitution and alternatives-backed tools without exposing host /etc.

## Validation

| Check                      | Command                                                                          | Result  | Notes                  |
| -------------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------- |
| Verification Command       | `bun test event-runtime/lib/verify.test.mjs --timeout 60000 && bun run format:check` | pass    | 67 tests, 0 failures   |
| Repo verify                | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2015 pass, 10 skipped  |
| Handoff sandbox regression | `runHandoffCommand("bun test bin/live-stack.test.mjs bin/worktree-common.test.mjs --timeout 20000")` | pass | 77 tests match host |
| UX critique                | factory-ux-critic                                                                | not run | no user-facing surface |

UX critique: skipped