### PR TITLE
fix(handoff): validate PR form at verification

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -105,6 +105,7 @@ export const HANDOFF_REASON_CODES = new Set([
   "handoff_verification_failed",
   "handoff_verification_unspecified",
   "handoff_owned_paths_violation",
+  "handoff_pr_form_invalid",
 ]);
 export const HANDOFF_TAIL_LINES = 40;
 export const HANDOFF_WEB_SRC_PREFIX = "event-runtime/web/src/";
@@ -897,17 +898,36 @@ function commandLine(label, obs) {
  */
 export function composeHandoffVerification(handoff) {
   const lines = [HANDOFF_COMMENT_HEADING];
-  if (Number.isInteger(handoff.prNumber) && handoff.prNumber > 0) {
+  const prNumber = handoff.pr?.number ?? handoff.prNumber;
+  if (Number.isInteger(prNumber) && prNumber > 0) {
     // Only a boolean says anything about the PR's draft state: the
     // pr_base_unreadable path never sets prDraft, and the same composer writes
     // the failure comment before the worker drafts the PR.
     const draftState =
-      typeof handoff.prDraft === "boolean"
-        ? handoff.prDraft
+      typeof handoff.pr?.draft === "boolean"
+        ? handoff.pr.draft
           ? "draft"
           : "ready"
-        : "draft state unknown";
-    lines.push(`- PR: #${handoff.prNumber} (${draftState})`);
+        : typeof handoff.prDraft === "boolean"
+          ? handoff.prDraft
+            ? "draft"
+            : "ready"
+          : "draft state unknown";
+    const fixes =
+      typeof handoff.pr?.hasFixesLine === "boolean"
+        ? handoff.pr.hasFixesLine
+          ? "yes"
+          : "no"
+        : "unknown";
+    const runTrailer =
+      typeof handoff.pr?.hasRunTrailer === "boolean"
+        ? handoff.pr.hasRunTrailer
+          ? "yes"
+          : "no"
+        : "unknown";
+    lines.push(
+      `- PR: #${prNumber} (${draftState}) · Fixes: ${fixes} · run trailer: ${runTrailer}`,
+    );
   }
   const primary = handoff.verification;
   if (primary) {
@@ -1599,6 +1619,7 @@ function verifyCompleted({
       github: worktreeRecord.github ?? null,
       prNumber: candidate.artifact?.prNumber ?? null,
       prUrl: candidate.artifact?.prUrl ?? null,
+      runId: spec.runId,
       verification: null,
       repoVerify: null,
       webBuild: null,

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2146,7 +2146,9 @@ describe("handoff verification helpers (WM-718)", () => {
     });
     const lines = body.split("\n");
     expect(lines[0]).toBe("## Handoff verification (worker-observed)");
-    expect(lines[1]).toBe("- PR: #42 (draft)");
+    expect(lines[1]).toBe(
+      "- PR: #42 (draft) · Fixes: unknown · run trailer: unknown",
+    );
     expect(lines[2]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
     expect(body).toContain("(fail) x > y");
     expect(body).toContain(
@@ -2169,5 +2171,20 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(lines.filter((l) => l.startsWith("- Verification:"))).toHaveLength(
       1,
     );
+  });
+
+  test("composeHandoffVerification reports fetched PR form evidence", () => {
+    const body = composeHandoffVerification({
+      verification: null,
+      repoVerify: null,
+      webBuild: null,
+      pr: {
+        number: 77,
+        draft: false,
+        hasFixesLine: true,
+        hasRunTrailer: false,
+      },
+    });
+    expect(body).toContain("- PR: #77 (ready) · Fixes: yes · run trailer: no");
   });
 });

--- a/event-runtime/lib/worker-handoff.test.mjs
+++ b/event-runtime/lib/worker-handoff.test.mjs
@@ -286,7 +286,12 @@ describe("handoff verification gate (WM-718)", () => {
           returnHandoffTicket: (p) => (calls.returned.push(p), true),
           holdPullRequest: (p) => (calls.held.push(p), true),
           commentTicket: (p) => (calls.comments.push(p), true),
-          fetchHandoffPullRequest: () => ({ baseRefName: "develop" }),
+          // A live PR read always carries the body; an empty one is refused
+          // as a missing Fixes line, so the fixture supplies the minimum.
+          fetchHandoffPullRequest: () => ({
+            baseRefName: "develop",
+            body: `Fixes ${spec.input.ticket}`,
+          }),
           ...hooks,
         },
       }),

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2472,6 +2472,37 @@ function handoffPrNumber(handoff) {
   return null;
 }
 
+function escapeRegExp(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * True when some body line is a `Fixes <ticket>` line (case-insensitive,
+ * tolerant of surrounding whitespace and one trailing punctuation mark).
+ * Accepts the full `owner/repo#n` form, the short `#n` form when the PR
+ * lives in that repository, and Linear ids verbatim. Returns null when the
+ * handoff carries no usable ticket, so the caller reports "unknown" rather
+ * than probing the body for `Fixes null`.
+ */
+function handoffFixesLinePresent({ lines, ticket, github }) {
+  const ref = typeof ticket === "string" ? ticket.trim() : "";
+  if (!ref) return null;
+  const alternatives = [escapeRegExp(ref)];
+  const repoMatch = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([0-9]+)$/.exec(ref);
+  if (
+    repoMatch &&
+    typeof github === "string" &&
+    github.trim().toLowerCase() === repoMatch[1].toLowerCase()
+  ) {
+    alternatives.push(`#${repoMatch[2]}`);
+  }
+  const pattern = new RegExp(
+    `^\\s*fixes\\s+(?:${alternatives.join("|")})\\s*[.,;:]?\\s*$`,
+    "i",
+  );
+  return lines.some((line) => pattern.test(line));
+}
+
 /**
  * Fail the handoff closed if GitHub cannot prove that the PR targets the
  * configured repository base. Kept here, beside the worker's other external
@@ -2506,13 +2537,19 @@ export function assertHandoffPullRequestBase({
   const actual =
     typeof pr?.baseRefName === "string" ? pr.baseRefName.trim() : "";
   handoff.prBase = { expected, actual: actual || null };
-  const hasBody = typeof pr?.body === "string";
-  const hasFixesLine = hasBody
-    ? pr.body.split(/\r?\n/).includes(`Fixes ${handoff.ticket}`)
-    : true;
-  const hasRunTrailer = hasBody
-    ? pr.body.split(/\r?\n/).includes(`run:${handoff.runId}`)
-    : true;
+  // GitHub returns `body: null` for an empty description; treat it as "".
+  const bodyLines = (typeof pr?.body === "string" ? pr.body : "").split(
+    /\r?\n/,
+  );
+  const hasFixesLine = handoffFixesLinePresent({
+    lines: bodyLines,
+    ticket: handoff.ticket,
+    github: handoff.github,
+  });
+  const hasRunTrailer =
+    typeof handoff.runId === "string" && handoff.runId.trim()
+      ? bodyLines.some((line) => line.trim() === `run:${handoff.runId.trim()}`)
+      : null;
   handoff.pr = {
     number: prNumber,
     draft: pr?.isDraft === true,
@@ -2534,7 +2571,7 @@ export function assertHandoffPullRequestBase({
       { reasonCode: "handoff_verification_failed", handoff },
     );
   }
-  if (!hasFixesLine) {
+  if (hasFixesLine === false) {
     throw new ContractViolation(
       [
         `handoff_pr_form_invalid: PR #${prNumber} is missing Fixes ${handoff.ticket}`,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2455,13 +2455,13 @@ function defaultHoldPullRequest({ github, prNumber, body }) {
   return held;
 }
 
-/** Read the live PR base at handoff; dispatch must never rely on GitHub's default branch. */
+/** Read the live PR form at handoff; dispatch must never rely on GitHub's default branch. */
 function defaultFetchHandoffPullRequest({ github, prNumber }) {
   if (!github || !Number.isInteger(prNumber)) {
     throw new Error("handoff PR requires github and a numeric PR number");
   }
   return loadForge().prView(github, prNumber, {
-    fields: ["baseRefName", "isDraft"],
+    fields: ["baseRefName", "body", "isDraft"],
     timeout: workerSubprocessTimeoutMs(),
   });
 }
@@ -2477,7 +2477,11 @@ function handoffPrNumber(handoff) {
  * configured repository base. Kept here, beside the worker's other external
  * handoff effects, so tests can inject the PR read without a live forge.
  */
-function assertHandoffPullRequestBase({ handoff, base, fetchPullRequest }) {
+export function assertHandoffPullRequestBase({
+  handoff,
+  base,
+  fetchPullRequest,
+}) {
   const expected = typeof base === "string" ? base.trim() : "";
   const prNumber = handoffPrNumber(handoff);
   if (!expected || !handoff?.github || !prNumber) {
@@ -2502,7 +2506,20 @@ function assertHandoffPullRequestBase({ handoff, base, fetchPullRequest }) {
   const actual =
     typeof pr?.baseRefName === "string" ? pr.baseRefName.trim() : "";
   handoff.prBase = { expected, actual: actual || null };
-  handoff.prDraft = pr?.isDraft === true;
+  const hasBody = typeof pr?.body === "string";
+  const hasFixesLine = hasBody
+    ? pr.body.split(/\r?\n/).includes(`Fixes ${handoff.ticket}`)
+    : true;
+  const hasRunTrailer = hasBody
+    ? pr.body.split(/\r?\n/).includes(`run:${handoff.runId}`)
+    : true;
+  handoff.pr = {
+    number: prNumber,
+    draft: pr?.isDraft === true,
+    hasFixesLine,
+    hasRunTrailer,
+  };
+  handoff.prDraft = handoff.pr.draft;
   if (!actual) {
     throw new ContractViolation(
       [`pr_base_unreadable: PR #${prNumber} has no baseRefName`],
@@ -2515,6 +2532,14 @@ function assertHandoffPullRequestBase({ handoff, base, fetchPullRequest }) {
         `pr_base_mismatch: PR #${prNumber} targets ${actual}, expected configured base ${expected}`,
       ],
       { reasonCode: "handoff_verification_failed", handoff },
+    );
+  }
+  if (!hasFixesLine) {
+    throw new ContractViolation(
+      [
+        `handoff_pr_form_invalid: PR #${prNumber} is missing Fixes ${handoff.ticket}`,
+      ],
+      { reasonCode: "handoff_pr_form_invalid", handoff },
     );
   }
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -18,7 +18,7 @@ import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
  * state, so a real hang still fails, just not a slow host.
  */
 const EXECUTE_SPAWN_TIMEOUT_MS = loadAdjustedTimeout(5_000);
-import { insideHandoffSandbox } from "./verify.mjs";
+import { composeHandoffVerification, insideHandoffSandbox } from "./verify.mjs";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
@@ -4239,6 +4239,112 @@ sh -c 'sleep 5 & wait'
       hasFixesLine: false,
       hasRunTrailer: true,
     });
+  });
+
+  test("handoff PR Fixes line tolerates the short #n form, case, and trailing punctuation", () => {
+    const base = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    for (const body of [
+      "Fixes #1504\n\nrun:run-1504",
+      "fixes watt-mind/factory#1504.\n\nrun:run-1504",
+      "  Fixes watt-mind/factory#1504  \r\nrun:run-1504",
+    ]) {
+      const handoff = { ...base };
+      assertHandoffPullRequestBase({
+        handoff,
+        base: "develop",
+        fetchPullRequest: () => ({
+          baseRefName: "develop",
+          isDraft: false,
+          body,
+        }),
+      });
+      expect(handoff.pr).toMatchObject({
+        hasFixesLine: true,
+        hasRunTrailer: true,
+      });
+    }
+
+    // The short form only counts when the PR lives in the ticket's repo, and
+    // a different issue number or a mid-line mention never matches.
+    for (const [github, body] of [
+      ["watt-mind/other", "Fixes #1504"],
+      ["watt-mind/factory", "Fixes #15040"],
+      ["watt-mind/factory", "This Fixes #1504 for real"],
+    ]) {
+      const handoff = { ...base, github };
+      expect(() =>
+        assertHandoffPullRequestBase({
+          handoff,
+          base: "develop",
+          fetchPullRequest: () => ({
+            baseRefName: "develop",
+            isDraft: false,
+            body,
+          }),
+        }),
+      ).toThrow("handoff_pr_form_invalid");
+      expect(handoff.pr.hasFixesLine).toBe(false);
+    }
+
+    const linear = { ...base, ticket: "WM-1234" };
+    assertHandoffPullRequestBase({
+      handoff: linear,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: false,
+        body: "Fixes WM-1234",
+      }),
+    });
+    expect(linear.pr.hasFixesLine).toBe(true);
+  });
+
+  test("handoff PR form refuses a null body and reports unknown for a missing ticket or run id", () => {
+    const base = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    const nullBody = { ...base };
+    expect(() =>
+      assertHandoffPullRequestBase({
+        handoff: nullBody,
+        base: "develop",
+        fetchPullRequest: () => ({
+          baseRefName: "develop",
+          isDraft: false,
+          body: null,
+        }),
+      }),
+    ).toThrow("handoff_pr_form_invalid");
+    expect(nullBody.pr).toMatchObject({
+      hasFixesLine: false,
+      hasRunTrailer: false,
+    });
+
+    const noTicket = { ...base, ticket: null, runId: undefined };
+    assertHandoffPullRequestBase({
+      handoff: noTicket,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: false,
+        body: "Fixes null\nrun:undefined",
+      }),
+    });
+    expect(noTicket.pr).toMatchObject({
+      hasFixesLine: null,
+      hasRunTrailer: null,
+    });
+    expect(composeHandoffVerification(noTicket)).toContain(
+      "Fixes: unknown · run trailer: unknown",
+    );
   });
 
   test("worker preserves push credentials for mutating runs and strips them for non-mutating runs (WM-128)", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -64,6 +64,7 @@ import {
   dispatchIdentityEnv,
   acquireClaimLock,
   adapterExecuteTimeoutMs,
+  assertHandoffPullRequestBase,
   cancelRun,
   CLAIM_LOCK_BACKOFF_MAX_MS,
   claimNext,
@@ -4180,6 +4181,64 @@ sh -c 'sleep 5 & wait'
       });
       expect(untouched).toBe(env);
     }
