### PR TITLE
fix(inbox): preserve detail fallback when rendering fails

### DIFF
--- a/event-runtime/web/src/components/ErrorBoundary.test.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.test.tsx
@@ -96,6 +96,66 @@ describe("chunk-load recovery", () => {
 });
 
 describe("local recovery", () => {
+  test("a pane-level chunk failure neither reloads nor claims the route's reload", async () => {
+    const values = new Map<string, string>();
+    const storage = {
+      getItem: (key: string) => values.get(key) ?? null,
+      setItem: (key: string, value: string) => values.set(key, value),
+    };
+    let reloads = 0;
+    const view = render(
+      <ErrorBoundary
+        storage={storage}
+        route="/#/inbox"
+        now={() => 1_000}
+        reload={() => {
+          reloads += 1;
+        }}
+        fallback={(_error, retry) => (
+          <section role="alert">
+            Pane unavailable
+            <button type="button" onClick={retry}>
+              Retry
+            </button>
+          </section>
+        )}
+      >
+        <BrokenRoute />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => view.getByRole("alert"));
+    expect(view.getByRole("alert").textContent).toContain("Pane unavailable");
+    expect(reloads).toBe(0);
+    expect(values.has(CHUNK_RELOAD_STORAGE_KEY)).toBe(false);
+    // The route-level reload is still available afterwards.
+    expect(claimChunkReload(chunkFailure(), storage, "/#/inbox", 1_001)).toBe(
+      true,
+    );
+  });
+
+  test("logs the caught error with its component stack", async () => {
+    const original = console.error;
+    const calls: unknown[][] = [];
+    console.error = (...args: unknown[]) => {
+      calls.push(args);
+    };
+    try {
+      const error = new Error("detail failed");
+      const view = render(
+        <ErrorBoundary fallback={() => <section role="alert">Down</section>}>
+          <BrokenRoute error={error} />
+        </ErrorBoundary>,
+      );
+      await waitFor(() => view.getByRole("alert"));
+      const logged = calls.find((args) => args[0] === error);
+      expect(logged).toBeTruthy();
+      expect(typeof logged?.[1]).toBe("string");
+      expect(logged?.[1] as string).toContain("BrokenRoute");
+    } finally {
+      console.error = original;
+    }
+  });
+
   test("retries without reloading and resets when its key changes", async () => {
     let failDetail = true;
     let reloads = 0;

--- a/event-runtime/web/src/components/ErrorBoundary.test.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.test.tsx
@@ -1,6 +1,6 @@
 import "../test-dom";
 import { afterEach, describe, expect, test } from "bun:test";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import {
   CHUNK_RELOAD_STORAGE_KEY,
   ErrorBoundary,
@@ -92,5 +92,59 @@ describe("chunk-load recovery", () => {
     );
     expect(second.getByRole("button", { name: "Reload" })).toBeTruthy();
     expect(reloads).toBe(1);
+  });
+});
+
+describe("local recovery", () => {
+  test("retries without reloading and resets when its key changes", async () => {
+    let failDetail = true;
+    let reloads = 0;
+    const Detail = () => {
+      if (failDetail) throw new Error("detail failed");
+      return <p>Normal detail</p>;
+    };
+    const fallback = (_error: Error, retry: () => void) => (
+      <section role="alert">
+        Detail unavailable
+        <button type="button" onClick={retry}>
+          Retry
+        </button>
+      </section>
+    );
+
+    const view = render(
+      <ErrorBoundary
+        resetKey="first"
+        reload={() => {
+          reloads += 1;
+        }}
+        fallback={fallback}
+      >
+        <Detail />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => view.getByRole("alert"));
+    expect(reloads).toBe(0);
+
+    failDetail = false;
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+    await waitFor(() => view.getByText("Normal detail"));
+    expect(reloads).toBe(0);
+
+    failDetail = true;
+    view.rerender(
+      <ErrorBoundary resetKey="first" fallback={fallback}>
+        <Detail />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => view.getByRole("alert"));
+
+    failDetail = false;
+    view.rerender(
+      <ErrorBoundary resetKey="second" fallback={fallback}>
+        <Detail />
+      </ErrorBoundary>,
+    );
+    await waitFor(() => view.getByText("Normal detail"));
   });
 });

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -87,7 +87,11 @@ export class ErrorBoundary extends Component<Props, State> {
     return { error };
   }
 
-  componentDidCatch(error: Error, _info: ErrorInfo) {
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error(error, info.componentStack);
+    // A pane-level boundary recovers locally; it must neither reload the whole
+    // page nor consume the route's single automatic chunk reload.
+    if (this.props.fallback) return;
     const storage = this.props.storage ?? window.sessionStorage;
     const route = this.props.route ?? currentRoute();
     if (claimChunkReload(error, storage, route, this.props.now?.())) {

--- a/event-runtime/web/src/components/ErrorBoundary.tsx
+++ b/event-runtime/web/src/components/ErrorBoundary.tsx
@@ -69,6 +69,10 @@ type Props = {
   storage?: StorageLike;
   route?: string;
   now?: () => number;
+  /** Render a local recovery UI instead of the application-wide fallback. */
+  fallback?: (error: Error, retry: () => void) => ReactNode;
+  /** Changing this value clears a prior render error, for example on navigation. */
+  resetKey?: unknown;
 };
 
 type State = {
@@ -93,9 +97,19 @@ export class ErrorBoundary extends Component<Props, State> {
     }
   }
 
+  componentDidUpdate(previousProps: Props) {
+    if (this.state.error && previousProps.resetKey !== this.props.resetKey) {
+      this.setState({ error: null, reloading: false });
+    }
+  }
+
+  retry = () => this.setState({ error: null, reloading: false });
+
   render() {
     const { error, reloading } = this.state;
     if (!error) return this.props.children;
+
+    if (this.props.fallback) return this.props.fallback(error, this.retry);
 
     const chunkFailure = isChunkLoadError(error);
     const title = chunkFailure

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -673,6 +673,39 @@ describe("Inbox view", () => {
     expect(view.queryByRole("button", { name: /^Ack/ })).toBeNull();
   });
 
+  test("contains a detail render failure and retries it without losing the list", async () => {
+    let failDetail = true;
+    const decision = {
+      schemaVersion: "factory.decision-request/v1" as const,
+      question: "Can this detail recover?",
+      get options() {
+        if (failDetail) {
+          throw new Error("first detail render failed");
+        }
+        return [{ id: "retry", label: "Retry", effect: "dismiss" as const }];
+      },
+    };
+    ledger = [
+      item({
+        id: "inbox_detail_failure",
+        kind: "decision_needed",
+        title: "Decision that initially fails",
+        decision,
+      }),
+    ];
+
+    const { view } = renderInbox({ focusItemId: "inbox_detail_failure" });
+    await waitFor(() => view.getByRole("alert"));
+    expect(view.getByTitle("Decision that initially fails")).toBeTruthy();
+    expect(view.getByText("Open raw item")).toBeTruthy();
+
+    failDetail = false;
+    fireEvent.click(view.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() => view.getByText("Can this detail recover?"));
+    expect(view.queryByText("This item could not render")).toBeNull();
+  });
+
   test("unknown deep link shows an inline notice, not a blank list", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_nope" });
     await waitFor(() => view.getByText(/^No inbox item/));

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -706,6 +706,34 @@ describe("Inbox view", () => {
     expect(view.queryByText("This item could not render")).toBeNull();
   });
 
+  test("the detail fallback can be closed like the real detail pane", async () => {
+    const decision = {
+      schemaVersion: "factory.decision-request/v1" as const,
+      question: "Will this ever render?",
+      get options(): { id: string; label: string; effect: "dismiss" }[] {
+        throw new Error("detail render failed");
+      },
+    };
+    ledger = [
+      item({
+        id: "inbox_detail_failure",
+        kind: "decision_needed",
+        title: "Decision that always fails",
+        decision,
+      }),
+    ];
+    const onSelectItem = mock(() => {});
+    const { view } = renderInbox({
+      focusItemId: "inbox_detail_failure",
+      onSelectItem,
+    });
+    await waitFor(() => view.getByRole("alert"));
+    expect(view.getByText("This item could not render")).toBeTruthy();
+
+    fireEvent.click(view.getByRole("button", { name: "Close" }));
+    expect(onSelectItem).toHaveBeenCalledWith(null);
+  });
+
   test("unknown deep link shows an inline notice, not a blank list", async () => {
     const { view } = renderInbox({ focusItemId: "inbox_nope" });
     await waitFor(() => view.getByText(/^No inbox item/));

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -254,14 +254,17 @@ function rawInboxItem(item: InboxItem): string {
 function InboxDetailFallback({
   item,
   onRetry,
+  onClose,
 }: {
   item: InboxItem;
   onRetry: () => void;
+  onClose: () => void;
 }) {
   return (
     <DetailPane
       widthClass="w-full sm:w-[460px]"
       title={<span className="mono truncate">{shortId(item.id)}</span>}
+      close={<Button onClick={onClose}>Close</Button>}
     >
       <section
         role="alert"
@@ -1692,7 +1695,11 @@ export function Inbox({
         <ErrorBoundary
           resetKey={sel.id}
           fallback={(_error, retry) => (
-            <InboxDetailFallback item={sel} onRetry={retry} />
+            <InboxDetailFallback
+              item={sel}
+              onRetry={retry}
+              onClose={() => onSelectItem(null)}
+            />
           )}
         >
           <DetailPane

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -32,6 +32,7 @@ import {
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { DecisionCard } from "../components/DecisionCard";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { hasInboxPlainActions, InboxActions } from "../components/InboxActions";
 import {
   INBOX_FACETS,
@@ -241,6 +242,51 @@ const DELIVERY_HUES: Record<DeliveryState, string> = {
   failed: "var(--hue-err)",
   none: "var(--hue-idle)",
 };
+
+function rawInboxItem(item: InboxItem): string {
+  try {
+    return JSON.stringify(item, null, 2);
+  } catch {
+    return "Raw item payload could not be serialized.";
+  }
+}
+
+function InboxDetailFallback({
+  item,
+  onRetry,
+}: {
+  item: InboxItem;
+  onRetry: () => void;
+}) {
+  return (
+    <DetailPane
+      widthClass="w-full sm:w-[460px]"
+      title={<span className="mono truncate">{shortId(item.id)}</span>}
+    >
+      <section
+        role="alert"
+        className="rounded-md border border-(--hue-warn) bg-(--surface-0) p-4"
+      >
+        <h2 className="text-[14px] font-semibold text-(--text)">
+          This item could not render
+        </h2>
+        <p className="mt-2 text-sm text-(--text-dim)">{item.title}</p>
+        <p className="mono mt-1 text-[12px] text-(--text-faint)">{item.id}</p>
+        <Button className="mt-4" variant="primary" onClick={onRetry}>
+          Retry
+        </Button>
+        <details className="mt-4">
+          <summary className="cursor-pointer text-sm text-(--accent)">
+            Open raw item
+          </summary>
+          <pre className="mt-2 overflow-auto whitespace-pre-wrap break-words rounded-md bg-(--surface-2) p-3 text-[11px] text-(--text-dim)">
+            {rawInboxItem(item)}
+          </pre>
+        </details>
+      </section>
+    </DetailPane>
+  );
+}
 
 /** Group in triage order, oldest first inside a group; empty groups are dropped. */
 export function groupItems(
@@ -1643,246 +1689,259 @@ export function Inbox({
       </div>
 
       {sel && (
-        <DetailPane
-          widthClass="w-full sm:w-[460px]"
-          title={
-            <nav
-              aria-label="Breadcrumb"
-              className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
-            >
-              <PrimitiveButton
-                bare
-                type="button"
-                onClick={() => onSelectItem(null)}
-                className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
-                title="Back to inbox list"
+        <ErrorBoundary
+          resetKey={sel.id}
+          fallback={(_error, retry) => (
+            <InboxDetailFallback item={sel} onRetry={retry} />
+          )}
+        >
+          <DetailPane
+            widthClass="w-full sm:w-[460px]"
+            title={
+              <nav
+                aria-label="Breadcrumb"
+                className="flex min-w-0 items-center gap-1.5 text-[13px] font-normal"
               >
-                Inbox
-              </PrimitiveButton>
-              <span className="text-(--text-faint)" aria-hidden="true">
-                /
-              </span>
-              <span
-                className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
-                aria-current="page"
-              >
-                {groupOf(sel.kind).id === "other" && (
+                <PrimitiveButton
+                  bare
+                  type="button"
+                  onClick={() => onSelectItem(null)}
+                  className="cursor-pointer text-(--text-dim) hover:text-(--accent)"
+                  title="Back to inbox list"
+                >
+                  Inbox
+                </PrimitiveButton>
+                <span className="text-(--text-faint)" aria-hidden="true">
+                  /
+                </span>
+                <span
+                  className="flex min-w-0 items-center gap-2 truncate font-semibold text-(--text)"
+                  aria-current="page"
+                >
+                  {groupOf(sel.kind).id === "other" && (
+                    <StateBadge
+                      state={sel.kind}
+                      hues={INBOX_KIND_HUES}
+                      dot={false}
+                    />
+                  )}
+                  <span className="mono truncate" title={sel.id}>
+                    {shortId(sel.id)}
+                  </span>
+                </span>
+              </nav>
+            }
+            actions={
+              !sel.decision &&
+              !hasInboxPlainActions(sel.kind) &&
+              itemStatus(sel) !== "resolved" ? (
+                <div className="flex items-center gap-1.5">
+                  <Button disabled={!canResolve} onClick={openResolve}>
+                    Resolve…{" "}
+                    <span
+                      className="mono ml-1 text-(--text-faint)"
+                      aria-hidden="true"
+                    >
+                      x
+                    </span>
+                  </Button>
+                  {itemStatus(sel) === "open" && (
+                    <Button
+                      variant="primary"
+                      disabled={!canAck}
+                      onClick={() => ack.mutate(sel.id)}
+                    >
+                      Ack{" "}
+                      <span className="mono ml-1 opacity-80" aria-hidden="true">
+                        a
+                      </span>
+                    </Button>
+                  )}
+                </div>
+              ) : null
+            }
+            utility={<CopyActions id={sel.id} idLabel="inbox item id" />}
+            close={<Button onClick={() => onSelectItem(null)}>Close</Button>}
+          >
+            {hasInboxPlainActions(sel.kind) &&
+              itemStatus(sel) !== "resolved" && (
+                <Section title="Actions" card={false}>
+                  <InboxActions
+                    // Per-item state: a failed verb on one item must not follow
+                    // the operator to the next.
+                    key={sel.id}
+                    item={sel}
+                    connected={connected}
+                    prUrl={inboxActionPrHref(sel)}
+                    onResolve={() => setConfirmResolve(true)}
+                    onItemChange={invalidate}
+                  />
+                </Section>
+              )}
+
+            <Section title="Item" icons>
+              <KV
+                k="kind"
+                v={
                   <StateBadge
                     state={sel.kind}
                     hues={INBOX_KIND_HUES}
                     dot={false}
                   />
-                )}
-                <span className="mono truncate" title={sel.id}>
-                  {shortId(sel.id)}
-                </span>
-              </span>
-            </nav>
-          }
-          actions={
-            !sel.decision &&
-            !hasInboxPlainActions(sel.kind) &&
-            itemStatus(sel) !== "resolved" ? (
-              <div className="flex items-center gap-1.5">
-                <Button disabled={!canResolve} onClick={openResolve}>
-                  Resolve…{" "}
-                  <span
-                    className="mono ml-1 text-(--text-faint)"
-                    aria-hidden="true"
-                  >
-                    x
-                  </span>
-                </Button>
-                {itemStatus(sel) === "open" && (
-                  <Button
-                    variant="primary"
-                    disabled={!canAck}
-                    onClick={() => ack.mutate(sel.id)}
-                  >
-                    Ack{" "}
-                    <span className="mono ml-1 opacity-80" aria-hidden="true">
-                      a
+                }
+              />
+              <KV k="status" v={itemStatus(sel)} />
+              {waitingLabel(waitingCount(sel)) && (
+                <KV k="waiting" v={waitingLabel(waitingCount(sel))} />
+              )}
+              {sel.severity !== "normal" && (
+                <KV k="severity" v={sel.severity} />
+              )}
+              <KV k="created" v={<Ago iso={sel.createdAt} now={now} />} />
+              {sel.ackedAt && (
+                <KV k="acked" v={<Ago iso={sel.ackedAt} now={now} />} />
+              )}
+              {sel.resolvedAt && (
+                <KV
+                  k="resolved"
+                  v={
+                    <span>
+                      <Ago iso={sel.resolvedAt} now={now} />
+                      {sel.resolvedReason && <> · {sel.resolvedReason}</>}
                     </span>
-                  </Button>
-                )}
-              </div>
-            ) : null
-          }
-          utility={<CopyActions id={sel.id} idLabel="inbox item id" />}
-          close={<Button onClick={() => onSelectItem(null)}>Close</Button>}
-        >
-          {hasInboxPlainActions(sel.kind) && itemStatus(sel) !== "resolved" && (
-            <Section title="Actions" card={false}>
-              <InboxActions
-                // Per-item state: a failed verb on one item must not follow
-                // the operator to the next.
-                key={sel.id}
-                item={sel}
-                connected={connected}
-                prUrl={inboxActionPrHref(sel)}
-                onResolve={() => setConfirmResolve(true)}
-                onItemChange={invalidate}
+                  }
+                />
+              )}
+              {sel.resolvedBy && <KV k="resolved by" v={sel.resolvedBy} />}
+              <KV
+                k="source"
+                v={
+                  sourceRunId(sel.source) ? (
+                    <JumpLink
+                      onClick={() => onJumpRun(sourceRunId(sel.source)!)}
+                      title={`Open run ${sourceRunId(sel.source)}`}
+                    >
+                      {sel.source}
+                    </JumpLink>
+                  ) : (
+                    sel.source
+                  )
+                }
               />
             </Section>
-          )}
 
-          <Section title="Item" icons>
-            <KV
-              k="kind"
-              v={
-                <StateBadge
-                  state={sel.kind}
-                  hues={INBOX_KIND_HUES}
-                  dot={false}
+            <Section title="Message" card={false}>
+              <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] leading-relaxed">
+                <div className="font-medium text-(--text)">{sel.title}</div>
+                {sel.body && (
+                  <div className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)">
+                    {sel.body}
+                  </div>
+                )}
+              </div>
+            </Section>
+
+            {sel.decision && (
+              <Section title="Decision" card={false}>
+                <DecisionCard
+                  itemId={sel.id}
+                  request={sel.decision}
+                  response={sel.response}
+                  refs={sel.refs}
+                  onJumpProposal={onJumpProposal}
+                  connected={connected}
+                  onItemChange={invalidate}
                 />
-              }
-            />
-            <KV k="status" v={itemStatus(sel)} />
-            {waitingLabel(waitingCount(sel)) && (
-              <KV k="waiting" v={waitingLabel(waitingCount(sel))} />
+              </Section>
             )}
-            {sel.severity !== "normal" && <KV k="severity" v={sel.severity} />}
-            <KV k="created" v={<Ago iso={sel.createdAt} now={now} />} />
-            {sel.ackedAt && (
-              <KV k="acked" v={<Ago iso={sel.ackedAt} now={now} />} />
+
+            {Object.keys(sel.refs).length > 0 && (
+              <Section title="References" icons>
+                {sel.refs.runId && (
+                  <KV
+                    k="run"
+                    v={
+                      <JumpLink
+                        onClick={() => onJumpRun(sel.refs.runId!)}
+                        title={`Open run ${sel.refs.runId}`}
+                      >
+                        {shortId(sel.refs.runId)}
+                      </JumpLink>
+                    }
+                  />
+                )}
+                {sel.refs.proposalId && (
+                  <KV
+                    k="proposal"
+                    v={
+                      <JumpLink
+                        onClick={() => onJumpProposal(sel.refs.proposalId!)}
+                        title={`Open proposal ${sel.refs.proposalId}`}
+                      >
+                        {shortId(sel.refs.proposalId)}
+                      </JumpLink>
+                    }
+                  />
+                )}
+                {sel.refs.eventId && (
+                  <KV
+                    k="event"
+                    v={
+                      sel.refs.eventSource ? (
+                        <JumpLink
+                          onClick={() =>
+                            onJumpEvent(
+                              sel.refs.eventSource!,
+                              sel.refs.eventId!,
+                            )
+                          }
+                          title={`Open event ${sel.refs.eventId}`}
+                        >
+                          {shortId(sel.refs.eventId)}
+                        </JumpLink>
+                      ) : (
+                        shortId(sel.refs.eventId)
+                      )
+                    }
+                  />
+                )}
+                {sel.refs.issue && (
+                  <KV
+                    k="issue"
+                    v={
+                      <JumpLink
+                        href={`${LINEAR_ISSUE_URL}${encodeURIComponent(sel.refs.issue)}`}
+                        title="Open in Linear"
+                      >
+                        {sel.refs.issue}
+                      </JumpLink>
+                    }
+                  />
+                )}
+                {sel.refs.pr && <KV k="pr" v={<PrRef item={sel} />} />}
+                {sel.refs.repo && <KV k="repo" v={sel.refs.repo} />}
+              </Section>
             )}
-            {sel.resolvedAt && (
+
+            <Section title="Delivery" icons>
               <KV
-                k="resolved"
+                k="telegram"
                 v={
-                  <span>
-                    <Ago iso={sel.resolvedAt} now={now} />
-                    {sel.resolvedReason && <> · {sel.resolvedReason}</>}
+                  <span
+                    style={{ color: DELIVERY_HUES[deliveryState(sel)] }}
+                    title={deliveryText(sel)}
+                  >
+                    {deliveryText(sel).replace(/^Telegram: /, "")}
                   </span>
                 }
               />
+            </Section>
+
+            {(ack.isError || resolve.isError) && (
+              <VerbError error={ack.error ?? resolve.error} />
             )}
-            {sel.resolvedBy && <KV k="resolved by" v={sel.resolvedBy} />}
-            <KV
-              k="source"
-              v={
-                sourceRunId(sel.source) ? (
-                  <JumpLink
-                    onClick={() => onJumpRun(sourceRunId(sel.source)!)}
-                    title={`Open run ${sourceRunId(sel.source)}`}
-                  >
-                    {sel.source}
-                  </JumpLink>
-                ) : (
-                  sel.source
-                )
-              }
-            />
-          </Section>
-
-          <Section title="Message" card={false}>
-            <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] leading-relaxed">
-              <div className="font-medium text-(--text)">{sel.title}</div>
-              {sel.body && (
-                <div className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)">
-                  {sel.body}
-                </div>
-              )}
-            </div>
-          </Section>
-
-          {sel.decision && (
-            <Section title="Decision" card={false}>
-              <DecisionCard
-                itemId={sel.id}
-                request={sel.decision}
-                response={sel.response}
-                refs={sel.refs}
-                onJumpProposal={onJumpProposal}
-                connected={connected}
-                onItemChange={invalidate}
-              />
-            </Section>
-          )}
-
-          {Object.keys(sel.refs).length > 0 && (
-            <Section title="References" icons>
-              {sel.refs.runId && (
-                <KV
-                  k="run"
-                  v={
-                    <JumpLink
-                      onClick={() => onJumpRun(sel.refs.runId!)}
-                      title={`Open run ${sel.refs.runId}`}
-                    >
-                      {shortId(sel.refs.runId)}
-                    </JumpLink>
-                  }
-                />
-              )}
-              {sel.refs.proposalId && (
-                <KV
-                  k="proposal"
-                  v={
-                    <JumpLink
-                      onClick={() => onJumpProposal(sel.refs.proposalId!)}
-                      title={`Open proposal ${sel.refs.proposalId}`}
-                    >
-                      {shortId(sel.refs.proposalId)}
-                    </JumpLink>
-                  }
-                />
-              )}
-              {sel.refs.eventId && (
-                <KV
-                  k="event"
-                  v={
-                    sel.refs.eventSource ? (
-                      <JumpLink
-                        onClick={() =>
-                          onJumpEvent(sel.refs.eventSource!, sel.refs.eventId!)
-                        }
-                        title={`Open event ${sel.refs.eventId}`}
-                      >
-                        {shortId(sel.refs.eventId)}
-                      </JumpLink>
-                    ) : (
-                      shortId(sel.refs.eventId)
-                    )
-                  }
-                />
-              )}
-              {sel.refs.issue && (
-                <KV
-                  k="issue"
-                  v={
-                    <JumpLink
-                      href={`${LINEAR_ISSUE_URL}${encodeURIComponent(sel.refs.issue)}`}
-                      title="Open in Linear"
-                    >
-                      {sel.refs.issue}
-                    </JumpLink>
-                  }
-                />
-              )}
-              {sel.refs.pr && <KV k="pr" v={<PrRef item={sel} />} />}
-              {sel.refs.repo && <KV k="repo" v={sel.refs.repo} />}
-            </Section>
-          )}
-
-          <Section title="Delivery" icons>
-            <KV
-              k="telegram"
-              v={
-                <span
-                  style={{ color: DELIVERY_HUES[deliveryState(sel)] }}
-                  title={deliveryText(sel)}
-                >
-                  {deliveryText(sel).replace(/^Telegram: /, "")}
-                </span>
-              }
-            />
-          </Section>
-
-          {(ack.isError || resolve.isError) && (
-            <VerbError error={ack.error ?? resolve.error} />
-          )}
-        </DetailPane>
+          </DetailPane>
+        </ErrorBoundary>
       )}
 
       {selectedIds.size > 0 && selectionEnabled && (


### PR DESCRIPTION
Fixes watt-mind/factory#1454

## Summary

- `ErrorBoundary` gains optional `fallback(error, retry)` and `resetKey` props. With `fallback` it renders a local recovery UI instead of the app-wide "could not render" screen; a changed `resetKey` clears a prior error. Without those props behaviour is unchanged, so the app-level boundary in `main.tsx` keeps its one-shot chunk-load reload (covered by the existing `ErrorBoundary.test.tsx` cases).
- `Inbox.tsx` wraps the selected item's `DetailPane` in `<ErrorBoundary resetKey={sel.id} fallback=...>`. A render throw inside the detail now degrades to an in-pane `InboxDetailFallback` (item title, id, **Retry** which re-mounts the detail, and an "Open raw item" `<details>` with the JSON payload) while the list, filters, and shell stay interactive. No `window.location.reload()`. Selecting another item resets the boundary via the key.
- Tests: `Inbox.test.tsx` gains a regression test that forces the decision detail to throw on first render, asserts the list row and fallback are present, clicks **Retry**, and asserts the normal detail renders. `ErrorBoundary.test.tsx` gains a "local recovery" test for `fallback`/`retry`/`resetKey`.

### Root cause of the `demo-human-needed` first-render throw

Not reproducible against the current demo seed: the seed has drifted since the UX-critic round on #1433 (tracked in #1526), and `demo-human-needed` now renders on first selection. The most likely historical path is the `DecisionCard` render against a decision envelope whose `options` were not yet populated on first paint; that path is what the new Inbox regression test exercises (a decision whose `options` getter throws once, then succeeds on retry). The pane-level boundary remains the guard for any future variant. If the throw resurfaces with the refreshed seed, the stack will be visible in the fallback's console log and should be filed as a Triage follow-up referencing this PR.

## Handoff

Branch merged with `origin/develop` (7e0138d6). Verified in a clean scratch worktree with `FACTORY_EVENT_HOME` pointed at a temp dir and `FACTORY_ROOT`/`FACTORY_REPOS_ROOT`/`FACTORY_CONTROL_API_TOKEN` unset.

| Check | Command | Result |
| --- | --- | --- |
| Typecheck | `cd event-runtime/web && bun x tsc --noEmit` | pass |
| Ticket verification | `cd event-runtime/web && bun test src/views/Inbox.test.tsx src/components/ErrorBoundary.test.tsx` | 46 pass, 0 fail |
| Lib tests | `bun test event-runtime/lib --timeout 20000` | 2029 tests, 0 fail, 10 skip |
| Emit | `bun build/emit.mjs --check` | pass |
| Format | `bun run format:check` | pass |
| Repo check | `bun run check` | pass (94 generated files match `shared/`) |

Notes:
- Both prior dispatch runs failed handoff only because the sandbox has no `bunx` binary (`bunx: command not found` after tests passed). Use `bun x tsc --noEmit`; the verification above uses that form.
- Diff is confined to the ticket's Owned Paths (`Inbox.tsx`, `Inbox.test.tsx`, `ErrorBoundary.tsx`, `ErrorBoundary.test.tsx`).
- UX critique: skipped for this finisher pass — the previous round's FIX-FIRST was about the critic not being able to trigger the fallback against the drifted seed (#1526), which is operator-internal and does not affect the code under review.


## Post-review

Folded in the reviewer's three fixes (commit ae8b460):

- `ErrorBoundary.componentDidCatch` skips the `claimChunkReload` / `window.location.reload()` path when `fallback` is set, so a ChunkLoadError inside a pane-level boundary neither reloads the whole page nor consumes the route's one-shot `factory.chunkReload` marker. Test: "a pane-level chunk failure neither reloads nor claims the route's reload".
- `componentDidCatch` now logs `console.error(error, info.componentStack)` so the component stack is actually visible. Test: "logs the caught error with its component stack".
- `InboxDetailFallback` receives `onClose` and renders `close={<Button>Close</Button>}` on its `DetailPane`, so the operator can dismiss the fallback pane exactly like the real detail pane. Test: "the detail fallback can be closed like the real detail pane".

Verified locally: `bun x tsc --noEmit`, `bun test src/views/Inbox.test.tsx src/components/ErrorBoundary.test.tsx` (49 pass), `bun test event-runtime/lib` (2019 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
