### PR TITLE
fix(outbox): expose parked delivery failures

### DIFF
--- a/docs/event-runtime-outbox.md
+++ b/docs/event-runtime-outbox.md
@@ -7,7 +7,8 @@ are delivered after that transaction commits. Successful rows are stamped with
 Malformed event JSON is deterministic poison: it is parked on its first
 delivery attempt. Sink failures are treated as transient: retries wait at least
 five seconds and then use exponential backoff before the configured attempt
-limit parks the row. A parked row has both `published_at` and `delivery_error`
+limit parks the row. Delivery is in order, so a backed-off head row delays
+every subsequent row until it is delivered or parked. A parked row has both `published_at` and `delivery_error`
 set. Its error remains available through `GET /outbox` and it is excluded from
 the published-row retention sweep for forensic review.
 

--- a/docs/event-runtime-outbox.md
+++ b/docs/event-runtime-outbox.md
@@ -12,5 +12,7 @@ set. Its error remains available through `GET /outbox` and it is excluded from
 the published-row retention sweep for forensic review.
 
 `GET /outbox` exposes `deliveryAttempts`, `deliveryError`, and `parked` for
-each row. The status view reports both `unpublishedOutbox` and `parkedOutbox`
-so delayed deliveries and terminal delivery failures remain distinguishable.
+each row; a malformed event is returned as `{ "raw": "..." }` so one poison
+row cannot hide the rest of the feed. The status view reports both
+`unpublishedOutbox` and `parkedOutbox` so delayed deliveries and terminal
+delivery failures remain distinguishable.

--- a/docs/event-runtime-outbox.md
+++ b/docs/event-runtime-outbox.md
@@ -1,0 +1,16 @@
+# Outbox delivery
+
+Result events enter the outbox in the transaction that accepts the result and
+are delivered after that transaction commits. Successful rows are stamped with
+`published_at` and are eligible for retention sweeping after 14 days.
+
+Malformed event JSON is deterministic poison: it is parked on its first
+delivery attempt. Sink failures are treated as transient: retries wait at least
+five seconds and then use exponential backoff before the configured attempt
+limit parks the row. A parked row has both `published_at` and `delivery_error`
+set. Its error remains available through `GET /outbox` and it is excluded from
+the published-row retention sweep for forensic review.
+
+`GET /outbox` exposes `deliveryAttempts`, `deliveryError`, and `parked` for
+each row. The status view reports both `unpublishedOutbox` and `parkedOutbox`
+so delayed deliveries and terminal delivery failures remain distinguishable.

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -3,6 +3,7 @@ import { ControlPlaneError } from "../../lib/control-plane/types.mjs";
 import { artifactHead } from "./api-artifacts.mjs";
 import { DEFAULT_MAX_IN_FLIGHT, FACTORY_ROOT } from "./config.mjs";
 import { STALE_SCAN_MS, loadLinearSupply } from "./linear.mjs";
+import { deliveryErrorMessage } from "./outbox.mjs";
 import { loadRepos, RepoError } from "./repos.mjs";
 import { isBusyError, retryBusy, runUsage } from "./db.mjs";
 import { hookDecisionsFor } from "./hooks.mjs";
