### PR TITLE
fix(web): show inline validation for required decision text

### DIFF
--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -150,6 +150,15 @@ afterEach(() => {
   cleanup();
 });
 
+// Drives a controlled text input's React `onChange`. Under happy-dom React
+// takes its input-event polyfill path (focus tracking + key events), so a bare
+// `fireEvent.change` never reaches `onChange`; bracket it with focus + keyup.
+function typeInto(element: HTMLElement, value: string): void {
+  fireEvent.focusIn(element);
+  fireEvent.change(element, { target: { value } });
+  fireEvent.keyUp(element);
+}
+
 describe("DecisionCard", () => {
   test("shows the field error for touched empty required text and clears it for meaningful text", () => {
     const view = render(
@@ -169,25 +178,29 @@ describe("DecisionCard", () => {
     const submit = view.getByRole("button", {
       name: "Confirm",
     }) as HTMLButtonElement;
-    expect(view.queryByText("Reason is required.")).toBeNull();
+    // Untouched: no inline hint yet, but the status line still names the gap.
+    expect(reason.hasAttribute("aria-describedby")).toBe(false);
+    expect(reason.hasAttribute("aria-invalid")).toBe(false);
+    expect(view.getByRole("status").textContent).toBe("Reason is required.");
     expect(submit.disabled).toBe(true);
 
     const expectedError = fieldErrors(requiredTextRequest, "confirm", {
       reason: "   ",
     }).reason;
-    fireEvent.input(reason, { target: { value: "   " } });
+    typeInto(reason, "   ");
     const hint = view.getByText(expectedError);
+    expect(view.queryByRole("status")).toBeNull();
     expect(submit.disabled).toBe(true);
     expect(reason.getAttribute("aria-invalid")).toBe("true");
     expect(reason.getAttribute("aria-describedby")).toBe(hint.id);
 
-    fireEvent.input(reason, { target: { value: "Reviewed the scope." } });
+    typeInto(reason, "Reviewed the scope.");
     expect(view.queryByText("Reason is required.")).toBeNull();
     expect(reason.hasAttribute("aria-invalid")).toBe(false);
     expect(reason.hasAttribute("aria-describedby")).toBe(false);
     expect(submit.disabled).toBe(false);
 
-    fireEvent.input(reason, { target: { value: "" } });
+    typeInto(reason, "");
     expect(view.getByText(expectedError)).toBeTruthy();
     expect(submit.disabled).toBe(true);
   });
@@ -213,9 +226,10 @@ describe("DecisionCard", () => {
     fireEvent.click(
       view.getByRole("group", { name: "Options" }).querySelector("button")!,
     );
-    fireEvent.input(view.getByRole("textbox", { name: /Reason/ }), {
-      target: { value: "Reviewed the original question." },
-    });
+    typeInto(
+      view.getByRole("textbox", { name: /Reason/ }),
+      "Reviewed the original question.",
+    );
     fireEvent.click(view.getByRole("button", { name: "Confirm" }));
 
     await waitFor(() =>
@@ -224,7 +238,10 @@ describe("DecisionCard", () => {
     fireEvent.click(
       view.getByRole("group", { name: "Options" }).querySelector("button")!,
     );
-    expect(view.queryByText("Reason is required.")).toBeNull();
+    const reason = view.getByRole("textbox", { name: /Reason/ });
+    expect(reason.hasAttribute("aria-describedby")).toBe(false);
+    expect(reason.hasAttribute("aria-invalid")).toBe(false);
+    expect(view.getByRole("status").textContent).toBe("Reason is required.");
   });
 
   test("renders the §2.1 options recommended-first and gates its fields", () => {

--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -69,6 +69,28 @@ const request: DecisionRequest = {
   ],
 };
 
+const requiredTextRequest: DecisionRequest = {
+  schemaVersion: "factory.decision-request/v1",
+  question: "Why should we proceed?",
+  options: [
+    {
+      id: "confirm",
+      label: "Confirm",
+      effect: "dismiss",
+      tone: "primary",
+    },
+  ],
+  fields: [
+    {
+      id: "reason",
+      kind: "text",
+      label: "Reason",
+      required: true,
+      maxLength: 120,
+    },
+  ],
+};
+
 function item(overrides: Partial<InboxItem> = {}): InboxItem {
   return {
     id: "inbox_decision",
@@ -128,6 +150,40 @@ afterEach(() => {
 });
 
 describe("DecisionCard", () => {
+  test("shows an accessible required-text hint after whitespace and clears it for meaningful text", () => {
+    const view = render(
+      <DecisionCard
+        itemId="inbox_required_text"
+        request={requiredTextRequest}
+        apiCalls={apiCalls}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+
+    const reason = view.getByRole("textbox", {
+      name: /Reason/,
+    }) as HTMLInputElement;
+    const submit = view.getByRole("button", {
+      name: "Confirm",
+    }) as HTMLButtonElement;
+    expect(view.queryByText("Reason is required.")).toBeNull();
+    expect(submit.disabled).toBe(true);
+
+    fireEvent.input(reason, { target: { value: "   " } });
+    const hint = view.getByText("Reason is required.");
+    expect(submit.disabled).toBe(true);
+    expect(reason.getAttribute("aria-invalid")).toBe("true");
+    expect(reason.getAttribute("aria-describedby")).toBe(hint.id);
+
+    fireEvent.input(reason, { target: { value: "Reviewed the scope." } });
+    expect(view.queryByText("Reason is required.")).toBeNull();
+    expect(reason.hasAttribute("aria-invalid")).toBe(false);
+    expect(reason.hasAttribute("aria-describedby")).toBe(false);
+    expect(submit.disabled).toBe(false);
+  });
+
   test("renders the §2.1 options recommended-first and gates its fields", () => {
     const view = render(
       <DecisionCard

--- a/event-runtime/web/src/components/DecisionCard.test.tsx
+++ b/event-runtime/web/src/components/DecisionCard.test.tsx
@@ -4,6 +4,7 @@ import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { ApiError } from "../api";
 import type { DecisionRequest, InboxItem } from "../types";
 import { decisionRequestHash } from "../lib/decision";
+import { fieldErrors } from "../lib/decisionForm";
 import { DecisionCard } from "./DecisionCard";
 
 const request: DecisionRequest = {
@@ -150,7 +151,7 @@ afterEach(() => {
 });
 
 describe("DecisionCard", () => {
-  test("shows an accessible required-text hint after whitespace and clears it for meaningful text", () => {
+  test("shows the field error for touched empty required text and clears it for meaningful text", () => {
     const view = render(
       <DecisionCard
         itemId="inbox_required_text"
@@ -171,8 +172,11 @@ describe("DecisionCard", () => {
     expect(view.queryByText("Reason is required.")).toBeNull();
     expect(submit.disabled).toBe(true);
 
+    const expectedError = fieldErrors(requiredTextRequest, "confirm", {
+      reason: "   ",
+    }).reason;
     fireEvent.input(reason, { target: { value: "   " } });
-    const hint = view.getByText("Reason is required.");
+    const hint = view.getByText(expectedError);
     expect(submit.disabled).toBe(true);
     expect(reason.getAttribute("aria-invalid")).toBe("true");
     expect(reason.getAttribute("aria-describedby")).toBe(hint.id);
@@ -182,6 +186,45 @@ describe("DecisionCard", () => {
     expect(reason.hasAttribute("aria-invalid")).toBe(false);
     expect(reason.hasAttribute("aria-describedby")).toBe(false);
     expect(submit.disabled).toBe(false);
+
+    fireEvent.input(reason, { target: { value: "" } });
+    expect(view.getByText(expectedError)).toBeTruthy();
+    expect(submit.disabled).toBe(true);
+  });
+
+  test("resets required-text interaction state when a stale request is loaded", async () => {
+    const changed = {
+      ...requiredTextRequest,
+      question: "The required-text question changed. Continue?",
+    };
+    apiCalls.decide = mock(async () => {
+      throw new ApiError("stale_request", 409);
+    });
+    apiCalls.get = mock(async () => ({
+      item: item({ decision: changed, response: null }),
+    }));
+    const view = render(
+      <DecisionCard
+        itemId="inbox_required_text"
+        request={requiredTextRequest}
+        apiCalls={apiCalls}
+      />,
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+    fireEvent.input(view.getByRole("textbox", { name: /Reason/ }), {
+      target: { value: "Reviewed the original question." },
+    });
+    fireEvent.click(view.getByRole("button", { name: "Confirm" }));
+
+    await waitFor(() =>
+      view.getByText("This question changed — please re-read"),
+    );
+    fireEvent.click(
+      view.getByRole("group", { name: "Options" }).querySelector("button")!,
+    );
+    expect(view.queryByText("Reason is required.")).toBeNull();
   });
 
   test("renders the §2.1 options recommended-first and gates its fields", () => {

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useId, useMemo, useState } from "react";
 import { keyGuard, modal } from "../hooks";
 import { goPrefixActive } from "../goSequence";
 import {
@@ -180,11 +180,12 @@ export function DecisionCard({
   const invalidReason = !selected
     ? "Choose an option to continue."
     : (Object.values(errors)[0] ?? null);
-  const invalidField = selected
-    ? visibleFields.find((field) => errors[field.id] !== undefined)
-    : undefined;
-  const showInvalidReason =
-    invalidReason !== null && invalidField?.kind !== "text";
+  const statusReason = !selected
+    ? invalidReason
+    : (visibleFields
+        .filter((field) => field.kind !== "text")
+        .map((field) => errors[field.id])
+        .find((error) => error !== undefined) ?? null);
 
   const refresh = async (): Promise<InboxItem> => {
     const { item } = await apiCalls.get(itemId);
@@ -217,6 +218,7 @@ export function DecisionCard({
         const nextRequest = item.decision ?? currentRequest;
         setSelected(null);
         setValues(initialValues(nextRequest));
+        setTouchedFields(new Set());
         setMessage("This question changed — please re-read");
       } else {
         setMessage((error as Error).message);
@@ -518,9 +520,9 @@ export function DecisionCard({
             "Choose an option"
           )}
         </Button>
-        {showInvalidReason && (
+        {statusReason && (
           <span className="text-[11px] text-(--text-faint)" role="status">
-            {invalidReason}
+            {statusReason}
           </span>
         )}
       </div>
@@ -548,7 +550,7 @@ function DecisionFieldControl({
   onChange: (value: unknown) => void;
 }) {
   const required = field.required ? " *" : "";
-  const hintId = `decision-field-${field.id}-error`;
+  const hintId = useId();
   if (field.kind === "confirm") {
     return (
       <label className="flex cursor-pointer items-start gap-2 text-[12px] text-(--text)">
@@ -679,8 +681,9 @@ function DecisionFieldControl({
     maxLength: field.maxLength,
     "aria-describedby": error ? hintId : undefined,
     "aria-invalid": error ? true : undefined,
-    onInput: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-      onChange(event.currentTarget.value),
+    onChange: (
+      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => onChange(event.target.value),
     className: `${controlClass} mt-1`,
   };
   return (

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -140,6 +140,9 @@ export function DecisionCard({
   const [values, setValues] = useState<DecisionValues>(() =>
     initialValues(request),
   );
+  const [touchedFields, setTouchedFields] = useState<Set<string>>(
+    () => new Set(),
+  );
   const [pending, setPending] = useState(false);
   const [retrying, setRetrying] = useState(false);
   const [message, setMessage] = useState<string | null>(null);
@@ -158,6 +161,7 @@ export function DecisionCard({
     setCurrentResponse(response);
     setSelected(null);
     setValues(initialValues(request));
+    setTouchedFields(new Set());
     setMessage(null);
   }
 
@@ -176,6 +180,11 @@ export function DecisionCard({
   const invalidReason = !selected
     ? "Choose an option to continue."
     : (Object.values(errors)[0] ?? null);
+  const invalidField = selected
+    ? visibleFields.find((field) => errors[field.id] !== undefined)
+    : undefined;
+  const showInvalidReason =
+    invalidReason !== null && invalidField?.kind !== "text";
 
   const refresh = async (): Promise<InboxItem> => {
     const { item } = await apiCalls.get(itemId);
@@ -231,8 +240,10 @@ export function DecisionCard({
     }
   };
 
-  const update = (id: string, value: unknown) =>
+  const update = (id: string, value: unknown) => {
+    setTouchedFields((previous) => new Set(previous).add(id));
     setValues((previous) => ({ ...previous, [id]: value }));
+  };
 
   // While an undecided card is on screen:
   // - Number keys 1–6 pick options from anywhere in the view (when not editing an input).
@@ -478,6 +489,7 @@ export function DecisionCard({
               key={field.id}
               field={field}
               value={values[field.id]}
+              error={touchedFields.has(field.id) ? errors[field.id] : undefined}
               onChange={(value) => update(field.id, value)}
             />
           ))}
@@ -506,7 +518,7 @@ export function DecisionCard({
             "Choose an option"
           )}
         </Button>
-        {invalidReason && (
+        {showInvalidReason && (
           <span className="text-[11px] text-(--text-faint)" role="status">
             {invalidReason}
           </span>
@@ -527,13 +539,16 @@ export function DecisionCard({
 function DecisionFieldControl({
   field,
   value,
+  error,
   onChange,
 }: {
   field: DecisionField;
   value: unknown;
+  error?: string;
   onChange: (value: unknown) => void;
 }) {
   const required = field.required ? " *" : "";
+  const hintId = `decision-field-${field.id}-error`;
   if (field.kind === "confirm") {
     return (
       <label className="flex cursor-pointer items-start gap-2 text-[12px] text-(--text)">
@@ -662,9 +677,10 @@ function DecisionFieldControl({
     value: typeof value === "string" ? value : "",
     placeholder: field.placeholder,
     maxLength: field.maxLength,
-    onChange: (
-      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => onChange(event.target.value),
+    "aria-describedby": error ? hintId : undefined,
+    "aria-invalid": error ? true : undefined,
+    onInput: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      onChange(event.currentTarget.value),
     className: `${controlClass} mt-1`,
   };
   return (
@@ -675,6 +691,11 @@ function DecisionFieldControl({
         <input type="text" {...common} />
       ) : (
         <textarea rows={3} {...common} />
+      )}
+      {error && (
+        <span id={hintId} className="mt-1 block text-[11px] text-(--hue-err)">
+          {error}
+        </span>
       )}
     </label>
   );

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -180,10 +180,14 @@ export function DecisionCard({
   const invalidReason = !selected
     ? "Choose an option to continue."
     : (Object.values(errors)[0] ?? null);
+  // Text-field errors are shown inline once the field is touched; keep them
+  // out of the status line only while that inline hint is actually rendered.
   const statusReason = !selected
     ? invalidReason
     : (visibleFields
-        .filter((field) => field.kind !== "text")
+        .filter(
+          (field) => !(field.kind === "text" && touchedFields.has(field.id)),
+        )
         .map((field) => errors[field.id])
         .find((error) => error !== undefined) ?? null);
 
@@ -681,8 +685,9 @@ function DecisionFieldControl({
     maxLength: field.maxLength,
     "aria-describedby": error ? hintId : undefined,
     "aria-invalid": error ? true : undefined,
-    onInput: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) =>
-      onChange(event.currentTarget.value),
+    onChange: (
+      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+    ) => onChange(event.target.value),
     className: `${controlClass} mt-1`,
   };
   return (
@@ -695,7 +700,11 @@ function DecisionFieldControl({
         <textarea rows={3} {...common} />
       )}
       {error && (
-        <span id={hintId} className="mt-1 block text-[11px] text-(--hue-err)">
+        <span
+          id={hintId}
+          className="mt-1 block text-[11px] text-(--hue-err)"
+          aria-live="polite"
+        >
           {error}
         </span>
       )}

--- a/event-runtime/web/src/components/DecisionCard.tsx
+++ b/event-runtime/web/src/components/DecisionCard.tsx
@@ -681,9 +681,8 @@ function DecisionFieldControl({
     maxLength: field.maxLength,
     "aria-describedby": error ? hintId : undefined,
     "aria-invalid": error ? true : undefined,
-    onChange: (
-      event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
-    ) => onChange(event.target.value),
+    onInput: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>) =>
+      onChange(event.currentTarget.value),
     className: `${controlClass} mt-1`,
   };
   return (


### PR DESCRIPTION
Fixes watt-mind/factory#1452

## Summary
- `DecisionCard` now renders the per-field error from `fieldErrors` (the single trim rule from `lib/decisionForm.ts`) directly under a required text input once the field has been touched, with `aria-describedby` → hint id and `aria-invalid="true"` on the input; the hint clears and the primary action re-enables when meaningful text is typed.
- Pristine fields are not shouted at: the hint is gated on a per-field touched set that resets when the request is reset (stale-request 409 reload included).
- The status line next to the primary button no longer duplicates text-field errors (they live beside the input); non-text errors and "Choose an option to continue." still show there.
- `DecisionCard.test.tsx`: whitespace-only required text shows the hint and keeps Confirm disabled; meaningful text clears the hint and enables Confirm; emptied-after-typing re-shows the hint; `aria-describedby`/`aria-invalid` wiring; touched state resets on stale-request reload.

## Handoff
Branch merged with `origin/develop` (fa8c0b7a). Verified in a clean worktree with `FACTORY_EVENT_HOME=$(mktemp -d)`:

- `cd event-runtime/web && bun x tsc --noEmit` — clean
- `cd event-runtime/web && bun test src/components/DecisionCard.test.tsx` — 15 pass / 0 fail
- `bun test event-runtime/lib --timeout 20000` — 2029 pass / 0 fail (103 files)
- `bun build/emit.mjs --check` — ok, 94 generated files match
- `bun run format:check` — clean
- `bun run check` — clean

Diff stays inside Owned Paths (`DecisionCard.tsx`, `DecisionCard.test.tsx`).

Note: the two dispatch runs each reported a handoff failure only because the sandbox had no `bunx` binary (`bunx: command not found`) — the tests themselves passed (14/0) both times. Re-ran with `bun x` here; those were false fails.

UX critique: skipped (operator-internal inbox UI; not cheaply exercisable from this finisher).


## Post-review
Reviewer verdict FIX; addressed in 597ca567:
- `statusReason` now suppresses a text-field error only while its inline hint is actually rendered (field touched). Option selected + Reason never touched again shows "Reason is required." on the status line next to the disabled Confirm; once touched, the message moves beside the input (no duplication). Test covers both states.
- Controlled text inputs use `onChange` again (no React "value without onChange" warning). Note: under happy-dom React takes its input-event polyfill path, so `fireEvent.change` alone never reaches `onChange` — the tests use a small `typeInto` helper (focusIn + change + keyUp) documented inline.
- Inline hint carries `aria-live="polite"`.

Re-verified: `bun x tsc --noEmit` clean; `DecisionCard.test.tsx` 15/0; `bun test event-runtime/lib` 2019/0; `bun build/emit.mjs --check` ok; `format:check` and `bun run check` clean.
