### PR TITLE
fix(agents): wrap merge result artifacts

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:7ccfd603e4c39fe0349e7d4b3e4482ace2dbf3aee9270866451eb5bd650218e3",
+    "agents/merge-fix.md": "sha256:807ec05aa55816d61e510726cc911dfb31c13abe6655ca29729529256e624a65",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -17,14 +17,10 @@
     "services": ["tracker:write", "repo:write", "github:write"],
     "tools": ["Bash", "Read", "Write", "Edit", "Grep", "Glob"]
   },
-  "limits": {
-    "timeout_seconds": 2700,
-    "attempts": 1,
-    "budget_usd": 15
-  },
+  "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:c06dba00c6fa4d34fcb97a0adc0fedf3d7f87c94e4535c4acd7afab2427e7b9b",
+    "agents/merge-fix.md": "sha256:7ccfd603e4c39fe0349e7d4b3e4482ace2dbf3aee9270866451eb5bd650218e3",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -65,18 +65,44 @@ BLOCKED.
 
 ## Result contract
 
-Write `result.json` as a completed `factory.agent-result/v1` result whose
-`artifact` conforms to `factory.merge-fix-result/v1`. Both artifacts must
-contain exactly these properties, in this order: `outcome`, `repo`, `ticket`,
-`pr`, `headSha`, `round`, `summary`. Do not add diagnostic properties; put the
-reason or change description in `summary`.
+Write `result.json` as a completed `factory.agent-result/v1` wrapper. Put the
+`factory.merge-fix-result/v1` value under its `artifact` property: the
+registered output schema validates that nested artifact, not the wrapper.
+Both artifacts (the nested `artifact` values in the UPDATED and BLOCKED
+examples) must contain exactly these properties, in this order: `outcome`,
+`repo`, `ticket`, `pr`, `headSha`, `round`, `summary`. Do not put those fields
+beside `schemaVersion`, `terminalState`, or `reasonCode`, and do not add
+diagnostic artifact properties; put the reason or change description in
+`summary`.
 
 Copy `repo`, `ticket`, `pr`, and `round` from `input.json`. Substitute the real
 values for the representative values below.
 
-### UPDATED artifact
+### UPDATED result envelope
 
 Use the new commit SHA that was successfully pushed as `headSha`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "outcome": "UPDATED",
