### PR TITLE
fix(memos): retire pins with missing artifacts

### DIFF
--- a/docs/event-runtime-memos.md
+++ b/docs/event-runtime-memos.md
@@ -255,9 +255,11 @@ the top of `memos.json` and a note nobody has confirmed sinks under the
 consumer's `max`.
 
 A binding observed broken retires the memo (`retired_at`, `retired_reason`)
-so the next fold is cheaper and the Notes panel can show why it died. Reads
-never fetch: liveness is decided from state the runtime already holds, so
-planning stays offline-cheap and deterministic for a given database state.
+so the next fold is cheaper and the Notes panel can show why it died. Reasons
+include `description_hash_mismatch`, `head_sha_mismatch`, `artifact_missing`,
+and `contradicted`. The artifact-store presence check is local; reads never
+fetch, so liveness is decided from state the runtime already holds and planning
+stays offline-cheap and deterministic for a given database state.
 
 ### 3.3 Registration is part of accept, not a separate step
 

--- a/docs/event-runtime-memos.md
+++ b/docs/event-runtime-memos.md
@@ -259,7 +259,11 @@ so the next fold is cheaper and the Notes panel can show why it died. Reasons
 include `description_hash_mismatch`, `head_sha_mismatch`, `artifact_missing`,
 and `contradicted`. The artifact-store presence check is local; reads never
 fetch, so liveness is decided from state the runtime already holds and planning
-stays offline-cheap and deterministic for a given database state.
+stays offline-cheap and deterministic for a given database state. The
+`artifact_missing` sweep runs only when the store root itself exists: a missing
+or unreadable root would make every blob look absent and retire the whole
+subject in one pass, so the fold skips the sweep (warning once per root) and
+leaves the memos live until the store is back.
 
 ### 3.3 Registration is part of accept, not a separate step
 

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -14,7 +14,7 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { storeCollected } from "./artifacts.mjs";
+import { findArtifact, storeCollected } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import { artifactsRoot, RUNTIME_ROOT } from "./config.mjs";
 import { loadRepos } from "./repos.mjs";
@@ -541,6 +541,47 @@ function maybeRetireContradicted(db, sha256, now) {
   ).run(now, sha256);
 }
 
