### PR TITLE
fix(status): resolve documented branch defaults

### DIFF
--- a/lib/repo-status.mjs
+++ b/lib/repo-status.mjs
@@ -8,6 +8,15 @@ export const DEFAULT_REVISION_FIELDS = [
   "sha",
 ];
 
+/** Resolve status branches using the same defaults as the repository loader. */
+export function resolveStatusBranches(repoConfig = {}) {
+  const baseBranch = repoConfig.base ?? "main";
+  const deployBranch = repoConfig.deploy_branch ?? null;
+  const metadataBranch =
+    repoConfig.deployment?.branch ?? deployBranch ?? baseBranch;
+  return { baseBranch, deployBranch, metadataBranch };
+}
+
 export function deployedRevision(payload, configuredField) {
   if (!payload || typeof payload !== "object") return null;
   const fields = configuredField

--- a/lib/repo-status.test.mjs
+++ b/lib/repo-status.test.mjs
@@ -4,7 +4,33 @@ import {
   deploymentState,
   formatAge,
   metadataUrl,
+  resolveStatusBranches,
 } from "./repo-status.mjs";
+
+test("resolves status branches with loader-compatible defaults", () => {
+  expect(resolveStatusBranches({})).toEqual({
+    baseBranch: "main",
+    deployBranch: null,
+    metadataBranch: "main",
+  });
+  expect(resolveStatusBranches({ base: "develop" })).toEqual({
+    baseBranch: "develop",
+    deployBranch: null,
+    metadataBranch: "develop",
+  });
+  expect(
+    resolveStatusBranches({ base: "develop", deploy_branch: "main" }),
+  ).toEqual({
+    baseBranch: "develop",
+    deployBranch: "main",
+    metadataBranch: "main",
+  });
+  expect(resolveStatusBranches({ deployment: { branch: "release" } })).toEqual({
+    baseBranch: "main",
+    deployBranch: null,
+    metadataBranch: "release",
+  });
+});
 
 test("uses a configured revision field and accepts common revision payloads", () => {
   expect(

--- a/orchestrator/status.mjs
+++ b/orchestrator/status.mjs
@@ -20,6 +20,7 @@ import {
   deployedRevision,
   deploymentState,
   metadataUrl,
+  resolveStatusBranches,
 } from "../lib/repo-status.mjs";
 import { latestReaperRunMs } from "./reaper.mjs";
 
@@ -172,17 +173,15 @@ if (!existsSync(repoPath)) {
   process.exit(2);
 }
 
-const deployBranch =
-  repoConfig.deploy_branch ?? (repoConfig.base === "main" ? "main" : "master");
-const baseBranch = repoConfig.base;
-const metadataBranch = repoConfig.deployment?.branch ?? deployBranch;
+const { baseBranch, deployBranch, metadataBranch } =
+  resolveStatusBranches(repoConfig);
 const fetchResult = sh(
   [
     "git",
     "fetch",
     "--quiet",
     "origin",
-    ...new Set([baseBranch, deployBranch, metadataBranch]),
+    ...new Set([baseBranch, deployBranch, metadataBranch].filter(Boolean)),
   ],
   repoPath,
 );
@@ -227,9 +226,9 @@ function remoteRef(name) {
   };
 }
 const base = remoteRef(baseBranch);
-const deploy = remoteRef(deployBranch);
+const deploy = deployBranch ? remoteRef(deployBranch) : null;
 const metadataRef =
-  metadataBranch === deployBranch
+  metadataBranch === deployBranch && deploy
     ? deploy
     : metadataBranch === baseBranch
       ? base
@@ -398,6 +397,10 @@ for (const [label, ref] of [
   ["Base", base],
   ["Deploy", deploy],
 ]) {
+  if (!ref) {
+    console.log(`${label.padEnd(10)} ${c.dim("not configured")}`);
+    continue;
+  }
   const delta =
     ref.checkoutAhead == null
       ? "unavailable"


### PR DESCRIPTION
Fixes watt-mind/factory#1622

Status now uses loader-compatible branch defaults and reports an unset deploy branch as not configured.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/repo-status.test.mjs && bun orchestrator/status.mjs --repo factory --json >/dev/null` | pass    | 4 tests, 0 failures    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2087 pass, 0 failures  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_fa23c4f5-9365-4c90-9b2e-b8a6090c5fd5