+    "repo": "factory",
+    "ticket": "WM-500",
+    "pr": 42,
+    "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+    "round": 1,
+    "summary": "Applied the mechanical correction, verified it, and pushed the updated head."
+  },
+  "evidence": {
+    "commands": []
+  }
+}
+```
+
+### UPDATED artifact
 
 ```json
 {
@@ -90,11 +116,33 @@ Use the new commit SHA that was successfully pushed as `headSha`:
 }
 ```
 
-### BLOCKED artifact
+### BLOCKED result envelope
 
 Use the pinned `input.json` `headSha` as the required `headSha`, including when
 the live PR head moved. Describe the observed mismatch or other blocking reason
 only in `summary`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "outcome": "BLOCKED",
+    "repo": "factory",
+    "ticket": "WM-500",
+    "pr": 42,
+    "headSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+    "round": 1,
+    "summary": "Blocked because the live PR head no longer matches the pinned input head."
+  },
+  "evidence": {
+    "commands": []
+  }
+}
+```
+
+### BLOCKED artifact
 
 ```json
 {

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -80,7 +80,8 @@ values for the representative values below.
 
 ### UPDATED result envelope
 
-Use the new commit SHA that was successfully pushed as `headSha`:
+Emit exactly this wrapper shape (never the bare `artifact` object). Use the new
+commit SHA that was successfully pushed as `artifact.headSha`:
 
 ```json
 {
@@ -102,25 +103,12 @@ Use the new commit SHA that was successfully pushed as `headSha`:
 }
 ```
 
-### UPDATED artifact
-
-```json
-{
-  "outcome": "UPDATED",
-  "repo": "factory",
-  "ticket": "WM-500",
-  "pr": 42,
-  "headSha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-  "round": 1,
-  "summary": "Applied the mechanical correction, verified it, and pushed the updated head."
-}
-```
-
 ### BLOCKED result envelope
 
-Use the pinned `input.json` `headSha` as the required `headSha`, including when
+Emit exactly this wrapper shape (never the bare `artifact` object). Use the
+pinned `input.json` `headSha` as the required `artifact.headSha`, including when
 the live PR head moved. Describe the observed mismatch or other blocking reason
-only in `summary`:
+only in `artifact.summary`:
 
 ```json
 {
@@ -139,19 +127,5 @@ only in `summary`:
   "evidence": {
     "commands": []
   }
-}
-```
-
-### BLOCKED artifact
-
-```json
-{
-  "outcome": "BLOCKED",
-  "repo": "factory",
-  "ticket": "WM-500",
-  "pr": 42,
-  "headSha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
-  "round": 1,
-  "summary": "Blocked because the live PR head no longer matches the pinned input head."
 }
 ```

--- a/event-runtime/agents/merge-notify.json
+++ b/event-runtime/agents/merge-notify.json
@@ -6,21 +6,15 @@
   "output_schema": "schemas/command-result.output.json",
   "output_contract": "factory.command-result/v1",
   "command": ["factory", "notify", "ESCALATED merge {repo}: {summary}"],
-  "workspace": {
-    "type": "ephemeral",
-    "retainOnFailure": true
-  },
+  "workspace": { "type": "ephemeral", "retainOnFailure": true },
   "capabilities": {
     "filesystem": "workspace-only",
     "services": ["notify:telegram"]
   },
-  "limits": {
-    "timeout_seconds": 60,
-    "attempts": 1
-  },
+  "limits": { "timeout_seconds": 60, "attempts": 1 },
   "mutating": true,
   "pins": {
-    "agents/merge-notify.md": "sha256:08c6b9c75db11728b3959b7f75e15d88f5d38d4dc39009b4c5ff77211011df17",
+    "agents/merge-notify.md": "sha256:90b186eb0ab0159721cd2dab45cea4d72ce400551b3cb6e233b8c377867968c9",
     "schemas/merge-notify.input.json": "sha256:cf759d06e47abd5e60335da8881358e82670b09f81e95a7df69e0d9216b30f26",
     "schemas/command-result.output.json": "sha256:f158c1c76dd848407237c45a12c521b5d8e103cefd6fafdfdd51070a2b7e2585"
   }

--- a/event-runtime/agents/merge-notify.md
+++ b/event-runtime/agents/merge-notify.md
@@ -12,3 +12,35 @@ Pushes the operator notification for an `ESCALATE` recommendation from
 matches `escalate_paths`) needs the human decision, per the notification
 protocol (escalations only, never routine progress). Same shape as
 `ci-notify@1` for `ci-doctor@2`'s TICKET verdict.
+
+## Result envelope
+
+The deterministic command adapter, not this command, writes the completed
+`factory.agent-result/v1` wrapper. Its `artifact` is the
+`factory.command-result/v1` value validated by this definition's registered
+output schema:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "command": [
+      "factory",
+      "notify",
+      "ESCALATED merge factory: PR needs a human decision"
+    ],
+    "exitCode": 0,
+    "outputTail": "Notification sent."
+  },
+  "evidence": {
+    "command": [
+      "factory",
+      "notify",
+      "ESCALATED merge factory: PR needs a human decision"
+    ],
+    "outputTail": "Notification sent."
+  }
+}
+```

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -25,7 +25,7 @@
     }
   ],
   "pins": {
-    "agents/merge-review.md": "sha256:6a3ce56bcee1af7422efcc04c14a58af983bc9cee1e7947843f6b8d50f23742c",
+    "agents/merge-review.md": "sha256:4c6c9608c5dd046fb1e4f93c4d6d9104034d17efd16da38baf5b8e2e0d5a2516",
     "schemas/merge-review.input.json": "sha256:d7051604031742a3b0e060f9fb1359aa5de3b3d42a80714f11492054e81a50f8",
     "schemas/merge-review.output.json": "sha256:efad4e30c1fed1978794630397819d71d78391381a6375edab704eaf5458b282"
   }

