### PR TITLE
fix(worker): recover PRs after missing dispatch results

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:b2b133b7fb5b733861d1d241f4f3597e1e91451d335e46b7046086710bf0add9",
+    "agents/dispatch.md": "sha256:6db511f92f7fac640afd73f103a8e62d63fda362419fea9e56ed79d8a3722b6c",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -9,8 +9,10 @@ You are a ticket agent. `./input.json` names one repo and one ticket:
 The repo's source is at `./repo` — a full worktree the repo's **own**
 `worktree_up` script built for this ticket, with its own branch, ports, and
 database. Do not create another worktree, do not touch any sibling worktree,
-and do not work anything except this one ticket. Write `./result.json` before
-you finish. Work only inside this directory (the `./repo` worktree included).
+and do not work anything except this one ticket. Write `./result.json` **before
+posting the final `## Handoff` comment**: a handoff without its result envelope
+fails the run after the PR is already open. Work only inside this directory
+(the `./repo` worktree included).
 
 ## 1. Claim
 
@@ -183,7 +185,9 @@ shell` means the spawn prompt was defective: correct its path/launch details
    worker's `## Handoff verification (worker-observed)` comment is what
    settles the question.
 
-   Post the structured `## Handoff` comment on the ticket before transitioning:
+   After `./result.json` has been written, post the structured `## Handoff`
+   comment on the ticket before transitioning. This ordering prevents a
+   completed PR and Handoff from being discarded as `missing_result`:
 
    ```
    ## Handoff

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -680,6 +680,26 @@ function fetchPullRequestDefault(payload) {
   }
 }
 
+function findWorkspacePullRequestDefault(payload) {
+  const workspacePath = payload?.workspacePath;
+  if (!workspacePath || !existsSync(workspacePath)) return null;
+  const branch = execFileSync(
+    "git",
+    ["-C", workspacePath, "branch", "--show-current"],
+    { encoding: "utf8", stdio: ["ignore", "pipe", "pipe"] },
+  ).trim();
+  if (!branch) return null;
+  return (
+    loadForge()
+      .prList(payload?.github, {
+        cwd: workspacePath,
+        state: "open",
+        fields: ["number", "url", "headRefName", "isDraft", "state"],
+      })
+      .find((pr) => pr?.headRefName === branch) ?? null
+  );
+}
+
 // WM-1006: in-flight tickets come from the control-plane adapter via the
 // `inflight` CLI verb — never raw tracker GraphQL (plane-specific).
 
@@ -1155,6 +1175,7 @@ export function worktreeDispatchAutoEligibility(
     fetchTicket = fetchTicketDefault,
     fetchViewer = fetchViewerDefault,
     fetchPullRequest = fetchPullRequestDefault,
+    findWorkspacePullRequest = findWorkspacePullRequestDefault,
     fetchInFlight = fetchInFlightDefault,
     countLeases = (repoName) => liveWorkerLeases(repoName).length,
     hasTicketLease = (repoName, ticket) =>
@@ -1422,6 +1443,32 @@ export function worktreeDispatchAutoEligibility(
     evidence.checks.ticket_in_progress_label_retry = true;
   } else {
     evidence.checks.ticket_agent_ready = true;
+  }
+  // Resolve the checkout branch only after the tracker proves this continuation
+  // still owns the ticket. A foreign claim is a tracker refusal and must not be
+  // converted into a transient forge-read failure.
+  if (canResumeEscalation && escalatedContinuation?.workspacePath) {
+    let workspacePullRequest;
+    try {
+      workspacePullRequest = findWorkspacePullRequest({
+        github: repo.github,
+        workspacePath: escalatedContinuation.workspacePath,
+      });
+    } catch (err) {
+      return refusal(
+        "ticket_escalation_pr_read_failed",
+        evidence,
+        "noop",
+        err?.message ?? String(err),
+      );
+    }
+    evidence.escalatedWorkspacePullRequest = workspacePullRequest;
+    evidence.checks.ticket_escalation_workspace_pr_read = true;
+    if (workspacePullRequest && workspacePullRequest.isDraft !== true) {
+      evidence.checks.ticket_escalation_workspace_pr_ready = true;
+      return refusal("ticket_pr_already_open", evidence);
+    }
+    evidence.checks.ticket_escalation_workspace_pr_ready = false;
   }
   if (
     evidence.ticket.labels.includes("ai:escalated") &&

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1303,6 +1303,39 @@ describe("planEvent worktree gate (WM-108)", () => {
       });
       expect(viewerRepos).toEqual(["tiered"]);
 
+      const workspaceEscalation = {
+        failedRunId: base.runId,
+        continuationRunId: continuation.runId,
+        rootRunId: base.runId,
+        repo: "tiered",
+        ticket: "WM-694",
+        workspacePath: "/tmp/tiered-checkout",
+        projectionState: "applied",
+      };
+      expect(
+        worktreeDispatchGate(continuation.input, {
+          ...dispatch,
+          escalatedContinuation: workspaceEscalation,
+          findWorkspacePullRequest: () => ({
+            number: 1533,
+            state: "OPEN",
+            isDraft: false,
+          }),
+        }),
+      ).toEqual({ decision: "noop", reason: "ticket_pr_already_open" });
+      for (const pullRequest of [
+        { number: 1533, state: "OPEN", isDraft: true },
+        null,
+      ]) {
+        expect(
+          worktreeDispatchAutoEligibility(continuation.input, {
+            ...dispatch,
+            escalatedContinuation: workspaceEscalation,
+            findWorkspacePullRequest: () => pullRequest,
+          }).ok,
+        ).toBe(true);
+      }
+
       const closedEscalation = {
         failedRunId: base.runId,
         continuationRunId: continuation.runId,
@@ -2690,7 +2723,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:440db0b0151fee722647bc17ea2808976c65558e50d36fec0a02cdd754843c88","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:600c6d9b252f1e775aae23caa838313fbb0308fb22f69d9aea0e6c3e446ab19e","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -229,6 +229,30 @@ describe("registry", () => {
     }
   });
 
+  test("dispatch documented result envelope validates its registered output schema", () => {
+    const registry = loadRegistry();
+    const def = getAgent(registry, "dispatch@1");
+    const examples = [
+      ...readFileSync(def.promptPath, "utf8").matchAll(
+        /```json\n([\s\S]*?)\n```/g,
+      ),
+    ]
+      .map(([, source]) => JSON.parse(source))
+      .filter(
+        (example) => example.terminalState === "completed" && example.artifact,
+      );
+
+    expect(examples).toHaveLength(1);
+    expect(validate(registry.schemas.agentResult, examples[0])).toEqual({
+      valid: true,
+      errors: [],
+    });
+    expect(validate(def.outputSchema, examples[0].artifact)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  });
+
   test("zero-pack merged-view digest matches the develop baseline", () => {
     // Regenerate with registryDigest(loadRegistry({ packRoots: [] })) on develop.
     // The serializer omits only WM-470's new pack provenance and normalizes
@@ -358,8 +382,10 @@ describe("registry", () => {
     // is filed with `ticket.mjs file --dedupe-key <source issue id>`;
     // triage-apply.json is re-pinned. Prompt text and its pin only — no
     // schema, contract, route, capability, or model tier changed.
+    // Regenerated (#1539): dispatch orders result.json before the final
+    // Handoff comment; prompt pin only.
     const expected =
-      "sha256:847555a80cb0dc6df59d012c1885ab673ad8fef65a8e39af5d04498550d3aa77";
+      "sha256:720af55c39f0287aa93f084f11eb96bc763c934f5cd49cf8f831177aab2a737a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -638,8 +664,10 @@ describe("registry", () => {
     // Regenerated (CLNT-123): dispatch prompt pin moved for the web typecheck
     // and bounded handoff-failure continuation instructions; `pack` remains
     // non-enumerable.
+    // Regenerated (#1539): dispatch orders result.json before the final
+    // Handoff comment; `pack` remains non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:440db0b0151fee722647bc17ea2808976c65558e50d36fec0a02cdd754843c88",
+      "sha256:600c6d9b252f1e775aae23caa838313fbb0308fb22f69d9aea0e6c3e446ab19e",
     );
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4227,6 +4227,7 @@ export async function executeClaimed(
       }
     } catch (err) {
       if (!(err instanceof ContractViolation)) throw err;
+      let activeError = err;
       const recovered = recoverMissingDispatchResult({
         error: err,
         spec,
@@ -4261,22 +4262,23 @@ export async function executeClaimed(
         } catch (recoveryError) {
           if (!(recoveryError instanceof ContractViolation))
             throw recoveryError;
-          err = recoveryError;
+          activeError = recoveryError;
         }
       }
       const reasonCode =
-        err.reasonCode === "baseline_red" ||
-        err.reasonCode === HANDOFF_SANDBOX_UNAVAILABLE ||
-        HANDOFF_REASON_CODES.has(err.reasonCode)
-          ? err.reasonCode
+        activeError.reasonCode === "baseline_red" ||
+        activeError.reasonCode === HANDOFF_SANDBOX_UNAVAILABLE ||
+        HANDOFF_REASON_CODES.has(activeError.reasonCode)
+          ? activeError.reasonCode
           : "contract_violation";
       let failureReason =
-        err.violations.length === 1 && err.violations[0] === "missing_result"
+        activeError.violations.length === 1 &&
+        activeError.violations[0] === "missing_result"
           ? `${reasonCode}: ${missingResultFailure(workspaceDir)}`
-          : `${reasonCode}: ${err.violations.join(", ")}`;
-      const handoff = err.handoff ?? null;
+          : `${reasonCode}: ${activeError.violations.join(", ")}`;
+      const handoff = activeError.handoff ?? null;
       const handoffBody = handoff
-        ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${err.violations.join("; ")}`
+        ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${activeError.violations.join("; ")}`
         : null;
       const escalating = tierEscalationDue(reasonCode);
       // WM-718: the PR is the agent's, already opened; the structural hold is

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -67,6 +67,7 @@ import {
   composeHandoffVerification,
   HANDOFF_REASON_CODES,
   HANDOFF_SANDBOX_UNAVAILABLE,
+  normalizeFailureOutput,
   verifyResult,
 } from "./verify.mjs";
 import {
@@ -1238,6 +1239,12 @@ function tierEscalationForContinuation(db, runId) {
  * `ContractViolation.message` is split back into its lines first.
  */
 export function continuationHandoffFailure(violations) {
+  if (
+    typeof violations === "string" &&
+    /^contract_violation: missing_result\b/.test(violations)
+  ) {
+    return violations;
+  }
   const lines = Array.isArray(violations)
     ? violations
     : typeof violations === "string"
@@ -1246,7 +1253,9 @@ export function continuationHandoffFailure(violations) {
   const failure = lines.find(
     (line) =>
       typeof line === "string" &&
-      /^(?:web_build_failed|ticket_verify_failed):/.test(line),
+      /^(?:(?:web_build_failed|ticket_verify_failed):|contract_violation: missing_result\b)/.test(
+        line,
+      ),
   );
   return failure ?? null;
 }
@@ -1409,7 +1418,7 @@ export function scheduleTierEscalation(
 
 const TIER_ESCALATION_COMMENT_MARKER = "factory:tier-escalation:";
 
-function defaultFindWorkspacePullRequest({ workspacePath }) {
+export function defaultFindWorkspacePullRequest({ workspacePath }) {
   if (!workspacePath) return null;
   const branch = execFileSync(
     "git",
@@ -1427,6 +1436,137 @@ function defaultFindWorkspacePullRequest({ workspacePath }) {
       })
       .find((pr) => pr?.headRefName === branch && pr?.url) ?? null
   );
+}
+
+const RECOVERED_RESULT_REASON = "worker_recovered_missing_result";
+const MISSING_RESULT_OUTPUT_CHARS = 2 * 1024;
+
+function missingResultFailure(workspaceDir) {
+  const resultPath = path.resolve(workspaceDir, "result.json");
+  const output = [
+    ["stdout", ".transcript.json"],
+    ["stderr", ".stderr.txt"],
+    ["sandbox console", ".sandbox-console.log"],
+  ]
+    .flatMap(([label, file]) => {
+      try {
+        return [
+          `[${label}]`,
+          readFileSync(path.join(workspaceDir, file), "utf8"),
+        ];
+      } catch {
+        return [];
+      }
+    })
+    .join("\n");
+  const normalized = normalizeFailureOutput(output).join("\n");
+  const tail = normalized.slice(-MISSING_RESULT_OUTPUT_CHARS);
+  return `missing_result: expected ${resultPath}; agent stdout/stderr (last 2 KB): ${tail || "(no captured output)"}`;
+}
+
+function recoveredDispatchDefinition(def) {
+  return {
+    ...def,
+    outputSchema: {
+      ...def.outputSchema,
+      properties: {
+        ...def.outputSchema.properties,
+        headSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
+      },
+    },
+  };
+}
+
+/**
+ * Recover the one contract failure whose durable work may already be complete.
+ * The finder resolves the branch from the checkout; the PR read then proves
+ * the agent reached its final Handoff before the worker authors result.json.
+ */
+export function recoverMissingDispatchResult({
+  error,
+  spec,
+  def,
+  workspaceDir,
+  worktreeRecord,
+  findPullRequest = defaultFindWorkspacePullRequest,
+  fetchPullRequest = defaultFetchHandoffPullRequest,
+}) {
+  if (
+    spec?.agent !== "dispatch@1" ||
+    !(error instanceof ContractViolation) ||
+    error.violations.length !== 1 ||
+    error.violations[0] !== "missing_result" ||
+    !worktreeRecord?.path
+  ) {
+    return null;
+  }
+
+  let listed;
+  try {
+    listed = findPullRequest({
+      workspacePath: worktreeRecord.path,
+      github: worktreeRecord.github,
+    });
+  } catch {
+    return null;
+  }
+  const prNumber = Number(listed?.number);
+  if (!Number.isInteger(prNumber) || prNumber < 1 || !listed?.url) return null;
+  if (listed?.state && String(listed.state).toUpperCase() !== "OPEN")
+    return null;
+
+  let pullRequest;
+  try {
+    pullRequest = fetchPullRequest({
+      github: worktreeRecord.github,
+      prNumber,
+    });
+  } catch {
+    return null;
+  }
+  const body = pullRequest?.body ?? listed?.body;
+  if (typeof body !== "string" || !/^## Handoff\s*$/m.test(body)) return null;
+
+  const headSha = pullRequest?.headRefOid ?? listed?.headRefOid ?? null;
+  if (!/^[0-9a-f]{40}$/.test(String(headSha))) return null;
+
+  const verificationCommand =
+    worktreeRecord.handoff?.verificationCommand ??
+    worktreeRecord.verify ??
+    null;
+  const candidate = {
+    schemaVersion: "factory.agent-result/v1",
+    terminalState: "completed",
+    reasonCode: RECOVERED_RESULT_REASON,
+    artifact: {
+      outcome: "PR_OPEN",
+      repo: spec.input?.repo,
+      ticket: spec.input?.ticket,
+      prUrl: listed.url,
+      prNumber,
+      headSha,
+      verification: {
+        command: verificationCommand,
+        passed: true,
+        output: "worker recovery; normal handoff verification pending",
+      },
+      summary:
+        "Worker recovered an open PR after the agent omitted result.json",
+    },
+    evidence: {
+      commands: [
+        `git -C ${worktreeRecord.path} branch --show-current`,
+        `forge.prList(open, headRefName)`,
+        `forge.prView(${prNumber})`,
+      ],
+    },
+  };
+  writeFileSync(
+    path.join(workspaceDir, "result.json"),
+    `${JSON.stringify(candidate, null, 2)}\n`,
+    "utf8",
+  );
+  return { candidate, definition: recoveredDispatchDefinition(def) };
 }
 
 export function defaultProjectTierEscalation({
@@ -2491,7 +2631,7 @@ function defaultFetchHandoffPullRequest({ github, prNumber }) {
     throw new Error("handoff PR requires github and a numeric PR number");
   }
   return loadForge().prView(github, prNumber, {
-    fields: ["baseRefName", "body", "isDraft"],
+    fields: ["baseRefName", "body", "headRefOid", "isDraft"],
     timeout: workerSubprocessTimeoutMs(),
   });
 }
@@ -2799,6 +2939,7 @@ export async function executeClaimed(
       returnHandoffTicket: () => true,
       reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
+      findWorkspacePullRequest: () => null,
     };
   } else if (dispatchStubSelected) {
     // A caller that supplies only some dispatch seams (locks, ticket reads,
@@ -2812,6 +2953,7 @@ export async function executeClaimed(
       returnHandoffTicket: () => true,
       reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
+      findWorkspacePullRequest: () => null,
       ...dispatchOpts,
     };
   }
@@ -3482,6 +3624,7 @@ export async function executeClaimed(
             "ticket_claimed_by_other",
             "ticket_escalation_pr_closed",
             "ticket_escalation_pr_read_failed",
+            "ticket_pr_already_open",
           ].includes(gateRefusal.reason) &&
           worktreeHandoff
         ) {
@@ -4062,7 +4205,7 @@ export async function executeClaimed(
     }
 
     let verified;
-    try {
+    verificationAttempt: try {
       verified = verifyResult({
         spec,
         def,
@@ -4084,13 +4227,53 @@ export async function executeClaimed(
       }
     } catch (err) {
       if (!(err instanceof ContractViolation)) throw err;
+      const recovered = recoverMissingDispatchResult({
+        error: err,
+        spec,
+        def,
+        workspaceDir,
+        worktreeRecord,
+        findPullRequest:
+          dispatchOpts?.findWorkspacePullRequest ??
+          defaultFindWorkspacePullRequest,
+        fetchPullRequest: fetchHandoffPullRequestFn,
+      });
+      if (recovered) {
+        try {
+          verified = verifyResult({
+            spec,
+            def: recovered.definition,
+            registry,
+            workspaceDir,
+            attempt,
+            extraArtifacts: RUNTIME_ARTIFACTS,
+            worktreeRecord,
+          });
+          if (verified.handoff && handoffPrNumber(verified.handoff)) {
+            assertHandoffPullRequestBase({
+              handoff: verified.handoff,
+              base: worktreeRecord?.base,
+              fetchPullRequest: fetchHandoffPullRequestFn,
+            });
+          }
+          verified.result.reasonCode = RECOVERED_RESULT_REASON;
+          break verificationAttempt;
+        } catch (recoveryError) {
+          if (!(recoveryError instanceof ContractViolation))
+            throw recoveryError;
+          err = recoveryError;
+        }
+      }
       const reasonCode =
         err.reasonCode === "baseline_red" ||
         err.reasonCode === HANDOFF_SANDBOX_UNAVAILABLE ||
         HANDOFF_REASON_CODES.has(err.reasonCode)
           ? err.reasonCode
           : "contract_violation";
-      let failureReason = `${reasonCode}: ${err.violations.join(", ")}`;
+      let failureReason =
+        err.violations.length === 1 && err.violations[0] === "missing_result"
+          ? `${reasonCode}: ${missingResultFailure(workspaceDir)}`
+          : `${reasonCode}: ${err.violations.join(", ")}`;
       const handoff = err.handoff ?? null;
       const handoffBody = handoff
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${err.violations.join("; ")}`
@@ -4217,7 +4400,7 @@ export async function executeClaimed(
             policyVersion,
             now: currentNow,
             reasonCode,
-            handoffFailure: continuationHandoffFailure(err.violations),
+            handoffFailure: continuationHandoffFailure(failureReason),
           });
         }
         return { ok: true, escalation };

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1260,6 +1260,19 @@ export function continuationHandoffFailure(violations) {
   return failure ?? null;
 }
 
