### PR TITLE
fix(cli): validate worker drain timeout

### DIFF
--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -215,8 +215,17 @@ export default async function supervise(args) {
       "supervise: --interval-ms must be an integer between 100 and 60000",
     );
   }
-  const drainTimeoutMs =
-    Number(flagValue(args, "--drain-timeout") ?? 60) * 1000;
+  const drainTimeoutSeconds = Number(flagValue(args, "--drain-timeout") ?? 60);
+  if (
+    !Number.isInteger(drainTimeoutSeconds) ||
+    drainTimeoutSeconds < 1 ||
+    drainTimeoutSeconds > 3_600
+  ) {
+    return fail(
+      "supervise: --drain-timeout must be an integer between 1 and 3600 seconds",
+    );
+  }
+  const drainTimeoutMs = drainTimeoutSeconds * 1000;
   const spawnGraceMs = Number(
     flagValue(args, "--spawn-grace-ms") ?? SPAWN_GRACE_MS,
   );

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -80,6 +80,21 @@ describe("supervise (WM-226)", () => {
     }
   });
 
+  test("rejects unsafe drain timeouts before writing its pidfile", () => {
+    for (const value of ["not-a-number", "0", "-1"]) {
+      const dir = tmpDir("evrt-pool-invalid-drain-");
+      const r = runCli(
+        ["supervise", "--workers", "1:1", "--drain-timeout", value, "--once"],
+        { FACTORY_RUN_DIR: dir },
+      );
+      expect(r.status).not.toBe(0);
+      expect(r.all).toContain(
+        "supervise: --drain-timeout must be an integer between 1 and 3600 seconds",
+      );
+      expect(existsSync(path.join(dir, "supervisor.pid"))).toBe(false);
+    }
+  });
+
   test("refuses to be the second supervisor on one run dir — two would orphan each other's workers", () => {
     const dir = tmpDir("evrt-pool-dup-");
     try {

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -23,12 +23,16 @@ usage: bun event-runtime/cli.mjs <command>
                                  only between claims (dev; see factory up --dev)
                                  --drain-file exits 0 once that file appears, at
                                  an idle poll boundary — never mid-run (WM-226)
-  supervise [--workers min:max] [--interval-ms N] [--once]
+  supervise [--workers min:max] [--interval-ms N] [--drain-timeout N]
+            [--spawn-grace-ms N] [--once]
                                  worker pool supervisor (WM-226): scales \`work\`
                                  processes between workers.min and workers.max
                                  from config/policy.yaml on observed queue depth.
                                  Scales down by draining, never by signalling a
                                  worker that holds a lease.
+                                 --adapter-override, --poll-ms, --drain-timeout,
+                                 --reload-on-change, and --label worker-shaping
+                                 flags pass through to every worker.
   status                         events, proposals, runs, anomalies
   doctor                         system health check: anomaly report (exits non-zero on anomalies)
   events [status]                admitted events, optionally filtered by status

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -48,6 +48,14 @@ export default async function work(args) {
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
+  const drainTimeoutSeconds = Number(flagValue(args, "--drain-timeout") ?? 60);
+  if (
+    !Number.isInteger(drainTimeoutSeconds) ||
+    drainTimeoutSeconds < 1 ||
+    drainTimeoutSeconds > 3_600
+  ) {
+    fail("work: --drain-timeout must be an integer between 1 and 3600 seconds");
+  }
   // Built-ins first, then allow-listed extensions (lib/extensions.mjs,
   // WM-838) — before toMap(), which is a snapshot. The registry validates the
   // contract and wraps every adapter in the sandbox seam (WM-837); a broken
@@ -260,8 +268,7 @@ export default async function work(args) {
   // SIGKILL, which orphans the agent AND leaves a lying registry row. After
   // the grace period the worker leaves honestly and says what happens next —
   // the lease expires and the reaper requeues the run.
-  const drainTimeoutMs =
-    Number(flagValue(args, "--drain-timeout") ?? 60) * 1000;
+  const drainTimeoutMs = drainTimeoutSeconds * 1000;
   const finish = (reason, code = 0) => {
     clearInterval(beat);
     deregisterWorker(db, workerId);

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -68,6 +68,16 @@ describe("work command", () => {
     );
   });
 
+  test("work rejects unsafe drain timeouts before registering", () => {
+    for (const value of ["not-a-number", "0", "-1"]) {
+      const r = runCli(["work", "--drain-timeout", value]);
+      expect(r.status).not.toBe(0);
+      expect(r.all).toContain(
+        "work: --drain-timeout must be an integer between 1 and 3600 seconds",
+      );
+    }
+  });
+
   test("work with unknown --adapter-override exits non-zero with error", () => {
     const r = runCli(["work", "--adapter-override", "nonexistent"]);
     expect(r.status).not.toBe(0);


### PR DESCRIPTION
Fixes watt-mind/factory#1545

Reject invalid drain timeout values before worker registration or supervisor PID creation.

## Validation

| Check                | Command                                                                  | Result  | Notes                               |
| -------------------- | ------------------------------------------------------------------------ | ------- | ----------------------------------- |
| Verification Command | `bun test --timeout 60000 event-runtime/cli/work.test.mjs event-runtime/cli/supervise.test.mjs` | pass    | 25 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2027 tests; emit and format clean   |
| UX critique          | factory-ux-critic                                                        | skipped | backend CLI; no user-facing surface |

UX critique: skipped

run:run_53684ea9-a0a9-46ec-a6cc-5adc51706e47