### PR TITLE
fix(workers): preserve recoverable registry rows

### DIFF
--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -37,18 +37,23 @@ const unleasedWorker = `NOT EXISTS (
   FROM attempts
   JOIN runs ON runs.run_id = attempts.run_id
   WHERE attempts.lease_owner = workers.worker_id
+    AND attempts.attempt = runs.attempts
     AND runs.state IN (${ACTIVE_ATTEMPT_STATES})
 )`;
 
 function pruneHostWorkers(db, { host, workerId, now }) {
+  const stoppedCutoff = iso(now - STOPPED_WORKER_RETENTION_MS);
   const inactiveCutoff = iso(now - INACTIVE_WORKER_RETENTION_MS);
   db.query(
     `DELETE FROM workers
      WHERE host = ?
        AND worker_id != ?
-       AND (state = 'stopped' OR (state != 'stopped' AND last_seen < ?))
+       AND (
+         (state = 'stopped' AND stopped_at < ?)
+         OR (state != 'stopped' AND last_seen < ?)
+       )
        AND ${unleasedWorker}`,
-  ).run(host, workerId, inactiveCutoff);
+  ).run(host, workerId, stoppedCutoff, inactiveCutoff);
 }
 
 export function registerWorker(
@@ -87,9 +92,21 @@ export function heartbeat(
   workerId,
   { state = "idle", runId = null, now = Date.now() } = {},
 ) {
+  const at = iso(now);
+  const { changes } = db
+    .query(
+      `UPDATE workers SET last_seen = ?, state = ?, current_run = ? WHERE worker_id = ?`,
+    )
+    .run(at, state, runId, workerId);
+  if (changes) return;
+
   db.query(
-    `UPDATE workers SET last_seen = ?, state = ?, current_run = ? WHERE worker_id = ?`,
-  ).run(iso(now), state, runId, workerId);
+    `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
+     VALUES (?, ?, ?, '{}', '', ?, ?, ?, ?)
+     ON CONFLICT(worker_id) DO UPDATE SET
+       last_seen = excluded.last_seen, state = excluded.state,
+       current_run = excluded.current_run`,
+  ).run(workerId, hostname(), process.pid, at, at, state, runId);
 }
 
 /** Clean exit: recorded, so a stopped worker is distinguishable from a dead one. */

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -247,16 +247,77 @@ describe("worker registry and heartbeats (OPS-233)", () => {
     ).toEqual(["fresh-stopped", "stale-but-leased"]);
   });
 
-  test("registering a worker removes obsolete rows from its host", () => {
+  test("pruning correlates a lease with its run's current attempt", () => {
+    const d = db();
+    const now = Date.now();
+    const hour = 60 * 60 * 1000;
+
+    registerWorker(d, { workerId: "dead-first-attempt", now });
+    queueRun(d, { runId: "retried-run" });
+    d.query(
+      `UPDATE runs SET state = 'RUNNING', attempts = 2 WHERE run_id = ?`,
+    ).run("retried-run");
+    d.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner)
+       VALUES (?, ?, ?, ?), (?, ?, ?, ?)`,
+    ).run(
+      "retried-run",
+      1,
+      1,
+      "dead-first-attempt",
+      "retried-run",
+      2,
+      2,
+      "current-worker",
+    );
+    heartbeat(d, "dead-first-attempt", { now: now - 7 * hour });
+
+    expect(pruneWorkers(d, { now })).toBe(1);
+    expect(listWorkers(d, { now })).toEqual([]);
+  });
+
+  test("registering a worker retains recently stopped host rows", () => {
     const d = db();
     const now = Date.now();
 
-    registerWorker(d, { workerId: "previous-pool", now });
-    deregisterWorker(d, "previous-pool", { now });
+    registerWorker(d, { workerId: "recently-stopped", now });
+    registerWorker(d, { workerId: "expired-stopped", now });
+    deregisterWorker(d, "recently-stopped", { now });
+    deregisterWorker(d, "expired-stopped", { now: now - 2 * 60 * 60 * 1000 });
     registerWorker(d, { workerId: "new-pool", now: now + 1 });
 
-    expect(listWorkers(d, { now: now + 1 }).map((w) => w.workerId)).toEqual([
-      "new-pool",
+    expect(
+      listWorkers(d, { now: now + 1 })
+        .map((w) => w.workerId)
+        .sort(),
+    ).toEqual(["new-pool", "recently-stopped"]);
+  });
+
+  test("a heartbeat restores a worker pruned while it was suspended", () => {
+    const d = db();
+    const now = Date.now();
+
+    registerWorker(d, { workerId: "recovered", now });
+    heartbeat(d, "recovered", {
+      state: "busy",
+      runId: "run_recovered",
+      now: now - 7 * 60 * 60 * 1000,
+    });
+
+    expect(pruneWorkers(d, { now })).toBe(1);
+    expect(listWorkers(d, { now })).toEqual([]);
+
+    heartbeat(d, "recovered", {
+      state: "idle",
+      now: now + 1,
+    });
+    expect(listWorkers(d, { now: now + 1 })).toEqual([
+      expect.objectContaining({
+        workerId: "recovered",
+        state: "idle",
+        currentRun: null,
+        stale: false,
+      }),
     ]);
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1520

Review the worker lifecycle pruning and heartbeat recovery regressions.

## Validation

| Check                | Command                                                                          | Result | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------ | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/workers.test.mjs event-runtime/lib/reaper.test.mjs --timeout 20000` | pass   | 39 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass   | 2,021 tests; emit and format clean |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface             |

UX critique: skipped

run:run_9c500638-78ba-48dc-b2e2-1e2d984fbe46