### PR TITLE
fix(web): preserve artifact reader return context (#1446)

### DIFF
--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -20,6 +20,7 @@ import {
   type OperatorContext,
 } from "./context";
 import {
+  artifactFullHash,
   artifactsHash,
   eventsHash,
   hashPath,
@@ -277,8 +278,8 @@ export function App() {
     navigate(hashPath("runs", runId));
   };
   const openRunFull = (runId: string) => navigate(hashPath("run", runId));
-  const openArtifactFull = (digest: string) =>
-    navigate(hashPath("artifact", digest));
+  const openArtifactFull = (digest: string, backHash?: string) =>
+    navigate(artifactFullHash(digest, backHash));
   const jumpToTicket = (ticketId: string) =>
     navigate(hashPath("tickets", ticketId));
   const jumpToPr = (number: number) =>

--- a/event-runtime/web/src/hash.test.ts
+++ b/event-runtime/web/src/hash.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import type { HashWriteScheduler } from "./hash";
 import {
+  artifactFullHash,
   createHashWriter,
   eventsHash,
   flushHash,
@@ -128,6 +129,26 @@ describe("eventsHash", () => {
     );
     expect(eventsHash("web", "evt_1", "factory.ticket.ready")).toBe(
       "events/web/evt_1?type=factory.ticket.ready",
+    );
+  });
+});
+
+describe("artifactFullHash", () => {
+  test("carries the filtered inspector as the full reader's return target", () => {
+    const digest = "a".repeat(64);
+    expect(
+      artifactFullHash(
+        digest,
+        `#/artifacts/${digest}?kind=transcript&search=f99e8b&project=factory`,
+      ),
+    ).toBe(
+      `artifact/${digest}?back=artifacts%2F${digest}%3Fkind%3Dtranscript%26search%3Df99e8b%26project%3Dfactory`,
+    );
+  });
+
+  test("does not add a return target outside the catalogue", () => {
+    expect(artifactFullHash("a".repeat(64), "#/runs/run_1")).toBe(
+      `artifact/${"a".repeat(64)}`,
     );
   });
 });

--- a/event-runtime/web/src/hash.ts
+++ b/event-runtime/web/src/hash.ts
@@ -208,6 +208,18 @@ export function artifactsHash(
   return qs ? `artifacts?${qs}` : "artifacts";
 }
 
+/**
+ * Full-page artifact reader hash with an optional, URL-backed catalogue return
+ * target. Keep the source path explicit: the reader must not infer filters
+ * from shell state when returning to the inspector.
+ */
+export function artifactFullHash(digest: string, backHash?: string): string {
+  const path = hashPath("artifact", digest);
+  if (!backHash || hashView(backHash) !== "artifacts") return path;
+  const back = backHash.replace(/^#\/?/, "");
+  return `${path}?back=${encodeURIComponent(back)}`;
+}
+
 /** `?project=` on the hash — the context strip's active filter, not the view. */
 export function hashProject(hash: string): string | null {
   return hashSearch(hash).get("project");

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -929,6 +929,32 @@ describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", ()
     fireEvent.click(openBtns[0]);
     expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A, `#/artifacts/${SHA_A}`);
   });
+
+  test("passes filtered catalogue context when opening the full-page reader", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/api/artifacts") || u.includes("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: ITEMS }), {
+          status: 200,
+        });
+      }
+      return new Response("line one\nline two", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts();
+    await view.findByRole("region", { name: "Artifact content" });
+
+    const query = "kind=transcript&search=f99e8b&project=demo";
+    window.location.hash = `#/artifacts/${SHA_A}?${query}`;
+    fireEvent.click(
+      view.getAllByRole("button", { name: "Open in full page" })[0]!,
+    );
+    expect(view.onOpenFull).toHaveBeenCalledWith(
+      SHA_A,
+      `#/artifacts/${SHA_A}?${query}`,
+    );
+  });
 });
 
 describe("Artifacts list row height (WM-843)", () => {

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -904,7 +904,7 @@ describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", ()
     await view.findByRole("region", { name: "Artifact content" });
 
     fireEvent.keyDown(document.body, { key: "o" });
-    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A);
+    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A, `#/artifacts/${SHA_A}`);
   });
 
   test("detail pane includes Open in full page action with 'o' shortcut hint", async () => {
@@ -927,7 +927,7 @@ describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", ()
     expect(openBtns[0].getAttribute("title")).toBe("Open in full page (o)");
 
     fireEvent.click(openBtns[0]);
-    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A);
+    expect(view.onOpenFull).toHaveBeenCalledWith(SHA_A, `#/artifacts/${SHA_A}`);
   });
 });
 

