### PR TITLE
fix(merge): evaluate the live configured workflow run

### DIFF
--- a/docs/ci.md
+++ b/docs/ci.md
@@ -55,10 +55,11 @@ or `failure` result makes `Verify` fail.
 
 This matters because concurrency cancellation can leave a historical
 `Verify=success` check-run visible for a superseded workflow. The
-merge-proof helper ignores cancelled/superseded runs and requires exactly one
-remaining non-cancelled run for the reviewed head SHA (consumer-side wiring
-tracked in #1553); it never treats that stale check as proof that a merge is
-green.
+merge apply selects the newest non-cancelled configured workflow run for the
+reviewed head SHA and requires it to be the sole remaining live run. When a
+repo configures `merge_ci`, both the branch's required contexts and that run's
+configured required jobs must be green; a stale check from a cancelled run is
+never sufficient merge proof.
 
 ## Dependabot dependency policy
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -55,8 +55,8 @@ or `failure` result makes `Verify` fail.
 
 This matters because concurrency cancellation can leave a historical
 `Verify=success` check-run visible for a superseded workflow. The
-merge apply selects the newest non-cancelled configured workflow run for the
-reviewed head SHA and requires it to be the sole remaining live run. When a
+merge apply selects the sole non-cancelled configured workflow run for the
+reviewed head SHA; two live runs fail closed rather than trusting list order. When a
 repo configures `merge_ci`, both the branch's required contexts and that run's
 configured required jobs must be green; a stale check from a cancelled run is
 never sufficient merge proof.

--- a/event-runtime/lib/merge-apply.mjs
+++ b/event-runtime/lib/merge-apply.mjs
@@ -112,7 +112,13 @@ function proveRequiredCi({ github, pr, headRef, headSha, repo, factoryRoot }) {
       return { ok: false, reason: "required CI is pending or not green" };
     }
   }