--- a/event-runtime/agents/merge-review.md
+++ b/event-runtime/agents/merge-review.md
@@ -157,7 +157,8 @@ head/base SHA, and exact head branch. A moved SHA requires a new review.
 
 `./result.json` must always be a `factory.agent-result/v1` wrapper. On a
 completed review, put the complete `factory.merge-review/v1` artifact under
-`artifact`, never at the wrapper root:
+`artifact`, never at the wrapper root; the registered output schema validates
+that nested artifact:
 
 ```json
 {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -204,8 +204,9 @@ describe("registry", () => {
       ["merge-notify@1", 1],
     ]);
 
+    const registry = loadRegistry();
     for (const [ref, expectedCount] of expectedCompletedExamples) {
-      const def = getAgent(loadRegistry(), ref);
+      const def = getAgent(registry, ref);
       const examples = [
         ...readFileSync(def.promptPath, "utf8").matchAll(
           /```json\n([\s\S]*?)\n```/g,
@@ -216,7 +217,7 @@ describe("registry", () => {
 
       expect(examples).toHaveLength(expectedCount);
       for (const example of examples) {
-        expect(validate(loadRegistry().schemas.agentResult, example)).toEqual({
+        expect(validate(registry.schemas.agentResult, example)).toEqual({
           valid: true,
           errors: [],
         });
@@ -341,9 +342,10 @@ describe("registry", () => {
     // contract, route, capability, or model tier changed.
     // Regenerated (#1521): merge-fix now documents the required outer result
     // wrapper; merge-review and merge-notify document the same artifact
-    // nesting, and all three agent definitions are re-pinned.
+    // nesting, and all three agent definitions are re-pinned. Post-review:
+    // merge-fix.md drops the bare-artifact twin examples (re-pinned again).
     const expected =
-      "sha256:20c93306632dc7ca3d92c6d03648e2ce441d03ffe791522f3c5365b9519822de";
+      "sha256:3da3fdd6554606b51aa8c8c907d0e84fae8e370e0f97c93c2d3234f75af1bdb3";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -30,6 +30,7 @@ import {
 } from "./registry.mjs";
 import { computeDefHash } from "./receipts.mjs";
 import { updateHarnessPins } from "./pins.mjs";
+import { validate } from "./schema.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
 function tempRegistry(root = tmpDir("event-registry-")) {
@@ -196,6 +197,37 @@ describe("registry", () => {
     );
   });
 
+  test("merge-agent documented result envelopes validate their registered artifact schemas", () => {
+    const expectedCompletedExamples = new Map([
+      ["merge-fix@1", 2],
+      ["merge-review@1", 1],
+      ["merge-notify@1", 1],
+    ]);
+
+    for (const [ref, expectedCount] of expectedCompletedExamples) {
+      const def = getAgent(loadRegistry(), ref);
+      const examples = [
+        ...readFileSync(def.promptPath, "utf8").matchAll(
+          /```json\n([\s\S]*?)\n```/g,
+        ),
+      ]
+        .map(([, source]) => JSON.parse(source))
+        .filter((example) => example.terminalState === "completed");
+
+      expect(examples).toHaveLength(expectedCount);
+      for (const example of examples) {
+        expect(validate(loadRegistry().schemas.agentResult, example)).toEqual({
+          valid: true,
+          errors: [],
+        });
+        expect(validate(def.outputSchema, example.artifact)).toEqual({
+          valid: true,
+          errors: [],
+        });
+      }
+    }
+  });
+
   test("zero-pack merged-view digest matches the develop baseline", () => {
     // Regenerate with registryDigest(loadRegistry({ packRoots: [] })) on develop.
     // The serializer omits only WM-470's new pack provenance and normalizes
@@ -307,8 +339,11 @@ describe("registry", () => {
     // the configured handoff gate includes Prettier after the unit and emit
     // checks; dispatch.json is re-pinned. Prompt text only — no schema,
     // contract, route, capability, or model tier changed.
+    // Regenerated (#1521): merge-fix now documents the required outer result
+    // wrapper; merge-review and merge-notify document the same artifact
+    // nesting, and all three agent definitions are re-pinned.
     const expected =
-      "sha256:9478df60d64bd504a50935c322760df759dc0055dd3b781f06a0a7165f1c6172";
+      "sha256:20c93306632dc7ca3d92c6d03648e2ce441d03ffe791522f3c5365b9519822de";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -388,12 +388,12 @@ function seedPlanPredecessor(db, runId = "parent-run") {
 }
 
 describe("merge-fix result contract (WM-447)", () => {
-  test("UPDATED and BLOCKED prompt artifacts exactly match the registered schema", () => {
+  test("UPDATED and BLOCKED prompt envelope artifacts exactly match the registered schema", () => {
     const def = registry.agents.get("merge-fix@1");
     const schema = def.outputSchema;
     const prompt = readFileSync(def.promptPath, "utf8");
     const declaration = prompt.match(
-      /Both artifacts must\s+contain exactly these properties, in this order:([\s\S]*?)\. Do not add/,
+      /Both artifacts[\s\S]*?must\s+contain exactly these properties, in this order:([\s\S]*?)\. Do not (?:put|add)/,
     );
 
     expect(declaration).not.toBeNull();
@@ -401,15 +401,19 @@ describe("merge-fix result contract (WM-447)", () => {
       [...declaration[1].matchAll(/`([^`]+)`/g)].map((match) => match[1]),
     ).toEqual(schema.required);
 
