### PR TITLE
test(api-runs): pin nested ticket journey parity

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -308,7 +308,8 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
 
   // Keep only the small connected component for this ticket in memory. JSON
   // LIKE is deliberately a broad prefilter for legacy event/proposal/result
-  // payloads; runs carry a normalized, indexed subject instead.
+  // payloads and direct runs that named their ticket only in a nested input
+  // field. Newer runs also carry a normalized, indexed subject.
   const ticketLike = `%${ticket}%`;
   const eventRows = new Map();
   const proposalRows = new Map();
@@ -419,7 +420,9 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
     (row) => row.id,
   );
   addRows(
-    db.query(`SELECT * FROM runs WHERE subject = ?`).all(ticket),
+    db
+      .query(`SELECT * FROM runs WHERE subject = ? OR UPPER(spec_json) LIKE ?`)
+      .all(ticket, ticketLike),
     runRows,
     (row) => row.run_id,
   );
@@ -445,7 +448,10 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
       proposals.add(row.id);
   }
   for (const row of runRows.values()) {
-    if (String(row.subject ?? "").toUpperCase() === ticket)
+    if (
+      String(row.subject ?? "").toUpperCase() === ticket ||
+      objectNamesTicket(parseObject(row.spec_json).input, ticket)
+    )
       runs.add(row.run_id);
   }
   for (const row of resultRows.values()) {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -602,6 +602,22 @@ describe("ticket journey join (WM-595)", () => {
           "2026-01-01T10:10:00.000Z",
           "WM-595",
         );
+      // A legacy direct run can name its ticket only below a nested input
+      // field. It has no linked proposal/event to pull it into the journey.
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, 1, ?, ?)`,
+        )
+        .run(
+          "run_nested_issue_id",
+          "nested-issue-key",
+          spec({ repo: "factory", dispatch: { issueId: "WM-595" } }),
+          "sha256:nested-issue",
+          "COMPLETED",
+          "2026-01-01T10:05:00.000Z",
+          "2026-01-01T10:06:00.000Z",
+        );
       s.db
         .query(
           `INSERT INTO results
@@ -673,8 +689,12 @@ describe("ticket journey join (WM-595)", () => {
       expect(journey.events.map((event) => event.eventId)).toContain(
         "pr-linked-merge",
       );
+      expect(journey.runs.map((run) => run.run.runId)).toEqual(
+        expect.arrayContaining(["run_ticket", "run_nested_issue_id"]),
+      );
       expect(journey.runs.map((run) => run.run.runId)).toEqual([
         "run_ticket",
+        "run_nested_issue_id",
         "run_merge",
       ]);
       expect(journey.activity).toBe(true);
@@ -750,7 +770,7 @@ describe("ticket journey join (WM-595)", () => {
           payload: { ticket: "WM-999" },
         }),
       );
-      const spec = (ticket) =>
+      const spec = () =>
         JSON.stringify({
           schemaVersion: "factory.run-spec/v1",
           runId: "ignored",
@@ -769,7 +789,7 @@ describe("ticket journey join (WM-595)", () => {
           .run(
             runId,
             `${runId}-key`,
-            spec(ticket),
+            spec(),
             `sha256:${runId}`,
             "COMPLETED",
             "2026-01-01T10:00:00.000Z",

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -146,12 +146,23 @@ CREATE INDEX IF NOT EXISTS idx_attempt_trace_run ON attempt_trace (run_id, seq);
 
 const SCHEMA = SCHEMA_V1;
 
-/** Return the normalized ticket subject carried by a run specification. */
+const LINEAR_TICKET_ID = /^[A-Z][A-Z0-9]{1,9}-\d+$/i;
+const GITHUB_ISSUE_REF =
+  /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*#\d+$/;
+
+/**
+ * Return the ticket subject carried by a run specification. Linear IDs are
+ * normalized to uppercase; GitHub-style owner/repo#number references are
+ * retained verbatim for the GitHub control plane. Ambiguous non-ticket values
+ * are left unclassified rather than being indexed as ticket subjects.
+ */
 export function runSubject(spec) {
   const candidates = [spec?.input?.ticket, spec?.subject];
   for (const candidate of candidates) {
-    if (typeof candidate === "string" && candidate.trim())
-      return candidate.trim().toUpperCase();
+    if (typeof candidate !== "string") continue;
+    const subject = candidate.trim();
+    if (LINEAR_TICKET_ID.test(subject)) return subject.toUpperCase();
+    if (GITHUB_ISSUE_REF.test(subject)) return subject;
   }
   return null;
 }

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -25,6 +25,7 @@ import {
   recordRunUsage,
   retryBusy,
   runUsage,
+  runSubject,
   setSchemaVersion,
   txImmediate,
   usageSpend,
@@ -391,7 +392,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
   });
 
-  test("runs subject migration backfills populated v18 rows and indexes the column", () => {
+  test("runs subject migration retains ticket identifiers and indexes the column", () => {
     const db = new Database(freshFile());
     migrateDb(db, { targetVersion: 18 });
     db.query(
@@ -410,7 +411,17 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     ).run(
       "with-subject",
       "with-subject-key",
-      JSON.stringify({ subject: "ops-42" }),
+      JSON.stringify({ subject: "watt-mind/factory#873" }),
+      "2026-08-30T00:00:00.000Z",
+      "2026-08-30T00:00:00.000Z",
+    );
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, ?, 'hash', 'COMPLETED', 1, ?, ?)`,
+    ).run(
+      "with-ambiguous-subject",
+      "with-ambiguous-subject-key",
+      JSON.stringify({ subject: "#865" }),
       "2026-08-30T00:00:00.000Z",
       "2026-08-30T00:00:00.000Z",
     );
@@ -431,7 +442,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     expect(
       db.query(`SELECT run_id, subject FROM runs ORDER BY run_id`).all(),
     ).toEqual([
-      { run_id: "with-subject", subject: "OPS-42" },
+      { run_id: "with-ambiguous-subject", subject: null },
+      { run_id: "with-subject", subject: "watt-mind/factory#873" },
       { run_id: "with-ticket", subject: "WM-1503" },
       { run_id: "without-ticket", subject: null },
     ]);
@@ -443,6 +455,14 @@ describe("schema migration runner and assertions (OPS-415)", () => {
         .get()?.sql,
     ).toContain("runs (subject)");
     db.close();
+  });
+
+  test("runSubject normalizes Linear IDs and retains GitHub refs verbatim", () => {
+    expect(runSubject({ input: { ticket: " wm-1503 " } })).toBe("WM-1503");
+    expect(runSubject({ subject: "watt-mind/factory#873" })).toBe(
+      "watt-mind/factory#873",
+    );
+    expect(runSubject({ subject: "873" })).toBeNull();
   });
 
   test("hot proposal, inbox and runs subject lookup indexes upgrade an existing database", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1522

Restores nested-ticket journey coverage and constrains indexed run subjects.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | \`bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/db.test.mjs --timeout 20000\` | pass | 74 tests, 0 failures |
| Repo verify | \`bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check\` | pass | 2022 tests, emit and format clean |
| UX critique | factory-ux-critic | skipped | no user-facing surface |

UX critique: skipped

run:$FACTORY_RUN_ID