### PR TITLE
fix(control-plane): file GitHub tickets without a team

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1843,9 +1843,15 @@ export function githubControlPlane(options = {}) {
       dedupeKey,
       matchTitle = false,
     } = {}) {
-      if (!team || !title)
-        throw new ControlPlaneError("file requires team and title");
-      const repo = repoForTeam(team);
+      if (!title) throw new ControlPlaneError("file requires title");
+      // GitHub tickets are repository-scoped rather than team-scoped. A
+      // configured default repository therefore supplies the destination for
+      // factory findings that have no Linear-style team key.
+      const repo = team ? repoForTeam(team) : defaultRepo;
+      if (!repo)
+        throw new ControlPlaneError(
+          "file requires team or a configured default repository",
+        );
       await requireLabelsExist(repo, labels);
       const key =
         typeof dedupeKey === "string" && dedupeKey.trim()

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1267,6 +1267,21 @@ describe("control-plane contract: github", () => {
     await expect(cp.file({ team: TEAM })).rejects.toThrow(ControlPlaneError);
   });
 
+  test("file uses the configured GitHub repository when team is omitted", async () => {
+    const { cp } = makePlane();
+    const created = await cp.file({
+      title: "default-repo finding",
+      labels: ["type:bug"],
+      state: "Todo",
+    });
+
+    expect(created.identifier).toBe(`${REPO}#4`);
+    const filed = await cp.getTicket(created.identifier);
+    expect(filed.title).toBe("default-repo finding");
+    expect(filed.state.name).toBe("Todo");
+    expect(filed.labels.map((label) => label.name)).toEqual(["type:bug"]);
+  });
+
   test("file preserves and reuses an issue when setting its status fails", async () => {
     const seed = contractSeed();
     const api = fakeApi(seed);
@@ -1433,9 +1448,13 @@ describe("control-plane contract: github", () => {
     expect(t.description.match(/## Verification/g)).toHaveLength(1);
   });
 
-  test("raw is the escape hatch; unknown queries throw", async () => {
+  test("raw is the escape hatch for GitHub GraphQL and rooted REST paths", async () => {
     const { cp } = makePlane();
     expect(await cp.raw(RAW_PING)).toEqual({ ping: true });
+    expect(await cp.raw(`/repos/${REPO}/issues/1`)).toMatchObject({
+      number: 1,
+      title: "ready ticket",
+    });
     await expect(cp.raw("query { nope }")).rejects.toThrow(ControlPlaneError);
   });
 });

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -76,7 +76,8 @@
 
 /**
  * @typedef {object} FileTicketOpts
- * @property {string} team
+ * @property {string} [team]  Required unless the selected control plane has a
+ *   configured default repository/team.
  * @property {string} title
  * @property {string} [body]
  * @property {string[]} [labels]
@@ -136,8 +137,9 @@
  * @property {(opts: FileTicketOpts) => Promise<{ identifier: string, url: string }>} file
  * @property {(identifier: string, markdown: string) => Promise<{ appended: boolean }>} appendDetail
  * @property {(query: string, variables?: object) => Promise<object>} raw
- *   Escape hatch: tracker-native query (Linear GraphQL). Grows only when a
- *   call site cannot be expressed with the verbs above.
+ *   Escape hatch: tracker-native query. Linear accepts GraphQL; GitHub accepts
+ *   GraphQL or a leading-slash REST path (with variables as query parameters).
+ *   Grows only when a call site cannot be expressed with the verbs above.
  */
 
 /** Thrown by every ControlPlane method when the tracker could not answer. */


### PR DESCRIPTION
Fixes watt-mind/factory#1507

Default GitHub filing now creates the requested project-state issue without a team.

## Validation

| Check                | Command                                                                        | Result  | Notes                    |
| -------------------- | ------------------------------------------------------------------------------ | ------- | ------------------------ |
| Verification Command | `bun test lib/control-plane/github.test.mjs --timeout 20000`                   | pass    | 116 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2019 pass, 10 skipped   |
| UX critique          | factory-ux-critic                                                              | not run | no user-facing surface  |

UX critique: skipped

run:run_614da172-d8ea-4ab8-ad0d-98000a265b32