### PR TITLE
fix(pulse): paginate Linear supply counts

### DIFF
--- a/orchestrator/pulse.mjs
+++ b/orchestrator/pulse.mjs
@@ -30,6 +30,9 @@ const c = {
   cyan: (s) => `\x1b[36m${s}\x1b[0m`,
 };
 
+const LINEAR_SUPPLY_PAGE_SIZE = 100;
+const MAX_LINEAR_SUPPLY_PAGES = 5;
+
 function sh(args, cwd = ROOT) {
   try {
     const result = Bun.spawnSync({
@@ -74,6 +77,7 @@ export async function gatherPulse({
   repoName = "factory",
   fetchLinear = true,
   fetchGitHub = true,
+  controlPlane,
 } = {}) {
   const pulse = {
     timestamp: new Date().toISOString(),
@@ -89,6 +93,7 @@ export async function gatherPulse({
       dispatchable: 0,
       triage: 0,
       tickets: [],
+      truncated: false,
     },
     prs: { total: 0, candidates: [] },
     workspace: {
@@ -209,26 +214,46 @@ export async function gatherPulse({
       }
       pulse.supply.team = team;
 
-      if (!hasLinearKey()) {
+      if (!controlPlane && !hasLinearKey()) {
         pulse.supply.error = "LINEAR_API_KEY not configured";
       } else {
-        const d = await loadControlPlane().raw(
-          `query($t:String!){
-            issues(first:100, filter:{ team:{key:{eq:$t}}, state:{type:{nin:["completed","canceled"]}} }){
-              nodes{ id identifier title state{ name } labels(first:20){ nodes{ name } } assignee{ name } }
-            }
-          }`,
-          { t: team },
-        );
+        const linear = controlPlane ?? loadControlPlane();
+        const ready = [];
+        const triage = [];
+        let after = null;
 
-        const nodes = d?.issues?.nodes ?? [];
-        const ready = nodes.filter(
-          (i) =>
-            i.state?.name === "Todo" &&
-            !i.assignee &&
-            (i.labels?.nodes ?? []).some((l) => l.name === "ai:agent-ready"),
-        );
-        const triage = nodes.filter((i) => i.state?.name === "Triage");
+        for (let page = 0; page < MAX_LINEAR_SUPPLY_PAGES; page += 1) {
+          const d = await linear.raw(
+            `query($t:String!,$after:String){
+              issues(first:${LINEAR_SUPPLY_PAGE_SIZE}, after:$after, filter:{ team:{key:{eq:$t}}, state:{name:{in:["Todo","Triage"]}} }){
+                nodes{ id identifier title state{ name } labels(first:20){ nodes{ name } } assignee{ name } }
+                pageInfo{ hasNextPage endCursor }
+              }
+            }`,
+            { t: team, after },
+          );
+
+          const issues = d?.issues?.nodes ?? [];
+          ready.push(
+            ...issues.filter(
+              (i) =>
+                i.state?.name === "Todo" &&
+                !i.assignee &&
+                (i.labels?.nodes ?? []).some(
+                  (l) => l.name === "ai:agent-ready",
+                ),
+            ),
+          );
+          triage.push(...issues.filter((i) => i.state?.name === "Triage"));
+
+          const pageInfo = d?.issues?.pageInfo;
+          if (!pageInfo?.hasNextPage) break;
+          if (page === MAX_LINEAR_SUPPLY_PAGES - 1 || !pageInfo.endCursor) {
+            pulse.supply.truncated = true;
+            break;
+          }
+          after = pageInfo.endCursor;
+        }
 
         pulse.supply.dispatchable = ready.length;
         pulse.supply.triage = triage.length;
@@ -382,6 +407,9 @@ export function formatPulse(pulse) {
       `  Dispatchable:    ${supplyColor(`${pulse.supply.dispatchable} tickets`)} in Todo (ai:agent-ready, unassigned)`,
     );
     lines.push(`  Triage Backlog:  ${pulse.supply.triage} tickets in Triage`);
+    if (pulse.supply.truncated) {
+      lines.push(c.yellow("  Supply counts:   (truncated)"));
+    }
     if (pulse.supply.tickets.length > 0) {
       lines.push(c.dim("  Next up:"));
       for (const t of pulse.supply.tickets) {

--- a/orchestrator/pulse.test.mjs
+++ b/orchestrator/pulse.test.mjs
@@ -28,6 +28,7 @@ test("formatPulse renders structured pulse text", () => {
       dispatchable: 5,
       triage: 20,
       tickets: [{ identifier: "WM-100", title: "Sample ticket title" }],
+      truncated: true,
     },
     prs: {
       total: 1,
@@ -59,9 +60,94 @@ test("formatPulse renders structured pulse text", () => {
   expect(output).toContain("run_test_123");
   expect(output).toContain("LINEAR SUPPLY (WM)");
   expect(output).toContain("5 tickets");
+  expect(output).toContain("(truncated)");
   expect(output).toContain("WM-100");
   expect(output).toContain("#99");
   expect(output).toContain("[CI PASS]");
+});
+
+function linearIssue(number, { ready = false, triage = false } = {}) {
+  return {
+    id: `issue-${number}`,
+    identifier: `WM-${number}`,
+    title: `Issue ${number}`,
+    state: { name: triage ? "Triage" : "Todo" },
+    labels: { nodes: ready ? [{ name: "ai:agent-ready" }] : [] },
+    assignee: null,
+  };
+}
+
+test("gatherPulse counts qualifying Linear issues across pages", async () => {
+  const firstPage = Array.from({ length: 100 }, (_, index) =>
+    linearIssue(index + 1, {
+      ready: index < 45,
+      triage: index >= 45 && index < 55,
+    }),
+  );
+  const secondPage = Array.from({ length: 20 }, (_, index) =>
+    linearIssue(index + 101, {
+      ready: index < 10,
+      triage: index >= 10 && index < 15,
+    }),
+  );
+  const calls = [];
+  const controlPlane = {
+    raw(query, variables) {
+      calls.push({ query, variables });
+      return Promise.resolve(
+        variables.after
+          ? {
+              issues: {
+                nodes: secondPage,
+                pageInfo: { hasNextPage: false, endCursor: null },
+              },
+            }
+          : {
+              issues: {
+                nodes: firstPage,
+                pageInfo: { hasNextPage: true, endCursor: "page-2" },
+              },
+            },
+      );
+    },
+  };
+
+  const pulse = await gatherPulse({
+    fetchGitHub: false,
+    controlPlane,
+  });
+
+  expect(pulse.supply.dispatchable).toBe(55);
+  expect(pulse.supply.triage).toBe(15);
+  expect(pulse.supply.tickets).toHaveLength(5);
+  expect(pulse.supply.truncated).toBe(false);
+  expect(calls).toHaveLength(2);
+  expect(calls[0].query).toContain('state:{name:{in:["Todo","Triage"]}}');
+  expect(calls[1].variables.after).toBe("page-2");
+});
+
+test("gatherPulse marks Linear supply as truncated at the page cap", async () => {
+  const calls = [];
+  const controlPlane = {
+    raw(_query, variables) {
+      calls.push(variables);
+      return Promise.resolve({
+        issues: {
+          nodes: [linearIssue(calls.length, { ready: true })],
+          pageInfo: { hasNextPage: true, endCursor: `page-${calls.length}` },
+        },
+      });
+    },
+  };
+
+  const pulse = await gatherPulse({
+    fetchGitHub: false,
+    controlPlane,
+  });
+
+  expect(calls).toHaveLength(5);
+  expect(pulse.supply.dispatchable).toBe(5);
+  expect(pulse.supply.truncated).toBe(true);
 });
 
 test("gatherPulse handles unreachable API gracefully", async () => {

--- a/orchestrator/pulse.test.mjs
+++ b/orchestrator/pulse.test.mjs
@@ -77,6 +77,15 @@ function linearIssue(number, { ready = false, triage = false } = {}) {
   };
 }
 
+// Bind loopback:0 for an OS-assigned port, then release it immediately so
+// gatherPulse's /health probe hits nothing instead of a live local stack.
+function deadPort() {
+  const probe = Bun.serve({ port: 0, fetch: () => new Response("") });
+  const port = probe.port;
+  probe.stop(true);
+  return port;
+}
+
 test("gatherPulse counts qualifying Linear issues across pages", async () => {
   const firstPage = Array.from({ length: 100 }, (_, index) =>
     linearIssue(index + 1, {
@@ -113,6 +122,7 @@ test("gatherPulse counts qualifying Linear issues across pages", async () => {
   };
 
   const pulse = await gatherPulse({
+    port: deadPort(),
     fetchGitHub: false,
     controlPlane,
   });
@@ -141,6 +151,7 @@ test("gatherPulse marks Linear supply as truncated at the page cap", async () =>
   };
 
   const pulse = await gatherPulse({
+    port: deadPort(),
     fetchGitHub: false,
     controlPlane,
   });
@@ -153,14 +164,8 @@ test("gatherPulse marks Linear supply as truncated at the page cap", async () =>
 test("gatherPulse handles unreachable API gracefully", async () => {
   // A hardcoded port assumes nothing else is listening on it, which a
   // stranger process (or a concurrent worktree) can invalidate (#876).
-  // Bind loopback:0 to get an OS-assigned port, then release it
-  // immediately so it is unreachable when gatherPulse fetches it.
-  const probe = Bun.serve({ port: 0, fetch: () => new Response("") });
-  const port = probe.port;
-  probe.stop(true);
-
   const pulse = await gatherPulse({
-    port,
+    port: deadPort(),
     fetchLinear: false,
     fetchGitHub: false,
   });


### PR DESCRIPTION
Fixes watt-mind/factory#1623

Paginate bounded Linear supply reads and flag incomplete counts for operators.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test orchestrator/pulse.test.mjs` | pass | 6 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; 615 existing lint warnings |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_811ee9c2-60b3-423d-8b20-a0bf0a178ab0

## Post-review

- Folded: the two new `gatherPulse` Linear supply tests now pass an OS-assigned dead `port` (shared `deadPort()` helper with the unreachable-API test) instead of probing the live local stack on `/health`.
- Merged `origin/develop`; verified `bun test orchestrator/pulse.test.mjs`, `bun run lint`, `bun test event-runtime/lib` (2098 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