--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -21,6 +21,7 @@ import {
 } from "./Artifacts";
 import { ARTIFACT_RAW_KEY } from "../components/ArtifactView";
 import { handleRunArtifactClick } from "./Runs";
+import { createHashWriter, setActiveHashWriter } from "../hash";
 
 const originalFetch = globalThis.fetch;
 const originalClipboard = navigator.clipboard;
@@ -87,7 +88,9 @@ function renderArtifacts(
     nextBefore?: string | null;
     formatContent?: typeof formattedContent;
   } = {},
-  onOpenFull = mock(() => {}),
+  onOpenFull: ((sha256: string, backHash?: string) => void) | null = mock(
+    () => {},
+  ),
 ) {
   const client = new QueryClient({
     defaultOptions: {
@@ -149,7 +152,7 @@ function renderArtifacts(
           filters={filters}
           onFiltersChange={setFilters}
           onJumpRun={onJumpRun}
-          onOpenFull={onOpenFull}
+          onOpenFull={onOpenFull ?? undefined}
           formatContent={seed.formatContent}
         />
       </QueryClientProvider>
@@ -953,6 +956,74 @@ describe("Full-page artifact reader view navigation & 'o' shortcut (WM-828)", ()
     expect(view.onOpenFull).toHaveBeenCalledWith(
       SHA_A,
       `#/artifacts/${SHA_A}?${query}`,
+    );
+  });
+
+  test("flushes a buffered filter change before capturing the return context", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/api/artifacts") || u.includes("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: ITEMS }), {
+          status: 200,
+        });
+      }
+      return new Response("line one\nline two", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    // Stand in for App's coalescing writer: the first write lands, the second
+    // (inside the interval) stays buffered, so the URL trails the filters.
+    let now = 1_000;
+    const writer = createHashWriter(
+      (hash) => {
+        window.location.hash = hash;
+      },
+      { now: () => now, after: () => () => {} },
+    );
+    setActiveHashWriter(writer);
+    try {
+      writer.replace(`#/artifacts/${SHA_A}?kind=report`);
+      const view = renderArtifacts();
+      await view.findByRole("region", { name: "Artifact content" });
+
+      now += 100;
+      const query = "kind=transcript&search=f99e8b&project=demo";
+      writer.replace(`#/artifacts/${SHA_A}?${query}`);
+      expect(window.location.hash).toBe(`#/artifacts/${SHA_A}?kind=report`);
+
+      fireEvent.click(
+        view.getAllByRole("button", { name: "Open in full page" })[0]!,
+      );
+      expect(view.onOpenFull).toHaveBeenCalledWith(
+        SHA_A,
+        `#/artifacts/${SHA_A}?${query}`,
+      );
+    } finally {
+      setActiveHashWriter(null);
+    }
+  });
+
+  test("fallback reader route keeps ?project= alongside back=", async () => {
+    globalThis.fetch = mock(async (url: string | URL | Request) => {
+      const u = String(url);
+      if (u.endsWith("/api/artifacts") || u.includes("/api/artifacts?")) {
+        return new Response(JSON.stringify({ artifacts: ITEMS }), {
+          status: 200,
+        });
+      }
+      return new Response("line one\nline two", { status: 200 });
+    }) as unknown as typeof fetch;
+
+    window.location.hash = `#/artifacts/${SHA_A}`;
+    const view = renderArtifacts(undefined, undefined, {}, null);
+    await view.findByRole("region", { name: "Artifact content" });
+
+    const back = `artifacts/${SHA_A}?kind=transcript&project=demo`;
+    window.location.hash = `#/${back}`;
+    fireEvent.click(
+      view.getAllByRole("button", { name: "Open in full page" })[0]!,
+    );
+    expect(window.location.hash).toBe(
+      `#/artifact/${SHA_A}?back=${encodeURIComponent(back)}&project=demo`,
     );
   });
 });

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -32,7 +32,7 @@ import {
   type DisplayConfig,
 } from "../displayOptions";
 import { EMPTY, formatBytes, formatRelative } from "../format";