+  });
+
+  test("handoff PR form records draft and body markers, refusing only a missing Fixes line", () => {
+    const base = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    const valid = { ...base };
+    assertHandoffPullRequestBase({
+      handoff: valid,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: false,
+        body: "Fixes watt-mind/factory#1504\n\nImplemented\n\nrun:run-1504",
+      }),
+    });
+    expect(valid.pr).toEqual({
+      number: 77,
+      draft: false,
+      hasFixesLine: true,
+      hasRunTrailer: true,
+    });
+
+    const warningOnly = { ...base };
+    assertHandoffPullRequestBase({
+      handoff: warningOnly,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: true,
+        body: "Fixes watt-mind/factory#1504",
+      }),
+    });
+    expect(warningOnly.pr).toMatchObject({
+      draft: true,
+      hasFixesLine: true,
+      hasRunTrailer: false,
+    });
+
+    const missingFixes = { ...base };
+    expect(() =>
+      assertHandoffPullRequestBase({
+        handoff: missingFixes,
+        base: "develop",
+        fetchPullRequest: () => ({
+          baseRefName: "develop",
+          isDraft: false,
+          body: "run:run-1504",
+        }),
+      }),
+    ).toThrow("handoff_pr_form_invalid");
+    expect(missingFixes.pr).toMatchObject({
+      hasFixesLine: false,
+      hasRunTrailer: true,
+    });
   });
 
   test("worker preserves push credentials for mutating runs and strips them for non-mutating runs (WM-128)", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1504

Worker handoff now rejects PRs missing their ticket Fixes line and reports PR form evidence.

## Validation

| Check                | Command                                                                                     | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 177 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2021 pass, emit and formatting clean  |
| UX critique          | factory-ux-critic                                                                           | not run | backend handoff gate; no user surface  |

UX critique: skipped

run:run_f5ffff03-0038-4ad7-8caf-a17dd60facee


## Post-review

Reviewer verdict FIX, addressed in fee796e:

- `Fixes` line match is now a tolerant per-line regex: accepts the full `owner/repo#n` form, the short `#n` form when the PR lives in the ticket's repo, Linear ids, case-insensitive, surrounding whitespace and one trailing punctuation mark.
- GitHub's `body: null` is treated as an empty body and refused (missing Fixes line) instead of failing open.
- A handoff without a usable `ticket` / `runId` reports `hasFixesLine` / `hasRunTrailer` as unknown (null) rather than probing for `Fixes null` / `run:undefined`.
- Tests: `Fixes #1504`, `fixes watt-mind/factory#1504.`, CRLF/whitespace, wrong-repo short form, mid-line mention, Linear id, null body refused, null ticket reports unknown. The worker-handoff fixture PR now carries a minimal body since an empty one is refused.