-  const repoRecord = getRepo(loadRepos({ root: factoryRoot }), repo);
+  let repoRecord;
+  try {
+    repoRecord = getRepo(loadRepos({ root: factoryRoot }), repo);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    return { ok: false, reason: `merge_ci repo record unavailable: ${detail}` };
+  }
   const gate = repoRecord.mergeCi;
   if (!gate) {
     if (contexts.length > 0) return { ok: true };

--- a/event-runtime/lib/merge-apply.mjs
+++ b/event-runtime/lib/merge-apply.mjs
@@ -13,6 +13,7 @@ import {
   noRequiredChecksDiagnostic,
   proveMergeCiFallback,
   resolveRequiredContexts,
+  selectMergeCiRun,
 } from "./merge-ci-proof.mjs";
 import { loadRegistry } from "./registry.mjs";
 import { getRepo, loadRepos } from "./repos.mjs";
@@ -107,13 +108,14 @@ function proveRequiredCi({ github, pr, headRef, headSha, repo, factoryRoot }) {
     const green = contexts.every(
       (c) => c.bucket === "pass" && c.state === "SUCCESS",
     );
-    return green
-      ? { ok: true }
-      : { ok: false, reason: "required CI is pending or not green" };
+    if (!green) {
+      return { ok: false, reason: "required CI is pending or not green" };
+    }
   }
   const repoRecord = getRepo(loadRepos({ root: factoryRoot }), repo);
   const gate = repoRecord.mergeCi;
   if (!gate) {
+    if (contexts.length > 0) return { ok: true };
     return {
       ok: false,
       reason: `${noRequiredChecksDiagnostic(headRef)}; no merge_ci fallback`,
@@ -138,23 +140,25 @@ function proveRequiredCi({ github, pr, headRef, headSha, repo, factoryRoot }) {
   if (runsRaw.status !== 0) {
     return { ok: false, reason: "merge_ci fallback run list failed" };
   }
+  let run;
   try {
     const runs = JSON.parse(runsRaw.stdout || "[]");
-    const matching = runs.filter(
-      (run) => run.workflowName === gate.workflow && run.headSha === headSha,
-    );
-    if (matching.length !== 1) {
-      return { ok: false, reason: "configured workflow missing or ambiguous" };
-    }
+    run = selectMergeCiRun({ workflow: gate.workflow, headSha, runs });
     const jobsRaw = sh("gh", [
       "run",
       "view",
-      String(matching[0].databaseId),
+      String(run.databaseId),
       "--repo",
       github,
       "--json",
       "jobs",
     ]);
+    if (jobsRaw.status !== 0) {
+      return {
+        ok: false,
+        reason: `configured CI run ${run.databaseId}: job lookup failed`,
+      };
+    }
     const jobs = parseJobs(jobsRaw.stdout);
     proveMergeCiFallback({
       workflow: gate.workflow,
@@ -164,10 +168,11 @@ function proveRequiredCi({ github, pr, headRef, headSha, repo, factoryRoot }) {
       jobs,
     });
     return { ok: true };
-  } catch {
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
     return {
       ok: false,
-      reason: "configured CI checks missing, pending, or red",
+      reason: run ? `configured CI run ${run.databaseId}: ${detail}` : detail,
     };
   }
 }

--- a/event-runtime/lib/merge-ci-proof.mjs
+++ b/event-runtime/lib/merge-ci-proof.mjs
@@ -8,6 +8,45 @@ function isCancelledWorkflowRun(run) {
   );
 }
 
+/**
+ * Select the sole non-cancelled configured workflow run for a reviewed head.
+ * `gh run list` returns newest first, but multiple live runs are ambiguous and
+ * therefore fail closed rather than making list order into merge evidence.
+ */
+export function selectMergeCiRun({ workflow, headSha, runs }) {
+  for (const [label, value] of [
+    ["workflow", workflow],
+    ["head SHA", headSha],
+  ]) {
+    if (typeof value !== "string" || value.trim().length === 0) {
+      throw new Error(`${label} must be a nonempty string`);
+    }
+  }
+  if (!Array.isArray(runs)) {
+    throw new Error("workflow runs must be an array");
+  }
+
+  const matchingRuns = runs.filter(
+    (run) =>
+      run?.workflowName === workflow &&
+      run?.headSha === headSha &&
+      !isCancelledWorkflowRun(run),
+  );
+  if (matchingRuns.length !== 1) {
+    throw new Error(
+      "configured non-cancelled workflow run is missing or ambiguous",
+    );
+  }
+  const [run] = matchingRuns;
+  if (
+    !Number.isInteger(run.databaseId) &&
+    (typeof run.databaseId !== "string" || run.databaseId.length === 0)
+  ) {
+    throw new Error("configured workflow run has no valid database ID");
+  }
+  return run;
+}
+
 export function noRequiredChecksDiagnostic(headRef) {
   if (typeof headRef !== "string" || headRef.length === 0) {
     throw new Error("head ref must be a nonempty string");
@@ -81,14 +120,6 @@ export function proveMergeCiFallback({
   runs,
   jobs,
 }) {
-  for (const [label, value] of [
-    ["workflow", workflow],
-    ["head SHA", headSha],
-  ]) {
-    if (typeof value !== "string" || value.trim().length === 0) {
-      throw new Error(`${label} must be a nonempty string`);
-    }
-  }
   if (
     !Array.isArray(requiredChecks) ||
     requiredChecks.length === 0 ||
@@ -103,27 +134,7 @@ export function proveMergeCiFallback({
     throw new Error("workflow runs and jobs must be arrays");
   }
 
-  // `gh run list` returns newest first. A newer workflow can supersede and
-  // cancel an older run for the same head SHA, while its old Verify check-run
-  // remains success. That stale success must never be merge evidence.
-  const matchingRuns = runs.filter(
-    (run) =>
-      run?.workflowName === workflow &&
-      run?.headSha === headSha &&
-      !isCancelledWorkflowRun(run),
-  );
-  if (matchingRuns.length !== 1) {
-    throw new Error(
-      "configured non-cancelled workflow run is missing or ambiguous",
-    );
-  }
-  const [run] = matchingRuns;
-  if (
-    !Number.isInteger(run.databaseId) &&
-    (typeof run.databaseId !== "string" || run.databaseId.length === 0)
-  ) {
-    throw new Error("configured workflow run has no valid database ID");
-  }
+  const run = selectMergeCiRun({ workflow, headSha, runs });
 
   for (const requiredName of requiredChecks) {
     const matches = jobs.filter((job) => job?.name === requiredName);

--- a/event-runtime/lib/merge-ci-proof.test.mjs
+++ b/event-runtime/lib/merge-ci-proof.test.mjs
@@ -5,6 +5,7 @@ import {
   noRequiredChecksDiagnostic,
   proveMergeCiFallback,
   resolveRequiredContexts,
+  selectMergeCiRun,
 } from "./merge-ci-proof.mjs";
 
 const HEAD_REF = "feat/WM-243";
@@ -102,6 +103,37 @@ describe("configured merge_ci proof", () => {
       { name: "Verify", status: "completed", conclusion: "success" },
     ],
   };
+
+  test("the selector ignores cancelled runs and requires exactly one live run", () => {
+    const live = fallback.runs[0];
+    const cancelled = {
+      ...live,
+      databaseId: 410,
+      conclusion: "cancelled",
+    };
+
+    expect(
+      selectMergeCiRun({
+        workflow: fallback.workflow,
+        headSha: fallback.headSha,
+        runs: [cancelled, live],
+      }),
+    ).toBe(live);
+    expect(() =>
+      selectMergeCiRun({
+        workflow: fallback.workflow,
+        headSha: fallback.headSha,
+        runs: [live, { ...live, databaseId: 411 }],
+      }),
+    ).toThrow("configured non-cancelled workflow run is missing or ambiguous");
+    expect(() =>
+      selectMergeCiRun({
+        workflow: fallback.workflow,
+        headSha: fallback.headSha,
+        runs: [cancelled],
+      }),
+    ).toThrow("configured non-cancelled workflow run is missing or ambiguous");
+  });
 
   test("Factory PR #409 uses the configured workflow and every exact job", () => {
     expect(

--- a/event-runtime/merge-apply.test.mjs
+++ b/event-runtime/merge-apply.test.mjs
@@ -16,7 +16,7 @@ const BASE_SHA = "b".repeat(40);
 const MERGE_SHA = "c".repeat(40);
 const HEAD_REF = "feat/WM-432";
 
-function applyInput() {
+function applyInput(overrides = {}) {
   return {
     repo: "factory",
     github: "watt-mind/factory",
@@ -41,13 +41,14 @@ function applyInput() {
         ambiguous: false,
       },
     ],
+    ...overrides,
   };
 }
 
-function applyCommand(fixture) {
+function applyCommand(fixture, overrides = {}) {
   writeFileSync(
     path.join(fixture.root, "input.json"),
-    `${JSON.stringify(applyInput(), null, 2)}\n`,
+    `${JSON.stringify(applyInput(overrides), null, 2)}\n`,
   );
   return [
     process.execPath,
@@ -217,6 +218,28 @@ describe("merge-apply configured workflow proof", () => {
     expect(log).toContain("run view 81");
     expect(log).not.toContain("run view 80");
     expect(log).toContain("pr merge");
+  });
+
+  test("green required contexts skip an unconfigured repo instead of aborting the apply run", () => {
+    const fixture = commandFixture("merge-apply-green-unconfigured-repo-");
+    installFakes(fixture);
+
+    const result = runCommand(
+      applyCommand(fixture, { repo: "not-in-repos-yaml" }),
+      fixture,
+      commandEnv({ FAKE_REQUIRED_MODE: "green" }),
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const log = commandLog(fixture);
+    expect(log).toContain("pr checks");
+    expect(log).not.toContain("run list");
+    expect(log).not.toContain("pr merge");
+    const reason = applyResult(fixture).artifact.skipped[0].reason;
+    expect(reason).toContain("merge_ci repo record unavailable:");
+    expect(reason).toContain(
+      'repo "not-in-repos-yaml" is not in config/repos.yaml',
+    );
   });
 
   test("green required contexts fail closed without a non-cancelled configured run", () => {

--- a/event-runtime/merge-apply.test.mjs
+++ b/event-runtime/merge-apply.test.mjs
@@ -81,13 +81,22 @@ function installFakes(fixture) {
       '    case "$FAKE_REQUIRED_MODE" in',
       '      no-required) printf "no required checks reported on the \'%s\' branch\\n" "$FAKE_HEAD_REF" >&2; exit 1 ;;',
       "      error) printf 'HTTP 502: upstream unavailable\\n' >&2; exit 1 ;;",
+      '      green) printf \'[{"name":"Verify","bucket":"pass","state":"SUCCESS"}]\\n\' ;;',
       "      *) exit 65 ;;",
       "    esac ;;",
       '  *"run list"*"--workflow CI"*"--event pull_request"*)',
-      '    printf \'[{"databaseId":81,"status":"completed","conclusion":"success","headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_HEAD_SHA" ;;',
+      '    case "$FAKE_RUN_MODE" in',
+      '      cancelled-live) printf \'[{"databaseId":80,"status":"completed","conclusion":"cancelled","headSha":"%s","workflowName":"CI"},{"databaseId":81,"status":"in_progress","conclusion":null,"headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_HEAD_SHA" "$FAKE_HEAD_SHA" ;;',
+      '      no-live) printf \'[{"databaseId":80,"status":"completed","conclusion":"cancelled","headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_HEAD_SHA" ;;',
+      '      *) printf \'[{"databaseId":81,"status":"completed","conclusion":"success","headSha":"%s","workflowName":"CI"}]\\n\' "$FAKE_HEAD_SHA" ;;',
+      "    esac ;;",
+      '  *"run view 80"*)',
+      '    printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"},{"name":"Verify","status":"completed","conclusion":"success"}]\\n\' ;;',
       '  *"run view 81"*)',
       '    if [ "$FAKE_CI_MODE" = missing-job ]; then',
       '      printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"}]\\n\'',
+      '    elif [ "$FAKE_CI_MODE" = pending-job ]; then',
+      '      printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"},{"name":"Verify","status":"in_progress","conclusion":null}]\\n\'',
       "    else",
       '      printf \'[{"name":"Shadow runner fleet available","status":"completed","conclusion":"success"},{"name":"Verify","status":"completed","conclusion":"success"}]\\n\'',
       "    fi ;;",
@@ -108,12 +117,19 @@ function commandEnv(overrides = {}) {
     FAKE_MERGE_SHA: MERGE_SHA,
     FAKE_REQUIRED_MODE: "no-required",
     FAKE_CI_MODE: "success",
+    FAKE_RUN_MODE: "single",
     ...overrides,
   };
 }
 
 function commandLog(fixture) {
   return existsSync(fixture.log) ? readFileSync(fixture.log, "utf8") : "";
+}
+
+function applyResult(fixture) {
+  return JSON.parse(
+    readFileSync(path.join(fixture.root, "result.json"), "utf8"),
+  );
 }
 
 describe("merge-apply required-check fallback (WM-432)", () => {
@@ -155,5 +171,74 @@ describe("merge-apply required-check fallback (WM-432)", () => {
     expect(log).toContain("pr checks");
     expect(log).not.toContain("run list");
     expect(log).not.toContain("pr merge");
+  });
+});
+
+describe("merge-apply configured workflow proof", () => {
+  test("required contexts cannot merge on a cancelled run's stale green while the live run is pending", () => {
+    const fixture = commandFixture("merge-apply-cancelled-live-pending-");
+    installFakes(fixture);
+
+    const result = runCommand(
+      applyCommand(fixture),
+      fixture,
+      commandEnv({
+        FAKE_REQUIRED_MODE: "green",
+        FAKE_RUN_MODE: "cancelled-live",
+        FAKE_CI_MODE: "pending-job",
+      }),
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const log = commandLog(fixture);
+    expect(log).toContain("run view 81");
+    expect(log).not.toContain("run view 80");
+    expect(log).not.toContain("pr merge");
+    expect(applyResult(fixture).artifact.skipped[0].reason).toContain(
+      "configured CI run 81: required job Verify is not completed successfully",
+    );
+  });
+
+  test("required contexts and the live run's successful jobs permit merge", () => {
+    const fixture = commandFixture("merge-apply-cancelled-live-green-");
+    installFakes(fixture);
+
+    const result = runCommand(
+      applyCommand(fixture),
+      fixture,
+      commandEnv({
+        FAKE_REQUIRED_MODE: "green",
+        FAKE_RUN_MODE: "cancelled-live",
+      }),
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const log = commandLog(fixture);
+    expect(log).toContain("run view 81");
+    expect(log).not.toContain("run view 80");
+    expect(log).toContain("pr merge");
+  });
+
+  test("green required contexts fail closed without a non-cancelled configured run", () => {
+    const fixture = commandFixture("merge-apply-green-no-live-");
+    installFakes(fixture);
+
+    const result = runCommand(
+      applyCommand(fixture),
+      fixture,
+      commandEnv({
+        FAKE_REQUIRED_MODE: "green",
+        FAKE_RUN_MODE: "no-live",
+      }),
+    );
+
+    expect(result.status, result.stderr).toBe(0);
+    const log = commandLog(fixture);
+    expect(log).toContain("run list");
+    expect(log).not.toContain("run view");
+    expect(log).not.toContain("pr merge");
+    expect(applyResult(fixture).artifact.skipped[0].reason).toContain(
+      "configured non-cancelled workflow run is missing or ambiguous",
+    );
   });
 });

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -980,8 +980,16 @@ describe("executable merge command safety (WM-412)", () => {
       );
       expect(result.status, `${mode}: ${result.stderr}`).toBe(0);
       const log = readFileSync(fixture.log, "utf8");
+      expect(log).toContain("--required --json name,bucket,state");
+      if (mode === "green") {
+        expect(log).toContain("gh run list");
+        expect(log).toContain("--event pull_request");
+        expect(log).toContain("gh run view 81");
+      } else {
+        expect(log).not.toContain("gh run list");
+        expect(log).not.toContain("gh run view");
+      }
       expect(log.includes("gh pr merge")).toBe(shouldMerge);
-      expect(log).not.toContain("--event pull_request");
     }
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1553

Merge apply now proves protected contexts and the sole live configured workflow run before merging.

## Validation

| Check                | Command                                                                                                              | Result  | Notes                          |
| -------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test event-runtime/merge-apply.test.mjs event-runtime/lib/merge-ci-proof.test.mjs --timeout 20000`               | pass    | 15 tests, 0 failures           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`                    | pass    | 2046 pass, 10 skipped; clean   |
| UX critique          | factory-ux-critic                                                                                                    | not run | no user-facing surface         |

UX critique: skipped — no user-facing surface

run:run_da068a07-1bb8-454e-a4ff-c69f06a0df0b

## Post-review

- Reviewer verdict FIX addressed in 5dc9bc98.
- `merge.test.mjs` WM-412: replaced the stale `not.toContain("--event pull_request")` with the additive contract (green contexts → `gh run list`/`run view` on the live run → `gh pr merge`; `pending`/`duplicate` refuse).
- `merge-apply.mjs`: `getRepo(loadRepos())` on the green-contexts path now returns `{ ok:false, reason: "merge_ci repo record unavailable: ..." }` (per-PR skip) instead of aborting the whole apply run; covered by a new test.
- `docs/ci.md`: sole non-cancelled configured run for the head SHA; two live runs fail closed (no "newest").
