### PR TITLE
fix(web): prevent duplicate event detail replays

### DIFF
--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -125,13 +125,17 @@ describe("Events component harness: selection & detail view", () => {
         fireEvent.click(r.getByRole("button", { name: "Replay" }));
         await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
 
-        expect(
-          r.getByRole("button", { name: "Replay…" }).hasAttribute("disabled"),
-        ).toBe(true);
+        const replayedButton = await waitFor(() =>
+          r.getByRole("button", { name: "Replayed" }),
+        );
+        expect(replayedButton.hasAttribute("disabled")).toBe(true);
+        expect(replayedButton.getAttribute("title")).toContain(
+          "Already replayed",
+        );
         expect(r.getByTestId("palette-probe").textContent).not.toContain(
           `Replay ${first.eventId} through intake…`,
         );
-        fireEvent.click(r.getByRole("button", { name: "Replay…" }));
+        fireEvent.click(replayedButton);
         expect(replay).toHaveBeenCalledTimes(1);
 
         r.rerender(
@@ -159,6 +163,50 @@ describe("Events component harness: selection & detail view", () => {
         );
         expect(r.getByTestId("palette-probe").textContent).toContain(
           `Replay ${second.eventId} through intake…`,
+        );
+      },
+    );
+  });
+
+  test("a rejected detail replay keeps the control enabled and surfaces the error", async () => {
+    const replay = mock(async (_envelope: unknown) => {
+      throw new Error("boom");
+    });
+    const event = stubEvent("evt_replay_reject", "admitted");
+
+    await withApi(
+      {
+        events: async () => ({ events: [event] }),
+        replay,
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents({
+          focusEvent: { source: "github", eventId: event.eventId },
+        });
+
+        const detailReplay = await waitFor(() =>
+          r.getByRole("button", { name: "Replay…" }),
+        );
+        fireEvent.click(detailReplay);
+        fireEvent.click(r.getByRole("button", { name: "Replay" }));
+        await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+
+        // The dialog stays open with the failure; the confirm stays actionable.
+        await waitFor(() =>
+          expect(r.getAllByText("boom").length).toBeGreaterThan(0),
+        );
+        expect(
+          r.getByRole("button", { name: "Replay" }).hasAttribute("disabled"),
+        ).toBe(false);
+        expect(r.queryByRole("button", { name: "Replayed" })).toBeNull();
+
+        // The detail control is not consumed by a failed attempt.
+        expect(
+          r.getByRole("button", { name: "Replay…" }).hasAttribute("disabled"),
+        ).toBe(false);
+        expect(r.getByTestId("palette-probe").textContent).toContain(
+          `Replay ${event.eventId} through intake…`,
         );
       },
     );

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -14,6 +14,7 @@ import {
   withApi,
 } from "../test-render";
 import { shortId } from "../components/ui";
+import { useContextActions } from "../palette";
 import type { AdmittedEvent, AgentsView, EventFocus } from "../types";
 
 afterEach(() => {
@@ -24,6 +25,15 @@ afterEach(() => {
 
 const noop = () => {};
 const NOW = new Date().toISOString();
+
+function PaletteProbe() {
+  const actions = useContextActions();
+  return (
+    <div data-testid="palette-probe">
+      {actions.map((a) => a.label).join(" | ")}
+    </div>
+  );
+}
 
 function stubEvent(
   eventId: string,
@@ -46,19 +56,22 @@ function stubEvent(
 
 function renderEvents(props: Partial<Parameters<typeof Events>[0]> = {}) {
   return renderWithClient(
-    <Events
-      connected={true}
-      context={{ kind: "all" }}
-      focusEvent={null}
-      onFocusConsumed={noop}
-      onSelectEvent={noop}
-      onSelectType={noop}
-      onJumpProposal={noop}
-      onJumpRun={noop}
-      onTriggerAgain={noop}
-      onInject={noop}
-      {...props}
-    />,
+    <>
+      <Events
+        connected={true}
+        context={{ kind: "all" }}
+        focusEvent={null}
+        onFocusConsumed={noop}
+        onSelectEvent={noop}
+        onSelectType={noop}
+        onJumpProposal={noop}
+        onJumpRun={noop}
+        onTriggerAgain={noop}
+        onInject={noop}
+        {...props}
+      />
+      <PaletteProbe />
+    </>,
   );
 }
 
@@ -81,6 +94,76 @@ function ticketSchemaRegistry(eventType: string): AgentsView {
 }
 
 describe("Events component harness: selection & detail view", () => {
+  test("successful detail replay is one-shot until a different event is selected", async () => {
+    const replay = mock(async (_envelope: unknown) => ({
+      admitted: true,
+      duplicate: false,
+      eventId: "evt_replayed",
+    }));
+    const first = stubEvent("evt_replay_first", "admitted");
+    const second = stubEvent("evt_replay_second", "admitted");
+
+    await withApi(
+      {
+        events: async () => ({ events: [first, second] }),
+        replay,
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents({
+          focusEvent: { source: "github", eventId: first.eventId },
+        });
+
+        const detailReplay = await waitFor(() =>
+          r.getByRole("button", { name: "Replay…" }),
+        );
+        expect(r.getByTestId("palette-probe").textContent).toContain(
+          `Replay ${first.eventId} through intake…`,
+        );
+
+        fireEvent.click(detailReplay);
+        fireEvent.click(r.getByRole("button", { name: "Replay" }));
+        await waitFor(() => expect(replay).toHaveBeenCalledTimes(1));
+
+        expect(
+          r.getByRole("button", { name: "Replay…" }).hasAttribute("disabled"),
+        ).toBe(true);
+        expect(r.getByTestId("palette-probe").textContent).not.toContain(
+          `Replay ${first.eventId} through intake…`,
+        );
+        fireEvent.click(r.getByRole("button", { name: "Replay…" }));
+        expect(replay).toHaveBeenCalledTimes(1);
+
+        r.rerender(
+          <>
+            <Events
+              connected
+              context={{ kind: "all" }}
+              focusEvent={{ source: "github", eventId: second.eventId }}
+              onFocusConsumed={noop}
+              onSelectEvent={noop}
+              onSelectType={noop}
+              onJumpProposal={noop}
+              onJumpRun={noop}
+              onTriggerAgain={noop}
+              onInject={noop}
+            />
+            <PaletteProbe />
+          </>,
+        );
+
+        await waitFor(() =>
+          expect(
+            r.getByRole("button", { name: "Replay…" }).hasAttribute("disabled"),
+          ).toBe(false),
+        );
+        expect(r.getByTestId("palette-probe").textContent).toContain(
+          `Replay ${second.eventId} through intake…`,
+        );
+      },
+    );
+  });
+
   test("loads older event pages with the cursor and keeps existing rows", async () => {
     const newest = stubEvent("evt_newest", "admitted");
     const older = stubEvent("evt_older", "admitted");

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -457,6 +457,7 @@ export function Events({
     focusEvent?.type ? `type:${focusEvent.type}` : "",
   );
   const [confirmReplay, setConfirmReplay] = useState(false);
+  const [replayedEventKey, setReplayedEventKey] = useState<string | null>(null);
 
   const fetchAll = context.kind === "repo";
   const list = useInfiniteQuery({
@@ -699,6 +700,14 @@ export function Events({
         : null,
     [visible, selectedKey],
   );
+  const replayed = selectedKey === replayedEventKey;
+
+  // A replay is a one-shot action for the current detail selection. Closing
+  // the pane or selecting another event restores the action for that detail.
+  useEffect(() => {
+    setReplayedEventKey(null);
+  }, [selectedKey]);
+
   // The detail pane leaves a compact triage list. Keep the columns needed to
   // identify and compare events; the complete row remains in Display when the
   // pane closes, and every field remains available in the pane itself.
@@ -852,10 +861,11 @@ export function Events({
   });
 
   const replay = useMutation({
-    mutationFn: (envelope: unknown) => api.replay(envelope),
-    onSuccess: (data) => {
+    mutationFn: (event: AdmittedEvent) => api.replay(event.envelope),
+    onSuccess: (data, event) => {
       queryClient.invalidateQueries();
       setConfirmReplay(false);
+      setReplayedEventKey(keyOf(event));
       notify(
         data.duplicate
           ? `Duplicate event ${data.eventId}`
@@ -990,10 +1000,14 @@ export function Events({
               },
             ]
           : []),
-        {
-          label: `Replay ${sel.eventId} through intake…`,
-          run: () => setConfirmReplay(true),
-        },
+        ...(replayed
+          ? []
+          : [
+              {
+                label: `Replay ${sel.eventId} through intake…`,
+                run: () => setConfirmReplay(true),
+              },
+            ]),
         {
           label: `Trigger ${sel.type} again (new event id)…`,
           run: () =>
@@ -1013,6 +1027,7 @@ export function Events({
     sel ? keyOf(sel) : null,
     canRequeue,
     connected,
+    replayed,
     onJumpChain,
     onJumpRun,
     onJumpProposal,
@@ -1547,7 +1562,7 @@ export function Events({
                   </Button>
                 )}
                 <Button
-                  disabled={!connected || replay.isPending}
+                  disabled={!connected || replay.isPending || replayed}
                   onClick={() => setConfirmReplay(true)}
                 >
                   Replay…
@@ -1740,8 +1755,8 @@ export function Events({
             <Button onClick={() => setConfirmReplay(false)}>Cancel</Button>
             <Button
               variant="primary"
-              disabled={!connected || replay.isPending}
-              onClick={() => replay.mutate(sel.envelope)}
+              disabled={!connected || replay.isPending || replayed}
+              onClick={() => replay.mutate(sel)}
             >
               Replay
             </Button>

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -1563,9 +1563,18 @@ export function Events({
                 )}
                 <Button
                   disabled={!connected || replay.isPending || replayed}
+                  title={
+                    replayed
+                      ? "Already replayed — select another event to replay again"
+                      : undefined
+                  }
                   onClick={() => setConfirmReplay(true)}
                 >
-                  Replay…
+                  {replay.isPending
+                    ? "Replaying…"
+                    : replayed
+                      ? "Replayed"
+                      : "Replay…"}
                 </Button>
                 <Button
                   disabled={!connected}
@@ -1758,7 +1767,11 @@ export function Events({
               disabled={!connected || replay.isPending || replayed}
               onClick={() => replay.mutate(sel)}
             >
-              Replay
+              {replay.isPending
+                ? "Replaying…"
+                : replayed
+                  ? "Replayed"
+                  : "Replay"}
             </Button>
           </div>
         </Dialog>


### PR DESCRIPTION
Fixes watt-mind/factory#1451

## Summary
- `Events.tsx`: track `replayedEventKey`; after a successful detail Replay the `Replay…` button and the confirm-dialog `Replay` button are disabled and the palette action `Replay <id> through intake…` is hidden for that selection. A failed replay does not set the key, so the control stays enabled for retry and `VerbError` rendering is unchanged. Selecting a different event (or re-opening the detail) resets the guard via an effect on `selectedKey`.
- `Events.test.tsx`: regression test confirms Replay, asserts exactly one `/api/replay` call, clicks again and asserts still one, checks the palette action disappears, then re-renders with a new selection and asserts the control and palette action return.

## Handoff
Verified on the branch merged with `origin/develop` (`ffb25eba`), in a fresh worktree with `FACTORY_EVENT_HOME=$(mktemp -d)`:
- `cd event-runtime/web && bun x tsc --noEmit` — clean
- `cd event-runtime/web && bun test src/views/Events.test.tsx` — 33 pass / 0 fail
- `bun test event-runtime/lib --timeout 20000` — 2029 tests, 0 fail (10 skip)
- `bun build/emit.mjs --check` — 94 generated files match
- `bun run format:check` — clean
- `bun run check` — clean

Diff stays inside Owned Paths (`event-runtime/web/src/views/Events.tsx`, `Events.test.tsx`). Dispatch runs failed handoff verification only because the sandbox has no `bunx` binary (tests were 33/0 before the `bunx: command not found`); the ticket's verification command was re-run here with `bun x`. UX critique skipped: operator-internal web view, no new user journey.

## Post-review

- Detail-pane Replay control now reads `Replayed` once consumed (with a `title` explaining it re-arms on selecting another event), and `Replaying…` while pending — matching the #1435 InboxActions pattern. Dialog confirm button mirrors the same labels.
- New test: `api.replay` rejecting keeps `Replay…` enabled (`replayedEventKey` stays null), keeps the palette entry, and renders the dialog `VerbError`.
- Palette entry left removed-when-consumed: `PaletteAction` has no `disabled` field and `CommandPalette.tsx` is outside this change.
