### PR TITLE
fix(badge): count GitHub closing references

### DIFF
--- a/docs/oss/launch-drafts/dogfood-badge.md
+++ b/docs/oss/launch-drafts/dogfood-badge.md
@@ -7,6 +7,12 @@ The updater that refreshes the count lives on a sibling ticket
 (WM-958). This snippet is the static launch version, pinned to the
 window in `docs/oss/launch-post.md`.
 
+The rolling updater recognizes factory PRs from a closing reference in
+the PR body. Legacy Linear references such as `Fixes WM-958` remain
+valid, as do GitHub forms such as `Fixes #1570`, `Closes
+watt-mind/factory#1570`, and `Resolves
+https://github.com/watt-mind/factory/issues/1570`.
+
 ## README / social preview
 
 ```markdown

--- a/tools/update-dogfood-badge.mjs
+++ b/tools/update-dogfood-badge.mjs
@@ -22,7 +22,9 @@ import { loadForge } from "../lib/forge/index.mjs";
 export const WINDOW_DAYS = 30;
 export const DEFAULT_REPO = "watt-mind/factory";
 export const DEFAULT_README = "README.md";
-export const DEFAULT_PR_LIMIT = 1000;
+// The current repository can merge more than 1,000 PRs in a 30-day window.
+// Keep the default above that volume so the scheduled command can publish.
+export const DEFAULT_PR_LIMIT = 3000;
 export const BADGE_START = "<!-- factory-dogfood-badge -->";
 export const BADGE_END = "<!-- /factory-dogfood-badge -->";
 export const BADGE_COLOR = "0B6E4F";
@@ -36,8 +38,12 @@ export const PR_FIELDS = Object.freeze([
   "headRefName",
 ]);
 
-/** Factory protocol: `Fixes WM-958` / `Fixes CLNT-123` in the PR body. */
-export const FIXES_TICKET_RE = /\bFixes\s+[A-Z]{2,}-\d+\b/;
+/**
+ * Factory protocol: a closing keyword plus a Linear or GitHub issue reference
+ * in the PR body, for example `Fixes WM-958` or `Closes watt-mind/factory#1`.
+ */
+export const FIXES_TICKET_RE =
+  /\b(?:Fixes|Closes|Resolves)\s+(?:[A-Z]{2,}-\d+|#\d+|[A-Z0-9._-]+\/[A-Z0-9._-]+#\d+|https:\/\/github\.com\/[A-Z0-9._-]+\/[A-Z0-9._-]+\/issues\/\d+)\b/i;
 
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
@@ -165,7 +171,7 @@ export function collectMetrics(
   // count would under-state the trust signal.
   if (prs.length === limit && mergedInWindow.length === prs.length) {
     throw new Error(
-      `merged PR scan hit the --limit of ${limit} and every result is inside the ${windowDays}-day window; raise --limit (GitHub caps gh pr list at 1000) or the badge would under-count`,
+      `merged PR scan hit the --limit of ${limit} and every result is inside the ${windowDays}-day window; raise --limit or the badge would under-count`,
     );
   }
   return {

--- a/tools/update-dogfood-badge.test.mjs
+++ b/tools/update-dogfood-badge.test.mjs
@@ -50,14 +50,21 @@ function forgeWith(prs) {
 }
 
 // -------------------------------------------------------- heuristic ---
-test("Fixes <TICKET> in the body is autonomous", () => {
-  expect(isAutonomousPr({ body: "Fixes WM-958\n\nrun:abc" })).toBe(true);
-  expect(isAutonomousPr({ body: "See also Fixes CLNT-12." })).toBe(true);
+test("closing references in the body are autonomous", () => {
+  for (const body of [
+    "Fixes WM-958\n\nrun:abc",
+    "See also fixes clnt-12.",
+    "Closes #1570",
+    "resolves watt-mind/factory#1570",
+    "Fixes https://github.com/watt-mind/factory/issues/1570",
+  ]) {
+    expect(isAutonomousPr({ body })).toBe(true);
+  }
 });
 
 test("human or protocol-less bodies are not autonomous", () => {
   expect(isAutonomousPr({ body: "this PR fixes a bug" })).toBe(false);
-  expect(isAutonomousPr({ body: "Fixes wm-958" })).toBe(false);
+  expect(isAutonomousPr({ body: "Fixes null" })).toBe(false);
   expect(isAutonomousPr({ body: "" })).toBe(false);
   expect(isAutonomousPr({})).toBe(false);
   expect(


### PR DESCRIPTION
Fixes watt-mind/factory#1570

Badge metrics now recognize GitHub closing references and report current autonomous merges.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test tools/update-dogfood-badge.test.mjs` | pass | 16 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 617 existing lint warnings |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped

run:run_324cfa89-4f13-4f3a-a3b3-56c8c4dd6457