### PR TITLE
fix(api): code artifact validation failures

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -1,4 +1,10 @@
-/** Artifact endpoints and bounded transcript reads. */
+/**
+ * Artifact endpoints and bounded transcript reads.
+ *
+ * Validation errors: GET /artifacts returns `invalid_limit`, `invalid_orphan`,
+ * or `invalid_before`; POST /artifacts/prune returns `invalid_body`,
+ * `invalid_dry_run`, `invalid_apply`, or `conflicting_flags`.
+ */
 import {
   closeSync,
   createReadStream,
@@ -24,6 +30,30 @@ function looksLikeText(file) {
 }
 
 export const TRANSCRIPT_MODEL_SCAN_BYTES = 64 * 1024;
+
+function parseBeforeCursor(rawBefore) {
+  if (!rawBefore) return null;
+  try {
+    const before = JSON.parse(
+      Buffer.from(rawBefore, "base64url").toString("utf8"),
+    );
+    if (
+      !before ||
+      typeof before.mtime !== "string" ||
+      !Number.isFinite(Date.parse(before.mtime)) ||
+      new Date(before.mtime).toISOString() !== before.mtime ||
+      !/^[0-9a-f]{64}$/.test(before.sha256)
+    ) {
+      throw new Error("invalid cursor");
+    }
+    return before;
+  } catch {
+    throw new ApiParameterError(
+      "invalid_before",
+      "before must be a valid cursor",
+    );
+  }
+}
 
 /** Bounded head of a stored artifact; null when it is missing or unreadable. */
 export function artifactHead(
@@ -64,38 +94,24 @@ export async function handleArtifactApiRoute({
 }) {
   if (route === "GET /artifacts") {
     const orphanParam = url.searchParams.get("orphan");
-    if (
-      orphanParam !== null &&
-      orphanParam !== "true" &&
-      orphanParam !== "false"
-    ) {
-      return send(422, { error: "orphan must be true or false" });
-    }
     let limit;
+    let before;
     try {
+      if (
+        orphanParam !== null &&
+        orphanParam !== "true" &&
+        orphanParam !== "false"
+      ) {
+        throw new ApiParameterError(
+          "invalid_orphan",
+          "orphan must be true or false",
+        );
+      }
       limit = parseListLimit(url, { defaultLimit: 100, maxLimit: 500 });
+      before = parseBeforeCursor(url.searchParams.get("before"));
     } catch (err) {
       if (err instanceof ApiParameterError) return send(422, err.body);
       throw err;
-    }
-    const rawBefore = url.searchParams.get("before");
-    let before = null;
-    if (rawBefore) {
-      try {
-        before = JSON.parse(
-          Buffer.from(rawBefore, "base64url").toString("utf8"),
-        );
-        if (
-          !before ||
-          typeof before.mtime !== "string" ||
-          !Number.isFinite(Date.parse(before.mtime)) ||
-          !/^[0-9a-f]{64}$/.test(before.sha256)
-        ) {
-          throw new Error("invalid cursor");
-        }
-      } catch {
-        return send(422, { error: "invalid before cursor" });
-      }
     }
     const page = getArtifactPage(
       {
@@ -117,19 +133,40 @@ export async function handleArtifactApiRoute({
   if (route === "POST /artifacts/prune") {
     const raw = await readBody(req);
     const parsed = raw.length === 0 ? { value: {} } : parseJson(raw);
-    if (parsed.error) return send(422, { error: parsed.error });
-    const body = parsed.value ?? {};
+    if (parsed.error) {
+      return send(
+        422,
+        new ApiParameterError("invalid_body", parsed.error).body,
+      );
+    }
+    const body = parsed.value;
     if (!body || typeof body !== "object" || Array.isArray(body)) {
-      return send(422, { error: "body must be an object" });
+      return send(
+        422,
+        new ApiParameterError("invalid_body", "body must be an object").body,
+      );
     }
     if (body.dryRun !== undefined && typeof body.dryRun !== "boolean") {
-      return send(422, { error: "dryRun must be a boolean" });
+      return send(
+        422,
+        new ApiParameterError("invalid_dry_run", "dryRun must be a boolean")
+          .body,
+      );
     }
     if (body.apply !== undefined && typeof body.apply !== "boolean") {
-      return send(422, { error: "apply must be a boolean" });
+      return send(
+        422,
+        new ApiParameterError("invalid_apply", "apply must be a boolean").body,
+      );
     }
     if (body.apply === true && body.dryRun === true) {
-      return send(422, { error: "apply and dryRun cannot both be true" });
+      return send(
+        422,
+        new ApiParameterError(
+          "conflicting_flags",
+          "apply and dryRun cannot both be true",
+        ).body,
+      );
     }
     const apply = body.apply === true;
     const result = pruneArtifacts(db, artifactsRoot(env.home), {

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -230,7 +230,37 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       ).json();
       expect(secondPage.artifacts).toHaveLength(1);
       expect(secondPage.nextBefore).toBeNull();
-      expect((await fetch(`${base}/artifacts?orphan=maybe`)).status).toBe(422);
+      for (const before of [
+        "%",
+        Buffer.from("not JSON").toString("base64url"),
+        Buffer.from(
+          JSON.stringify({
+            mtime: old.toISOString(),
+            sha256: "not-a-sha256",
+          }),
+        ).toString("base64url"),
+        Buffer.from(
+          JSON.stringify({
+            mtime: "January 1, 2026",
+            sha256: reportHash,
+          }),
+        ).toString("base64url"),
+      ]) {
+        const response = await fetch(
+          `${base}/artifacts?before=${encodeURIComponent(before)}`,
+        );
+        expect(response.status).toBe(422);
+        expect(await response.json()).toEqual({
+          error: "invalid_before",
+          message: "before must be a valid cursor",
+        });
+      }
+      const invalidOrphan = await fetch(`${base}/artifacts?orphan=maybe`);
+      expect(invalidOrphan.status).toBe(422);
+      expect(await invalidOrphan.json()).toEqual({
+        error: "invalid_orphan",
+        message: "orphan must be true or false",
+      });
       for (const limit of ["abc", "0", "501"]) {
         const response = await fetch(`${base}/artifacts?limit=${limit}`);
         expect(response.status).toBe(422);
@@ -238,6 +268,37 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
           error: "invalid_limit",
           message: "limit must be an integer between 1 and 500",
         });
+      }
+
+      for (const { body, error, message } of [
+        {
+          body: null,
+          error: "invalid_body",
+          message: "body must be an object",
+        },
+        {
+          body: { dryRun: "true" },
+          error: "invalid_dry_run",
+          message: "dryRun must be a boolean",
+        },
+        {
+          body: { apply: "true" },
+          error: "invalid_apply",
+          message: "apply must be a boolean",
+        },
+        {
+          body: { apply: true, dryRun: true },
+          error: "conflicting_flags",
+          message: "apply and dryRun cannot both be true",
+        },
+      ]) {
+        const response = await fetch(`${base}/artifacts/prune`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify(body),
+        });
+        expect(response.status).toBe(422);
+        expect(await response.json()).toEqual({ error, message });
       }
 
       const dry = await fetch(`${base}/artifacts/prune`, {


### PR DESCRIPTION
Fixes watt-mind/factory#1609

Clients can distinguish artifact cursor and prune validation failures by stable error code.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-artifacts.test.mjs event-runtime/lib/api-params.test.mjs event-runtime/lib/api-inbox.test.mjs event-runtime/lib/api-runs.test.mjs --timeout 20000` | pass | 51 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,087 pass, 0 failures; lint warnings only |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend API validation-only change

run:run_2b3b6227-f89c-4853-93b5-746f52f4fced