### PR TITLE
perf(linear): avoid duplicate label catalog pagination

### DIFF
--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -248,10 +248,8 @@ export function linearControlPlane({
     const bad = validateLabels(add);
     if (bad.length)
       throw new ControlPlaneError("invalid label(s):\n  " + bad.join("\n  "));
-    let all = await allLabels();
-    let missing = add.filter((n) => !all.some((l) => l.name === n));
-    if (missing.length) all = await allLabels();
-    missing = add.filter((n) => !all.some((l) => l.name === n));
+    const all = await allLabels();
+    const missing = add.filter((n) => !all.some((l) => l.name === n));
     if (missing.length)
       throw new ControlPlaneError(
         `label(s) do not exist in this workspace: ${missing.join(", ")}`,
@@ -449,12 +447,6 @@ export function linearControlPlane({
       );
       if (!target)
         throw new ControlPlaneError(`team ${team} has no "${state}" state`);
-      const all = await allLabels();
-      const missing = labels.filter((n) => !all.some((l) => l.name === n));
-      if (missing.length)
-        throw new ControlPlaneError(
-          `label(s) do not exist in this workspace: ${missing.join(", ")}`,
-        );
       const d = await call(
         `mutation($in:IssueCreateInput!){ issueCreate(input:$in){ success issue{ identifier url } } }`,
         {
@@ -463,7 +455,7 @@ export function linearControlPlane({
             title,
             description: stampRun(body),
             stateId: target.id,
-            labelIds: resolveLabelIds([], { add: labels }, all),
+            labelIds: await labelIdsFor({ labels: [] }, labels, []),
             ...(projectId ? { projectId } : {}),
           },
         },

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -244,6 +244,45 @@ describe("Linear ControlPlane pagination (GH-1393)", () => {
     expect(update).toEqual({ labelIds: ["second"] });
   });
 
+  test("checks a missing transition label with one label-catalog query", async () => {
+    let labelQueries = 0;
+    const cp = linearControlPlane({
+      gql: async (query) => {
+        if (query.includes("issue(id:$k)")) {
+          return {
+            issue: {
+              id: "issue-1",
+              identifier: "WM-1",
+              title: "Issue",
+              state: { id: "todo", name: "Todo", type: "started" },
+              assignee: null,
+              team: { key: "WM" },
+              project: null,
+              labels: { nodes: [] },
+              comments: { nodes: [] },
+              inverseRelations: { nodes: [] },
+            },
+          };
+        }
+        if (query.includes("issueLabels")) {
+          labelQueries++;
+          return {
+            issueLabels: {
+              nodes: [{ id: "existing", name: "existing" }],
+              pageInfo: { hasNextPage: false, endCursor: null },
+            },
+          };
+        }
+        throw new Error(`unexpected query: ${query}`);
+      },
+    });
+
+    await expect(
+      cp.transition("WM-1", undefined, { add: ["missing"] }),
+    ).rejects.toThrow("label(s) do not exist in this workspace: missing");
+    expect(labelQueries).toBe(1);
+  });
+
   test("listComments concatenates cursor-paginated comment results", async () => {
     const cursors = [];
     const cp = linearControlPlane({


### PR DESCRIPTION
Fixes watt-mind/factory#1549

Review the single-query label validation refactor and its missing-transition-label regression test.

## Validation

| Check                | Command                                                        | Result  | Notes                       |
| -------------------- | -------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `bun test --timeout 20000 lib/control-plane/linear.test.mjs`  | pass    | 8 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2032 pass, 0 failures       |
| UX critique          | factory-ux-critic                                              | not run | backend control-plane change |

UX critique: skipped

run:run_690a8c58-0755-4dfc-8e24-f8d5f9751db4