### PR TITLE
fix(ci): reject cancelled Verify evidence

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -683,6 +683,7 @@ jobs:
       EVENT_NAME: ${{ github.event_name }}
       IS_DRAFT: ${{ github.event.pull_request.draft }}
       SELF_HOSTED: ${{ needs.route.outputs.self_hosted }}
+      ROUTE_RESULT: ${{ needs.route.result }}
       HEALTH_RESULT: ${{ needs.shadow-runner-health.result }}
       FAST_RESULT: ${{ needs.fast-unit-tests.result }}
       FULL_RESULT: ${{ needs.verify.result }}
@@ -698,26 +699,34 @@ jobs:
           fi
 
           failed=0
-          if [ "$SELF_HOSTED" = "true" ]; then
-            echo "Shadow runner fleet available=$HEALTH_RESULT"
-            if [ "$HEALTH_RESULT" != "success" ]; then
-              failed=1
-            fi
-          else
-            echo "Cloud runner lane active: shadow runner fleet health check skipped."
-          fi
+          require_success() {
+            local name="$1"
+            local result="$2"
+            echo "$name=$result"
+            case "$result" in
+              success) ;;
+              cancelled|skipped|failure) echo "::error::$name was $result."; failed=1 ;;
+              *) echo "::error::$name did not succeed (result: ${result:-missing})."; failed=1 ;;
+            esac
+          }
 
-          for result in \
-            "Fast unit tests=$FAST_RESULT" \
-            "Full verification=$FULL_RESULT"
-          do
-            echo "$result"
-            if [ "${result##*=}" != "success" ]; then
+          # This job is intentionally `always()` so it reports cancelled and
+          # skipped dependencies instead of inheriting GitHub's implicit
+          # success gate. The cloud lane is the sole expected skipped job.
+          require_success "Route CI lane" "$ROUTE_RESULT"
+          if [ "$SELF_HOSTED" = "true" ]; then
+            require_success "Shadow runner fleet available" "$HEALTH_RESULT"
+          else
+            echo "Shadow runner fleet available=$HEALTH_RESULT (expected skipped on cloud lane)"
+            if [ "$HEALTH_RESULT" != "skipped" ]; then
+              echo "::error::Cloud lane expected Shadow runner fleet available to be skipped."
               failed=1
             fi
-          done
+          fi
+          require_success "Fast unit tests" "$FAST_RESULT"
+          require_success "Full verification" "$FULL_RESULT"
 
           if [ "$failed" -ne 0 ]; then
-            echo "::error::One or more required verification jobs did not succeed."
+            echo "::error::One or more required verification jobs did not succeed; Verify cannot be green."
           fi
           exit "$failed"

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -43,6 +43,22 @@ The event-runtime merge lane is being split into parallel per-PR review with a l
 
 CI and Security use `concurrency.group` keyed by PR number for pull requests and by ref for pushes, with `cancel-in-progress` for both. A newer push to `develop` cancels the older develop run — only the latest develop head is verified — and a newer PR push cancels that PR's older run. Runs never wait in a concurrency group for a _different_ PR, so nothing is dropped across PRs; queueing across PRs happens in GitHub's runner queue for the `verify-lane` label.
 
+### Required Verify umbrella
+
+`Verify` is the required umbrella for the CI test lanes. It uses `if: always()`
+so GitHub evaluates it after every dependency result rather than silently
+skipping it behind the default success gate. Except for `Shadow runner fleet
+available`, which is intentionally `skipped` on the cloud lane, every gating
+dependency (`Route CI lane`, shadow health on self-hosted, `Fast unit tests`,
+and `Full verification`) must conclude `success`. A `cancelled`, `skipped`,
+or `failure` result makes `Verify` fail.
+
+This matters because concurrency cancellation can leave a historical
+`Verify=success` check-run visible for a superseded workflow. The factory
+merge gate rejects cancelled/superseded workflow runs and evaluates the newest
+non-cancelled run for the reviewed head SHA; it never treats that stale check
+as proof that a merge is green.
+
 ## Dependabot dependency policy
 
 Dependabot opens one weekly grouped pull request per npm ecosystem for minor

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -54,10 +54,11 @@ and `Full verification`) must conclude `success`. A `cancelled`, `skipped`,
 or `failure` result makes `Verify` fail.
 
 This matters because concurrency cancellation can leave a historical
