### PR TITLE
fix(memos): validate expiry bindings before registration

### DIFF
--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -165,6 +165,13 @@ export function validateMemo(
   errors.push(...shape.errors);
   if (!shape.valid) return { valid: false, errors };
 
+  const expiresAt = document.bindings?.expiresAt;
+  if (
+    typeof expiresAt === "string" &&
+    !Number.isFinite(Date.parse(expiresAt))
+  ) {
+    errors.push(`${at}.bindings.expiresAt: not a valid time`);
+  }
   if (hasOwn(document, "provenance") && !allowProvenance) {
     errors.push(`${at}.provenance: agent-supplied provenance is rejected`);
   }

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -151,7 +151,7 @@ function emittedKinds(def) {
  */
 export function validateMemo(
   document,
-  { allowProvenance = false, at = "$" } = {},
+  { allowProvenance = false, at = "$", now = Date.now() } = {},
 ) {
   const errors = [];
   if (
@@ -166,11 +166,13 @@ export function validateMemo(
   if (!shape.valid) return { valid: false, errors };
 
   const expiresAt = document.bindings?.expiresAt;
-  if (
-    typeof expiresAt === "string" &&
-    !Number.isFinite(Date.parse(expiresAt))
-  ) {
-    errors.push(`${at}.bindings.expiresAt: not a valid time`);
+  if (typeof expiresAt === "string") {
+    const expiresAtMs = Date.parse(expiresAt);
+    if (!Number.isFinite(expiresAtMs)) {
+      errors.push(`${at}.bindings.expiresAt: not a valid time`);
+    } else if (expiresAtMs <= now) {
+      errors.push(`${at}.bindings.expiresAt: already in the past`);
+    }
   }
   if (hasOwn(document, "provenance") && !allowProvenance) {
     errors.push(`${at}.provenance: agent-supplied provenance is rejected`);
@@ -436,7 +438,7 @@ function collectRegisterEntries(result, { runId, agent, now }) {
 }
 
 function insertMemoRow(db, { sha256, document }, { now }) {
-  const check = validateMemo(document, { allowProvenance: true });
+  const check = validateMemo(document, { allowProvenance: true, now });
   if (!check.valid) {
     throw new Error(
       `memo ${sha256} failed contract: ${check.errors.join("; ")}`,
@@ -948,7 +950,10 @@ export function processResultMemos({
       errors.push(...parsed.errors);
       continue;
     }
-    const check = validateMemo(parsed.document, { allowProvenance: false });
+    const check = validateMemo(parsed.document, {
+      allowProvenance: false,
+      now,
+    });
     if (!check.valid) {
       errors.push(...check.errors);
       continue;

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -124,6 +124,24 @@ describe("factory.memo/v1 contract", () => {
     expect(validateMemo(decision).valid).toBe(true);
     expect(validateMemo(postmortemDoc({ kind: "decision" })).valid).toBe(false);
   });
+
+  test("rejects an unparsable expiresAt binding at validation time", () => {
+    const naturalLanguage = validateMemo(
+      postmortemDoc({ bindings: { expiresAt: "next sprint" } }),
+    );
+    expect(naturalLanguage.valid).toBe(false);
+    expect(
+      naturalLanguage.errors.some((error) =>
+        error.startsWith("$.bindings.expiresAt:"),
+      ),
+    ).toBe(true);
+
+    const { valid, errors } = validateMemo(
+      postmortemDoc({ bindings: { expiresAt: "2026-99-99T99:99:99Z" } }),
+    );
+    expect(valid).toBe(false);
+    expect(errors).toContain("$.bindings.expiresAt: not a valid time");
+  });
 });
 
 describe("subject normalization", () => {
@@ -676,6 +694,22 @@ describe("verifyResult memo collection", () => {
     expect(out.result.memos).toHaveLength(1);
     expect(out.result.memos[0].document.provenance.runId).toBe("run_memo_test");
     expect(out.result.artifacts[0].kind).toBe("memo");
+  });
+
+  test("rejects an unparsable expiresAt before memo registration", () => {
+    const def = { ...statusDef, emits: { memos: ["postmortem"] } };
+    const dir = writeMemoWorkspace(
+      postmortemDoc({ bindings: { expiresAt: "2026-99-99T99:99:99Z" } }),
+    );
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
   });
 
   test("a memo without emits.memos is a contract violation", () => {

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -142,6 +142,33 @@ describe("factory.memo/v1 contract", () => {
     expect(valid).toBe(false);
     expect(errors).toContain("$.bindings.expiresAt: not a valid time");
   });
+
+  test("rejects an expiresAt binding that is already in the past", () => {
+    const now = Date.parse("2026-08-30T12:00:00.000Z");
+    const past = validateMemo(
+      postmortemDoc({ bindings: { expiresAt: "2026-08-30T11:59:59Z" } }),
+      { now },
+    );
+    expect(past.valid).toBe(false);
+    expect(past.errors).toContain("$.bindings.expiresAt: already in the past");
+    const future = validateMemo(
+      postmortemDoc({ bindings: { expiresAt: "2026-08-30T12:00:01Z" } }),
+      { now },
+    );
+    expect(future.valid).toBe(true);
+  });
+
+  test("rejects an abbreviated headSha binding", () => {
+    const { valid, errors } = validateMemo(
+      postmortemDoc({ bindings: { headSha: "abc1234" } }),
+    );
+    expect(valid).toBe(false);
+    expect(errors.some((e) => e.startsWith("$.bindings.headSha"))).toBe(true);
+    expect(
+      validateMemo(postmortemDoc({ bindings: { headSha: "a".repeat(40) } }))
+        .valid,
+    ).toBe(true);
+  });
 });
 
 describe("subject normalization", () => {
@@ -700,6 +727,22 @@ describe("verifyResult memo collection", () => {
     const def = { ...statusDef, emits: { memos: ["postmortem"] } };
     const dir = writeMemoWorkspace(
       postmortemDoc({ bindings: { expiresAt: "2026-99-99T99:99:99Z" } }),
+    );
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+      }),
+    ).toThrow(ContractViolation);
+  });
+
+  test("rejects an abbreviated headSha before memo registration", () => {
+    const def = { ...statusDef, emits: { memos: ["postmortem"] } };
+    const dir = writeMemoWorkspace(
+      postmortemDoc({ bindings: { headSha: "abc1234" } }),
     );
     expect(() =>
       verifyResult({

--- a/event-runtime/schemas/factory.memo.v1.json
+++ b/event-runtime/schemas/factory.memo.v1.json
@@ -38,7 +38,7 @@
           "type": "string",
           "pattern": "^sha256:[a-f0-9]{64}$"
         },
-        "headSha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+        "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
         "expiresAt": {
           "type": "string",
           "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",

--- a/event-runtime/schemas/factory.memo.v1.json
+++ b/event-runtime/schemas/factory.memo.v1.json
@@ -38,8 +38,12 @@
           "type": "string",
           "pattern": "^sha256:[a-f0-9]{64}$"
         },
-        "headSha": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
-        "expiresAt": { "type": "string", "minLength": 1 }
+        "headSha": { "type": "string", "pattern": "^[0-9a-f]{7,40}$" },
+        "expiresAt": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}(?:\\.\\d+)?(?:Z|[+-]\\d{2}:\\d{2})$",
+          "description": "RFC 3339 date-time"
+        }
       }
     },
     "supersedes": {


### PR DESCRIPTION
Fixes watt-mind/factory#1548

Reject malformed memo expiry bindings before registration can publish.

## Validation

| Check                | Command                                                                          | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/memos.test.mjs event-runtime/lib/verify.test.mjs` | pass    | 98 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2029 pass, 10 skipped, generated clean     |
| UX critique          | factory-ux-critic                                                                | skipped | no user-facing surface                     |

UX critique: skipped

run:run_93b4e667-a617-43f8-bc80-3d3bf00b5d56

## Post-review

- Restored `bindings.headSha` to `^[0-9a-f]{40}$`. The ticket's AC line asking to type `headSha` was declined as written: the schema already required a full sha, and the earlier change had *loosened* it to 7-40 chars, which would let an abbreviated sha register and then be silently retired as `head_sha_mismatch`. Added a verify-time test asserting a 7-char sha is a `ContractViolation`.
- `validateMemo` now also rejects an `expiresAt` already in the past (clock threaded through registration and verify-time collection), with tests.
