### PR TITLE
fix(artifacts): tolerate malformed result_json rows and surface tmp leaks to GC (#1612)

### DIFF
--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -29,7 +29,10 @@ import { canonicalJson, hashJson } from "./canonical.mjs";
 import { confinedRegularFile } from "./workspace.mjs";
 
 const HEX64 = /^[0-9a-f]{64}$/;
+const ARTIFACT_TEMP = /^[0-9a-f]{64}\.tmp\./;
 const SHA256 = /^sha256:([0-9a-f]{64})$/;
+/** Interrupted artifact publishes are eligible for reclamation after one hour. */
+export const ARTIFACT_TEMP_GRACE_MS = 60 * 60 * 1000;
 const TRUSTED_ROOTLESS_SOURCES = new Map([
   ["memo", null],
   ["transcript", ".transcript.json"],
@@ -315,13 +318,28 @@ export function materializeArtifact({
   return { path: dest, sha256: sha256hex, sizeBytes: found.sizeBytes };
 }
 
-/** Every artifact hash any accepted result still points at. */
+/**
+ * Every artifact hash any accepted result still points at.
+ *
+ * A malformed historical result is counted in `hashes.invalid` rather than
+ * thrown. Callers that delete bytes must fail closed when it is non-zero;
+ * read-only callers can continue with the valid rows.
+ *
+ * @returns {Set<string> & { invalid: number }}
+ */
 export function referencedHashes(db) {
   const hashes = new Set();
+  hashes.invalid = 0;
   for (const row of db
     .query(`SELECT result_json, artifact_hash FROM results`)
     .all()) {
-    const result = JSON.parse(row.result_json);
+    let result;
+    try {
+      result = JSON.parse(row.result_json);
+    } catch {
+      hashes.invalid += 1;
+      continue;
+    }
     for (const entry of result.artifacts ?? []) {
       if (entry.sha256) hashes.add(entry.sha256);
     }
@@ -374,7 +392,13 @@ export function artifactReferenceIndex(db) {
     } catch {
       // A catalogue read should still expose the bytes if an old spec is bad.
     }
-    const result = JSON.parse(row.result_json);
+    let result;
+    try {
+      result = JSON.parse(row.result_json);
+    } catch {
+      // A bad historical result must not make the whole catalogue unavailable.
+      continue;
+    }
     for (const entry of result.artifacts ?? []) {
       if (!HEX64.test(entry.sha256 ?? "")) continue;
       const refs = references.get(entry.sha256) ?? [];
@@ -495,18 +519,36 @@ export function listArtifactPage(
  * Store inventory: total bytes, and the orphans — files no accepted result
  * references. Orphans are normal (a failed attempt stores nothing, but a
  * superseded one can leave bytes behind); they are only a problem unattended.
+ * Interrupted publish temp files are separately reported in `tempFiles` and
+ * `tempBytes`; they are not content-addressed artifacts or orphan candidates.
  */
 export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
   if (!existsSync(storeRoot))
-    return { files: 0, bytes: 0, orphans: 0, orphanBytes: 0 };
+    return {
+      files: 0,
+      bytes: 0,
+      orphans: 0,
+      orphanBytes: 0,
+      tempFiles: 0,
+      tempBytes: 0,
+    };
   const referenced = referencedHashes(db);
   let files = 0;
   let bytes = 0;
   let orphans = 0;
   let orphanBytes = 0;
+  let tempFiles = 0;
+  let tempBytes = 0;
   for (const name of readdirSync(storeRoot)) {
+    const stat = statSync(path.join(storeRoot, name));
+    if (!stat.isFile()) continue;
+    if (ARTIFACT_TEMP.test(name)) {
+      tempFiles += 1;
+      tempBytes += stat.size;
+      continue;
+    }
     if (!HEX64.test(name)) continue;
-    const size = statSync(path.join(storeRoot, name)).size;
+    const size = stat.size;
     files += 1;
     bytes += size;
     if (!referenced.has(name)) {
@@ -519,6 +561,8 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
     bytes,
     orphans,
     orphanBytes,
+    tempFiles,
+    tempBytes,
     at: new Date(now).toISOString(),
   };
 }
@@ -526,13 +570,16 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
 /**
  * Delete unreferenced artifacts older than `olderThanMs`. Referenced bytes are
  * never touched: a receipt that points at a deleted file is worse than a full
- * disk, because it turns the audit trail into a lie.
+ * disk, because it turns the audit trail into a lie. Interrupted publish temp
+ * files are also removed after `ARTIFACT_TEMP_GRACE_MS`. A malformed result
+ * fails closed: no files are removed, while dry-runs still report candidates.
  */
 export function pruneArtifacts(
   db,
   storeRoot,
   {
     olderThanMs = 7 * 24 * 60 * 60 * 1000,
+    tempGraceMs = ARTIFACT_TEMP_GRACE_MS,
     now = Date.now(),
     dryRun = false,
   } = {},
@@ -540,15 +587,22 @@ export function pruneArtifacts(
   if (!existsSync(storeRoot))
     return { deleted: 0, freedBytes: 0, remainingOrphans: 0 };
   const referenced = referencedHashes(db);
+  const canDelete = dryRun || referenced.invalid === 0;
   let deleted = 0;
   let freedBytes = 0;
   let remainingOrphans = 0;
   for (const name of readdirSync(storeRoot)) {
-    if (!HEX64.test(name) || referenced.has(name)) continue;
     const file = path.join(storeRoot, name);
     const stat = statSync(file);
     if (!stat.isFile()) continue;
-    if (now - stat.mtimeMs < olderThanMs) {
+    const isTemp = ARTIFACT_TEMP.test(name);
+    if (!isTemp && (!HEX64.test(name) || referenced.has(name))) continue;
+    const graceMs = isTemp ? tempGraceMs : olderThanMs;
+    if (now - stat.mtimeMs < graceMs) {
+      remainingOrphans += 1;
+      continue;
+    }
+    if (!canDelete) {
       remainingOrphans += 1;
       continue;
     }
@@ -560,7 +614,13 @@ export function pruneArtifacts(
       rmSync(file, { force: true });
     }
   }
-  return { deleted, freedBytes, remainingOrphans };
+  const result = {
+    deleted,
+    freedBytes,
+    remainingOrphans,
+  };
+  if (referenced.invalid > 0) result.invalidResults = referenced.invalid;
+  return result;
 }
 
 /**

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -540,8 +540,11 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
   let tempFiles = 0;
   let tempBytes = 0;
   for (const name of readdirSync(storeRoot)) {
-    const stat = statSync(path.join(storeRoot, name));
-    if (!stat.isFile()) continue;
+    // A concurrent prune may remove the entry between readdir and stat.
+    const stat = statSync(path.join(storeRoot, name), {
+      throwIfNoEntry: false,
+    });
+    if (!stat?.isFile()) continue;
     if (ARTIFACT_TEMP.test(name)) {
       tempFiles += 1;
       tempBytes += stat.size;
@@ -571,8 +574,11 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
  * Delete unreferenced artifacts older than `olderThanMs`. Referenced bytes are
  * never touched: a receipt that points at a deleted file is worse than a full
  * disk, because it turns the audit trail into a lie. Interrupted publish temp
- * files are also removed after `ARTIFACT_TEMP_GRACE_MS`. A malformed result
- * fails closed: no files are removed, while dry-runs still report candidates.
+ * files are also removed after `ARTIFACT_TEMP_GRACE_MS`, regardless of the
+ * result table's health — no result can reference a temp name. A malformed
+ * result fails closed for content-addressed files: none are removed, while
+ * dry-runs still report candidates. `remainingOrphans` counts only
+ * content-addressed orphans left behind; in-grace temp files are not orphans.
  */
 export function pruneArtifacts(
   db,
@@ -593,23 +599,27 @@ export function pruneArtifacts(
   let remainingOrphans = 0;
   for (const name of readdirSync(storeRoot)) {
     const file = path.join(storeRoot, name);
-    const stat = statSync(file);
-    if (!stat.isFile()) continue;
+    // A concurrent prune may remove the entry between readdir and stat.
+    const stat = statSync(file, { throwIfNoEntry: false });
+    if (!stat?.isFile()) continue;
     const isTemp = ARTIFACT_TEMP.test(name);
     if (!isTemp && (!HEX64.test(name) || referenced.has(name))) continue;
     const graceMs = isTemp ? tempGraceMs : olderThanMs;
     if (now - stat.mtimeMs < graceMs) {
-      remainingOrphans += 1;
+      // An in-grace temp file is a publish still in flight, not an orphan.
+      if (!isTemp) remainingOrphans += 1;
       continue;
     }
-    if (!canDelete) {
+    // Temp files are never referenced by a result, so a malformed row does not
+    // make them ambiguous: reclaim them even when artifact deletion is held.
+    if (!isTemp && !canDelete) {
       remainingOrphans += 1;
       continue;
     }
     freedBytes += stat.size;
     deleted += 1;
     if (dryRun) {
-      remainingOrphans += 1;
+      if (!isTemp) remainingOrphans += 1;
     } else {
       rmSync(file, { force: true });
     }

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -613,10 +613,54 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
     expect(pruneArtifacts(db, storeRoot, { now })).toEqual({
       deleted: 1,
       freedBytes: 3,
-      remainingOrphans: 1,
+      remainingOrphans: 0,
     });
     expect(existsSync(oldTemp)).toBe(false);
     expect(existsSync(freshTemp)).toBe(true);
+  });
+
+  test("stale temp files are reclaimed even when a malformed result holds artifact deletion", () => {
+    const db = openDb(":memory:");
+    const { storeRoot, hash: orphanHash } = makeStore("orphan");
+    const now = Date.now();
+    const oldTemp = path.join(storeRoot, `${"b".repeat(64)}.tmp.1.old`);
+    writeFileSync(oldTemp, "old");
+    utimesSync(
+      oldTemp,
+      new Date(now - ARTIFACT_TEMP_GRACE_MS - 1),
+      new Date(now - ARTIFACT_TEMP_GRACE_MS - 1),
+    );
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, '{not json', 'sha256:x', '{}', '{}', ?)`,
+    ).run("run_invalid", new Date().toISOString());
+
+    expect(pruneArtifacts(db, storeRoot, { now, olderThanMs: -1 })).toEqual({
+      deleted: 1,
+      freedBytes: 3,
+      remainingOrphans: 1,
+      invalidResults: 1,
+    });
+    expect(existsSync(oldTemp)).toBe(false);
+    expect(findArtifact(storeRoot, orphanHash)).not.toBeNull();
+  });
+
+  test("stats and prune skip entries that vanish between readdir and stat", () => {
+    const db = openDb(":memory:");
+    const { storeRoot, hash } = makeStore("stays");
+    // A dangling symlink stats like a blob a concurrent prune already removed:
+    // readdir lists it, stat reports ENOENT.
+    const vanished = path.join(storeRoot, "c".repeat(64));
+    symlinkSync(path.join(storeRoot, "never-written"), vanished);
+    expect(storeStats(db, storeRoot)).toMatchObject({
+      files: 1,
+      bytes: 5,
+      orphans: 1,
+    });
+    expect(
+      pruneArtifacts(db, storeRoot, { olderThanMs: -1, dryRun: true }),
+    ).toEqual({ deleted: 1, freedBytes: 5, remainingOrphans: 1 });
+    expect(findArtifact(storeRoot, hash)).not.toBeNull();
   });
 
   test("pinRunArtifact retrieves artifact hash by kind", () => {

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -7,11 +7,15 @@ import {
   readFileSync,
   readdirSync,
   symlinkSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
 import {
+  ARTIFACT_TEMP_GRACE_MS,
   artifactPath,
+  artifactInventory,
+  artifactReferenceIndex,
   backfillResultArtifacts,
   findArtifact,
   hashFile,
@@ -542,6 +546,77 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
     expect(pruned.deleted).toBe(1);
     expect(findArtifact(storeRoot, hash1)).not.toBeNull();
     expect(findArtifact(storeRoot, hash2)).toBeNull();
+  });
+
+  test("malformed result rows fail prune closed but do not hide valid catalogue rows", () => {
+    const db = openDb(":memory:");
+    const { storeRoot, hash: referencedHash } = makeStore("referenced");
+    const { hash: orphanHash } = makeStore("orphan", storeRoot);
+    const acceptedAt = new Date().toISOString();
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, ?, 'sha256:x', '{}', '{}', ?)`,
+    ).run(
+      "run_valid",
+      JSON.stringify({
+        artifacts: [{ kind: "transcript", sha256: referencedHash }],
+      }),
+      acceptedAt,
+    );
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES (?, 1, '{not json', 'sha256:x', '{}', '{}', ?)`,
+    ).run("run_invalid", acceptedAt);
+
+    const hashes = referencedHashes(db);
+    expect(hashes.has(referencedHash)).toBe(true);
+    expect(hashes.invalid).toBe(1);
+    expect(artifactReferenceIndex(db).get(referencedHash)).toEqual([
+      expect.objectContaining({ runId: "run_valid", kind: "transcript" }),
+    ]);
+    expect(artifactInventory(storeRoot).map(({ sha256 }) => sha256)).toEqual(
+      expect.arrayContaining([referencedHash, orphanHash]),
+    );
+
+    expect(pruneArtifacts(db, storeRoot, { olderThanMs: -1 })).toEqual({
+      deleted: 0,
+      freedBytes: 0,
+      remainingOrphans: 1,
+      invalidResults: 1,
+    });
+    expect(findArtifact(storeRoot, orphanHash)).not.toBeNull();
+  });
+
+  test("prune reclaims only stale interrupted publish temp files and counts them in stats", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmp("evrt-store-");
+    mkdirSync(storeRoot, { recursive: true });
+    const now = Date.now();
+    const prefix = "a".repeat(64);
+    const oldTemp = path.join(storeRoot, `${prefix}.tmp.1.old`);
+    const freshTemp = path.join(storeRoot, `${prefix}.tmp.1.fresh`);
+    writeFileSync(oldTemp, "old");
+    writeFileSync(freshTemp, "fresh");
+    utimesSync(
+      oldTemp,
+      new Date(now - ARTIFACT_TEMP_GRACE_MS - 1),
+      new Date(now - ARTIFACT_TEMP_GRACE_MS - 1),
+    );
+    utimesSync(freshTemp, new Date(now), new Date(now));
+
+    expect(storeStats(db, storeRoot)).toMatchObject({
+      files: 0,
+      bytes: 0,
+      tempFiles: 2,
+      tempBytes: 8,
+    });
+    expect(pruneArtifacts(db, storeRoot, { now })).toEqual({
+      deleted: 1,
+      freedBytes: 3,
+      remainingOrphans: 1,
+    });
+    expect(existsSync(oldTemp)).toBe(false);
+    expect(existsSync(freshTemp)).toBe(true);
   });
 
   test("pinRunArtifact retrieves artifact hash by kind", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1612

Keep artifact GC and the catalogue available after a corrupt `results.result_json` row, and reclaim interrupted-publish temp files.

- `referencedHashes` returns a `Set` with an `invalid` count instead of throwing; `artifactReferenceIndex` skips the bad row (JSDoc documents the contract).
- `pruneArtifacts` fails closed when `invalid > 0` (deletes nothing, dry-run still reports candidates, returns `invalidResults: n`); it also removes `<sha>.tmp.*` files older than the exported `ARTIFACT_TEMP_GRACE_MS` (1h), counted in `deleted`/`freedBytes`.
- `storeStats` reports temp files under separate `tempFiles`/`tempBytes` fields.
- Tests: malformed row (prune, index, inventory) and fresh-vs-stale temp file coverage in `artifacts.test.mjs`; `api-artifacts.test.mjs` unchanged.

## Handoff

Finisher re-verification in a fresh worktree of `feat/gh-1612` (already contains `origin/develop`; working tree clean, no new commit needed), with `FACTORY_EVENT_HOME=$(mktemp -d)` and `FACTORY_ROOT`/`FACTORY_REPOS_ROOT`/`FACTORY_CONTROL_API_TOKEN` unset.

| Check | Command | Result |
| --- | --- | --- |
| Verification Command (run 2x) | `bun test event-runtime/lib/artifacts.test.mjs event-runtime/lib/api-artifacts.test.mjs --timeout 20000 && bun run format:check` | pass, 33/33 both runs; also passes with `FACTORY_EVENT_HOME` unset |
| Lint | `bun run lint` | pass (0 errors, 615 pre-existing warnings) |
| Runtime tests | `bun test event-runtime/lib --timeout 20000` | pass, 2086/0 |
| Emit / format / check | `bun build/emit.mjs --check && bun run format:check && bun run check` | pass (web typecheck skipped: no web node_modules) |
| Owned paths | `git diff --stat origin/develop...HEAD` | only `event-runtime/lib/artifacts.mjs`, `event-runtime/lib/artifacts.test.mjs` |

**Dispatch handoff failure diagnosis:** the sandbox re-run failed `declared artifacts and the transcript survive the workspace and stream from the API` with an "Unhandled error between tests: Cannot find package 'prettier' from event-runtime/lib/registry.mjs" — the sandbox checkout had no `node_modules`. It is an environment issue, not a regression from this diff and not a home-isolation problem in the test (the suite passes with and without `FACTORY_EVENT_HOME`). After `bun install --frozen-lockfile` the same command passes 33/33.

## Post-review

- `storeStats`/`pruneArtifacts`: `statSync(file, { throwIfNoEntry: false })` + skip when `!stat?.isFile()` — blobs pruned concurrently no longer throw ENOENT mid-walk.
- In-grace temp files are no longer counted in `remainingOrphans` (they are in-flight publishes, not orphans).
- Stale temp files are reclaimed regardless of `referenced.invalid`; only content-addressed deletion fails closed.
- Tests: temp-reclaim expectation updated (`remainingOrphans: 0`), new cases for temp reclaim under a malformed result row and for entries vanishing between readdir and stat.
- Verified: ticket command, `bun run lint`, `bun test event-runtime/lib`, `bun build/emit.mjs --check`, `format:check`, `bun run check`.
