### PR TITLE
feat(cli): expose live-stack log controls

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -156,6 +156,7 @@ case "$cmd" in
   up)           exec bash "$ROOT/bin/live-stack.sh" up "$@" ;;
   down)         exec bash "$ROOT/bin/live-stack.sh" down "$@" ;;
   tail)         exec bash "$ROOT/bin/live-stack.sh" tail "$@" ;;
+  logs)         exec bash "$ROOT/bin/live-stack.sh" logs "$@" ;;
   init)
     # Preserve the existing GitHub control-plane initializer while making the
     # no-argument command scaffold all operator-local config from templates.
@@ -357,6 +358,7 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   up            start live event-runtime stack (API 7381, live worker, and Web UI 7382)
   down          stop live event-runtime stack
   tail          tail live daemon logs (~/.factory/run/{serve,worker,web}.log)
+  logs          manage live daemon logs (factory logs rotate)
   init --control-plane github [--root DIR] [--repo owner/name]
                 scaffold GitHub Issues control-plane defaults
   onboard       print the prompt that connects a repo to factory (#938);

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -396,6 +396,35 @@ test("factory workers executes orchestrator/workers.mjs via CLI", () => {
   expect(result.stdout.toString()).toContain("factory workers");
 });
 
+test("factory logs rotate delegates to live-stack with logs rotate", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-logs-"));
+  const argsFile = path.join(root, "args");
+  const factory = path.join(root, "bin", "factory");
+  const liveStack = path.join(root, "bin", "live-stack.sh");
+  mkdirSync(path.join(root, "bin"), { recursive: true });
+  copyFileSync(FACTORY, factory);
+  writeFileSync(
+    liveStack,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$@" >"$FACTORY_LOGS_TEST_ARGS"
+`,
+  );
+  chmodSync(liveStack, 0o755);
+
+  try {
+    const result = Bun.spawnSync({
+      cmd: ["bash", factory, "logs", "rotate"],
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, FACTORY_LOGS_TEST_ARGS: argsFile },
+    });
+    expect(result.exitCode).toBe(0);
+    expect(readFileSync(argsFile, "utf8")).toBe("logs\nrotate\n");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("factory approve delegates to event-runtime/cli.mjs", () => {
   const result = Bun.spawnSync({
     cmd: ["bash", FACTORY, "approve"],

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -310,6 +310,28 @@ function latestJanitorRunMs(repo) {
   return latest;
 }
 
+// Keep this file set aligned with run_log_total_bytes in bin/worktree-common.sh:
+// active *.log files plus every numbered archive (*.log.[0-9]*). A missing run
+// directory is normal before the live stack has ever been started.
+function liveStackLogBytes() {
+  const runDir = path.join(homedir(), ".factory", "run");
+  let total = 0;
+  try {
+    for (const name of readdirSync(runDir)) {
+      if (!/\.log(?:\.[0-9].*)?$/.test(name)) continue;
+      try {
+        const stat = statSync(path.join(runDir, name));
+        if (stat.isFile()) total += stat.size;
+      } catch {
+        // A daemon may rotate or remove a log between readdir and stat.
+      }
+    }
+  } catch {
+    // No live stack run directory yet.
+  }
+  return total;
+}
+
 const { repos, defaultCap } = loadQueueConfig([repoConfig.name]);
 let queue = null,
   next = null,
@@ -338,6 +360,7 @@ const output = {
     reaperLastRun: latestReaperRunMs(),
     janitorLastRun: latestJanitorRunMs(repoConfig.name),
   },
+  liveStack: { logBytes: liveStackLogBytes() },
   factory: queueUnavailable
     ? {
         available: false,
@@ -405,6 +428,7 @@ const factoryStatus = output.factory;
 console.log(
   `\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`,
 );
+console.log(`Live stack   ${output.liveStack.logBytes} log bytes`);
 console.log(c.bold("\nFactory now:"));
 
 if (!factoryStatus.available) {

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -314,7 +314,9 @@ function latestJanitorRunMs(repo) {
 // active *.log files plus every numbered archive (*.log.[0-9]*). A missing run
 // directory is normal before the live stack has ever been started.
 function liveStackLogBytes() {
-  const runDir = path.join(homedir(), ".factory", "run");
+  // Honour the same override bin/live-stack.sh uses for its run directory.
+  const runDir =
+    process.env.FACTORY_RUN_DIR || path.join(homedir(), ".factory", "run");
   let total = 0;
   try {
     for (const name of readdirSync(runDir)) {
@@ -428,7 +430,9 @@ const factoryStatus = output.factory;
 console.log(
   `\nMaintenance  reaper ${formatAge(output.maintenance.reaperLastRun)}  ·  janitor ${formatAge(output.maintenance.janitorLastRun)}`,
 );
-console.log(`Live stack   ${output.liveStack.logBytes} log bytes`);
+console.log(
+  `Live stack   ${(output.liveStack.logBytes / (1024 * 1024)).toFixed(1)} MiB of logs`,
+);
 console.log(c.bold("\nFactory now:"));
 
 if (!factoryStatus.available) {


### PR DESCRIPTION
Fixes #1487

Run `factory logs rotate` to rotate daemon logs and inspect their total footprint with `factory status`.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test bin/factory.test.mjs bin/live-stack.test.mjs --timeout 20000 && bash -n bin/factory && bun run format:check` | pass | 53 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass | 2015 pass, 10 skip |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

## Post-review

- `liveStackLogBytes()` honours `FACTORY_RUN_DIR` (same override `bin/live-stack.sh` uses) instead of hardcoding `~/.factory/run`.
- Console line renders log size as MiB (one decimal); JSON output keeps raw `logBytes`.
- Verified: `bun test bin`, `bun test event-runtime/lib`, `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` all green.
