### PR TITLE
chore(web): type journey run attempts

### DIFF
--- a/event-runtime/web/src/subjectJourney.test.ts
+++ b/event-runtime/web/src/subjectJourney.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
   buildTicketJourney,
-  formatDuration,
+  formatDurationMs,
   parsePrRef,
   prNumbersIn,
   scanVerdictFor,
@@ -298,8 +298,8 @@ describe("buildTicketJourney concurrent rows", () => {
 
 describe("ticket journey helpers", () => {
   test("formats durations and ticket ids without guessing from prose", () => {
-    expect(formatDuration(3_720_000)).toBe("1h 2m");
-    expect(formatDuration(null)).toBe("—");
+    expect(formatDurationMs(3_720_000)).toBe("1h 2m");
+    expect(formatDurationMs(null)).toBe("—");
     expect(
       ticketIdsIn({ subject: "wm-542", payload: { ticket: "WM-544" } }),
     ).toEqual(["WM-542", "WM-544"]);

--- a/event-runtime/web/src/subjectJourney.ts
+++ b/event-runtime/web/src/subjectJourney.ts
@@ -8,6 +8,7 @@
 
 import { nextScheduledRetry, scheduledRetryLabel } from "./chainTimeline";
 import { REASONS, humanizeReason } from "./reasons";
+import type { Attempt } from "./types";
 
 export const TICKET_ID_PATTERN = /^[A-Z][A-Z0-9]{1,9}-\d+$/;
 
@@ -223,6 +224,8 @@ export interface JourneyRun {
     };
   };
   lifecycle: JourneyLifecycle[];
+  /** Attempts emitted by `runView`, ordered by ascending attempt number. */
+  attempts?: Array<Partial<Attempt>>;
   result: Record<string, any> | null;
   usage?: {
     totals?: { attempts?: number; totalTokens?: number; costUSD?: number };
@@ -502,7 +505,8 @@ function runDuration(run: JourneyRun): number | null {
   return window ? window.end - window.start : null;
 }
 
-export function formatDuration(ms: number | null): string {
+/** Formats a duration expressed in milliseconds. */
+export function formatDurationMs(ms: number | null): string {
   if (ms == null || !Number.isFinite(ms) || ms < 0) return "—";
   const seconds = Math.round(ms / 1000);
   if (seconds < 60) return `${seconds}s`;
@@ -1003,7 +1007,7 @@ export function subjectJourney(
       run.run.spec.agent,
       run.run.spec.adapter,
       model,
-      formatDuration(duration),
+      formatDurationMs(duration),
       attempts > 0 ? `$${Number(totals?.costUSD ?? 0).toFixed(2)}` : "—",
     ]
       .filter(Boolean)

--- a/event-runtime/web/src/views/Ticket.tsx
+++ b/event-runtime/web/src/views/Ticket.tsx
@@ -24,7 +24,7 @@ import {
 } from "../hooks";
 import {
   buildTicketJourney,
-  formatDuration,
+  formatDurationMs,
   parsePrRef,
   prHref,
   prNumbersIn,
@@ -65,10 +65,6 @@ import type {
   TicketSummary,
   Worker,
 } from "../types";
-
-type TicketRunWithAttempts = JourneyRun & {
-  attempts?: Array<{ started_at: string | null; lease_owner: string | null }>;
-};
 
 function Metric({ label, value }: { label: string; value: string }) {
   return (
@@ -168,7 +164,7 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
   return (
     <li className="flex items-start gap-3" data-kind={item.kind}>
       <div className="mono w-16 shrink-0 pt-0.5 text-right text-xs tabular-nums text-(--text-faint)">
-        {item.durationMs == null ? "" : `+${formatDuration(item.durationMs)}`}
+        {item.durationMs == null ? "" : `+${formatDurationMs(item.durationMs)}`}
       </div>
       {item.children?.length ? (
         <details className="min-w-0 flex-1" open>
@@ -184,7 +180,7 @@ function TimelineRow({ item, last }: { item: TimelineItem; last: boolean }) {
                 <span className="mono text-right tabular-nums text-(--text-faint)">
                   {child.durationMs == null
                     ? ""
-                    : `+${formatDuration(child.durationMs)}`}
+                    : `+${formatDurationMs(child.durationMs)}`}
                 </span>
                 <SourceLink item={child}>
                   <span className="inline-flex flex-wrap items-baseline gap-x-2">
@@ -855,7 +851,7 @@ function JourneyLayout({
   detail?: TicketTrackerDetail | null;
   detailPending?: boolean;
   detailError?: string | null;
-  currentRunDetail?: TicketRunWithAttempts | null;
+  currentRunDetail?: JourneyRun | null;
   currentWorker?: Worker | null;
 }) {
   const [tab, setTab] = useState<JourneyTab>("timeline");
@@ -971,7 +967,7 @@ function JourneyLayout({
             <Metric label="total cost" value={cost} />
             <Metric
               label="lead time"
-              value={formatDuration(journey.leadTimeMs)}
+              value={formatDurationMs(journey.leadTimeMs)}
             />
             <Metric label="runs" value={String(journey.runCount)} />
             {!isPr && (
@@ -1097,9 +1093,9 @@ function JourneyLayout({
                       <>
                         {journey.currentRun.runId}
                         {currentRunDetail?.attempts?.at(-1)?.started_at &&
-                          ` · elapsed ${formatDuration(now - Date.parse(currentRunDetail.attempts.at(-1)!.started_at!))}`}
+                          ` · elapsed ${formatDurationMs(now - Date.parse(currentRunDetail.attempts.at(-1)!.started_at!))}`}
                         {currentWorker &&
-                          ` · ${currentWorker.workerId} · ${currentWorker.stale ? `stale · ${formatDuration(now - Date.parse(currentWorker.lastSeen))}` : `heartbeat ${formatDuration(now - Date.parse(currentWorker.lastSeen))} ago`}`}
+                          ` · ${currentWorker.workerId} · ${currentWorker.stale ? `stale · ${formatDurationMs(now - Date.parse(currentWorker.lastSeen))}` : `heartbeat ${formatDurationMs(now - Date.parse(currentWorker.lastSeen))} ago`}`}
                         {!currentWorker &&
                           journey.currentRun.actor &&
                           ` · ${journey.currentRun.actor}`}
@@ -1283,9 +1279,9 @@ export function Ticket({
     detailQuery.data,
   );
   const currentRunDetail =
-    (query.data.runs.find(
+    query.data.runs.find(
       (run) => run.run.runId === journey.currentRun?.runId,
-    ) as TicketRunWithAttempts | undefined) ?? null;
+    ) ?? null;
   const workers = workersQuery.data?.workers ?? [];
   const leaseOwner = currentRunDetail?.attempts?.at(-1)?.lease_owner ?? null;
   const currentWorker =


### PR DESCRIPTION
Fixes watt-mind/factory#1519

Type journey run attempts from the emitted API shape and make millisecond duration formatting explicit.

## Validation

| Check                | Command                                                                                                   | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `cd event-runtime/web && bun test src/subjectJourney.test.ts src/views/Ticket.test.tsx src/views/RunFull.test.tsx && bunx tsc --noEmit` | pass    | 63 tests, 0 failures; TypeScript clean     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`       | pass    | 2019 tests, emit and formatting clean      |
| UX critique          | `factory-ux-critic`                                                                                       | not run | skipped: type-only refactor, no flow change |

UX critique: skipped — type-only refactor with no user-completable flow change

run:run_4f863e3b-4827-48bf-87f6-87809a1902e6
