### PR TITLE
fix(merge): protect concurrent rebase heads (#1445)

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:807ec05aa55816d61e510726cc911dfb31c13abe6655ca29729529256e624a65",
+    "agents/merge-fix.md": "sha256:9ebd623d5a871f2f5d34233dab2b0a16a688c368ce4c93d12d2c05b3aac107b6",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -17,14 +17,10 @@
     "services": ["tracker:write", "repo:write", "github:write"],
     "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
-  "limits": {
-    "timeout_seconds": 2700,
-    "attempts": 1,
-    "budget_usd": 15
-  },
+  "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:c06dba00c6fa4d34fcb97a0adc0fedf3d7f87c94e4535c4acd7afab2427e7b9b",
+    "agents/merge-fix.md": "sha256:5cf9e0bdcfeb8b83464d3c37805da168d1ee82e527803655f410bb230b411bcd",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -68,9 +68,10 @@ isolated worktree for the ticket. This is not a general implementation run.
      Owned Paths, because a rebase touches what the base touched. Never stash
      changes or use `--autostash`. If a hunk is genuinely ambiguous — two real
      behaviours, no way to keep both — that is the one case to BLOCK with the
-     hunk named. After every rebase, run the same changed-file-only prettier
-     and eslint commands described for `format_and_lint`, then re-run
-     verification. Push exactly once with the fetched-tip lease:
+     hunk named. After every rebase, run the same
+     changed-file-only prettier and eslint commands described for
+     `format_and_lint`, then re-run verification. Push exactly once with the
+     fetched-tip lease:
 
      ```sh
      git push origin "HEAD:refs/heads/<headRef>" \

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -4,8 +4,11 @@
 isolated worktree for the ticket. This is not a general implementation run.
 
 1. Read the ticket and all comments. Re-read the PR head/base and required
-   checks. Refuse if head SHA, base SHA, ticket, branch, finding hash, or PR
-   identity moved; stale evidence requires a fresh independent scan.
+   checks. Refuse if the ticket, PR identity, branch, finding hash, or base
+   identity moved. A changed PR head is not by itself a refusal for an
+   operational rebase: handle it with the concurrent-head protocol below so a
+   fixer cannot be erased. Other stale evidence requires a fresh independent
+   scan.
 2. Confirm the finding is mechanical, round is 1 or 2, and no
    security/product/policy judgment is involved. Otherwise move the ticket to
    Blocked, notify when policy requires, and output BLOCKED without editing.
@@ -27,17 +30,52 @@ isolated worktree for the ticket. This is not a general implementation run.
      scan establish green. This deterministic correction does not consume a
      `max_fix_rounds` round.
 
-   - `rebase_onto_base` / `rerun_ci_at_head`: rebase the head branch onto the
-     current base. Resolve conflicts faithfully to both sides, reading the
-     surrounding code; the files git reports as conflicting are in scope for
-     the resolution regardless of the ticket's Owned Paths, because a rebase
-     touches what the base touched. Never `git stash` or `--autostash`. If a
-     hunk is genuinely ambiguous — two real behaviours, no way to keep both —
-     that is the one case to BLOCK with the hunk named. After every rebase,
-     run the same changed-file-only prettier and eslint commands described for
-     `format_and_lint`, then re-run verification and push with
-     `--force-with-lease`. Formatting drift after a rebase is predictable, so
-     never push the rebased branch before this hygiene step.
+   - `rebase_onto_base` / `rerun_ci_at_head`: first fetch both the PR branch
+     and base, record the fetched PR tip as `expectedRemoteSha`, and keep that
+     exact value for the push lease:
+
+     ```sh
+     git fetch --no-tags origin \
+       "+refs/heads/<headRef>:refs/remotes/origin/<headRef>" \
+       "+refs/heads/<base>:refs/remotes/origin/<base>"
+     expectedRemoteSha=$(git rev-parse "origin/<headRef>")
+     ```
+
+     Before editing, inspect the fetched tip's committer email and timestamp.
+     If it was pushed by an actor other than this run (`git config user.email`)
+     within `MERGE_FIX_IN_FLIGHT_MINUTES` (default `10`), do not touch or push
+     the branch. Return the structured no-op reason `branch_in_flight` (with
+     `outcome: "BLOCKED"` under this agent's bounded result contract) instead
+     of racing the active fixer. Treat an unknown actor or timestamp as in
+     flight; validate the optional minute value as a positive integer before
+     using it.
+
+     If `expectedRemoteSha` is not an ancestor of local `HEAD`, someone pushed
+     commits the worktree does not contain. Rebase local work **on top of** the
+     fetched remote branch first (`git rebase "origin/<headRef>"`), then rebase
+     onto `origin/<base>`; never reconstruct the branch by replaying only this
+     run's original dispatch commit. This preserves foreign commits even when
+     the local and remote histories diverged. Resolve conflicts faithfully to
+     both sides, reading the surrounding code; the files git reports as
+     conflicting are in scope for the resolution regardless of the ticket's
+     Owned Paths, because a rebase touches what the base touched. Never stash
+     changes or use `--autostash`. If a hunk is genuinely ambiguous — two real
+     behaviours, no way to keep both — that is the one case to BLOCK with the
+     hunk named. After every rebase, run the same changed-file-only prettier
+     and eslint commands described for `format_and_lint`, then re-run
+     verification. Push exactly once with the fetched-tip lease:
+
+     ```sh
+     git push origin "HEAD:refs/heads/<headRef>" \
+       "--force-with-lease=<headRef>:${expectedRemoteSha}"
+     ```
+
+     A lease failure means another writer moved the branch after the fetch:
+     make no retry push, return `outcome: "BLOCKED"` with structured reason
+     `branch_moved`, and leave the remote branch untouched. Formatting drift
+     after a rebase is predictable, so never push the rebased branch before
+     this hygiene step.
+
    - A finding that names an Owned Paths deviation (an expectation outside the
      ticket's paths that the PR's own change invalidated): make that one
      correction, and record the deviation on the ticket in your comment.

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -42,15 +42,20 @@ isolated worktree for the ticket. This is not a general implementation run.
      ```
 
      Compare `expectedRemoteSha` with the pinned `input.json` `headSha`. Only
-     when they differ, inspect the fetched tip's committer email and timestamp:
-     that difference proves the PR head changed after this run was planned. If
-     the changed tip was pushed by an actor other than this run
-     (`git config user.email`) within `MERGE_FIX_IN_FLIGHT_MINUTES` (default
-     `10`), do not touch or push the branch. Return `outcome: "BLOCKED"` and a
-     `summary` beginning `branch_in_flight:` instead of racing the active
-     fixer. When the head changed, treat an unknown actor or timestamp as in
-     flight; validate the optional minute value as a positive integer before
-     using it. Never classify the unchanged pinned head as `branch_in_flight`.
+     when they differ, query the live PR with
+     `gh pr view <pr> --repo <github> --json headRefOid,updatedAt`. Refuse with
+     `branch_moved:` before editing if that live head no longer equals
+     `expectedRemoteSha`. A differing fetched head proves another actor moved
+     the branch because this run has not pushed yet; do not substitute commit
+     author/committer metadata, which does not identify who pushed or when.
+     Treat the PR's `updatedAt` as a conservative upper bound on the head-change
+     time. If it is within `MERGE_FIX_IN_FLIGHT_MINUTES` (default `10`), do not
+     touch or push the branch. Return `outcome: "BLOCKED"` and a `summary`
+     beginning `branch_in_flight:` instead of racing the active fixer. Treat an
+     unknown live head or timestamp as in flight; validate the optional minute
+     value as a positive integer before using it. Never classify the unchanged
+     pinned head as `branch_in_flight`. PR activity other than a push can only
+     make this conservative check wait longer; it cannot allow a clobber.
 
      If `expectedRemoteSha` is not an ancestor of local `HEAD`, someone pushed
      commits the worktree does not contain. Rebase local work **on top of** the

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -41,14 +41,16 @@ isolated worktree for the ticket. This is not a general implementation run.
      expectedRemoteSha=$(git rev-parse "origin/<headRef>")
      ```
 
-     Before editing, inspect the fetched tip's committer email and timestamp.
-     If it was pushed by an actor other than this run (`git config user.email`)
-     within `MERGE_FIX_IN_FLIGHT_MINUTES` (default `10`), do not touch or push
-     the branch. Return the structured no-op reason `branch_in_flight` (with
-     `outcome: "BLOCKED"` under this agent's bounded result contract) instead
-     of racing the active fixer. Treat an unknown actor or timestamp as in
+     Compare `expectedRemoteSha` with the pinned `input.json` `headSha`. Only
+     when they differ, inspect the fetched tip's committer email and timestamp:
+     that difference proves the PR head changed after this run was planned. If
+     the changed tip was pushed by an actor other than this run
+     (`git config user.email`) within `MERGE_FIX_IN_FLIGHT_MINUTES` (default
+     `10`), do not touch or push the branch. Return `outcome: "BLOCKED"` and a
+     `summary` beginning `branch_in_flight:` instead of racing the active
+     fixer. When the head changed, treat an unknown actor or timestamp as in
      flight; validate the optional minute value as a positive integer before
-     using it.
+     using it. Never classify the unchanged pinned head as `branch_in_flight`.
 
      If `expectedRemoteSha` is not an ancestor of local `HEAD`, someone pushed
      commits the worktree does not contain. Rebase local work **on top of** the
@@ -71,10 +73,12 @@ isolated worktree for the ticket. This is not a general implementation run.
      ```
 
      A lease failure means another writer moved the branch after the fetch:
-     make no retry push, return `outcome: "BLOCKED"` with structured reason
-     `branch_moved`, and leave the remote branch untouched. Formatting drift
-     after a rebase is predictable, so never push the rebased branch before
-     this hygiene step.
+     make no retry push, return `outcome: "BLOCKED"` with a `summary` beginning
+     `branch_moved:`, and leave the remote branch untouched. The stable summary
+     prefix is the structured reason because this agent's exact-property
+     result schema has no separate reason field. Formatting drift after a
+     rebase is predictable, so never push the rebased branch before this
+     hygiene step.
 
    - A finding that names an Owned Paths deviation (an expectation outside the
      ticket's paths that the PR's own change invalidated): make that one

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -440,6 +440,35 @@ describe("registry", () => {
     ]);
   });
 
