### PR TITLE
fix(lifecycle): release attempts-exhausted failed idempotency runs

### DIFF
--- a/event-runtime/lib/lifecycle.mjs
+++ b/event-runtime/lib/lifecycle.mjs
@@ -286,11 +286,22 @@ const IDEMPOTENCY_TRIGGER_MARKER = ":trigger:";
 function idempotencyFamily(db, idempotencyKey) {
   return db
     .query(
-      `SELECT run_id, idempotency_key, state, created_at, rowid
+      `SELECT run_id, idempotency_key, state, created_at, rowid,
+              CASE WHEN state NOT IN ('COMPLETED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')
+                         AND (
+                           state <> 'FAILED'
+                           -- Keep this FAILED clause aligned with
+                           -- planner.mjs:liveRunForInput.
+                           OR (
+                             json_extract(spec_json, '$.maxAttempts') IS NULL
+                             OR attempts < json_extract(spec_json, '$.maxAttempts')
+                           )
+                         )
+                   THEN 1 ELSE 0 END AS idempotency_active
        FROM runs
       WHERE idempotency_key = ?
          OR instr(idempotency_key, ? || ?) = 1
-      ORDER BY CASE WHEN state IN ('COMPLETED', 'REFUSED', 'TIMED_OUT', 'CANCELLED') THEN 1 ELSE 0 END,
+      ORDER BY idempotency_active DESC,
                created_at DESC, rowid DESC`,
     )
     .all(idempotencyKey, idempotencyKey, IDEMPOTENCY_TRIGGER_MARKER);
@@ -325,7 +336,7 @@ export function resolveIdempotency(
   const family = idempotencyFamily(db, idempotencyKey);
   if (family.length === 0) return null;
 
-  const active = family.find((run) => !TERMINAL_STATES.has(run.state));
+  const active = family.find((run) => run.idempotency_active);
   if (active) return active;
 
   const run = family[0];

--- a/event-runtime/lib/lifecycle.test.mjs
+++ b/event-runtime/lib/lifecycle.test.mjs
@@ -28,6 +28,34 @@ function freshRun(db, key = `key-${Math.random()}`) {
   return runId;
 }
 
+function createIdempotentRun(
+  db,
+  { runId, idempotencyKey, maxAttempts, correlationId, causationId },
+) {
+  const spec = maxAttempts === undefined ? {} : { maxAttempts };
+  createRun(db, {
+    runId,
+    idempotencyKey,
+    spec,
+    specJson: JSON.stringify(spec),
+    specHash: "sha256:0",
+    actor: "planner",
+    correlationId,
+    causationId,
+    policyVersion: "test",
+  });
+}
+
+function failRun(db, runId, attempts) {
+  for (const to of ["APPROVED", "QUEUED", "LEASED", "RUNNING", "FAILED"]) {
+    transition(db, { runId, to, actor: "test" });
+  }
+  db.query(`UPDATE runs SET attempts = ? WHERE run_id = ?`).run(
+    attempts,
+    runId,
+  );
+}
+
 describe("lifecycle", () => {
   test("createRun persists a normalized ticket subject", () => {
     const db = openDb(":memory:");
@@ -175,6 +203,88 @@ describe("lifecycle", () => {
       causationId: "run_dispatch_1",
     });
     expect(duplicate?.run_id).toBe("run_chain_1");
+  });
+
+  test("resolveIdempotency keeps a retryable FAILED run active", () => {
+    const db = openDb(":memory:");
+    createIdempotentRun(db, {
+      runId: "run_retryable_failed",
+      idempotencyKey: "failed-retryable-key",
+      maxAttempts: 2,
+      correlationId: "lineage-retryable",
+      causationId: "dispatch-original",
+    });
+    failRun(db, "run_retryable_failed", 1);
+
+    const duplicate = resolveIdempotency(db, {
+      idempotencyKey: "failed-retryable-key",
+      correlationId: "lineage-retryable",
+      causationId: "dispatch-distinct",
+    });
+    expect(duplicate?.run_id).toBe("run_retryable_failed");
+  });
+
+  test("resolveIdempotency releases an attempts-exhausted FAILED run but resolves its redelivery", () => {
+    const db = openDb(":memory:");
+    createIdempotentRun(db, {
+      runId: "run_exhausted_failed",
+      idempotencyKey: "failed-exhausted-key",
+      maxAttempts: 2,
+      correlationId: "lineage-exhausted",
+      causationId: "dispatch-original",
+    });
+    failRun(db, "run_exhausted_failed", 2);
+
+    expect(
+      resolveIdempotency(db, {
+        idempotencyKey: "failed-exhausted-key",
+        correlationId: "lineage-exhausted",
+        causationId: "dispatch-distinct",
+      }),
+    ).toBeNull();
+    expect(
+      resolveIdempotency(db, {
+        idempotencyKey: "failed-exhausted-key",
+        correlationId: "lineage-exhausted",
+        causationId: "dispatch-original",
+      })?.run_id,
+    ).toBe("run_exhausted_failed");
+  });
+
+  test("resolveIdempotency prefers a later completed generation over an exhausted FAILED run", () => {
+    const db = openDb(":memory:");
+    createIdempotentRun(db, {
+      runId: "run_exhausted_generation",
+      idempotencyKey: "failed-family-key",
+      maxAttempts: 1,
+      correlationId: "lineage-exhausted",
+      causationId: "dispatch-exhausted",
+    });
+    failRun(db, "run_exhausted_generation", 1);
+    createIdempotentRun(db, {
+      runId: "run_completed_generation",
+      idempotencyKey: "failed-family-key:trigger:new-generation",
+      correlationId: "lineage-completed",
+      causationId: "dispatch-completed",
+    });
+    for (const to of [
+      "APPROVED",
+      "QUEUED",
+      "LEASED",
+      "RUNNING",
+      "VERIFYING",
+      "COMPLETED",
+    ]) {
+      transition(db, { runId: "run_completed_generation", to, actor: "test" });
+    }
+
+    expect(
+      resolveIdempotency(db, {
+        idempotencyKey: "failed-family-key",
+        correlationId: "lineage-completed",
+        causationId: "dispatch-completed",
+      })?.run_id,
+    ).toBe("run_completed_generation");
   });
 
   test("lifecycle timestamps are monotonic and distinct across states when clock advances", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1608

Exhausted FAILED runs now release their idempotency family while retryable failures still coalesce.

## Validation

| Check                | Command                                                                                              | Result  | Notes                                   |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | --------------------------------------- |
| Verification Command | `bun test event-runtime/lib/lifecycle.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 224 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2081 pass; emit, format, lint clean     |
| UX critique          | factory-ux-critic                                                                                    | not run | no user-facing surface                  |

UX critique: skipped — backend lifecycle behavior only

run:run_e1437a9f-97ce-46e0-b908-558697868ba0