-import { hashSearch } from "../hash";
+import { artifactFullHash, hashSearch } from "../hash";
 import {
   refetchIntervals,
   useDisplayOptions,
@@ -276,7 +276,7 @@ export function Artifacts({
   filters: ArtifactFilters;
   onFiltersChange: (filters: ArtifactFilters) => void;
   onJumpRun: (runId: string) => void;
-  onOpenFull?: (digest: string) => void;
+  onOpenFull?: (digest: string, backHash?: string) => void;
   /** Injectable formatter keeps the expensive preview derivation testable. */
   formatContent?: typeof formattedContent;
 }) {
@@ -473,11 +473,12 @@ export function Artifacts({
   const openFull = useCallback(
     (sha256: string) => {
       if (onOpenFull) {
-        onOpenFull(sha256);
+        onOpenFull(sha256, window.location.hash);
       } else {
-        window.location.hash = withCurrentArtifactQuery(
-          `artifact/${encodeURIComponent(sha256)}`,
-        );
+        window.location.hash = `#/${artifactFullHash(
+          sha256,
+          window.location.hash,
+        )}`;
       }
     },
     [onOpenFull],

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -32,7 +32,13 @@ import {
   type DisplayConfig,
 } from "../displayOptions";
 import { EMPTY, formatBytes, formatRelative } from "../format";
-import { artifactFullHash, hashSearch } from "../hash";
+import {
+  artifactFullHash,
+  flushHash,
+  hashProject,
+  hashSearch,
+  withProject,
+} from "../hash";
 import {
   refetchIntervals,
   useDisplayOptions,
@@ -472,12 +478,18 @@ export function Artifacts({
 
   const openFull = useCallback(
     (sha256: string) => {
+      // App-level hash writes are coalesced (HASH_WRITE_INTERVAL_MS), so a
+      // filter change made just before opening the reader may not have
+      // reached the URL yet. Land it first, or `back=` carries the stale
+      // catalogue — the very bug the return context exists to fix.
+      flushHash();
+      const backHash = window.location.hash;
       if (onOpenFull) {
-        onOpenFull(sha256, window.location.hash);
+        onOpenFull(sha256, backHash);
       } else {
-        window.location.hash = `#/${artifactFullHash(
-          sha256,
-          window.location.hash,
+        window.location.hash = `#/${withProject(
+          artifactFullHash(sha256, backHash),
+          hashProject(backHash),
         )}`;
       }
     },

--- a/event-runtime/web/src/views/registry.test.ts
+++ b/event-runtime/web/src/views/registry.test.ts
@@ -5,6 +5,7 @@ import {
   NAV as REGISTRY_NAV,
   RESERVED_GO_SUFFIXES,
   VIEWS,
+  artifactBackPath,
   findView,
   navIsCurrent,
   resolveView,
@@ -12,6 +13,16 @@ import {
 } from "./registry";
 
 describe("view registry (WM-839)", () => {
+  test("artifact reader returns to its explicit catalogue context or the plain fallback", () => {
+    const digest = "a".repeat(64);
+    expect(
+      artifactBackPath(
+        `#/artifact/${digest}?back=artifacts%2F${digest}%3Fkind%3Dtranscript%26search%3Df99e8b%26project%3Dfactory`,
+      ),
+    ).toBe(`artifacts/${digest}?kind=transcript&search=f99e8b&project=factory`);
+    expect(artifactBackPath(`#/artifact/${digest}`)).toBe("artifacts");
+  });
+
   test("every view has a unique key", () => {
     const keys = VIEWS.map((v) => v.key);
     expect(new Set(keys).size).toBe(keys.length);

--- a/event-runtime/web/src/views/registry.ts
+++ b/event-runtime/web/src/views/registry.ts
@@ -19,7 +19,13 @@
  */
 import { createElement, lazy, type ComponentType } from "react";
 import type { OperatorContext } from "../context";
-import { artifactsHash, eventsHash, hashPath, hashSearch } from "../hash";
+import {
+  artifactsHash,
+  eventsHash,
+  hashPath,
+  hashSearch,
+  hashView,
+} from "../hash";
 import type { EventFocus, StatusView } from "../types";
 import type { ArtifactFilters } from "./Artifacts";
 import { Events } from "./Events";
@@ -58,7 +64,7 @@ export type Shell = {
     run: (runId: string) => void;
     runFull: (runId: string) => void;
     runs: (state?: string) => void;
-    artifactFull: (digest: string) => void;
+    artifactFull: (digest: string, backHash?: string) => void;
     ticket: (ticketId: string) => void;
     pr: (number: number) => void;
     proposal: (id: string) => void;
@@ -180,6 +186,12 @@ export const workerHash = (
   const path = hashPath("workers", id);
   return health ? `${path}?health=${encodeURIComponent(health)}` : path;
 };
+
+/** The full reader accepts only catalogue return paths; direct links fall back. */
+export function artifactBackPath(hash: string): string {
+  const back = hashSearch(hash).get("back");
+  return back && hashView(back) === "artifacts" ? back : "artifacts";
+}
 
 // First-paint views (entry chunk, no Suspense flash on the operator's landing).
 const OverviewView = adapt(Overview, ({ navigate, shell }) => ({
@@ -596,9 +608,9 @@ const DEFS = [
     load: load(
       () => import("./ArtifactFull"),
       "ArtifactFull",
-      ({ params, navigate, shell }) => ({
+      ({ params, hash, navigate, shell }) => ({
         digest: params[0]!,
-        onBack: () => navigate("artifacts"),
+        onBack: () => navigate(artifactBackPath(hash)),
         onJumpRun: shell.jump.run,
       }),
     ),


### PR DESCRIPTION
Fixes watt-mind/factory#1446

## Summary

The full-page artifact reader (`#/artifact/:digest`) now carries its originating catalogue hash as a `back=` query key, so the visible **← Artifacts** button and the Esc shortcut return to the same filtered catalogue (`kind` / `orphan` / `search`) with the same artifact selected in the inspector — matching what native browser Back already did.

- `hash.ts`: new `artifactFullHash(digest, backHash?)` builds `artifact/<digest>?back=<encoded catalogue hash>`; only `artifacts` hashes are accepted as a return target.
- `registry.ts`: new `artifactBackPath(hash)` reads `back=` off the reader route and falls back to plain `artifacts` for direct links; the `artifact` view's `onBack` uses it instead of a constant path. The reader never reads catalogue filters from shell state.
- `Artifacts.tsx` / `App.tsx`: `openFull` / `openArtifactFull` pass the current catalogue hash through `onOpenFull(digest, backHash)`.
- `?project=` is preserved by the existing `navigate → withProject` wrapper (set, not appended), so it is neither dropped nor duplicated across the round trip.
- Tests: `registry.test.ts` covers the back target with and without originating context; `hash.test.ts` covers `artifactFullHash`; `Artifacts.test.tsx` covers opening the reader from a filtered catalogue (`kind=transcript&search=f99e8b&project=demo`) and the plain case.

## Handoff

Verified in a fresh worktree on this branch merged with current `origin/develop` (`FACTORY_EVENT_HOME` pointed at an empty temp dir; `FACTORY_ROOT` / `FACTORY_REPOS_ROOT` / `FACTORY_CONTROL_API_TOKEN` unset).

| Check | Command | Result |
| --- | --- | --- |
| Web types | `cd event-runtime/web && bun x tsc --noEmit` | pass |
| Ticket verification | `cd event-runtime/web && bun test src/views/registry.test.ts src/views/ArtifactFull.test.tsx src/views/Artifacts.test.tsx src/hash.test.ts` | 80 pass / 0 fail |
| Runtime lib | `bun test event-runtime/lib --timeout 20000` | 2031 tests, 0 fail (10 skip) |
| Emit | `bun build/emit.mjs --check` | pass (94 generated files match) |
| Format | `bun run format:check` | pass |
| Repo check | `bun run check` | pass |

Notes:
- The dispatch run's handoff failed only because its sandbox has no `bunx` binary (the Verification Command's tests had already passed 80/0 before `bunx: command not found`). The ticket's own command uses `bun x`, which is what was run here; no code change was required.
- UX critique: skipped — operator-internal web change, covered by the unit-level round-trip tests above.
- Diff stays inside the ticket's Owned Paths (`event-runtime/web/src/{App.tsx,hash.ts,hash.test.ts,views/Artifacts.tsx,views/Artifacts.test.tsx,views/registry.ts,views/registry.test.ts}`).


## Post-review

- `openFull` in `Artifacts.tsx` read `window.location.hash` directly, but App-level hash writes are coalesced by `HashWriter` (`HASH_WRITE_INTERVAL_MS = 500`), so a filter change followed quickly by opening the reader captured the pre-change catalogue in `back=`. It now calls `flushHash()` first (same pattern as `copyLink`). New test: buffered filter change + open within the interval asserts `back=` carries the new filters.
- The no-`onOpenFull` fallback now keeps `?project=` on the reader route via `withProject`, matching App's `navigate`; covered by a test.
- Re-verified: `bun x tsc --noEmit`, the four web test files (82 pass), `bun test event-runtime/lib` (2019 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