+  test("merge-fix rebase instructions preserve concurrent branch commits", () => {
+    const prompt = readFileSync(
+      path.join(RUNTIME_ROOT, "agents", "merge-fix.md"),
+      "utf8",
+    );
+    const flat = prompt.replace(/\s+/g, " ");
+
+    expect(flat).toContain('git rebase "origin/<headRef>"');
+    expect(flat).toContain(
+      '"--force-with-lease=<headRef>:${expectedRemoteSha}"',
+    );
+    expect(flat).toContain("MERGE_FIX_IN_FLIGHT_MINUTES");
+    expect(flat).toContain(
+      "Compare `expectedRemoteSha` with the pinned `input.json` `headSha`",
+    );
+    expect(flat).toContain(
+      "gh pr view <pr> --repo <github> --json headRefOid,updatedAt",
+    );
+    expect(flat).toContain(
+      "do not substitute commit author/committer metadata",
+    );
+    expect(flat).toContain(
+      "Never classify the unchanged pinned head as `branch_in_flight`",
+    );
+    expect(flat).toContain("`summary` beginning `branch_in_flight:`");
+    expect(flat).toContain("`summary` beginning `branch_moved:`");
+    expect(flat).toContain("make no retry push");
+  });
+
   test("local schedule overlay permits new complete entries and rejects kernel routing changes", () => {
     const config = path.join(tmpDir("event-schedule-new-"), "schedule.yaml");
     writeFileSync(

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -344,8 +344,13 @@ describe("registry", () => {
     // wrapper; merge-review and merge-notify document the same artifact
     // nesting, and all three agent definitions are re-pinned. Post-review:
     // merge-fix.md drops the bare-artifact twin examples (re-pinned again).
+    // Regenerated (#1445): merge-fix.md preserves freshly fetched foreign PR
+    // commits, uses an exact force-with-lease, compares the pinned headSha
+    // against live PR evidence, and returns stable `branch_in_flight:` /
+    // `branch_moved:` summary prefixes; merge-fix.json is re-pinned. Prompt
+    // text only.
     const expected =
-      "sha256:3da3fdd6554606b51aa8c8c907d0e84fae8e370e0f97c93c2d3234f75af1bdb3";
+      "sha256:a59770c105431644d5c8aa00ceba315ad57c20adf83d8244363bc4ccc9fbc44a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -307,8 +307,11 @@ describe("registry", () => {
     // the configured handoff gate includes Prettier after the unit and emit
     // checks; dispatch.json is re-pinned. Prompt text only — no schema,
     // contract, route, capability, or model tier changed.
+    // Regenerated (#1445): merge-fix.md preserves freshly fetched foreign PR
+    // commits, uses an exact force-with-lease, and returns typed concurrent
+    // branch no-ops; merge-fix.json is re-pinned. Prompt text only.
     const expected =
-      "sha256:9478df60d64bd504a50935c322760df759dc0055dd3b781f06a0a7165f1c6172";
+      "sha256:3317a3c069bbdef2e7c22486ace3f1b7cbaf429e9bc6d6455eb6630caf360dc5";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -401,6 +404,23 @@ describe("registry", () => {
     expect(warnings).toEqual([
       expect.stringContaining("not named in overlay_auto_approve"),
     ]);
+  });
+
+  test("merge-fix rebase instructions preserve concurrent branch commits", () => {
+    const prompt = readFileSync(
+      path.join(RUNTIME_ROOT, "agents", "merge-fix.md"),
+      "utf8",
+    );
+    const flat = prompt.replace(/\s+/g, " ");
+
+    expect(flat).toContain('git rebase "origin/<headRef>"');
+    expect(flat).toContain(
+      '"--force-with-lease=<headRef>:${expectedRemoteSha}"',
+    );
+    expect(flat).toContain("MERGE_FIX_IN_FLIGHT_MINUTES");
+    expect(flat).toContain("branch_in_flight");
+    expect(flat).toContain("branch_moved");
+    expect(flat).toContain("make no retry push");
   });
 
   test("local schedule overlay permits new complete entries and rejects kernel routing changes", () => {


### PR DESCRIPTION
## Summary
- Protect merge-fix rebase runs from overwriting concurrent branch updates by fetching and leasing the exact remote tip.
- Block safely for in-flight writers or lease failures, and preserve foreign commits before rebasing onto the base.
- Add prompt-contract coverage and refresh the registry pin.

## Validation
| Check | Result |
| --- | --- |
| `bun test event-runtime/lib/registry.test.mjs` | 119 tests, 0 failures |
| Repository gate | 2020 tests, emit + format clean |

## UX review
Skipped: operational agent prompt change only; no user-facing surface.

Fixes watt-mind/factory#1445



## Handoff
Head `7b71da0e` = origin/feat/gh-1445 merged with origin/develop (on top of #1536), plus the two orphan commits from `wip/orphan-1445-1788070090` (`9d653336` scope in-flight head guard, `12a93c57` use live PR freshness evidence) folded in via cherry-pick; that wip branch is deleted. The original dispatch run ended `missing_result` (no result artifact was emitted), which is why the fix landed through this manual handoff.

Commands run in a clean worktree (`FACTORY_EVENT_HOME=$(mktemp -d)`, FACTORY_ROOT/REPOS_ROOT/CONTROL_API_TOKEN unset):

| Check | Result |
| --- | --- |
| `bun test event-runtime/lib/registry.test.mjs event-runtime/merge.test.mjs event-runtime/lib/merge-reviews.test.mjs bin/worktree-checkout.test.mjs --timeout 60000` | 165 pass, 0 fail |
| `bun event-runtime/cli.mjs update-pins --check` | pins already current |
| `bun build/emit.mjs --check` | clean |
| `bun test event-runtime/lib --timeout 20000` | 2026 pass, 0 fail |
| `bun run format:check` | clean |
| `bun run check` | clean |

## Post-review
- Replaced the dead committer-email in-flight check: merge-fix now compares `expectedRemoteSha` to the pinned `input.json` `headSha`; on mismatch it consults `gh pr view <pr> --json headRefOid,updatedAt`, treats unknown freshness as in-flight, and never classifies the unchanged pinned head as `branch_in_flight`.
- The structured reason moved into a stable `summary` prefix (`branch_in_flight:` / `branch_moved:`) because the result artifact forbids extra properties.
- Reflowed the "After every rebase" bullet so the literal `changed-file-only prettier and eslint` sits on one line; `event-runtime/merge.test.mjs` asserts on it and was failing.
- Regenerated (not copied) the `merge-fix.md` pin in `merge-fix.json` via `update-pins` and the zero-pack registry digest baseline in `registry.test.mjs`, keeping #1536's removal of the bare-artifact examples.