+/**
+ * Pick the continuation's handoff failure from a verification failure. The
+ * matcher anchors each violation at its start, so the composed
+ * `<reasonCode>: ...` failure reason (`handoff_verification_failed: web_build_failed: ...`)
+ * would defeat it; only the `missing_result` diagnostic lives in that string.
+ */
+export function escalationHandoffFailure(error, failureReason) {
+  const violations = Array.isArray(error?.violations) ? error.violations : [];
+  const missingResult =
+    violations.length === 1 && violations[0] === "missing_result";
+  return continuationHandoffFailure(missingResult ? failureReason : violations);
+}
+
 /** Add worker-observed handoff context without mutating the validated spec. */
 export function continuationExecutionInput(input, handoffFailure) {
   return typeof handoffFailure === "string" && handoffFailure
@@ -1464,23 +1477,13 @@ function missingResultFailure(workspaceDir) {
   return `missing_result: expected ${resultPath}; agent stdout/stderr (last 2 KB): ${tail || "(no captured output)"}`;
 }
 
-function recoveredDispatchDefinition(def) {
-  return {
-    ...def,
-    outputSchema: {
-      ...def.outputSchema,
-      properties: {
-        ...def.outputSchema.properties,
-        headSha: { type: "string", pattern: "^[0-9a-f]{40}$" },
-      },
-    },
-  };
-}
-
 /**
  * Recover the one contract failure whose durable work may already be complete.
  * The finder resolves the branch from the checkout; the PR read then proves
  * the agent reached its final Handoff before the worker authors result.json.
+ * The artifact stays inside the registered `factory.dispatch-result/v1`
+ * schema (`additionalProperties: false`); the observed head SHA is carried as
+ * top-level evidence so the real definition verifies the synthesized result.
  */
 export function recoverMissingDispatchResult({
   error,
@@ -1544,7 +1547,6 @@ export function recoverMissingDispatchResult({
       ticket: spec.input?.ticket,
       prUrl: listed.url,
       prNumber,
-      headSha,
       verification: {
         command: verificationCommand,
         passed: true,
@@ -1554,6 +1556,7 @@ export function recoverMissingDispatchResult({
         "Worker recovered an open PR after the agent omitted result.json",
     },
     evidence: {
+      headSha,
       commands: [
         `git -C ${worktreeRecord.path} branch --show-current`,
         `forge.prList(open, headRefName)`,
@@ -1566,7 +1569,7 @@ export function recoverMissingDispatchResult({
     `${JSON.stringify(candidate, null, 2)}\n`,
     "utf8",
   );
-  return { candidate, definition: recoveredDispatchDefinition(def) };
+  return { candidate };
 }
 
 export function defaultProjectTierEscalation({
@@ -4243,7 +4246,7 @@ export async function executeClaimed(
         try {
           verified = verifyResult({
             spec,
-            def: recovered.definition,
+            def,
             registry,
             workspaceDir,
             attempt,
@@ -4276,6 +4279,10 @@ export async function executeClaimed(
         activeError.violations[0] === "missing_result"
           ? `${reasonCode}: ${missingResultFailure(workspaceDir)}`
           : `${reasonCode}: ${activeError.violations.join(", ")}`;
+      const continuationFailure = escalationHandoffFailure(
+        activeError,
+        failureReason,
+      );
       const handoff = activeError.handoff ?? null;
       const handoffBody = handoff
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${activeError.violations.join("; ")}`
@@ -4402,7 +4409,7 @@ export async function executeClaimed(
             policyVersion,
             now: currentNow,
             reasonCode,
-            handoffFailure: continuationHandoffFailure(failureReason),
+            handoffFailure: continuationFailure,
           });
         }
         return { ok: true, escalation };

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -18,7 +18,12 @@ import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
  * state, so a real hang still fails, just not a slow host.
  */
 const EXECUTE_SPAWN_TIMEOUT_MS = loadAdjustedTimeout(5_000);
-import { composeHandoffVerification, insideHandoffSandbox } from "./verify.mjs";
+import {
+  composeHandoffVerification,
+  ContractViolation,
+  insideHandoffSandbox,
+  verifyResult,
+} from "./verify.mjs";
 import { createHash } from "node:crypto";
 import { execFileSync, spawn, spawnSync } from "node:child_process";
 import {
@@ -99,6 +104,7 @@ import {
   repositoryIsClean,
   repositoryStatus,
   provisionInstanceLocalConfigs,
+  recoverMissingDispatchResult,
   runClaimPathGitProbe,
   resolveLinearApiKey,
   reconcileTierEscalations,
@@ -1219,13 +1225,128 @@ sh -c 'sleep 5 & wait'
     }
   });
 
-  test("no-result: FAILED/contract_violation", async () => {
+  test("no-result reports the expected absolute path and bounded agent output", async () => {
     const db = openDb(":memory:");
-    const spec = queueRun(db, makeSpec({ input: { repos: ["no-result"] } }));
+    const diagnosticAdapter = {
+      async execute({ workspaceDir }) {
+        writeFileSync(
+          path.join(workspaceDir, ".transcript.json"),
+          `${"discarded-prefix\n".repeat(300)}agent-final-diagnostic\n`,
+        );
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const spec = queueRun(db, makeSpec({ adapter: "diagnostic-no-result" }));
+    const o = opts();
 
-    const summary = await runOnce(db, registry, adapters, opts());
+    const summary = await runOnce(
+      db,
+      registry,
+      { "diagnostic-no-result": diagnosticAdapter },
+      o,
+    );
     expect(summary.terminalState).toBe("FAILED");
     expect(summary.reasonCode).toBe("contract_violation");
+    expect(summary.detail).toContain(
+      path.resolve(o.workspacesRoot, `${spec.runId}-a1`, "result.json"),
+    );
+    expect(summary.detail).toContain("agent-final-diagnostic");
+    const outputTail = summary.detail.split(
+      "agent stdout/stderr (last 2 KB): ",
+    )[1];
+    expect(outputTail.length).toBeLessThanOrEqual(2 * 1024);
+  });
+
+  test("dispatch missing-result recovery is exact and requires an open PR Handoff", () => {
+    const workspaceDir = tmpDir("dispatch-result-recovery-");
+    const checkoutPath = tmpDir("dispatch-result-checkout-");
+    const def = getAgent(registry, "dispatch@1");
+    const spec = makeSpec({
+      agent: "dispatch@1",
+      input: { repo: "factory", ticket: "watt-mind/factory#1539" },
+      outputContract: "factory.dispatch-result/v1",
+    });
+    const worktreeRecord = {
+      path: checkoutPath,
+      github: "watt-mind/factory",
+      verify: "bun test event-runtime/lib/worker.test.mjs",
+      handoff: {
+        verificationCommand: "bun test event-runtime/lib/worker.test.mjs",
+      },
+    };
+    const missing = new ContractViolation(["missing_result"]);
+    const openPr = {
+      number: 1533,
+      url: "https://github.com/watt-mind/factory/pull/1533",
+      state: "OPEN",
+    };
+    const headSha = "a".repeat(40);
+
+    const recovered = recoverMissingDispatchResult({
+      error: missing,
+      spec,
+      def,
+      workspaceDir,
+      worktreeRecord,
+      findPullRequest: () => openPr,
+      fetchPullRequest: () => ({
+        body: "Fixes watt-mind/factory#1539\n\n## Handoff\ncomplete",
+        headRefOid: headSha,
+      }),
+    });
+    expect(recovered.candidate).toMatchObject({
+      reasonCode: "worker_recovered_missing_result",
+      artifact: {
+        outcome: "PR_OPEN",
+        prNumber: 1533,
+        headSha,
+      },
+    });
+    const verified = verifyResult({
+      spec,
+      def: recovered.definition,
+      registry,
+      workspaceDir,
+      attempt: 1,
+      worktreeRecord: {},
+    });
+    expect(verified.kind).toBe("completed");
+    expect(verified.result.artifact.headSha).toBe(headSha);
+
+    for (const { error, findPullRequest, body, recoveredHeadSha = headSha } of [
+      { error: missing, findPullRequest: () => null, body: "## Handoff" },
+      { error: missing, findPullRequest: () => openPr, body: "Fixes #1539" },
+      {
+        error: missing,
+        findPullRequest: () => openPr,
+        body: "## Handoff",
+        recoveredHeadSha: null,
+      },
+      {
+        error: new ContractViolation(["missing_result", "missing_artifact"]),
+        findPullRequest: () => openPr,
+        body: "## Handoff",
+      },
+      {
+        error: new ContractViolation(["missing_artifact"]),
+        findPullRequest: () => openPr,
+        body: "## Handoff",
+      },
+    ]) {
+      rmSync(path.join(workspaceDir, "result.json"), { force: true });
+      expect(
+        recoverMissingDispatchResult({
+          error,
+          spec,
+          def,
+          workspaceDir,
+          worktreeRecord,
+          findPullRequest,
+          fetchPullRequest: () => ({ body, headRefOid: recoveredHeadSha }),
+        }),
+      ).toBeNull();
+      expect(existsSync(path.join(workspaceDir, "result.json"))).toBe(false);
+    }
   });
 
   test("hang: TIMED_OUT with a tiny timeout", async () => {
@@ -2540,6 +2661,17 @@ sh -c 'sleep 5 & wait'
     ).toBe("web_build_failed: error TS7053");
     expect(continuationHandoffFailure(undefined)).toBeNull();
     expect(continuationHandoffFailure([42, null])).toBeNull();
+    const missingResultReason =
+      "contract_violation: missing_result: expected /tmp/run/result.json; agent stdout/stderr (last 2 KB): text; ticket_verify_failed: quoted output";
+    expect(continuationHandoffFailure(missingResultReason)).toBe(
+      missingResultReason,
+    );
+    expect(
+      continuationExecutionInput(
+        { repo: "factory", ticket: "watt-mind/factory#1539" },
+        continuationHandoffFailure(missingResultReason),
+      ).handoffFailure,
+    ).toBe(missingResultReason);
   });
 
   test("tier continuation input carries the worker-observed handoff failure verbatim", () => {
@@ -2781,6 +2913,90 @@ sh -c 'sleep 5 & wait'
     ).toEqual({
       projection_state: "refused",
       projection_error: "ticket_escalation_pr_closed",
+    });
+    db.close();
+  });
+
+  test("tier escalation marks its projection refused when the checkout branch already has a ready PR", async () => {
+    const db = openDb(":memory:");
+    const failedRunId = "run_tier_open_pr_failed";
+    const continuationRunId = "run_tier_open_pr_continuation";
+    queueRun(
+      db,
+      makeSpec({
+        runId: continuationRunId,
+        agent: "dispatch@1",
+        input: {
+          repo: "factory",
+          ticket: "watt-mind/factory#1539",
+          modelTier: "strong",
+        },
+        workspace: { type: "worktree", checkoutDir: "repo" },
+        outputContract: "factory.dispatch-result/v1",
+        modelTier: "strong",
+      }),
+    );
+    db.query(
+      `INSERT INTO tier_escalations
+         (root_run_id, failed_run_id, continuation_run_id, repo, ticket,
+          workspace_path, source_workspace_path, projection_state, created_at)
+       VALUES (?, ?, ?, 'factory', 'watt-mind/factory#1539', '/tmp/checkout', '/tmp/wrapper', 'applied', ?)`,
+    ).run(
+      failedRunId,
+      failedRunId,
+      continuationRunId,
+      new Date(T0).toISOString(),
+    );
+
+    const locksDir = tmpDir("tier-open-pr-locks-");
+    const leasesDir = tmpDir("tier-open-pr-leases-");
+    let claims = 0;
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        dispatch: {
+          locksDir,
+          leasesDir,
+          fetchTicket: () => ({
+            identifier: "watt-mind/factory#1539",
+            state: { name: "In Progress" },
+            assignee: { id: "factory-owner", name: "Factory" },
+            labels: {
+              nodes: [{ name: "ai:in-progress" }, { name: "tier:strong" }],
+            },
+            description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
+          }),
+          fetchViewer: () => ({ id: "factory-owner", name: "Factory" }),
+          findWorkspacePullRequest: () => ({
+            number: 1533,
+            state: "OPEN",
+            isDraft: false,
+          }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          claimTicket: () => ((claims += 1), { ok: true }),
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      runId: continuationRunId,
+      terminalState: "REFUSED",
+      reasonCode: "ticket_pr_already_open",
+    });
+    expect(claims).toBe(0);
+    expect(
+      db
+        .query(
+          `SELECT projection_state, projection_error FROM tier_escalations WHERE continuation_run_id = ?`,
+        )
+        .get(continuationRunId),
+    ).toEqual({
+      projection_state: "refused",
+      projection_error: "ticket_pr_already_open",
     });
     db.close();
   });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -80,6 +80,7 @@ import {
   codeStampRoot,
   continuationExecutionInput,
   continuationHandoffFailure,
+  escalationHandoffFailure,
   createReloadWatcher,
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultLocksDir,
@@ -1296,22 +1297,24 @@ sh -c 'sleep 5 & wait'
     });
     expect(recovered.candidate).toMatchObject({
       reasonCode: "worker_recovered_missing_result",
-      artifact: {
-        outcome: "PR_OPEN",
-        prNumber: 1533,
-        headSha,
-      },
+      artifact: { outcome: "PR_OPEN", prNumber: 1533 },
+      evidence: { headSha },
     });
+    // The synthesized artifact must satisfy the registered dispatch-result
+    // schema (additionalProperties: false) — no cloned, widened definition.
+    expect(recovered.candidate.artifact).not.toHaveProperty("headSha");
+    expect(recovered).not.toHaveProperty("definition");
     const verified = verifyResult({
       spec,
-      def: recovered.definition,
+      def,
       registry,
       workspaceDir,
       attempt: 1,
       worktreeRecord: {},
     });
     expect(verified.kind).toBe("completed");
-    expect(verified.result.artifact.headSha).toBe(headSha);
+    expect(verified.result.artifact.headSha).toBeUndefined();
+    expect(verified.result.evidence.headSha).toBe(headSha);
 
     for (const { error, findPullRequest, body, recoveredHeadSha = headSha } of [
       { error: missing, findPullRequest: () => null, body: "## Handoff" },
@@ -2672,6 +2675,37 @@ sh -c 'sleep 5 & wait'
         continuationHandoffFailure(missingResultReason),
       ).handoffFailure,
     ).toBe(missingResultReason);
+  });
+
+  test("a handoff_verification_failed run hands its web_build_failed line to the continuation", () => {
+    const violations = [
+      "owned_paths_violation: docs/x.md",
+      "web_build_failed: src/views/Ticket.tsx: error TS7053",
+    ];
+    const error = new ContractViolation(violations, {
+      reasonCode: "handoff_verification_failed",
+    });
+    const failureReason = `handoff_verification_failed: ${violations.join(", ")}`;
+    // The composed reason is prefixed, so the anchored matcher cannot see the
+    // diagnostic in it; the worker must hand over the raw violations instead.
+    expect(continuationHandoffFailure(failureReason)).toBeNull();
+    expect(escalationHandoffFailure(error, failureReason)).toBe(
+      "web_build_failed: src/views/Ticket.tsx: error TS7053",
+    );
+    const missingResultReason =
+      "contract_violation: missing_result: expected /tmp/run/result.json; agent stdout/stderr (last 2 KB): text";
+    expect(
+      escalationHandoffFailure(
+        new ContractViolation(["missing_result"]),
+        missingResultReason,
+      ),
+    ).toBe(missingResultReason);
+    expect(
+      escalationHandoffFailure(
+        new ContractViolation(["missing_artifact"]),
+        "contract_violation: missing_artifact",
+      ),
+    ).toBeNull();
   });
 
   test("tier continuation input carries the worker-observed handoff failure verbatim", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1539

Review the worker recovery path and continuation gate; missing dispatch envelopes now recover completed PR handoffs without redundant reimplementation.

## Validation

| Check                | Command                                                                                                                                                       | Result  | Notes                       |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass    | 266 tests, 0 failures       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check`                                                               | pass    | 2,051 pass, 10 skipped      |
| UX critique          | factory-ux-critic                                                                                                                                              | not run | no user-facing surface      |

UX critique: skipped — no user-facing surface

run:run_f650b197-1743-4931-bff2-c9e7c990c6bc


## Post-review

Reviewer verdict FIX; addressed in the follow-up commit:

1. `no-ex-assign`: the recovery catch no longer reassigns the outer catch param (already `activeError` on the branch head; lint is clean at 0 errors).
2. `continuationHandoffFailure` received the composed `handoff_verification_failed: ...` reason, which its anchored `web_build_failed|ticket_verify_failed` match cannot see. New `escalationHandoffFailure(error, failureReason)` hands over `err.violations` and uses the composed string only for the single `missing_result` case. Test added: `handoff_verification_failed` + a `web_build_failed:` violation still yields the `web_build_failed:` diagnostic line.
3. The synthesized PR_OPEN artifact injected `headSha` via a cloned, widened output schema that the registered `factory.dispatch-result/v1` (`additionalProperties: false`) would reject. `recoveredDispatchDefinition` is deleted; `headSha` now rides in top-level `evidence`, and the real definition verifies the recovered result (test updated to assert this).

Verified: ticket Verification Command (267 pass), `bun run lint` (0 errors), `bun test event-runtime/lib --timeout 20000` (2053 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.


Merge-fix loop: merged `origin/develop` (registry digest baseline recomputed after #1518 re-pinned triage-apply) — `69be31452653a9327cef763d52d9bad9485d0840`.
