### PR TITLE
fix(supervise): preserve crash-loop backoff (#1591)

### DIFF
--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -33,7 +33,7 @@ export function runDir() {
   return process.env.FACTORY_RUN_DIR || path.join(homedir(), ".factory", "run");
 }
 
-/** One pool slot's four files. The run dir IS the supervisor's durable state. */
+/** One pool slot's five files. The run dir IS the supervisor's durable state. */
 export function slotFiles(dir, n) {
   return {
     pid: path.join(dir, `worker-${n}.pid`),
@@ -41,6 +41,7 @@ export function slotFiles(dir, n) {
     log: path.join(dir, `worker-${n}.log`),
     id: path.join(dir, `worker-${n}.id`),
     crashLoop: path.join(dir, `worker-${n}.crash-loop.json`),
+    crashLoopFallback: path.join(dir, `worker-${n}.crash-loop.fallback.json`),
   };
 }
 
@@ -71,6 +72,13 @@ function writeCrashLoop(file, state) {
   const tmp = `${file}.${process.pid}.tmp`;
   writeFileSync(tmp, `${JSON.stringify(state)}\n`);
   renameSync(tmp, file);
+}
+
+/** Prefer the durable fallback while an invalid primary crash-loop file heals. */
+function readCrashLoopState(files) {
+  return (
+    readCrashLoop(files.crashLoopFallback) ?? readCrashLoop(files.crashLoop)
+  );
 }
 
 export function crashBackoffMs(fastExits) {
@@ -124,7 +132,9 @@ export function readPool(dir = runDir()) {
   }
   const slotNumbers = new Set();
   for (const name of names) {
-    const m = /^worker-(\d+)\.(?:pid|crash-loop\.json)$/.exec(name);
+    const m = /^worker-(\d+)\.(?:pid|crash-loop(?:\.fallback)?\.json)$/.exec(
+      name,
+    );
     if (!m) continue;
     slotNumbers.add(Number(m[1]));
   }
@@ -132,7 +142,7 @@ export function readPool(dir = runDir()) {
   for (const n of slotNumbers) {
     const files = slotFiles(dir, n);
     const pid = readPidFile(files.pid);
-    const crashLoop = readCrashLoop(files.crashLoop);
+    const crashLoop = readCrashLoopState(files);
     slots.push({
       n,
       pid,
@@ -239,7 +249,10 @@ export function spawnDetached(
  *
  *   bun event-runtime/cli.mjs supervise [--workers 1:3] [--interval-ms 2000] [--once]
  */
-export default async function supervise(args) {
+export default async function supervise(
+  args,
+  { writeCrashLoop: writeCrashLoopImpl = writeCrashLoop } = {},
+) {
   const dir = runDir();
   mkdirSync(dir, { recursive: true });
 
@@ -306,6 +319,32 @@ export default async function supervise(args) {
   );
 
   const spawnedAt = new Map();
+  const crashLoopFallbacks = new Map();
+
+  function slotCrashLoop(n, files = slotFiles(dir, n)) {
+    return crashLoopFallbacks.get(n) ?? readCrashLoopState(files);
+  }
+
+  function saveCrashLoop(n, state, files = slotFiles(dir, n)) {
+    // Keep the state before releasing its pidfile. The in-memory copy covers
+    // ENOSPC, while the sibling file survives a later tick or restart when the
+    // primary path is a directory or otherwise individually unwritable.
+    crashLoopFallbacks.set(n, state);
+    try {
+      writeCrashLoopImpl(files.crashLoop, state);
+      crashLoopFallbacks.delete(n);
+      rmSync(files.crashLoopFallback, { force: true });
+    } catch (err) {
+      try {
+        writeCrashLoop(files.crashLoopFallback, state);
+      } catch {
+        // The in-memory fallback still protects this live supervisor.
+      }
+      log(
+        `crash-loop state for slot ${n} could not be saved: ${String(err?.message ?? err)}; using fallback`,
+      );
+    }
+  }
 
   function releaseSlot(n) {
     const files = slotFiles(dir, n);
@@ -316,7 +355,7 @@ export default async function supervise(args) {
 
   function resetCrashLoop(n, state) {
     if (state.fastExits === 0 && state.nextAttemptAt === null) return;
-    writeCrashLoop(slotFiles(dir, n).crashLoop, {
+    saveCrashLoop(n, {
       ...state,
       fastExits: 0,
       nextAttemptAt: null,
@@ -329,7 +368,7 @@ export default async function supervise(args) {
     for (const slot of readPool(dir).slots) {
       if (!slot.alive || !slot.workerId) continue;
       const files = slotFiles(dir, slot.n);
-      const state = readCrashLoop(files.crashLoop);
+      const state = slotCrashLoop(slot.n, files);
       if (
         !state ||
         state.fastExits === 0 ||
@@ -351,31 +390,37 @@ export default async function supervise(args) {
 
   function recordExit(slot, now) {
     const files = slotFiles(dir, slot.n);
-    const state = readCrashLoop(files.crashLoop);
+    const state = slotCrashLoop(slot.n, files);
     const startedAt = spawnedAt.get(slot.n) ?? state?.spawnedAt;
     const fastExit =
       !slot.draining &&
       Number.isFinite(startedAt) &&
       now - startedAt < spawnGraceMs;
-    releaseSlot(slot.n);
-
     if (!fastExit) {
+      releaseSlot(slot.n);
       rmSync(files.crashLoop, { force: true });
+      rmSync(files.crashLoopFallback, { force: true });
+      crashLoopFallbacks.delete(slot.n);
       return null;
     }
 
     const fastExits = (state?.fastExits ?? 0) + 1;
     const nextAttemptAt =
       fastExits >= CRASH_LOOP_LIMIT ? now + crashBackoffMs(fastExits) : null;
-    writeCrashLoop(files.crashLoop, {
-      fastExits,
-      spawnedAt: null,
-      lastExitedAt: now,
-      lastExitDurationMs: now - startedAt,
-      workerId: slot.workerId ?? state?.workerId ?? null,
-      nextAttemptAt,
-      loggedRetryAt: null,
-    });
+    saveCrashLoop(
+      slot.n,
+      {
+        fastExits,
+        spawnedAt: null,
+        lastExitedAt: now,
+        lastExitDurationMs: now - startedAt,
+        workerId: slot.workerId ?? state?.workerId ?? null,
+        nextAttemptAt,
+        loggedRetryAt: null,
+      },
+      files,
+    );
+    releaseSlot(slot.n);
     return { fastExits, nextAttemptAt };
   }
 
@@ -402,8 +447,8 @@ export default async function supervise(args) {
     writeFileSync(files.id, `${workerId}\n`);
     const startedAt = Date.now();
     spawnedAt.set(n, startedAt);
-    const previous = readCrashLoop(files.crashLoop);
-    writeCrashLoop(files.crashLoop, {
+    const previous = slotCrashLoop(n, files);
+    saveCrashLoop(n, {
       fastExits: previous?.fastExits ?? 0,
       spawnedAt: startedAt,
       lastExitedAt: previous?.lastExitedAt ?? null,
@@ -452,7 +497,7 @@ export default async function supervise(args) {
     const alive = readPool(dir).slots.filter((s) => s.alive);
     const observed = poolCounts(db, { now });
     const pending = alive.filter((s) => {
-      const state = readCrashLoop(slotFiles(dir, s.n).crashLoop);
+      const state = slotCrashLoop(s.n);
       const startedAt = spawnedAt.get(s.n) ?? state?.spawnedAt ?? 0;
       return now - startedAt < spawnGraceMs;
     }).length;
@@ -477,16 +522,20 @@ export default async function supervise(args) {
         return decision;
       }
       const files = slotFiles(dir, slot);
-      const crashLoop = readCrashLoop(files.crashLoop);
+      const crashLoop = slotCrashLoop(slot, files);
       if (crashLoop?.nextAttemptAt && crashLoop.nextAttemptAt > now) {
         if (crashLoop.loggedRetryAt !== crashLoop.nextAttemptAt) {
           log(
             `crash-loop slot ${slot}: ${crashLoop.fastExits} fast exits, next attempt in ${remainingSeconds(crashLoop.nextAttemptAt, now)}s [${counts}]`,
           );
-          writeCrashLoop(files.crashLoop, {
-            ...crashLoop,
-            loggedRetryAt: crashLoop.nextAttemptAt,
-          });
+          saveCrashLoop(
+            slot,
+            {
+              ...crashLoop,
+              loggedRetryAt: crashLoop.nextAttemptAt,
+            },
+            files,
+          );
         }
         return decision;
       }

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -12,7 +12,7 @@ import {
 import path from "node:path";
 import { openDb } from "../lib/db.mjs";
 import { registerWorker } from "../lib/workers.mjs";
-import {
+import supervise, {
   crashBackoffMs,
   readPool,
   spawnDetached,
@@ -84,8 +84,8 @@ describe("supervise (WM-226)", () => {
     }
   });
 
-  test("--once propagates tick failures while daemon ticks are logged on every failure and retried", async () => {
-    const error = new Error("transient failure");
+  test("--once propagates tick failures while daemon ticks log non-Error throws and retry", async () => {
+    const error = "transient failure";
     expect(() =>
       startTickLoop(
         () => {
@@ -161,7 +161,7 @@ describe("supervise (WM-226)", () => {
     expect(new Set(lines)).toEqual(new Set(["tick error: spawn EAGAIN"]));
   });
 
-  test("a transient tick failure is logged and the supervisor keeps ticking", async () => {
+  test("an unwritable primary crash-loop file uses its fallback and keeps the supervisor live", async () => {
     const home = tmpDir("evrt-pool-tick-error-");
     const dir = tmpDir("evrt-pool-tick-error-run-");
     const box = spawnSupervisor(
@@ -184,36 +184,16 @@ describe("supervise (WM-226)", () => {
       rmSync(crashLoop, { force: true });
       mkdirSync(crashLoop);
       process.kill(worker.pid, "SIGKILL");
-      expect(await waitFor(box, "tick error:", 10_000)).toBe(true);
-      // The fault persists across ticks, so the line must repeat — never
-      // deduplicated the way `hold — …` is.
+      expect(
+        await waitFor(
+          box,
+          "crash-loop state for slot 1 could not be saved",
+          10_000,
+        ),
+      ).toBe(true);
       await until(
-        "a second failing tick to be logged",
-        () => box.out.split("tick error:").length - 1 >= 2,
-        { timeoutMs: 10_000 },
-      );
-      expect(box.child.exitCode ?? null).toBeNull();
-      expect(existsSync(path.join(dir, "supervisor.pid"))).toBe(true);
-      rmSync(crashLoop, { recursive: true, force: true });
-
-      // With the fault gone the loop must still be live: the slot a failing
-      // tick left behind is reaped and the pool is rebuilt on later ticks.
-      const faultClearedAt = box.out.length;
-      const after = () => box.out.slice(faultClearedAt);
-      const respawned = await until(
-        "a worker to occupy slot 1 after the fault cleared",
+        "a replacement worker after the crash-loop write fails",
         () => readPool(dir).slots.find((s) => s.n === 1 && s.alive) ?? null,
-        { timeoutMs: 10_000 },
-      );
-      process.kill(respawned.pid, "SIGKILL");
-      await until(
-        "the supervisor to reap the killed slot after the fault cleared",
-        () => after().includes("slot released"),
-        { timeoutMs: 10_000 },
-      );
-      await until(
-        "the supervisor to act on the freed slot after the fault cleared",
-        () => /spawn slot 1|crash-loop slot 1/.test(after()),
         { timeoutMs: 10_000 },
       );
       expect(box.child.exitCode ?? null).toBeNull();
@@ -224,6 +204,69 @@ describe("supervise (WM-226)", () => {
       rmSync(dir, { recursive: true, force: true });
     }
   }, 30_000);
+
+  test("preserves a failed fast exit before release so the next decision backs off", async () => {
+    const home = tmpDir("evrt-pool-crash-fallback-home-");
+    const dir = tmpDir("evrt-pool-crash-fallback-run-");
+    const before = Date.now();
+    const oldHome = process.env.FACTORY_EVENT_HOME;
+    const oldRunDir = process.env.FACTORY_RUN_DIR;
+    process.env.FACTORY_EVENT_HOME = home;
+    process.env.FACTORY_RUN_DIR = dir;
+    writeFileSync(path.join(dir, "worker-1.pid"), "2147483646\n");
+    writeFileSync(
+      path.join(dir, "worker-1.crash-loop.json"),
+      JSON.stringify({
+        fastExits: 2,
+        spawnedAt: before,
+        workerId: "fast-exit-worker",
+        nextAttemptAt: null,
+        loggedRetryAt: null,
+      }),
+    );
+
+    try {
+      await supervise(["--workers", "1:1", "--once"], {
+        writeCrashLoop: () => {
+          throw "injected crash-loop write failure";
+        },
+      });
+      const state = JSON.parse(
+        readFileSync(
+          path.join(dir, "worker-1.crash-loop.fallback.json"),
+          "utf8",
+        ),
+      );
+      expect(state.fastExits).toBe(3);
+      expect(state.nextAttemptAt).toBeGreaterThan(before);
+      expect(existsSync(path.join(dir, "worker-1.pid"))).toBe(false);
+      expect(readPool(dir).slots[0]).toMatchObject({
+        crashLoops: 3,
+        nextAttemptAt: state.nextAttemptAt,
+      });
+    } finally {
+      if (oldHome === undefined) delete process.env.FACTORY_EVENT_HOME;
+      else process.env.FACTORY_EVENT_HOME = oldHome;
+      if (oldRunDir === undefined) delete process.env.FACTORY_RUN_DIR;
+      else process.env.FACTORY_RUN_DIR = oldRunDir;
+      rmSync(home, { recursive: true, force: true });
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("the supervise process exits non-zero when its single tick throws", () => {
+    const dir = tmpDir("evrt-pool-once-tick-throw-");
+    try {
+      writeFileSync(path.join(dir, "worker-1.pid"), "2147483646\n");
+      mkdirSync(path.join(dir, "worker-1.crash-loop.json"));
+      const result = runCli(["supervise", "--workers", "1:1", "--once"], {
+        FACTORY_RUN_DIR: dir,
+      });
+      expect(result.status).not.toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
 
   test("rejects unsafe drain timeouts before writing its pidfile", () => {
     for (const value of ["not-a-number", "0", "-1"]) {


### PR DESCRIPTION
Fixes #1591

Review the fallback-backed crash-loop backoff and process-level `--once` failure coverage.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli/supervise.test.mjs --timeout 60000` | pass | 14 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 617 existing warnings |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_c6e4e0bd-d352-4168-bdb9-82d5cec96fd6