### PR TITLE
fix(bin): preserve live daemon log writers on rotation

### DIFF
--- a/bin/worktree-daemons.sh
+++ b/bin/worktree-daemons.sh
@@ -5,7 +5,7 @@
 #   bin/worktree-daemons.sh check [WT]        # exit 0 if healthy, non-zero on dead daemon / anomaly
 #   bin/worktree-daemons.sh anomalies [WT]    # print list of anomalies
 #   bin/worktree-daemons.sh supervise [WT]    # watch daemons and restart dead workers with bounded retries
-#   bin/worktree-daemons.sh rotate-logs [WT]  # rotate oversized .factory/run/*.log files
+#   bin/worktree-daemons.sh rotate-logs [WT]  # copy-truncate live daemon logs; rename stopped logs
 #
 set -euo pipefail
 
@@ -18,46 +18,23 @@ if [[ -z "${_WORKTREE_DAEMONS_LOADED:-}" ]]; then
     source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
   fi
 
-  # Get file size in bytes portably
-  file_size_bytes() { # <file>
-    local f="$1"
-    if [[ -f "$f" ]]; then
-      wc -c < "$f" | tr -d '[:space:]'
-    else
-      printf '0'
-    fi
-  }
-
-  # Rotate a single log file if it exceeds max_bytes (default: 10MB)
+  # Rotate a single daemon log through the shared live-owner-aware helper.
+  # A live daemon keeps its original file descriptor, so it must be
+  # copy-truncated rather than renamed.
   rotate_log_file() { # <logfile> [max_bytes]
     local logfile="$1"
     local max_bytes="${2:-10485760}" # 10MB default
-    if [[ ! -f "$logfile" ]]; then
-      return 0
-    fi
-    local size
-    size=$(file_size_bytes "$logfile")
-    if [[ "$size" =~ ^[0-9]+$ ]] && (( size > max_bytes )); then
-      mv -f "$logfile" "${logfile}.1"
-      touch "$logfile"
-      info "rotated $logfile (${size} bytes -> ${logfile}.1)"
-    fi
+    local keep="${FACTORY_LOG_KEEP:-3}"
+    rotate_run_log "$logfile" "$max_bytes" "$keep"
   }
 
-  # Rotate all daemon logs for a worktree if oversized
+  # Rotate all daemon logs through the shared helper, retaining generations.
   rotate_daemon_logs() { # <worktree> [max_bytes]
     local wt="$1"
     local max_bytes="${2:-10485760}"
-    local rdir
+    local rdir keep="${FACTORY_LOG_KEEP:-3}"
     rdir="$(run_dir "$wt")"
-    if [[ -d "$rdir" ]]; then
-      local log
-      for log in "$rdir"/serve.log "$rdir"/worker.log "$rdir"/web.log; do
-        if [[ -f "$log" ]]; then
-          rotate_log_file "$log" "$max_bytes"
-        fi
-      done
-    fi
+    rotate_run_logs "$rdir" "$max_bytes" "$keep"
   }
 
   # Check status of daemons in a worktree.
@@ -355,7 +332,7 @@ Commands:
   check [WT]        Exit 0 if healthy, 1 if any daemon is dead or anomalous
   anomalies [WT]    Print list of anomalies
   supervise [WT]    Run supervisor loop (or --once for single pass)
-  rotate-logs [WT]  Rotate oversized log files (> 10MB or custom bytes)
+  rotate-logs [WT]  Copy-truncate live daemon logs or rename stopped logs (> 10MB)
 
 Options:
   --once            Run a single supervisor tick and exit

--- a/bin/worktree-daemons.sh
+++ b/bin/worktree-daemons.sh
@@ -21,10 +21,19 @@ if [[ -z "${_WORKTREE_DAEMONS_LOADED:-}" ]]; then
   # Rotate a single daemon log through the shared live-owner-aware helper.
   # A live daemon keeps its original file descriptor, so it must be
   # copy-truncated rather than renamed.
+  # Resolve the archive retention count. Mirrors live-stack.sh's guard: a 0 or
+  # non-numeric value would make the prune loop delete every archive.
+  daemon_log_keep() {
+    local keep="${FACTORY_LOG_KEEP:-3}"
+    [[ "$keep" =~ ^[1-9][0-9]*$ ]] || die "FACTORY_LOG_KEEP must be a positive integer"
+    printf '%s\n' "$keep"
+  }
+
   rotate_log_file() { # <logfile> [max_bytes]
     local logfile="$1"
     local max_bytes="${2:-10485760}" # 10MB default
-    local keep="${FACTORY_LOG_KEEP:-3}"
+    local keep
+    keep="$(daemon_log_keep)" || exit 1
     rotate_run_log "$logfile" "$max_bytes" "$keep"
   }
 
@@ -32,7 +41,8 @@ if [[ -z "${_WORKTREE_DAEMONS_LOADED:-}" ]]; then
   rotate_daemon_logs() { # <worktree> [max_bytes]
     local wt="$1"
     local max_bytes="${2:-10485760}"
-    local rdir keep="${FACTORY_LOG_KEEP:-3}"
+    local rdir keep
+    keep="$(daemon_log_keep)" || exit 1
     rdir="$(run_dir "$wt")"
     rotate_run_logs "$rdir" "$max_bytes" "$keep"
   }

--- a/bin/worktree-daemons.test.mjs
+++ b/bin/worktree-daemons.test.mjs
@@ -41,6 +41,15 @@ function runScript(args = [], extraEnv = {}) {
   };
 }
 