+    // #1521: the prompt documents only the wrapped result envelope — a bare
+    // artifact twin is exactly the shape that produced contract_violation.
+    expect(prompt).not.toMatch(/### (UPDATED|BLOCKED) artifact\n/);
     for (const outcome of ["UPDATED", "BLOCKED"]) {
       const example = prompt.match(
         new RegExp(
-          `### ${outcome} artifact[\\s\\S]*?` + "```json\\n([\\s\\S]*?)\\n```",
+          `### ${outcome} result envelope[\\s\\S]*?` +
+            "```json\\n([\\s\\S]*?)\\n```",
         ),
       );
 
       expect(example).not.toBeNull();
-      const artifact = JSON.parse(example[1]);
+      const { artifact } = JSON.parse(example[1]);
       expect(Object.keys(artifact)).toEqual(schema.required);
       expect(artifact.outcome).toBe(outcome);
       expect(validate(schema, artifact)).toEqual({ valid: true, errors: [] });
@@ -423,7 +427,7 @@ describe("merge-fix result contract (WM-447)", () => {
     );
 
     expect(prompt).toMatch(
-      /Use the pinned `input\.json` `headSha` as the required `headSha`, including when\s+the live PR head moved/,
+      /Use the\s+pinned `input\.json` `headSha` as the required `artifact\.headSha`, including when\s+the live PR head moved/,
     );
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1521

Merge agents now document their outer result wrapper and validate nested artifacts.

## Validation

| Check                | Command                                                                            | Result  | Notes                              |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/registry.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass    | 57 tests, generated outputs current |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2020 pass, 10 skipped              |
| UX critique          | factory-ux-critic                                                                  | not run | no user-facing surface             |

UX critique: skipped

run:run_d54689a7-056c-47fd-b240-5d855f87df36

## Post-review

- Reviewer verdict FIX: removed the standalone `### UPDATED artifact` / `### BLOCKED artifact` bare-JSON examples from `event-runtime/agents/merge-fix.md` (they were the exact shape behind the `contract_violation`); the headSha guidance now lives in the result-envelope sections only. `merge-fix.json` re-pinned, zero-pack digest baseline refreshed, single `loadRegistry()` hoisted in the envelope test.
- AC 3 (a live merge-fix run emitting a validated wrapped envelope) is to be observed post-merge on the next real merge-fix dispatch.
- Out-of-scope touch (required by the fix): `event-runtime/merge.test.mjs` WM-447 contract test now reads the artifact from the envelope examples and asserts no bare twin heading remains; its declaration regex also had to follow the sentence this PR reworded.
