### PR TITLE
fix(runtime-overrides): harden malformed override and promotion drift handling

### DIFF
--- a/event-runtime/lib/runtime-overrides.mjs
+++ b/event-runtime/lib/runtime-overrides.mjs
@@ -37,7 +37,7 @@ export class OverlayError extends Error {
 }
 
 export function emptyOverrides() {
-  return { eventTypes: {}, agents: {}, modelTierCells: {} };
+  return { eventTypes: {}, agents: {}, modelTierCells: {}, unknown: [] };
 }
 
 /** Adapters the overlay may name: builtins plus any currently routed. */
@@ -51,6 +51,10 @@ export function knownAdapters(registry) {
   return names;
 }
 
+/**
+ * Return stored overrides, rejecting malformed known-kind rows with an
+ * actionable error and retaining unknown kinds for read-only diagnostics.
+ */
 export function listOverrides(db) {
   const rows = db
     .query(
@@ -59,11 +63,26 @@ export function listOverrides(db) {
     .all();
   const out = emptyOverrides();
   for (const row of rows) {
-    const patch = JSON.parse(row.patch_json);
+    if (
+      row.kind !== KIND_EVENT_TYPE &&
+      row.kind !== KIND_AGENT &&
+      row.kind !== KIND_MODEL_TIER_CELL
+    ) {
+      out.unknown.push({ kind: row.kind, key: row.key });
+      continue;
+    }
+    let patch;
+    try {
+      patch = JSON.parse(row.patch_json);
+    } catch (err) {
+      throw new OverlayError(
+        500,
+        `invalid stored ${row.kind} override ${row.key}: ${err.message} — delete or correct this runtime_overrides row`,
+      );
+    }
     if (row.kind === KIND_EVENT_TYPE) out.eventTypes[row.key] = patch;
     else if (row.kind === KIND_AGENT) out.agents[row.key] = patch;
-    else if (row.kind === KIND_MODEL_TIER_CELL)
-      out.modelTierCells[row.key] = patch;
+    else out.modelTierCells[row.key] = patch;
   }
   return out;
 }
@@ -445,10 +464,6 @@ export function overlayForAgent(overrides, ref) {
   return overrides?.agents?.[ref] ?? null;
 }
 
-export function effectiveAdapter(mapping, overrides, type) {
-  return overlayForEventType(overrides, type)?.adapter ?? mapping.adapter;
-}
-
 /*
  * Overlay promotion (gh-860).
  *
@@ -769,9 +784,28 @@ export async function applyPromotion({
   try {
     const readWorktree = requireSeam(seams, "readWorktree");
     const writeWorktree = requireSeam(seams, "writeWorktree");
-    const written = [];
+    const worktreeFiles = new Map();
+    // The isolated worktree is built from target.base, which may have moved
+    // after the live-checkout drift guard above. Validate every target in that
+    // actual base snapshot before writing any of them.
     for (const file of byFile.keys()) {
       const parsed = JSON.parse(readWorktree(dir, file));
+      for (const selection of selected) {
+        if (selection.target.file !== file) continue;
+        if (
+          readSelectionValue(parsed, selection) !== (selection.before ?? null)
+        ) {
+          throw new OverlayError(
+            409,
+            `target drift on ${selection.key}: base-branch value changed since preview`,
+          );
+        }
+      }
+      worktreeFiles.set(file, parsed);
+    }
+
+    const written = [];
+    for (const [file, parsed] of worktreeFiles) {
       for (const selection of selected) {
         if (selection.target.file !== file) continue;
         writeSelectionValue(parsed, selection);

--- a/event-runtime/lib/runtime-overrides.test.mjs
+++ b/event-runtime/lib/runtime-overrides.test.mjs
@@ -60,7 +60,11 @@ function seedDivergentOverrides(db) {
  * write outside a captured in-memory worktree. Records every seam call so a
  * test can prove nothing targets the live root and no merge/delete occurs.
  */
-function fakeSeams({ worktreeDir = "/tmp/promo-wt-860", readTracked } = {}) {
+function fakeSeams({
+  worktreeDir = "/tmp/promo-wt-860",
+  readTracked,
+  readWorktree,
+} = {}) {
   const calls = [];
   const writes = new Map();
   return {
@@ -84,9 +88,12 @@ function fakeSeams({ worktreeDir = "/tmp/promo-wt-860", readTracked } = {}) {
       },
       readWorktree(dir, file) {
         calls.push(["readWorktree", dir, file]);
-        return writes.has(file)
-          ? writes.get(file)
-          : readFileSync(path.join(REPO_ROOT, file), "utf8");
+        return (
+          readWorktree?.(dir, file) ??
+          (writes.has(file)
+            ? writes.get(file)
+            : readFileSync(path.join(REPO_ROOT, file), "utf8"))
+        );
       },
       writeWorktree(dir, file, text) {
         calls.push(["writeWorktree", dir, file]);
@@ -143,6 +150,48 @@ describe("runtime-overrides (WM-887)", () => {
     expect(journal).toHaveLength(2);
     expect(journal[0].after).toBeNull();
     expect(journal[1].after).toEqual({ adapter: "cursor" });
+    db.close();
+  });
+
+  test("malformed agent overrides identify the stored row instead of leaking SyntaxError", () => {
+    const db = openDb(":memory:");
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      KIND_AGENT,
+      "agy-malformed@1",
+      "{ not json",
+      new Date(0).toISOString(),
+      "test",
+    );
+
+    expect(() => listOverrides(db)).toThrow(OverlayError);
+    expect(() => listOverrides(db)).toThrow(
+      /invalid stored agent override agy-malformed@1:.*delete or correct this runtime_overrides row/,
+    );
+    db.close();
+  });
+
+  test("unknown override kinds are retained for diagnostics and not applied", () => {
+    const db = openDb(":memory:");
+    db.query(
+      `INSERT INTO runtime_overrides (kind, key, patch_json, updated_at, updated_by)
+       VALUES (?, ?, ?, ?, ?)`,
+    ).run(
+      "retiredKind",
+      "legacy-row",
+      "{ not json",
+      new Date(0).toISOString(),
+      "test",
+    );
+
+    expect(listOverrides(db)).toEqual({
+      eventTypes: {},
+      agents: {},
+      modelTierCells: {},
+      unknown: [{ kind: "retiredKind", key: "legacy-row" }],
+    });
     db.close();
   });
 
@@ -609,6 +658,35 @@ describe("overlay promotion (gh-860)", () => {
     ).rejects.toMatchObject({ status: 409 });
     // Failed drift means no worktree was ever created.
     expect(calls.some((c) => c[0] === "worktree.up")).toBe(false);
+    db.close();
+  });
+
+  test("base-branch drift after checkout fails before writing the worktree", async () => {
+    const db = openDb(":memory:");
+    seedDivergentOverrides(db);
+    const preview = buildPromotionPreview({ db, registry });
+    const key = preview.selections.find((s) => s.ref === PROMO_AGENT).key;
+    const { seams, calls } = fakeSeams({
+      readWorktree: () =>
+        JSON.stringify({ id: "agy-smoke", model_tier: "standard" }),
+    });
+
+    await expect(
+      applyPromotion({
+        db,
+        registry,
+        target: TARGET,
+        digest: preview.digest,
+        keys: [key],
+        seams,
+      }),
+    ).rejects.toMatchObject({
+      status: 409,
+      message: expect.stringContaining(
+        "target drift on agent:agy-smoke@1:modelTier: base-branch value changed since preview",
+      ),
+    });
+    expect(calls.some((call) => call[0] === "writeWorktree")).toBe(false);
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1613

Review contextual runtime override errors and base-worktree drift protection.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/runtime-overrides.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/api-registry.test.mjs --timeout 20000 && bun run format:check` | pass | 136 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2062 pass, 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_dc4f6601-4ec9-41b2-b795-7beb12e7045a