@@ -1715,7 +1716,8 @@ function journalView(db, since, limit) {
 function outboxView(db, limit) {
   return db
     .query(
-      `SELECT seq, event_json, created_at, published_at FROM outbox ORDER BY seq DESC LIMIT ?`,
+      `SELECT seq, event_json, created_at, published_at, delivery_attempts, delivery_error
+       FROM outbox ORDER BY seq DESC LIMIT ?`,
     )
     .all(limit)
     .map((row) => ({
@@ -1723,6 +1725,9 @@ function outboxView(db, limit) {
       event: JSON.parse(row.event_json),
       created_at: row.created_at,
       published_at: row.published_at,
+      deliveryAttempts: row.delivery_attempts,
+      deliveryError: deliveryErrorMessage(row.delivery_error),
+      parked: row.published_at !== null && row.delivery_error !== null,
     }));
 }
 

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1720,15 +1720,25 @@ function outboxView(db, limit) {
        FROM outbox ORDER BY seq DESC LIMIT ?`,
     )
     .all(limit)
-    .map((row) => ({
-      seq: row.seq,
-      event: JSON.parse(row.event_json),
-      created_at: row.created_at,
-      published_at: row.published_at,
-      deliveryAttempts: row.delivery_attempts,
-      deliveryError: deliveryErrorMessage(row.delivery_error),
-      parked: row.published_at !== null && row.delivery_error !== null,
-    }));
+    .map((row) => {
+      let event;
+      try {
+        event = JSON.parse(row.event_json);
+      } catch {
+        // Parse-poison rows are intentionally retained for inspection. Keep
+        // one malformed row from making the entire outbox endpoint fail.
+        event = { raw: row.event_json };
+      }
+      return {
+        seq: row.seq,
+        event,
+        created_at: row.created_at,
+        published_at: row.published_at,
+        deliveryAttempts: row.delivery_attempts,
+        deliveryError: deliveryErrorMessage(row.delivery_error),
+        parked: row.published_at !== null && row.delivery_error !== null,
+      };
+    });
 }
 
 export function observedModelFromTranscript(head) {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1597,6 +1597,18 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         deliveryError: "sink unavailable",
         parked: true,
       });
+
+      db.query(
+        `UPDATE outbox
+         SET event_json = ?, delivery_attempts = 1, delivery_error = ?
+         WHERE seq = ?`,
+      ).run("not JSON", "Unexpected token", outbox[0].seq);
+      expect((await client.outbox()).outbox[0]).toMatchObject({
+        event: { raw: "not JSON" },
+        deliveryAttempts: 1,
+        deliveryError: "Unexpected token",
+        parked: true,
+      });
     } finally {
       server.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1547,7 +1547,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
     }
   });
 
-  test("journal feed pages by seq and outbox lists published result events", async () => {
+  test("journal feed pages by seq and outbox exposes delivery state", async () => {
     const { db, server, port } = await makeServer();
     const client = apiClient({ port });
     try {
@@ -1580,6 +1580,23 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
       expect(outbox).toHaveLength(1);
       expect(outbox[0].event.type).toBe("factory.status-report.completed");
       expect(outbox[0].published_at).toBeNull(); // no serve loop in this test — sink not run
+      expect(outbox[0]).toMatchObject({
+        deliveryAttempts: 0,
+        deliveryError: null,
+        parked: false,
+      });
+
+      db.query(
+        `UPDATE outbox
+         SET delivery_attempts = 3, delivery_error = ?, published_at = ?
+         WHERE seq = ?`,
+      ).run("sink unavailable", new Date().toISOString(), outbox[0].seq);
+      const parked = (await client.outbox()).outbox[0];
+      expect(parked).toMatchObject({
+        deliveryAttempts: 3,
+        deliveryError: "sink unavailable",
+        parked: true,
+      });
     } finally {
       server.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1586,6 +1586,22 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         parked: false,
       });
 
+      // Real transient shape written by transientFailure(): a JSON envelope
+      // with the message and the retry deadline, and published_at still null.
+      db.query(
+        `UPDATE outbox
+         SET delivery_attempts = 1, delivery_error = ?, published_at = NULL
+         WHERE seq = ?`,
+      ).run(
+        JSON.stringify({ message: "sink down", retryAt: Date.now() + 5000 }),
+        outbox[0].seq,
+      );
+      expect((await client.outbox()).outbox[0]).toMatchObject({
+        deliveryAttempts: 1,
+        deliveryError: "sink down",
+        parked: false,
+      });
+
       db.query(
         `UPDATE outbox
          SET delivery_attempts = 3, delivery_error = ?, published_at = ?

--- a/event-runtime/lib/outbox.mjs
+++ b/event-runtime/lib/outbox.mjs
@@ -29,7 +29,7 @@ function retryAtFromFailure(deliveryError) {
 }
 
 export function deliveryErrorMessage(deliveryError) {
-  if (deliveryError === null) return null;
+  if (deliveryError == null) return null;
   try {
     const failure = JSON.parse(deliveryError);
     return typeof failure?.message === "string"

--- a/event-runtime/lib/outbox.mjs
+++ b/event-runtime/lib/outbox.mjs
@@ -12,7 +12,33 @@ import { tx } from "./db.mjs";
 export const DEFAULT_OUTBOX_RETENTION_DAYS = 14;
 export const DEFAULT_OUTBOX_BATCH_SIZE = 500;
 export const DEFAULT_OUTBOX_MAX_ATTEMPTS = 3;
+export const DEFAULT_OUTBOX_RETRY_BASE_MS = 5_000;
 const DAY_MS = 24 * 60 * 60 * 1000;
+
+function transientFailure(message, retryAt) {
+  return JSON.stringify({ message, retryAt });
+}
+
+function retryAtFromFailure(deliveryError) {
+  try {
+    const failure = JSON.parse(deliveryError);
+    return Number.isFinite(failure?.retryAt) ? failure.retryAt : null;
+  } catch {
+    return null;
+  }
+}
+
+export function deliveryErrorMessage(deliveryError) {
+  if (deliveryError === null) return null;
+  try {
+    const failure = JSON.parse(deliveryError);
+    return typeof failure?.message === "string"
+      ? failure.message
+      : deliveryError;
+  } catch {
+    return deliveryError;
+  }
+}
 
 /** Delete published rows older than the configured retention window. */
 export function sweepPublishedOutbox(
@@ -29,7 +55,9 @@ export function sweepPublishedOutbox(
       db
         .query(
           `DELETE FROM outbox
-           WHERE published_at IS NOT NULL AND published_at < ?`,
+           WHERE published_at IS NOT NULL
+             AND delivery_error IS NULL
+             AND published_at < ?`,
         )
         .run(cutoff).changes,
   );
@@ -38,13 +66,15 @@ export function sweepPublishedOutbox(
 /**
  * Deliver one bounded batch of unpublished outbox events to
  * `sink(envelope, row)` in insertion order. Each successful delivery is
- * stamped. Failures retry in order until `maxAttempts`; the final failure is
- * parked, logged, and allows the following row to proceed.
+ * stamped. Invalid JSON is deterministic poison and parks immediately. Sink
+ * failures retry in order with exponential backoff until `maxAttempts`; the
+ * final failure is parked, logged, and allows the following row to proceed.
  *
- * Published rows are pruned only after delivery, retaining a configurable
- * bounded window. Unpublished rows are never eligible for pruning.
+ * Delivered rows without a delivery error are pruned after a configurable
+ * bounded window. Unpublished and parked rows are never eligible for pruning.
  *
- * @returns {{ delivered: number, remaining: number }} rows delivered and still pending
+ * @returns {{ delivered: number, remaining: number }} delivered rows and every
+ * unpublished row still pending, including rows delayed by retry backoff
  */
 export function publishOutbox(
   db,
@@ -54,6 +84,7 @@ export function publishOutbox(
     retentionDays = DEFAULT_OUTBOX_RETENTION_DAYS,
     batchSize = DEFAULT_OUTBOX_BATCH_SIZE,
     maxAttempts = DEFAULT_OUTBOX_MAX_ATTEMPTS,
+    retryBaseMs = DEFAULT_OUTBOX_RETRY_BASE_MS,
     log = () => {},
   } = {},
 ) {
@@ -63,10 +94,18 @@ export function publishOutbox(
   if (!Number.isInteger(maxAttempts) || maxAttempts <= 0) {
     throw new Error("maxAttempts must be a positive integer");
   }
+  if (
+    !Number.isFinite(retryBaseMs) ||
+    retryBaseMs < DEFAULT_OUTBOX_RETRY_BASE_MS
+  ) {
+    throw new Error(
+      `retryBaseMs must be at least ${DEFAULT_OUTBOX_RETRY_BASE_MS} milliseconds`,
+    );
+  }
 
   const rows = db
     .query(
-      `SELECT seq, event_json, delivery_attempts
+      `SELECT seq, event_json, delivery_attempts, delivery_error
        FROM outbox
        WHERE published_at IS NULL
        ORDER BY seq
@@ -75,8 +114,32 @@ export function publishOutbox(
     .all(batchSize);
   let delivered = 0;
   for (const row of rows) {
+    const retryAt = retryAtFromFailure(row.delivery_error);
+    if (retryAt !== null && retryAt > now) break;
+
+    let envelope;
     try {
-      sink(JSON.parse(row.event_json), row);
+      envelope = JSON.parse(row.event_json);
+    } catch (error) {
+      const message = String(error?.message ?? error);
+      tx(db, () => {
+        db.query(
+          `UPDATE outbox
+           SET delivery_attempts = ?, delivery_error = ?, published_at = ?
+           WHERE seq = ?`,
+        ).run(
+          row.delivery_attempts + 1,
+          message,
+          new Date(now).toISOString(),
+          row.seq,
+        );
+      });
+      log(`outbox poison seq=${row.seq}: ${message}`);
+      continue;
+    }
+
+    try {
+      sink(envelope, row);
       tx(db, () => {
         db.query(
           `UPDATE outbox
@@ -98,7 +161,12 @@ export function publishOutbox(
            WHERE seq = ?`,
         ).run(
           attempts,
-          message,
+          parked
+            ? message
+            : transientFailure(
+                message,
+                now + retryBaseMs * 2 ** (attempts - 1),
+              ),
           parked ? 1 : 0,
           new Date(now).toISOString(),
           row.seq,

--- a/event-runtime/lib/outbox.test.mjs
+++ b/event-runtime/lib/outbox.test.mjs
@@ -32,7 +32,7 @@ describe("publishOutbox", () => {
     expect(seen).toEqual(["a", "b"]);
   });
 
-  test("parks a poisoned row and delivers its successor", () => {
+  test("parks a parse-poisoned row on its first failure and delivers its successor", () => {
     const db = openDb(":memory:");
     db.query(`INSERT INTO outbox (event_json, created_at) VALUES (?, ?)`).run(
       "not JSON",
@@ -40,34 +40,11 @@ describe("publishOutbox", () => {
     );
     seedOutbox(db, "successor");
     const logs = [];
-
-    expect(
-      publishOutbox(db, {
-        sink: () => {
-          throw new Error("should not receive malformed event");
-        },
-        maxAttempts: 2,
-        log: (line) => logs.push(line),
-      }),
-    ).toEqual({ delivered: 0, remaining: 2 });
-    expect(
-      db
-        .query(
-          `SELECT delivery_attempts, delivery_error, published_at
-           FROM outbox WHERE seq = 1`,
-        )
-        .get(),
-    ).toEqual({
-      delivery_attempts: 1,
-      delivery_error: expect.stringContaining("JSON"),
-      published_at: null,
-    });
-
     const seen = [];
+
     expect(
       publishOutbox(db, {
         sink: (event) => seen.push(event.eventId),
-        maxAttempts: 2,
         log: (line) => logs.push(line),
       }),
     ).toEqual({ delivered: 1, remaining: 0 });
@@ -80,7 +57,7 @@ describe("publishOutbox", () => {
         )
         .get(),
     ).toEqual({
-      delivery_attempts: 2,
+      delivery_attempts: 1,
       delivery_error: expect.stringContaining("JSON"),
       published_at: expect.any(String),
     });
@@ -120,7 +97,7 @@ describe("publishOutbox", () => {
     });
   });
 
-  test("retries a transient sink failure before later rows", () => {
+  test("backs off transient sink failures before retrying later rows", () => {
     const db = openDb(":memory:");
     seedOutbox(db, "a");
     seedOutbox(db, "b");
@@ -134,15 +111,62 @@ describe("publishOutbox", () => {
       seen.push(event.eventId);
     };
 
-    expect(publishOutbox(db, { sink })).toEqual({ delivered: 0, remaining: 2 });
+    expect(publishOutbox(db, { sink, now: 0 })).toEqual({
+      delivered: 0,
+      remaining: 2,
+    });
     expect(seen).toEqual([]);
-    expect(publishOutbox(db, { sink })).toEqual({ delivered: 2, remaining: 0 });
+    expect(publishOutbox(db, { sink, now: 4_999 })).toEqual({
+      delivered: 0,
+      remaining: 2,
+    });
+    expect(publishOutbox(db, { sink, now: 5_000 })).toEqual({
+      delivered: 2,
+      remaining: 0,
+    });
     expect(seen).toEqual(["a", "b"]);
+  });
+
+  test("doubles transient retry delays before parking at the attempt limit", () => {
+    const db = openDb(":memory:");
+    seedOutbox(db, "a");
+    const sink = () => {
+      throw new Error("sink down");
+    };
+
+    expect(publishOutbox(db, { sink, now: 0 })).toEqual({
+      delivered: 0,
+      remaining: 1,
+    });
+    expect(publishOutbox(db, { sink, now: 5_000 })).toEqual({
+      delivered: 0,
+      remaining: 1,
+    });
+    expect(publishOutbox(db, { sink, now: 14_999 })).toEqual({
+      delivered: 0,
+      remaining: 1,
+    });
+    expect(publishOutbox(db, { sink, now: 15_000 })).toEqual({
+      delivered: 0,
+      remaining: 0,
+    });
+    expect(
+      db
+        .query(
+          `SELECT delivery_attempts, delivery_error, published_at
+           FROM outbox WHERE seq = 1`,
+        )
+        .get(),
+    ).toEqual({
+      delivery_attempts: 3,
+      delivery_error: "sink down",
+      published_at: expect.any(String),
+    });
   });
 });
 
 describe("outbox retention and drain index", () => {
-  test("retention deletes only published rows outside its bounded window", () => {
+  test("retention deletes only delivered rows outside its bounded window", () => {
     const db = openDb(":memory:");
     const now = 30 * 24 * 60 * 60 * 1000;
     const old = new Date(0).toISOString();
@@ -153,6 +177,10 @@ describe("outbox retention and drain index", () => {
     insert.run('{"eventId":"old"}', old, old);
     insert.run('{"eventId":"recent"}', recent, recent);
     insert.run('{"eventId":"pending"}', old, null);
+    db.query(
+      `INSERT INTO outbox (event_json, created_at, published_at, delivery_error)
+       VALUES (?, ?, ?, ?)`,
+    ).run('{"eventId":"parked"}', old, old, "sink unavailable");
 
     expect(sweepPublishedOutbox(db, { now, retentionDays: 14 })).toBe(1);
     expect(
@@ -162,6 +190,7 @@ describe("outbox retention and drain index", () => {
     ).toEqual([
       { event_json: '{"eventId":"recent"}', published_at: recent },
       { event_json: '{"eventId":"pending"}', published_at: null },
+      { event_json: '{"eventId":"parked"}', published_at: old },
     ]);
   });
 

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -201,6 +201,12 @@ export function statusView(
   const unpublishedOutbox = db
     .query(`SELECT COUNT(*) AS n FROM outbox WHERE published_at IS NULL`)
     .get().n;
+  const parkedOutbox = db
+    .query(
+      `SELECT COUNT(*) AS n FROM outbox
+       WHERE published_at IS NOT NULL AND delivery_error IS NOT NULL`,
+    )
+    .get().n;
   const deadLettered = db
     .query(
       `SELECT source, event_id, last_plan_error FROM events WHERE status = 'dead_lettered' AND archived_at IS NULL`,
@@ -287,6 +293,7 @@ export function statusView(
       expiredOpenProposals: expiredOpen.map((p) => p.id),
       staleLeases,
       unpublishedOutbox,
+      parkedOutbox,
       deadLettered,
       stalledWorkers: stalled.map((w) => ({
         workerId: w.workerId,

--- a/event-runtime/lib/status-view.test.mjs
+++ b/event-runtime/lib/status-view.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test";
+import { openDb } from "./db.mjs";
+import { statusView } from "./status-view.mjs";
+
+describe("statusView outbox counts", () => {
+  test("reports parked rows separately from unpublished rows", () => {
+    const db = openDb(":memory:");
+    const now = Date.now();
+    const at = new Date(now).toISOString();
+    const insert = db.query(
+      `INSERT INTO outbox (event_json, created_at, published_at, delivery_error)
+       VALUES (?, ?, ?, ?)`,
+    );
+    insert.run("{}", at, null, null);
+    insert.run("{}", at, at, "sink unavailable");
+    insert.run("{}", at, at, null);
+
+    expect(statusView(db, { schedules: [] }, now).anomalies).toMatchObject({
+      unpublishedOutbox: 1,
+      parkedOutbox: 1,
+    });
+  });
+});

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -306,6 +306,9 @@ export interface OutboxRow {
   event: Record<string, unknown>;
   created_at: string;
   published_at: string | null;
+  deliveryAttempts: number;
+  deliveryError: string | null;
+  parked: boolean;
 }
 
 export interface LifecycleEvent {
@@ -829,6 +832,7 @@ export interface StatusView {
     expiredOpenProposals: string[];
     staleLeases: number;
     unpublishedOutbox: number;
+    parkedOutbox: number;
     deadLettered: {
       source: string;
       eventId: string;

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -306,9 +306,10 @@ export interface OutboxRow {
   event: Record<string, unknown>;
   created_at: string;
   published_at: string | null;
-  deliveryAttempts: number;
-  deliveryError: string | null;
-  parked: boolean;
+  /** Present on runtimes that expose delivery state. */
+  deliveryAttempts?: number;
+  deliveryError?: string | null;
+  parked?: boolean;
 }
 
 export interface LifecycleEvent {
@@ -832,7 +833,8 @@ export interface StatusView {
     expiredOpenProposals: string[];
     staleLeases: number;
     unpublishedOutbox: number;
-    parkedOutbox: number;
+    /** Present on runtimes that report terminal outbox delivery failures. */
+    parkedOutbox?: number;
     deadLettered: {
       source: string;
       eventId: string;


### PR DESCRIPTION
Fixes #1511

Review parked-row surfacing and retry backoff, including malformed-event inspection.

## Validation

| Check                | Command                                                                                                                              | Result  | Notes                           |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------- |
| Verification Command | `bun test event-runtime/lib/outbox.test.mjs event-runtime/lib/status-view.test.mjs event-runtime/lib/api-runs.test.mjs --timeout 20000` | pass    | 46 tests, 0 failures            |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`                                     | pass    | 2023 pass, 10 skipped           |
| UX critique          | factory-ux-critic                                                                                                                     | not run | no user-facing surface          |

UX critique: skipped — backend delivery and API metadata only

run:run_0bad147d-c28a-4c55-83aa-3562cd36411e

## Post-review

- `deliveryErrorMessage` now guards `== null`, so an undefined `delivery_error` is emitted as `deliveryError: null` rather than dropped from the row.
- `api-runs.test.mjs` seeds the real transient envelope written by `transientFailure()` (`{message, retryAt}` with `published_at` null) and asserts `GET /outbox` returns `{ deliveryError: "sink down", parked: false }`.
- `docs/event-runtime-outbox.md` notes that delivery is in order: a backed-off head row delays every subsequent row.