-`Verify=success` check-run visible for a superseded workflow. The factory
-merge gate rejects cancelled/superseded workflow runs and evaluates the newest
-non-cancelled run for the reviewed head SHA; it never treats that stale check
-as proof that a merge is green.
+`Verify=success` check-run visible for a superseded workflow. The
+merge-proof helper ignores cancelled/superseded runs and requires exactly one
+remaining non-cancelled run for the reviewed head SHA (consumer-side wiring
+tracked in #1553); it never treats that stale check as proof that a merge is
+green.
 
 ## Dependabot dependency policy
 

--- a/event-runtime/lib/merge-ci-proof.mjs
+++ b/event-runtime/lib/merge-ci-proof.mjs
@@ -1,4 +1,12 @@
 const REQUIRED_CHECK_FIELDS = ["name", "bucket", "state"];
+const CANCELLED_RUN_CONCLUSIONS = new Set(["cancelled", "stale"]);
+
+function isCancelledWorkflowRun(run) {
+  return (
+    run?.status === "cancelled" ||
+    CANCELLED_RUN_CONCLUSIONS.has(run?.conclusion)
+  );
+}
 
 export function noRequiredChecksDiagnostic(headRef) {
   if (typeof headRef !== "string" || headRef.length === 0) {
@@ -95,11 +103,19 @@ export function proveMergeCiFallback({
     throw new Error("workflow runs and jobs must be arrays");
   }
 
+  // `gh run list` returns newest first. A newer workflow can supersede and
+  // cancel an older run for the same head SHA, while its old Verify check-run
+  // remains success. That stale success must never be merge evidence.
   const matchingRuns = runs.filter(
-    (run) => run?.workflowName === workflow && run?.headSha === headSha,
+    (run) =>
+      run?.workflowName === workflow &&
+      run?.headSha === headSha &&
+      !isCancelledWorkflowRun(run),
   );
   if (matchingRuns.length !== 1) {
-    throw new Error("configured workflow run is missing or ambiguous");
+    throw new Error(
+      "configured non-cancelled workflow run is missing or ambiguous",
+    );
   }
   const [run] = matchingRuns;
   if (

--- a/event-runtime/lib/merge-ci-proof.test.mjs
+++ b/event-runtime/lib/merge-ci-proof.test.mjs
@@ -149,13 +149,13 @@ describe("configured merge_ci proof", () => {
         ...fallback,
         runs: [...fallback.runs, { ...fallback.runs[0], databaseId: 410 }],
       }),
-    ).toThrow("configured workflow run is missing or ambiguous");
+    ).toThrow("configured non-cancelled workflow run is missing or ambiguous");
     expect(() =>
       proveMergeCiFallback({
         ...fallback,
         runs: [{ ...fallback.runs[0], headSha: "b".repeat(40) }],
       }),
-    ).toThrow("configured workflow run is missing or ambiguous");
+    ).toThrow("configured non-cancelled workflow run is missing or ambiguous");
     expect(() =>
       proveMergeCiFallback({
         ...fallback,
@@ -165,5 +165,33 @@ describe("configured merge_ci proof", () => {
         ],
       }),
     ).toThrow("required job Verify is not completed successfully");
+  });
+
+  test("a cancelled Verify success is not merge evidence", () => {
+    const cancelled = {
+      ...fallback.runs[0],
+      databaseId: 410,
+      conclusion: "cancelled",
+    };
+
+    expect(() =>
+      proveMergeCiFallback({
+        ...fallback,
+        runs: [cancelled],
+      }),
+    ).toThrow("configured non-cancelled workflow run is missing or ambiguous");
+
+    expect(
+      proveMergeCiFallback({
+        ...fallback,
+        // Run-list order is newest first. The cancelled run is ignored, so
+        // jobs from the remaining non-cancelled run are authoritative.
+        runs: [cancelled, fallback.runs[0]],
+      }),
+    ).toEqual({
+      runId: 409,
+      workflow: "CI",
+      requiredChecks: ["Shadow runner fleet available", "Verify"],
+    });
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1530

Review the cancellation fail-closed behavior and the scoped consumer follow-up WM-1073.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/merge-ci-proof.test.mjs --timeout 20000 && bun x actionlint .github/workflows/ci.yml` | pass    | 9 tests; actionlint clean                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`         | pass    | 2,022 tests; emit and format clean         |
| UX critique          | factory-ux-critic                                                                                            | not run | no user-facing surface                     |

UX critique: skipped — backend CI, merge proof, and documentation only

run:run_a859d3ec-56ff-4ee6-9a81-f4173c729335


## Post-review

- Reviewer verdict: MERGE. The only red CI job was the known acp flake ("timeout kills a long-lived grandchild" / "could not resolve process group for test pid 0"); rerun requested.
- Applied the optional docs wording fix in `docs/ci.md` ("Required Verify umbrella"): the merge-proof helper ignores cancelled/superseded runs and requires exactly one remaining non-cancelled run for the reviewed head SHA; consumer-side wiring is tracked in #1553.
- The Handoff's "WM-1073" reference is superseded by #1553.
