### PR TITLE
fix(inbox): guard decision settlement ownership

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -224,16 +224,21 @@ write transactions around an unlocked effect, not one transaction:
    SQLite lock for that starved every other writer (#1434).
 3. **Settle.** The outcome replaces the pending record (`applied` resolves
    the item, `failed` keeps it open with the error) in a second transaction.
+   That write matches the pending claim's `claimedAt` and `retryAttempt`; a
+   late owner whose claim was taken over receives `claim_lost` and leaves the
+   newer settlement untouched.
 
 If serve dies between the claim and the settle, the pending record outlives
 it. `/decide/retry` treats a pending claim older than
 `PENDING_EFFECT_CLAIM_TIMEOUT_MS` (60 s, above the transport timeout —
 `event-runtime/lib/inbox.mjs`) as abandoned and takes it over: it re-stamps
 the claim with the next `retryAttempt` and a fresh `claimedAt`, runs the
-effect, and settles. Readers must tolerate `response.effect` being `null`
-(rows decided before this window existed) or `pending`; the web
-`DecisionCard` shows the outcome verbatim and offers retry for anything not
-`applied`.
+effect, and settles. This is deliberately at-least-once: if `answer` or
+`send_to_triage` reaches Linear but serve dies before settlement, the
+takeover repeats its comment-producing effect. Readers must tolerate
+`response.effect` being `null` (rows decided before this window existed) or
+`pending`; the web `DecisionCard` shows the outcome verbatim and offers retry
+for anything not `applied`.
 
 | Effect             | What the runtime does                                                                                                                                                                                                                                                                | Legal only when the item has            |
 | :----------------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------- |

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -549,7 +549,13 @@ function retargetedDedupeKey(db, row, previousProposalId, proposalId) {
  * superseded proposal with the new request installed, or decided against a
  * question nobody asked.
  */
-function retargetInboxDecision(db, id, answer, proposalId, { now }) {
+function retargetInboxDecision(
+  db,
+  id,
+  answer,
+  proposalId,
+  { now, claimEffect },
+) {
   const row = decisionRow(db, id);
   const refs = parseObject(row.refs_json);
   const previousProposalId = refs.proposalId ?? null;
@@ -578,33 +584,39 @@ function retargetInboxDecision(db, id, answer, proposalId, { now }) {
     previousProposalId && row.title.includes(previousProposalId)
       ? row.title.split(previousProposalId).join(proposalId)
       : row.title;
-  db.query(
-    `UPDATE inbox_items
+  const retargeted = db
+    .query(
+      `UPDATE inbox_items
      SET refs_json = ?, proposal_id = ?, decision_json = ?, dedupe_key = ?, delivery_json = ?,
          title = ?,
          response_json = NULL, decided_at = NULL, decided_by = NULL
-     WHERE id = ?`,
-  ).run(
-    JSON.stringify(nextRefs),
-    proposalId,
-    JSON.stringify(request),
-    retargetedDedupeKey(db, row, previousProposalId, proposalId),
-    JSON.stringify({
-      ...delivery,
-      responseHistory: [
-        ...history,
-        {
-          retargetedFrom: previousProposalId,
-          retargetedTo: proposalId,
-          retargetedAt: new Date(now).toISOString(),
-          response: answer,
-        },
-      ],
-    }),
-    nextTitle,
-    id,
-  );
-  return getInboxItem(db, id);
+     WHERE id = ?
+       AND json_extract(response_json, '$.effect.claimedAt') = ?
+       AND json_extract(response_json, '$.effect.retryAttempt') = ?`,
+    )
+    .run(
+      JSON.stringify(nextRefs),
+      proposalId,
+      JSON.stringify(request),
+      retargetedDedupeKey(db, row, previousProposalId, proposalId),
+      JSON.stringify({
+        ...delivery,
+        responseHistory: [
+          ...history,
+          {
+            retargetedFrom: previousProposalId,
+            retargetedTo: proposalId,
+            retargetedAt: new Date(now).toISOString(),
+            response: answer,
+          },
+        ],
+      }),
+      nextTitle,
+      id,
+      claimEffect.claimedAt,
+      claimEffect.retryAttempt,
+    );
+  return retargeted.changes === 1 ? getInboxItem(db, id) : null;
 }
 
 /**
@@ -620,7 +632,7 @@ function settleInboxDecision(
   id,
   response,
   effect,
-  { now, recordedEffect = effect, artifactStore },
+  { now, claimEffect, recordedEffect = effect, artifactStore },
 ) {
   const replanned =
     effect.outcome === "applied" && effect.detail === REPLANNED_DETAIL;
@@ -641,25 +653,45 @@ function settleInboxDecision(
   }
   const answer = { ...response, effect: recordedEffect };
   if (replanned && newProposalId) {
+    const item = retargetInboxDecision(db, id, answer, newProposalId, {
+      now,
+      claimEffect,
+    });
+    if (!item) return lostInboxDecisionClaim(db, id, effect);
     return {
-      item: retargetInboxDecision(db, id, answer, newProposalId, {
-        now,
-      }),
+      item,
       effect,
     };
   }
-  db.query("UPDATE inbox_items SET response_json = ? WHERE id = ?").run(
-    JSON.stringify(answer),
-    id,
-  );
-  if (effect.outcome === "applied" && !replanned) {
-    db.query(
-      `UPDATE inbox_items
-       SET resolved_at = COALESCE(resolved_at, ?),
+  const settled =
+    effect.outcome === "applied" && !replanned
+      ? db.query(
+          `UPDATE inbox_items
+       SET response_json = ?,
+           resolved_at = COALESCE(resolved_at, ?),
            resolved_by = COALESCE(resolved_by, ?)
-       WHERE id = ?`,
-    ).run(new Date(now).toISOString(), `operator:${effect.kind}`, id);
-  }
+       WHERE id = ?
+         AND json_extract(response_json, '$.effect.claimedAt') = ?
+         AND json_extract(response_json, '$.effect.retryAttempt') = ?`,
+        )
+      : db.query(
+          `UPDATE inbox_items
+           SET response_json = ?
+           WHERE id = ?
+             AND json_extract(response_json, '$.effect.claimedAt') = ?
+             AND json_extract(response_json, '$.effect.retryAttempt') = ?`,
+        );
+  const params = [
+    JSON.stringify(answer),
+    ...(effect.outcome === "applied" && !replanned
+      ? [new Date(now).toISOString(), `operator:${effect.kind}`]
+      : []),
+    id,
+    claimEffect.claimedAt,
+    claimEffect.retryAttempt,
+  ];
+  if (settled.run(...params).changes !== 1)
+    return lostInboxDecisionClaim(db, id, effect);
   const item = getInboxItem(db, id);
   let memos = [];
   if (effect.outcome === "applied" && !replanned) {
@@ -670,6 +702,16 @@ function settleInboxDecision(
     });
   }
   return { item, effect, memos };
+}
+
+/** A late owner must not overwrite the newer claim's settlement. */
+function lostInboxDecisionClaim(db, id, effect) {
+  return {
+    item: getInboxItem(db, id),
+    effect: { ...effect, outcome: "claim_lost" },
+    claimLost: true,
+    memos: [],
+  };
 }
 
 /** The effect record held while the effect runs outside the write lock. */
@@ -821,6 +863,7 @@ async function settleClaimedInboxDecision(
     settleInboxDecision(db, item.id, response, effect, {
       now,
       artifactStore,
+      claimEffect: item.response.effect,
       recordedEffect,
     }),
   );
@@ -898,8 +941,8 @@ function retryInboxDecisionInTransaction(
   }
   if (!recorded.effect) {
     throw new InboxDecisionError(
-      "retry_superseded",
-      `inbox item ${id} decision retry was superseded`,
+      "not_decided",
+      `inbox item ${id} has no decision effect to retry`,
       409,
     );
   }

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -663,38 +663,34 @@ function settleInboxDecision(
       effect,
     };
   }
-  const settled =
-    effect.outcome === "applied" && !replanned
-      ? db.query(
-          `UPDATE inbox_items
-       SET response_json = ?,
+  const resolves = effect.outcome === "applied" && !replanned;
+  const settled = db
+    .query(
+      `UPDATE inbox_items
+       SET response_json = ?${
+         resolves
+           ? `,
            resolved_at = COALESCE(resolved_at, ?),
-           resolved_by = COALESCE(resolved_by, ?)
+           resolved_by = COALESCE(resolved_by, ?)`
+           : ""
+       }
        WHERE id = ?
          AND json_extract(response_json, '$.effect.claimedAt') = ?
          AND json_extract(response_json, '$.effect.retryAttempt') = ?`,
-        )
-      : db.query(
-          `UPDATE inbox_items
-           SET response_json = ?
-           WHERE id = ?
-             AND json_extract(response_json, '$.effect.claimedAt') = ?
-             AND json_extract(response_json, '$.effect.retryAttempt') = ?`,
-        );
-  const params = [
-    JSON.stringify(answer),
-    ...(effect.outcome === "applied" && !replanned
-      ? [new Date(now).toISOString(), `operator:${effect.kind}`]
-      : []),
-    id,
-    claimEffect.claimedAt,
-    claimEffect.retryAttempt,
-  ];
-  if (settled.run(...params).changes !== 1)
-    return lostInboxDecisionClaim(db, id, effect);
+    )
+    .run(
+      JSON.stringify(answer),
+      ...(resolves
+        ? [new Date(now).toISOString(), `operator:${effect.kind}`]
+        : []),
+      id,
+      claimEffect.claimedAt,
+      claimEffect.retryAttempt,
+    );
+  if (settled.changes !== 1) return lostInboxDecisionClaim(db, id, effect);
   const item = getInboxItem(db, id);
   let memos = [];
-  if (effect.outcome === "applied" && !replanned) {
+  if (resolves) {
     memos = registerInboxDecisionMemos(db, item, response, {
       now,
       artifactStore,

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -694,6 +694,66 @@ describe("human inbox ledger (WM-285)", () => {
     void crashed;
   });
 
+  test("a stale owner cannot overwrite the settlement from its takeover", async () => {
+    const db = openDb(":memory:");
+    const request = decision([
+      { id: "triage", label: "Triage", effect: "send_to_triage" },
+    ]);
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "starved owner",
+        refs: { issue: "WM-1434" },
+        decision: request,
+      },
+      { id: "taken_over_claim" },
+    );
+    const response = {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "triage",
+      fields: {},
+    };
+    let finishStaleEffect;
+    const stale = decideInboxItem(db, "taken_over_claim", response, {
+      now: 1_000,
+      applyEffect: () =>
+        new Promise((resolve) => {
+          finishStaleEffect = () => resolve({ outcome: "applied" });
+        }),
+    });
+    await Promise.resolve();
+
+    const takeoverAt = 1_000 + PENDING_EFFECT_CLAIM_TIMEOUT_MS;
+    const takeover = await retryInboxDecision(db, "taken_over_claim", {
+      now: takeoverAt,
+      applyEffect: () => ({ outcome: "applied" }),
+    });
+    expect(takeover.item.response.effect).toEqual({
+      kind: "send_to_triage",
+      outcome: "applied",
+      retryAttempt: 1,
+    });
+
+    finishStaleEffect();
+    await expect(stale).resolves.toMatchObject({
+      claimLost: true,
+      effect: { kind: "send_to_triage", outcome: "claim_lost" },
+    });
+    expect(getInboxItem(db, "taken_over_claim")).toMatchObject({
+      resolvedAt: new Date(takeoverAt).toISOString(),
+      resolvedBy: "operator:send_to_triage",
+      response: {
+        effect: {
+          kind: "send_to_triage",
+          outcome: "applied",
+          retryAttempt: 1,
+        },
+      },
+    });
+  });
+
   test("a retry claim that dies mid-effect can be taken over as well", async () => {
     const db = openDb(":memory:");
     const request = decision([

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1776,6 +1776,51 @@ describe("approving an expired proposal retargets its item (WM-714)", () => {
     });
     expect(invoked).toBe(1);
   });
+
+  test("a starved approve that loses its claim to a takeover does not retarget", async () => {
+    const db = openDb(":memory:");
+    const { id, approve, applyEffect } = replanned(db);
+    let finishStaleEffect;
+    const stale = decideInboxItem(db, id, approve, {
+      now: 1_000,
+      applyEffect: () =>
+        new Promise((resolve) => {
+          finishStaleEffect = () => resolve(applyEffect());
+        }),
+    });
+    await Promise.resolve();
+
+    // The owner starves past the claim timeout and a retry takes the claim
+    // over, settling the item as a plain approval.
+    const takeoverAt = 1_000 + PENDING_EFFECT_CLAIM_TIMEOUT_MS;
+    const takeover = await retryInboxDecision(db, id, {
+      now: takeoverAt,
+      applyEffect: () => ({ outcome: "applied" }),
+    });
+    expect(takeover.claimLost).toBeUndefined();
+    expect(takeover.item.resolvedAt).toBe(new Date(takeoverAt).toISOString());
+    expect(takeover.item.refs.proposalId).toBe(OLD);
+
+    // The stale owner's re-plan lands late: it must lose, not re-open the item.
+    finishStaleEffect();
+    await expect(stale).resolves.toMatchObject({
+      claimLost: true,
+      effect: { kind: "approve_proposal", outcome: "claim_lost" },
+    });
+    const item = getInboxItem(db, id);
+    expect(item.refs.proposalId).toBe(OLD);
+    expect(item.title).toContain(OLD);
+    expect(item.title).not.toContain(FRESH);
+    expect(item.resolvedAt).toBe(new Date(takeoverAt).toISOString());
+    expect(item.resolvedBy).toBe("operator:approve_proposal");
+    expect(item.response.effect).toMatchObject({
+      outcome: "applied",
+      retryAttempt: 1,
+    });
+    expect(item.response.effect.detail).toBeUndefined();
+    expect(item.responseHistory ?? []).toHaveLength(0);
+    expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
+  });
 });
 
 describe("inbox decisions register precedent memos (WM-812)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1506

Review the ownership-guarded inbox settlement and stale-owner takeover regression.

## Validation

| Check                | Command                                                                        | Result  | Notes                       |
| -------------------- | ------------------------------------------------------------------------------ | ------- | --------------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs --timeout 20000`                    | pass    | 41 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2020 pass, 10 skipped       |
| UX critique          | factory-ux-critic                                                              | not run | no user-facing surface      |

UX critique: skipped

run:run_751b3e84-044c-403c-b7ab-25033811c4be

## Post-review

- Added `a starved approve that loses its claim to a takeover does not retarget` (WM-714 block): an `approve_proposal` owner starved past `PENDING_EFFECT_CLAIM_TIMEOUT_MS` while a retry takes the claim over and settles; the late re-plan returns `claimLost: true` / `outcome: "claim_lost"` and leaves the item resolved against the old proposal (no retarget, no history entry).
- `settleInboxDecision`: hoisted `const resolves = effect.outcome === "applied" && !replanned;` and folded the two UPDATE statements into one with a conditional resolve SET fragment and matching params; behaviour unchanged.
- Verified: `bun test event-runtime/lib` (2031 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