+/**
+ * Retire one live memo whose content-addressed blob is absent from the store.
+ * Presence is intentionally the only check here: `materializeArtifact` remains
+ * the integrity boundary that detects and purges a present-but-corrupt blob.
+ *
+ * @returns {{ retired: boolean, memo: object|null }}
+ */
+export function retireMemoArtifactMissing(
+  db,
+  sha256,
+  { artifactStore, now = Date.now() } = {},
+) {
+  const row = db
+    .query(`SELECT * FROM memos WHERE sha256 = ? AND retired_at IS NULL`)
+    .get(sha256);
+  if (!row || !artifactStore || findArtifact(artifactStore, sha256)) {
+    return {
+      retired: false,
+      memo: row ? foldMemo(row, { useful: 0, wrong: 0 }) : null,
+    };
+  }
+  const changed = db
+    .query(
+      `UPDATE memos SET retired_at = ?, retired_reason = 'artifact_missing'
+       WHERE sha256 = ? AND retired_at IS NULL`,
+    )
+    .run(now, sha256).changes;
+  return {
+    retired: changed === 1,
+    memo: foldMemo(
+      {
+        ...row,
+        ...(changed === 1
+          ? { retired_at: now, retired_reason: "artifact_missing" }
+          : {}),
+      },
+      { useful: 0, wrong: 0 },
+    ),
+  };
+}
+
 function usefulCounts(db, hashes) {
   const counts = new Map(hashes.map((sha) => [sha, { useful: 0, wrong: 0 }]));
   if (hashes.length === 0) return counts;
@@ -633,6 +674,8 @@ export function listMemos(
     now = Date.now(),
     descriptionHash,
     headSha,
+    artifactStore,
+    onArtifactMissing,
   } = {},
 ) {
   const normalized = normalizeSubject(subject);
@@ -644,31 +687,47 @@ export function listMemos(
   }
 
   if (live) {
-    const liveWhere = `${where}
+    return db.transaction(() => {
+      const liveWhere = `${where}
       AND superseded_by IS NULL
       AND retired_at IS NULL
       AND (expires_at IS NULL OR expires_at > ?)`;
-    const liveParams = [...params, now];
-    // Match the prior folding behavior: bindings are observed only for rows
-    // that are otherwise live, and description hash wins when both mismatch.
-    if (descriptionHash !== undefined && descriptionHash !== null) {
-      db.query(
-        `UPDATE memos SET retired_at = ?, retired_reason = 'description_hash_mismatch'
+      const liveParams = [...params, now];
+      // Match the prior folding behavior: bindings are observed only for rows
+      // that are otherwise live, and description hash wins when both mismatch.
+      if (descriptionHash !== undefined && descriptionHash !== null) {
+        db.query(
+          `UPDATE memos SET retired_at = ?, retired_reason = 'description_hash_mismatch'
          WHERE ${liveWhere} AND description_hash IS NOT NULL AND description_hash != ?`,
-      ).run(now, ...liveParams, descriptionHash);
-    }
-    if (headSha !== undefined && headSha !== null) {
-      db.query(
-        `UPDATE memos SET retired_at = ?, retired_reason = 'head_sha_mismatch'
+        ).run(now, ...liveParams, descriptionHash);
+      }
+      if (headSha !== undefined && headSha !== null) {
+        db.query(
+          `UPDATE memos SET retired_at = ?, retired_reason = 'head_sha_mismatch'
          WHERE ${liveWhere} AND head_sha IS NOT NULL AND head_sha != ?`,
-      ).run(now, ...liveParams, headSha);
-    }
+        ).run(now, ...liveParams, headSha);
+      }
 
-    const limit =
-      Number.isInteger(max) && max > 0 ? max : LIST_MEMOS_DEFAULT_MAX;
-    const rows = db
-      .query(
-        `SELECT memos.*,
+      if (artifactStore) {
+        const candidates = db
+          .query(`SELECT sha256 FROM memos WHERE ${liveWhere}`)
+          .all(...liveParams);
+        for (const candidate of candidates) {
+          const retirement = retireMemoArtifactMissing(db, candidate.sha256, {
+            artifactStore,
+            now,
+          });
+          if (retirement.retired && typeof onArtifactMissing === "function") {
+            onArtifactMissing(retirement.memo);
+          }
+        }
+      }
+
+      const limit =
+        Number.isInteger(max) && max > 0 ? max : LIST_MEMOS_DEFAULT_MAX;
+      const rows = db
+        .query(
+          `SELECT memos.*,
                 SUM(CASE WHEN memo_uses.verdict = 'useful' THEN 1 ELSE 0 END) AS useful_count,
                 SUM(CASE WHEN memo_uses.verdict = 'wrong' THEN 1 ELSE 0 END) AS wrong_count
          FROM memos LEFT JOIN memo_uses ON memo_uses.sha256 = memos.sha256
@@ -676,14 +735,15 @@ export function listMemos(
          GROUP BY memos.sha256
          ORDER BY useful_count DESC, memos.created_at DESC, memos.sha256 DESC
          LIMIT ?`,
-      )
-      .all(...liveParams, limit);
-    return rows.map((row) =>
-      foldMemo(row, {
-        useful: Number(row.useful_count),
-        wrong: Number(row.wrong_count),
-      }),
-    );
+        )
+        .all(...liveParams, limit);
+      return rows.map((row) =>
+        foldMemo(row, {
+          useful: Number(row.useful_count),
+          wrong: Number(row.wrong_count),
+        }),
+      );
+    })();
   }
 
   const rows = db.query(`SELECT * FROM memos WHERE ${where}`).all(...params);

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -6,6 +6,7 @@
  * over the ledger, never a directory listing. There is no write API.
  */
 import {
+  existsSync,
   mkdtempSync,
   mkdirSync,
   readFileSync,
@@ -659,6 +660,26 @@ export function sweepMemos(
   return result;
 }
 
+const warnedMissingStores = new Set();
+
+/**
+ * The artifact-missing sweep is only meaningful against a store that exists.
+ * `findArtifact` answers "absent" for every sha when the store root itself is
+ * missing or unreadable, so sweeping such a root would retire every live memo
+ * on the subject in one planning pass. Skip the sweep instead and warn once
+ * per root; the memos stay live until the store is back.
+ */
+function artifactStoreSweepable(artifactStore) {
+  if (existsSync(artifactStore)) return true;
+  if (!warnedMissingStores.has(artifactStore)) {
+    warnedMissingStores.add(artifactStore);
+    console.warn(
+      `memos: artifact store ${artifactStore} is missing; skipping artifact_missing sweep`,
+    );
+  }
+  return false;
+}
+
 /**
  * Fold memos on a subject. `live: true` (default) drops superseded, retired,
  * expired, and binding-broken rows. Bindings are compared only against
@@ -708,17 +729,32 @@ export function listMemos(
         ).run(now, ...liveParams, headSha);
       }
 
-      if (artifactStore) {
+      if (artifactStore && artifactStoreSweepable(artifactStore)) {
         const candidates = db
-          .query(`SELECT sha256 FROM memos WHERE ${liveWhere}`)
+          .query(`SELECT * FROM memos WHERE ${liveWhere}`)
           .all(...liveParams);
-        for (const candidate of candidates) {
-          const retirement = retireMemoArtifactMissing(db, candidate.sha256, {
-            artifactStore,
-            now,
-          });
-          if (retirement.retired && typeof onArtifactMissing === "function") {
-            onArtifactMissing(retirement.memo);
+        const missing = candidates.filter(
+          (row) => !findArtifact(artifactStore, row.sha256),
+        );
+        if (missing.length > 0) {
+          db.query(
+            `UPDATE memos SET retired_at = ?, retired_reason = 'artifact_missing'
+             WHERE retired_at IS NULL
+               AND sha256 IN (${missing.map(() => "?").join(", ")})`,
+          ).run(now, ...missing.map((row) => row.sha256));
+          if (typeof onArtifactMissing === "function") {
+            for (const row of missing) {
+              onArtifactMissing(
+                foldMemo(
+                  {
+                    ...row,
+                    retired_at: now,
+                    retired_reason: "artifact_missing",
+                  },
+                  { useful: 0, wrong: 0 },
+                ),
+              );
+            }
           }
         }
       }

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -632,6 +632,67 @@ describe("registerMemos / listMemos", () => {
     db.close();
   });
 
+  test("listMemos sweeps artifact_missing in one pass and skips a missing store root", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const store = tmpDir("evrt-memo-artifacts-");
+    const missing = accepted(postmortemDoc({ body: "missing" }), { now });
+    const present = accepted(postmortemDoc({ body: "present" }), { now });
+    registerMemos(db, "run_missing", missing.result, { now });
+    registerMemos(db, "run_present", present.result, { now });
+    writeFileSync(
+      path.join(store, present.sha256),
+      canonicalJson(present.full),
+    );
+
+    // A store root that does not exist must not retire anything: every sha
+    // would look absent, and one planning pass would wipe the subject.
+    const absentRoot = path.join(store, "does-not-exist");
+    const retirements = [];
+    const untouched = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      {
+        now,
+        artifactStore: absentRoot,
+        onArtifactMissing: (memo) => retirements.push(memo),
+      },
+    );
+    expect(untouched.map((row) => row.sha256).sort()).toEqual(
+      [missing.sha256, present.sha256].sort(),
+    );
+    expect(retirements).toEqual([]);
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM memos WHERE retired_at IS NOT NULL`)
+        .get().n,
+    ).toBe(0);
+
+    // With a real store root, only the sha whose blob is absent retires.
+    const live = listMemos(
+      db,
+      { type: "ticket", id: "WM-809" },
+      {
+        now,
+        artifactStore: store,
+        onArtifactMissing: (memo) => retirements.push(memo),
+      },
+    );
+    expect(live.map((row) => row.sha256)).toEqual([present.sha256]);
+    expect(retirements).toEqual([
+      expect.objectContaining({
+        sha256: missing.sha256,
+        retiredReason: "artifact_missing",
+      }),
+    ]);
+    expect(
+      db
+        .query(`SELECT retired_reason FROM memos WHERE sha256 = ?`)
+        .get(missing.sha256).retired_reason,
+    ).toBe("artifact_missing");
+    db.close();
+  });
+
   test("useful count orders the fold; two distinct wrong verdicts retire contradicted", () => {
     const db = openDb(":memory:");
     const now = Date.parse("2026-08-18T14:02:11.000Z");

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -1,10 +1,14 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-memos-test-mjs";
 import { describe, expect, test } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import path from "node:path";
-import { pruneArtifacts, referencedHashes } from "./artifacts.mjs";
-import { hashJson, sha256Hex } from "./canonical.mjs";
+import {
+  materializeArtifact,
+  pruneArtifacts,
+  referencedHashes,
+} from "./artifacts.mjs";
+import { canonicalJson, hashJson, sha256Hex } from "./canonical.mjs";
 import {
   CURRENT_SCHEMA_VERSION,
   getSchemaVersion,
@@ -21,6 +25,7 @@ import {
   memoDigest,
   normalizeSubjectId,
   registerMemos,
+  retireMemoArtifactMissing,
   sweepMemos,
   validateMemo,
   withProvenance,
@@ -544,6 +549,86 @@ describe("registerMemos / listMemos", () => {
       .query(`SELECT retired_reason FROM memos WHERE sha256 = ?`)
       .get(sha256);
     expect(stored.retired_reason).toBe("description_hash_mismatch");
+    db.close();
+  });
+
+  test("artifact-missing retirement is idempotent and leaves present or corrupt blobs to materialization", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const store = tmpDir("evrt-memo-artifacts-");
+    const workspace = tmpDir("evrt-memo-materialize-");
+    const missing = accepted(postmortemDoc({ body: "missing" }), { now });
+    const present = accepted(postmortemDoc({ body: "present" }), { now });
+    const corrupt = accepted(postmortemDoc({ body: "corrupt" }), { now });
+    for (const [runId, memo] of [
+      ["run_missing", missing],
+      ["run_present", present],
+      ["run_corrupt", corrupt],
+    ]) {
+      registerMemos(db, runId, memo.result, { now });
+    }
+    writeFileSync(
+      path.join(store, present.sha256),
+      canonicalJson(present.full),
+    );
+    writeFileSync(path.join(store, corrupt.sha256), "wrong bytes");
+
+    expect(
+      retireMemoArtifactMissing(db, missing.sha256, {
+        artifactStore: store,
+        now,
+      }),
+    ).toEqual({
+      retired: true,
+      memo: expect.objectContaining({
+        sha256: missing.sha256,
+        retiredReason: "artifact_missing",
+      }),
+    });
+    expect(
+      retireMemoArtifactMissing(db, missing.sha256, {
+        artifactStore: store,
+        now: now + 1,
+      }).retired,
+    ).toBe(false);
+    expect(
+      retireMemoArtifactMissing(db, present.sha256, {
+        artifactStore: store,
+        now,
+      }).retired,
+    ).toBe(false);
+    expect(
+      retireMemoArtifactMissing(db, corrupt.sha256, {
+        artifactStore: store,
+        now,
+      }).retired,
+    ).toBe(false);
+    expect(
+      db
+        .query(`SELECT sha256, retired_reason FROM memos ORDER BY sha256`)
+        .all(),
+    ).toEqual(
+      [
+        { sha256: missing.sha256, retired_reason: "artifact_missing" },
+        { sha256: present.sha256, retired_reason: null },
+        { sha256: corrupt.sha256, retired_reason: null },
+      ].sort((a, b) => a.sha256.localeCompare(b.sha256)),
+    );
+
+    expect(() =>
+      materializeArtifact({
+        storeRoot: store,
+        sha256hex: corrupt.sha256,
+        workspaceDir: workspace,
+        as: "memos/corrupt.json",
+      }),
+    ).toThrow(/corrupt artifact/);
+    expect(existsSync(path.join(store, corrupt.sha256))).toBe(false);
+    expect(
+      db
+        .query(`SELECT retired_at FROM memos WHERE sha256 = ?`)
+        .get(corrupt.sha256).retired_at,
+    ).toBeNull();
     db.close();
   });
 

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -146,7 +146,13 @@ export function pinMemos(
   db,
   def,
   payload,
-  { now = Date.now(), descriptionHash, headSha } = {},
+  {
+    now = Date.now(),
+    descriptionHash,
+    headSha,
+    artifactStore = artifactsRoot(),
+    onArtifactMissing,
+  } = {},
 ) {
   const declarations = def?.memos;
   if (!Array.isArray(declarations) || declarations.length === 0) return payload;
@@ -170,6 +176,8 @@ export function pinMemos(
         descriptionHash:
           decl.subject.type === "ticket" ? descriptionHash : undefined,
         headSha: decl.subject.type === "repo" ? headSha : undefined,
+        artifactStore,
+        onArtifactMissing,
       },
     );
     for (const row of folded) {
@@ -2103,6 +2111,7 @@ export function planEvent(
     artifactStore = artifactsRoot(),
     dispatch = {},
     configSnapshot = null,
+    log = console.log,
   } = {},
 ) {
   // Dispatch gate for tier-2 worktree agents (WM-108), evaluated BEFORE the
@@ -2173,7 +2182,8 @@ export function planEvent(
       resetAt: worktreeEligibility.resetAt ?? null,
     };
   }
-  return txImmediate(db, () => {
+  const missingArtifactRetirements = [];
+  const outcome = txImmediate(db, () => {
     const event = db
       .query(`SELECT * FROM events WHERE source = ? AND event_id = ?`)
       .get(source, eventId);
@@ -2506,6 +2516,8 @@ export function planEvent(
           descriptionHash:
             worktreeEligibility?.evidence?.ticket?.descriptionHash,
           headSha: payload.repoPin?.sha ?? null,
+          artifactStore,
+          onArtifactMissing: (memo) => missingArtifactRetirements.push(memo),
         });
       } catch (err) {
         return humanNeeded(
@@ -2691,6 +2703,23 @@ export function planEvent(
     setEventStatus(db, event, "planned");
     return { decision: "run", proposal, runId };
   });
+  // Emit only after the enclosing planning transaction commits. A later
+  // planning error rolls the retirement back and must not leave a false or
+  // duplicate line in serve.log.
+  for (const memo of missingArtifactRetirements) {
+    const subject = `${memo.subject.type}:${memo.subject.id}`;
+    const producer = memo.inboxItemId
+      ? `inbox_item_id=${memo.inboxItemId}`
+      : `run_id=${memo.runId ?? "null"}`;
+    try {
+      log(
+        `memo retired artifact_missing sha256=${memo.sha256} subject=${subject} ${producer}`,
+      );
+    } catch {
+      // Observability is best-effort after the durable decision is made.
+    }
+  }
+  return outcome;
 }
 
 /**

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1,11 +1,21 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-planner-test-mjs";
 import { describe, expect, spyOn, test } from "bun:test";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import * as nodeFs from "node:fs";
 import path from "node:path";
 import { canonicalJson, hashBytes, hashJson } from "./canonical.mjs";
-import { DEAD_LETTER_AFTER, DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
+import {
+  artifactsRoot,
+  DEAD_LETTER_AFTER,
+  DEFAULT_MAX_IN_FLIGHT,
+} from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { admitEvent } from "./intake.mjs";
 import { createRun, lifecycleOf, runState, transition } from "./lifecycle.mjs";
@@ -3351,6 +3361,9 @@ function memoDoc(overrides = {}) {
 
 function acceptMemo(document) {
   const sha256 = memoDigest(document);
+  const store = artifactsRoot();
+  mkdirSync(store, { recursive: true });
+  writeFileSync(path.join(store, sha256), canonicalJson(document));
   return {
     sha256,
     result: { memos: [{ sha256, document }] },
@@ -3644,6 +3657,161 @@ describe("planEvent memoPin (WM-810)", () => {
       );
       const again = pinMemos(db, def, first, { now: NOW + 3600 * 1000 });
       expect(again.memoPin).toEqual(first.memoPin);
+    });
+  });
+
+  test("missing memo artifacts retire once and leave the surviving fold stable", () => {
+    withMemoConfig(() => {
+      const db = openDb(":memory:");
+      const missing = memoDoc({
+        subject: { type: "repo", id: "factory" },
+        kind: "decision",
+        precedentOnly: true,
+        body: "The missing decision.",
+        refs: { inboxItemId: "inbox_missing" },
+        provenance: {
+          runId: null,
+          agent: "runtime:inbox",
+          createdAt: "2026-08-18T14:02:11.000Z",
+        },
+      });
+      const surviving = memoDoc({
+        subject: { type: "repo", id: "factory" },
+        kind: "decision",
+        precedentOnly: true,
+        body: "The surviving decision.",
+        refs: { inboxItemId: "inbox_surviving" },
+        provenance: {
+          runId: null,
+          agent: "runtime:inbox",
+          createdAt: "2026-08-18T14:02:12.000Z",
+        },
+      });
+      const missingAccepted = acceptMemo(missing);
+      const survivingAccepted = acceptMemo(surviving);
+      registerMemos(db, null, missingAccepted.result, { now: NOW });
+      registerMemos(db, null, survivingAccepted.result, { now: NOW });
+      unlinkSync(path.join(artifactsRoot(), missingAccepted.sha256));
+
+      const retired = [];
+      const def = {
+        memos: [
+          {
+            subject: { type: "repo", id: "$.input.repo" },
+            kinds: ["decision"],
+            max: 10,
+          },
+        ],
+      };
+      const first = pinMemos(
+        db,
+        def,
+        { repo: "factory" },
+        { now: NOW, onArtifactMissing: (memo) => retired.push(memo) },
+      );
+      expect(first.memoPin.entries.map((entry) => entry.sha256)).toEqual([
+        survivingAccepted.sha256,
+      ]);
+      expect(retired).toEqual([
+        expect.objectContaining({
+          sha256: missingAccepted.sha256,
+          inboxItemId: "inbox_missing",
+          retiredReason: "artifact_missing",
+          subject: { type: "repo", id: "factory" },
+        }),
+      ]);
+      expect(
+        db
+          .query(
+            `SELECT retired_at, retired_reason FROM memos WHERE sha256 = ?`,
+          )
+          .get(missingAccepted.sha256),
+      ).toEqual({ retired_at: NOW, retired_reason: "artifact_missing" });
+
+      const second = pinMemos(db, def, first, {
+        now: NOW + 1000,
+        onArtifactMissing: (memo) => retired.push(memo),
+      });
+      expect(second.memoPin).toEqual(first.memoPin);
+      expect(retired).toHaveLength(1);
+      db.close();
+    });
+  });
+
+  test("artifact-missing logging waits for the planner transaction to commit", () => {
+    withMemoConfig(() => {
+      const db = openDb(":memory:");
+      const document = memoDoc({
+        subject: { type: "repo", id: "factory" },
+        kind: "decision",
+        precedentOnly: true,
+        body: "Retire only after commit.",
+        refs: { inboxItemId: "inbox_commit" },
+        provenance: {
+          runId: null,
+          agent: "runtime:inbox",
+          createdAt: "2026-08-18T14:02:13.000Z",
+        },
+      });
+      const accepted = acceptMemo(document);
+      registerMemos(db, null, accepted.result, { now: NOW });
+      unlinkSync(path.join(artifactsRoot(), accepted.sha256));
+
+      const memoRegistry = memoReaderRegistry();
+      const def = memoRegistry.agents.get("memo-reader@1");
+      memoRegistry.agents.set("memo-reader@1", {
+        ...def,
+        memos: [
+          {
+            subject: { type: "repo", id: "$.input.repo" },
+            kinds: ["decision"],
+            max: 10,
+          },
+        ],
+      });
+      memoRegistry.eventTypes["test.memo.requested"] = {
+        ...memoRegistry.eventTypes["test.memo.requested"],
+        idempotencyScope: ["invalid-after-memo-fold"],
+      };
+      const ref = admitMemo(db, memoRegistry, {
+        eventId: "memo-rollback-log",
+        correlationId: "memo-rollback-log",
+      });
+      const logs = [];
+      expect(() =>
+        planEvent(db, memoRegistry, ref, {
+          now: NOW,
+          policyVersion: "git:test",
+          log: (line) => logs.push(line),
+        }),
+      ).toThrow(/unknown idempotency scope/);
+      expect(logs).toEqual([]);
+      expect(
+        db
+          .query(`SELECT retired_at FROM memos WHERE sha256 = ?`)
+          .get(accepted.sha256).retired_at,
+      ).toBeNull();
+
+      memoRegistry.eventTypes["test.memo.requested"] = {
+        ...memoRegistry.eventTypes["test.memo.requested"],
+        idempotencyScope: ["inputHash"],
+      };
+      expect(
+        planEvent(db, memoRegistry, ref, {
+          now: NOW + 1,
+          policyVersion: "git:test",
+          log: (line) => logs.push(line),
+        }).decision,
+      ).toBe("run");
+      expect(logs).toEqual([
+        `memo retired artifact_missing sha256=${accepted.sha256} subject=repo:factory inbox_item_id=inbox_commit`,
+      ]);
+      expect(
+        db
+          .query(`SELECT retired_reason FROM memos WHERE sha256 = ?`)
+          .get(accepted.sha256).retired_reason,
+      ).toBe("artifact_missing");
+      db.close();
     });
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1596

Review atomic artifact-missing memo retirement; worker failure-path follow-up remains #1614.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/planner.test.mjs event-runtime/lib/memos.test.mjs` | pass | 129 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2087 tests; emit, format, lint clean |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend/runtime-only change

run:run_96589933-a572-4717-90ca-24e503e09474


## Post-review

- Review fold: `listMemos()` now skips the `artifact_missing` sweep (warning once per root) when the artifact store root does not exist, so a missing/unreadable store cannot retire every live memo on a subject in one planning pass; the sweep batches the retirement into a single `UPDATE`. Test added (missing store root -> no retirements).
- AC3 (retirement visible in the Notes panel) is delivered by #1614.