+async function waitForFile(file, timeoutMs = 1_000) {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    if (existsSync(file)) return true;
+    await Bun.sleep(10);
+  }
+  return false;
+}
+
 test("spawn_daemon creates detached process that survives subshell exit", () => {
   const testDir = mkdtempSync(path.join(tmpdir(), "spawn-daemon-test-"));
   const pidfile = path.join(testDir, "test.pid");
@@ -232,6 +241,48 @@ test("rotate_log_file and rotate_daemon_logs rotate oversized logs", () => {
     expect(existsSync(`${workerLog}.1`)).toBe(false);
     expect(readFileSync(workerLog, "utf8").length).toBe(100);
   } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
+test("rotate_daemon_logs copy-truncates a live daemon log", async () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "live-log-rotate-test-"));
+  const runDir = path.join(testDir, ".factory", "run");
+  const serveLog = path.join(runDir, "serve.log");
+  const ready = path.join(testDir, "writer-ready");
+  const continueFile = path.join(testDir, "writer-continue");
+  mkdirSync(runDir, { recursive: true });
+
+  let writer;
+  try {
+    // The writer opens serve.log once, matching a daemon whose stdout was
+    // redirected when it started. It only emits the second line after rotation.
+    writer = Bun.spawn({
+      cmd: [
+        "bash",
+        "-c",
+        'exec > "$1"; printf "before\\n"; : > "$2"; while [[ ! -f "$3" ]]; do :; done; printf "after\\n"',
+        "bash",
+        serveLog,
+        ready,
+        continueFile,
+      ],
+      stdout: "ignore",
+      stderr: "pipe",
+    });
+    expect(await waitForFile(ready)).toBe(true);
+    writeFileSync(path.join(runDir, "serve.pid"), `${writer.pid}\n`);
+
+    const rotRes = sh(`rotate_daemon_logs "${testDir}" 1`);
+    expect(rotRes.status).toBe(0);
+    expect(readFileSync(`${serveLog}.1`, "utf8")).toContain("before\n");
+
+    writeFileSync(continueFile, "continue\n");
+    expect(await writer.exited).toBe(0);
+    expect(readFileSync(serveLog, "utf8")).toContain("after\n");
+    expect(readFileSync(`${serveLog}.1`, "utf8")).not.toContain("after\n");
+  } finally {
+    writer?.kill("SIGKILL");
     rmSync(testDir, { recursive: true, force: true });
   }
 });

--- a/bin/worktree-daemons.test.mjs
+++ b/bin/worktree-daemons.test.mjs
@@ -245,6 +245,39 @@ test("rotate_log_file and rotate_daemon_logs rotate oversized logs", () => {
   }
 });
 
+test("rotate_daemon_logs rejects a non-positive FACTORY_LOG_KEEP", () => {
+  const testDir = mkdtempSync(path.join(tmpdir(), "log-keep-guard-test-"));
+  const runDir = path.join(testDir, ".factory", "run");
+  const serveLog = path.join(runDir, "serve.log");
+  mkdirSync(runDir, { recursive: true });
+
+  try {
+    writeFileSync(serveLog, "x".repeat(500));
+    writeFileSync(`${serveLog}.1`, "archived\n");
+
+    for (const keep of ["0", "abc", "-1", "3x"]) {
+      const rotRes = sh(`rotate_daemon_logs "${testDir}" 300`, {
+        FACTORY_LOG_KEEP: keep,
+      });
+      expect(rotRes.status).not.toBe(0);
+      expect(rotRes.stderr).toContain(
+        "FACTORY_LOG_KEEP must be a positive integer",
+      );
+      // Nothing rotated or pruned when the knob is rejected.
+      expect(readFileSync(serveLog, "utf8").length).toBe(500);
+      expect(readFileSync(`${serveLog}.1`, "utf8")).toBe("archived\n");
+    }
+
+    const okRes = sh(`rotate_log_file "${serveLog}" 300`, {
+      FACTORY_LOG_KEEP: "2",
+    });
+    expect(okRes.status).toBe(0);
+    expect(readFileSync(serveLog, "utf8").length).toBe(0);
+  } finally {
+    rmSync(testDir, { recursive: true, force: true });
+  }
+});
+
 test("rotate_daemon_logs copy-truncates a live daemon log", async () => {
   const testDir = mkdtempSync(path.join(tmpdir(), "live-log-rotate-test-"));
   const runDir = path.join(testDir, ".factory", "run");
@@ -261,7 +294,7 @@ test("rotate_daemon_logs copy-truncates a live daemon log", async () => {
       cmd: [
         "bash",
         "-c",
-        'exec > "$1"; printf "before\\n"; : > "$2"; while [[ ! -f "$3" ]]; do :; done; printf "after\\n"',
+        'exec > "$1"; printf "before\\n"; : > "$2"; while [[ ! -f "$3" ]]; do sleep 0.01; done; printf "after\\n"',
         "bash",
         serveLog,
         ready,


### PR DESCRIPTION
Fixes watt-mind/factory#1547

Route daemon log rotation through the live-owner-aware helper so active writers keep appending to the current log.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test --timeout 60000 bin/worktree-daemons.test.mjs bin/worktree-common.test.mjs` | pass    | 55 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check` | pass    | 2027 tests; emit and format clean |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface             |

UX critique: skipped

run:run_24733859-559c-469a-9249-64aa85019352


## Post-review

- Reviewer nits (commit 0b460f8b): `rotate_log_file`/`rotate_daemon_logs` now validate `FACTORY_LOG_KEEP` with the same positive-integer guard as `live-stack.sh` (0/non-numeric previously pruned every archive); new test covers `0`, `abc`, `-1`, `3x` rejection and a valid value. The live-writer test spin loop sleeps 10ms per iteration instead of busy-looping.
- Verified: `bun test bin` (167 pass), `bun run format:check`, `bun run check`.
