### PR TITLE
fix(workspace): bound preservation comments

### DIFF
--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -421,16 +421,17 @@ export function detectWorktreeOwnershipConflict({
   };
 }
 
+export function preservationCommentTimeoutMs() {
+  return Math.min(worktreeScriptTimeoutMs(), PRESERVATION_COMMENT_TIMEOUT_MS);
+}
+
 export function commentOnPreservedWorktree({
   ticket,
   preservation,
   spawn = spawnSync,
+  timeoutMs = preservationCommentTimeoutMs(),
 }) {
   const text = `Recovered an abandoned dirty worktree before re-dispatch: preserved its uncommitted changes at \`${preservation.ref}\` (commit ${preservation.commit}, ${preservation.push === "pushed" ? "pushed to origin" : "kept locally because push failed"}).`;
-  const timeoutMs = Math.min(
-    worktreeScriptTimeoutMs(),
-    PRESERVATION_COMMENT_TIMEOUT_MS,
-  );
   const result = spawn(
     "bun",
     [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text],
@@ -442,6 +443,12 @@ export function commentOnPreservedWorktree({
   );
   if (result.error?.code === "ETIMEDOUT") {
     throw new Error(`Linear comment timed out after ${timeoutMs}ms`);
+  }
+  if (result.error) {
+    // ENOENT / signal kills leave status null and stderr empty; keep the cause.
+    throw new Error(
+      `Linear comment failed to run: ${result.error.message || result.error.code || String(result.error)}`,
+    );
   }
   if (result.status !== 0) {
     throw new Error(

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -34,6 +34,9 @@ import { findPriorResumeContext } from "./transcripts.mjs";
 /** Hard ceiling for repository-owned worktree lifecycle scripts (WM-262). */
 export const DEFAULT_WORKTREE_SCRIPT_TIMEOUT_MS = 120_000;
 
+/** Bound tracker notifications so a preserved worktree cannot wedge its worker. */
+export const PRESERVATION_COMMENT_TIMEOUT_MS = 30_000;
+
 function worktreeScriptTimeoutMs() {
   const configured = Number(process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS);
   return Number.isFinite(configured) && configured > 0
@@ -418,16 +421,28 @@ export function detectWorktreeOwnershipConflict({
   };
 }
 
-function commentOnPreservedWorktree({ ticket, preservation }) {
+export function commentOnPreservedWorktree({
+  ticket,
+  preservation,
+  spawn = spawnSync,
+}) {
   const text = `Recovered an abandoned dirty worktree before re-dispatch: preserved its uncommitted changes at \`${preservation.ref}\` (commit ${preservation.commit}, ${preservation.push === "pushed" ? "pushed to origin" : "kept locally because push failed"}).`;
-  const result = spawnSync(
+  const timeoutMs = Math.min(
+    worktreeScriptTimeoutMs(),
+    PRESERVATION_COMMENT_TIMEOUT_MS,
+  );
+  const result = spawn(
     "bun",
     [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text],
     {
       cwd: FACTORY_ROOT,
       encoding: "utf8",
+      timeout: timeoutMs,
     },
   );
+  if (result.error?.code === "ETIMEDOUT") {
+    throw new Error(`Linear comment timed out after ${timeoutMs}ms`);
+  }
   if (result.status !== 0) {
     throw new Error(
       String(

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -19,6 +19,7 @@ import {
   WorktreeSandboxUnsupportedError,
   WorktreeError,
   MEMOS_JSON_NOTICE,
+  commentOnPreservedWorktree,
   confinedRegularFile,
   createWorkspace,
   destroyWorkspace,
@@ -545,6 +546,57 @@ describe("worktree workspaces (WM-108)", () => {
       guidance: expect.stringContaining("abandoned prior attempt"),
     });
     expect(destroyWorkspace(dir)).toBe(true);
+  });
+
+  test("a timed-out preservation comment records the failure without losing the preserved ref", () => {
+    const previous = process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+    process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = "25";
+    const root = tmpRoot();
+    const workspaceDir = path.join(root, "run_wt13_timeout-a1");
+    const calls = [];
+    let caught;
+    try {
+      createWorkspace({
+        root,
+        runId: "run_wt13_timeout",
+        attempt: 1,
+        input: { repo: "recovered-up", ticket: "WM-13-timeout" },
+        workspace: { type: "worktree" },
+        worktreePreservationComment: ({ ticket, preservation }) =>
+          commentOnPreservedWorktree({
+            ticket,
+            preservation,
+            spawn: (...args) => {
+              calls.push(args);
+              return { error: { code: "ETIMEDOUT" } };
+            },
+          }),
+      });
+    } catch (error) {
+      caught = error;
+    } finally {
+      if (previous === undefined)
+        delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+      else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
+    }
+
+    expect(caught).toBeInstanceOf(WorktreeError);
+    expect(caught.message).toContain("Linear comment timed out after 25ms");
+    expect(calls).toHaveLength(1);
+    expect(calls[0][2]).toMatchObject({ timeout: 25 });
+    const marker = JSON.parse(
+      readFileSync(path.join(workspaceDir, ".worktree.json"), "utf8"),
+    );
+    expect(marker).toMatchObject({
+      preservedWip: {
+        ref: "wip/WM-13-20260817T183000Z",
+        commit: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        comment: {
+          status: "failed",
+          error: "Linear comment timed out after 25ms",
+        },
+      },
+    });
   });
 
   test("a red baseline is recorded in the marker and agent input without aborting workspace creation", () => {

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -20,6 +20,8 @@ import {
   WorktreeError,
   MEMOS_JSON_NOTICE,
   commentOnPreservedWorktree,
+  preservationCommentTimeoutMs,
+  PRESERVATION_COMMENT_TIMEOUT_MS,
   confinedRegularFile,
   createWorkspace,
   destroyWorkspace,
@@ -548,9 +550,42 @@ describe("worktree workspaces (WM-108)", () => {
     expect(destroyWorkspace(dir)).toBe(true);
   });
 
-  test("a timed-out preservation comment records the failure without losing the preserved ref", () => {
+  test("the preservation comment timeout is bounded by the worktree script timeout", () => {
     const previous = process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
-    process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = "25";
+    try {
+      delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+      expect(preservationCommentTimeoutMs()).toBe(
+        PRESERVATION_COMMENT_TIMEOUT_MS,
+      );
+      process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = "25";
+      expect(preservationCommentTimeoutMs()).toBe(25);
+    } finally {
+      if (previous === undefined)
+        delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
+      else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
+    }
+  });
+
+  test("a preservation comment that fails to spawn records the cause, not a blank error", () => {
+    expect(() =>
+      commentOnPreservedWorktree({
+        ticket: "WM-13-enoent",
+        preservation: { ref: "wip/x", commit: "abc", push: "pushed" },
+        spawn: () => ({
+          error: Object.assign(new Error("spawnSync bun ENOENT"), {
+            code: "ENOENT",
+          }),
+          status: null,
+          stdout: "",
+          stderr: "",
+        }),
+      }),
+    ).toThrow(/Linear comment failed to run: spawnSync bun ENOENT/);
+  });
+
+  test("a timed-out preservation comment records the failure without losing the preserved ref", () => {
+    // Only the preservation path gets the short timeout; the real worktree_up
+    // spawn keeps a generous bound so this cannot flake under load.
     const root = tmpRoot();
     const workspaceDir = path.join(root, "run_wt13_timeout-a1");
     const calls = [];
@@ -562,10 +597,12 @@ describe("worktree workspaces (WM-108)", () => {
         attempt: 1,
         input: { repo: "recovered-up", ticket: "WM-13-timeout" },
         workspace: { type: "worktree" },
+        worktreeTimeoutMs: 120_000,
         worktreePreservationComment: ({ ticket, preservation }) =>
           commentOnPreservedWorktree({
             ticket,
             preservation,
+            timeoutMs: 25,
             spawn: (...args) => {
               calls.push(args);
               return { error: { code: "ETIMEDOUT" } };
@@ -574,10 +611,6 @@ describe("worktree workspaces (WM-108)", () => {
       });
     } catch (error) {
       caught = error;
-    } finally {
-      if (previous === undefined)
-        delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
-      else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
     }
 
     expect(caught).toBeInstanceOf(WorktreeError);


### PR DESCRIPTION
Fixes #1625

Bounds preserved-worktree tracker comments at 30 seconds so a stalled tracker cannot wedge a worker.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/workspace.test.mjs` | pass | 32 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,088 pass, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_7fe0341f-5fd8-439a-b838-5d82c30649e4

## Post-review

- Reviewer flagged that the preservation-comment timeout test set `FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS=25`, which also bounded the real `worktree_up` spawn (latent flake under load).
- `commentOnPreservedWorktree` now accepts an explicit `timeoutMs` (default `preservationCommentTimeoutMs()` = min(script timeout, 30 s)); the test passes `worktreeTimeoutMs: 120_000` to `createWorkspace` and `timeoutMs: 25` only to the comment path, with no env mutation. A separate unit test covers the env-derived bound.
- Spawn results with `result.error` but no status (ENOENT / signal kill) now throw `Linear comment failed to run: <cause>` instead of a blank `exited null` message; covered by a new test.
- Verified: `bun test event-runtime/lib/workspace.test.mjs` x3 stable, `bun run lint`, `bun test event-runtime/lib` (2105 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
