### PR TITLE
fix(workers): preserve heartbeat resurrection metadata

### DIFF
--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -100,8 +100,14 @@ export default async function work(args) {
   const adapterNames = adapterOverride
     ? [adapterOverride]
     : Object.keys(adapters);
+  const startedAt = Date.now();
 
-  registerWorker(db, { workerId, labels, adapters: adapterNames });
+  registerWorker(db, {
+    workerId,
+    labels,
+    adapters: adapterNames,
+    now: startedAt,
+  });
   log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
   if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
   if (!sandboxReport.available)
@@ -138,9 +144,16 @@ export default async function work(args) {
   // so a loop-driven heartbeat would mark every legitimately busy worker as
   // stale — and the doctor's "stalled worker" check exists precisely to tell
   // busy apart from dead.
+  const workerHeartbeat = (options) =>
+    heartbeat(db, workerId, {
+      ...options,
+      labels,
+      adapters: adapterNames,
+      startedAt,
+    });
   const beat = setInterval(
     () =>
-      heartbeat(db, workerId, {
+      workerHeartbeat({
         state: inFlight ? "busy" : "idle",
         runId: inFlight,
       }),
@@ -185,7 +198,7 @@ export default async function work(args) {
           );
           return finish("drain_requested");
         }
-        heartbeat(db, workerId, {
+        workerHeartbeat({
           state: inFlight ? "busy" : "idle",
           runId: inFlight,
         });
@@ -212,7 +225,7 @@ export default async function work(args) {
           continue;
         }
         inFlight = claim.runId;
-        heartbeat(db, workerId, { state: "busy", runId: claim.runId });
+        workerHeartbeat({ state: "busy", runId: claim.runId });
         log(
           `claimed ${claim.runId} attempt ${claim.attempt} (${claim.spec.agent})`,
         );

--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -49,7 +49,7 @@ function pruneHostWorkers(db, { host, workerId, now }) {
      WHERE host = ?
        AND worker_id != ?
        AND (
-         (state = 'stopped' AND stopped_at < ?)
+         (state = 'stopped' AND COALESCE(stopped_at, last_seen) < ?)
          OR (state != 'stopped' AND last_seen < ?)
        )
        AND ${unleasedWorker}`,
@@ -90,7 +90,14 @@ export function registerWorker(
 export function heartbeat(
   db,
   workerId,
-  { state = "idle", runId = null, now = Date.now() } = {},
+  {
+    state = "idle",
+    runId = null,
+    labels = {},
+    adapters = [],
+    now = Date.now(),
+    startedAt = now,
+  } = {},
 ) {
   const at = iso(now);
   const { changes } = db
@@ -102,11 +109,21 @@ export function heartbeat(
 
   db.query(
     `INSERT INTO workers (worker_id, host, pid, labels_json, adapters, started_at, last_seen, state, current_run)
-     VALUES (?, ?, ?, '{}', '', ?, ?, ?, ?)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
      ON CONFLICT(worker_id) DO UPDATE SET
        last_seen = excluded.last_seen, state = excluded.state,
        current_run = excluded.current_run`,
-  ).run(workerId, hostname(), process.pid, at, at, state, runId);
+  ).run(
+    workerId,
+    hostname(),
+    process.pid,
+    JSON.stringify(labels),
+    adapters.join(","),
+    iso(startedAt),
+    at,
+    state,
+    runId,
+  );
 }
 
 /** Clean exit: recorded, so a stopped worker is distinguishable from a dead one. */
@@ -162,7 +179,7 @@ export function pruneWorkers(
       .query(
         `DELETE FROM workers
          WHERE (
-           (state = 'stopped' AND stopped_at < ?)
+           (state = 'stopped' AND COALESCE(stopped_at, last_seen) < ?)
            OR (state != 'stopped' AND last_seen < ?)
          )
          AND ${unleasedWorker}`,

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -296,8 +296,16 @@ describe("worker registry and heartbeats (OPS-233)", () => {
   test("a heartbeat restores a worker pruned while it was suspended", () => {
     const d = db();
     const now = Date.now();
+    const startedAt = now - 8 * 60 * 60 * 1000;
+    const labels = { node: "lab", can: "infra-exec" };
+    const adapters = ["fake", "pi"];
 
-    registerWorker(d, { workerId: "recovered", now });
+    registerWorker(d, {
+      workerId: "recovered",
+      labels,
+      adapters,
+      now: startedAt,
+    });
     heartbeat(d, "recovered", {
       state: "busy",
       runId: "run_recovered",
@@ -309,6 +317,9 @@ describe("worker registry and heartbeats (OPS-233)", () => {
 
     heartbeat(d, "recovered", {
       state: "idle",
+      labels,
+      adapters,
+      startedAt,
       now: now + 1,
     });
     expect(listWorkers(d, { now: now + 1 })).toEqual([
@@ -316,9 +327,28 @@ describe("worker registry and heartbeats (OPS-233)", () => {
         workerId: "recovered",
         state: "idle",
         currentRun: null,
+        labels,
+        adapters,
+        startedAt: new Date(startedAt).toISOString(),
         stale: false,
       }),
     ]);
+  });
+
+  test("pruning stopped workers falls back to last_seen when stopped_at is NULL", () => {
+    const d = db();
+    const now = Date.now();
+
+    registerWorker(d, {
+      workerId: "missing-stop-time",
+      now: now - 2 * 60 * 60 * 1000,
+    });
+    d.query(
+      `UPDATE workers SET state = 'stopped', stopped_at = NULL WHERE worker_id = ?`,
+    ).run("missing-stop-time");
+
+    expect(pruneWorkers(d, { now })).toBe(1);
+    expect(listWorkers(d, { now })).toEqual([]);
   });
 
   test("pruning retention windows are configurable", () => {


### PR DESCRIPTION
Fixes #1538

Preserves registered worker capabilities and original start times after heartbeat resurrection, while pruning malformed stopped rows.

## Validation

| Check                | Command                                                                  | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/workers.test.mjs --timeout 20000`          | pass    | 31 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2022 pass, 10 skipped; emit clean |
| UX critique          | factory-ux-critic                                                        | not run | no user-facing surface             |

UX critique: skipped — backend worker-registry behavior only
run:run_36663d87-9e51-46cc-9770-a373324ae86a