### PR TITLE
fix(watchdog): keep live verifying runs out of wedge alerts

### DIFF
--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -236,6 +236,53 @@ export async function fetchRecentSandboxRefusals({
   return refusals;
 }
 
+const IN_FLIGHT_STATES = Object.freeze(["LEASED", "RUNNING", "VERIFYING"]);
+const RUN_LIST_PAGE_SIZE = 200;
+
+/**
+ * Read every page for one active state. The status snapshot below is the
+ * authoritative in-flight count; this is only the per-run detail needed to
+ * identify a particular wedge, so it must not silently stop at the API's
+ * default 100-row page.
+ */
+async function allRunsInState(state, { host, port }) {
+  const runs = [];
+  let before = null;
+  const seenCursors = new Set();
+  do {
+    const params = new URLSearchParams({
+      state,
+      limit: String(RUN_LIST_PAGE_SIZE),
+    });
+    if (before) params.set("before", before);
+    const page = await controlApi(`/runs?${params}`, { host, port });
+    runs.push(...(page?.runs ?? []));
+    before = page?.nextBefore ?? null;
+  } while (before && !seenCursors.has(before) && seenCursors.add(before));
+  return runs;
+}
+
+async function inFlightRunDetails({ host, port }) {
+  const summaries = (
+    await Promise.all(
+      IN_FLIGHT_STATES.map((state) => allRunsInState(state, { host, port })),
+    )
+  ).flat();
+  return Promise.all(
+    summaries.map(async (run) => {
+      const detail = await controlApi(
+        `/runs/${encodeURIComponent(run.runId)}`,
+        {
+          host,
+          port,
+        },
+      );
+      const attempt = [...(detail?.attempts ?? [])].at(-1);
+      return { ...run, lease_expires_at: attempt?.lease_expires_at ?? null };
+    }),
+  );
+}
+
 export async function runWatchdogCheck({
   host = "127.0.0.1",
   port = 7381,
@@ -249,7 +296,10 @@ export async function runWatchdogCheck({
     apiOk: false,
     webOk: false,
     workersCount: 0,
+    inFlightRuns: 0,
+    leasedRuns: 0,
     runningRuns: 0,
+    verifyingRuns: 0,
     wedgedRuns: 0,
     queuedRuns: 0,
     sandboxRefusals: [],
@@ -309,13 +359,12 @@ export async function runWatchdogCheck({
 
   // 3. Workers & Runs Status from API
   try {
-    const [statusRes, workersRes, runningRes, sandboxRefusals] =
-      await Promise.all([
-        controlApi("/status", { host, port }),
-        controlApi("/workers", { host, port }),
-        controlApi("/runs?state=RUNNING", { host, port }),
-        fetchRecentSandboxRefusals({ host, port }),
-      ]);
+    const [statusRes, workersRes, runs, sandboxRefusals] = await Promise.all([
+      controlApi("/status", { host, port }),
+      controlApi("/workers", { host, port }),
+      inFlightRunDetails({ host, port }),
+      fetchRecentSandboxRefusals({ host, port }),
+    ]);
 
     const workers = workersRes?.workers ?? [];
     metrics.workersCount = workers.length;
@@ -327,15 +376,27 @@ export async function runWatchdogCheck({
       });
     }
 
-    const runs = runningRes?.runs ?? [];
-    metrics.runningRuns = runs.length;
+    // `/status` is one uncapped database snapshot. Do not derive fleet
+    // metrics from the paginated run summaries used below for diagnostics.
+    const byState = statusRes?.runs?.byState ?? {};
+    metrics.leasedRuns = byState.LEASED ?? 0;
+    metrics.runningRuns = byState.RUNNING ?? 0;
+    metrics.verifyingRuns = byState.VERIFYING ?? 0;
+    metrics.inFlightRuns =
+      metrics.leasedRuns + metrics.runningRuns + metrics.verifyingRuns;
     const now = Date.now();
     const wedged = runs.filter((r) => {
       const created = new Date(r.created_at || now).getTime();
       const updated = new Date(r.updated_at || r.created_at || now).getTime();
       const ageMin = (now - created) / 60000;
       const quietMin = (now - updated) / 60000;
-      return ageMin > stuckMinutes && quietMin > stuckMinutes / 2;
+      // A lease renewed by the worker is a heartbeat even when the run is
+      // parked in shared CI and has no lifecycle transition to update the run
+      // row. A future expiry proves the current attempt remains live.
+      const freshLease = Date.parse(r.lease_expires_at) > now;
+      return (
+        ageMin > stuckMinutes && quietMin > stuckMinutes / 2 && !freshLease
+      );
     });
 
     metrics.wedgedRuns = wedged.length;
@@ -350,7 +411,7 @@ export async function runWatchdogCheck({
       });
     }
 
-    metrics.queuedRuns = statusRes?.runs?.byState?.QUEUED ?? 0;
+    metrics.queuedRuns = byState.QUEUED ?? 0;
     metrics.sandboxRefusals = sandboxRefusals;
     if (metrics.sandboxRefusals.length > 0) {
       const agents = [
@@ -366,7 +427,7 @@ export async function runWatchdogCheck({
     if (
       metrics.queuedRuns > 0 &&
       idleWorkers > 0 &&
-      metrics.runningRuns === 0
+      metrics.inFlightRuns === 0
     ) {
       issues.push({
         severity: "WARNING",
@@ -473,7 +534,7 @@ export function formatWatchdogReport(result) {
   if (result.ok && result.issues.length === 0) {
     lines.push(`${c.green("✓")} ${c.bold("WATCHDOG OK")} — ${ts}`);
     lines.push(
-      `  Workers: ${result.metrics.workersCount} | Running: ${result.metrics.runningRuns} | Wedged: ${result.metrics.wedgedRuns}`,
+      `  Workers: ${result.metrics.workersCount} | In flight: ${result.metrics.inFlightRuns} (running ${result.metrics.runningRuns}, verifying ${result.metrics.verifyingRuns}, leased ${result.metrics.leasedRuns}) | Wedged: ${result.metrics.wedgedRuns}`,
     );
     if (fleetLine) lines.push(fleetLine);
   } else {

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -26,7 +26,10 @@ test("formatWatchdogReport formats clean watchdog status", () => {
       apiOk: true,
       webOk: true,
       workersCount: 3,
+      inFlightRuns: 1,
+      leasedRuns: 0,
       runningRuns: 1,
+      verifyingRuns: 0,
       wedgedRuns: 0,
       queuedRuns: 0,
       anomalies: [],
@@ -36,7 +39,9 @@ test("formatWatchdogReport formats clean watchdog status", () => {
   const formatted = formatWatchdogReport(cleanResult);
   expect(formatted).toContain("WATCHDOG OK");
   expect(formatted).toContain("Workers: 3");
-  expect(formatted).toContain("Running: 1");
+  expect(formatted).toContain(
+    "In flight: 1 (running 1, verifying 0, leased 0)",
+  );
 });
 
 test("formatWatchdogReport formats critical issues", () => {
@@ -58,7 +63,10 @@ test("formatWatchdogReport formats critical issues", () => {
       apiOk: true,
       webOk: false,
       workersCount: 2,
+      inFlightRuns: 1,
+      leasedRuns: 0,
       runningRuns: 1,
+      verifyingRuns: 0,
       wedgedRuns: 1,
       queuedRuns: 0,
       anomalies: [],
@@ -87,7 +95,10 @@ test("formatWatchdogReport keeps the fleet metrics line on warning/critical", ()
       apiOk: true,
       webOk: true,
       workersCount: 1,
+      inFlightRuns: 0,
+      leasedRuns: 0,
       runningRuns: 0,
+      verifyingRuns: 0,
       wedgedRuns: 0,
       queuedRuns: 0,
       anomalies: [],
@@ -310,6 +321,150 @@ test("runWatchdogCheck surfaces sandbox-unavailable scan refusals", async () => 
   } finally {
     server.stop(true);
   }
+});
+
+async function runWatchdogWithInFlightRuns({
+  leased = [],
+  running = [],
+  verifying = [],
+  queued = 0,
+} = {}) {
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/" || url.pathname === "/health") {
+        return Response.json({ ok: true });
+      }
+      if (url.pathname === "/status") {
+        return Response.json({
+          runs: {
+            byState: {
+              QUEUED: queued,
+              LEASED: leased.length,
+              RUNNING: running.length,
+              VERIFYING: verifying.length,
+            },
+          },
+        });
+      }
+      if (url.pathname === "/workers") {
+        return Response.json({
+          workers: [{ workerId: "worker_1", state: "idle" }],
+        });
+      }
+      if (url.pathname === "/runs") {
+        const byState = {
+          LEASED: leased,
+          RUNNING: running,
+          VERIFYING: verifying,
+        };
+        return Response.json({
+          runs: byState[url.searchParams.get("state")] ?? [],
+        });
+      }
+      const runId = url.pathname.match(/^\/runs\/([^/]+)$/)?.[1];
+      if (runId) {
+        const run = [...leased, ...running, ...verifying].find(
+          (entry) => entry.runId === runId,
+        );
+        if (run) {
+          return Response.json({
+            attempts: [{ lease_expires_at: run.lease_expires_at ?? null }],
+          });
+        }
+      }
+      return new Response("not found", { status: 404 });
+    },
+  });
+
+  try {
+    return await runWatchdogCheck({
+      port: server.port,
+      webPort: server.port,
+      stuckMinutes: 45,
+      checkShadowFleet: false,
+    });
+  } finally {
+    server.stop(true);
+  }
+}
+
+test("runWatchdogCheck detects stale active runs", async () => {
+  const result = await runWatchdogWithInFlightRuns({
+    leased: [
+      {
+        runId: "run_leased",
+        agent: "dispatch@1",
+        state: "LEASED",
+        created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        updated_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      },
+    ],
+    running: [
+      {
+        runId: "run_running",
+        agent: "dispatch@1",
+        state: "RUNNING",
+        created_at: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+        updated_at: new Date(Date.now() - 60 * 60 * 1000).toISOString(),
+      },
+    ],
+  });
+
+  expect(result.metrics).toMatchObject({
+    inFlightRuns: 2,
+    leasedRuns: 1,
+    runningRuns: 1,
+    verifyingRuns: 0,
+  });
+  expect(
+    result.issues.filter((issue) => issue.code === "WEDGED_RUN"),
+  ).toHaveLength(2);
+});
+
+test("runWatchdogCheck does not wedge an old VERIFYING run with a fresh lease", async () => {
+  const result = await runWatchdogWithInFlightRuns({
+    verifying: [
+      {
+        runId: "run_verifying_fresh_lease",
+        agent: "dispatch@1",
+        state: "VERIFYING",
+        created_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        updated_at: new Date(Date.now() - 30 * 60 * 1000).toISOString(),
+        lease_expires_at: new Date(Date.now() + 10 * 60 * 1000).toISOString(),
+      },
+    ],
+  });
+
+  expect(result.metrics).toMatchObject({
+    inFlightRuns: 1,
+    leasedRuns: 0,
+    runningRuns: 0,
+    verifyingRuns: 1,
+  });
+  expect(result.issues.some((issue) => issue.code === "WEDGED_RUN")).toBe(
+    false,
+  );
+});
+
+test("runWatchdogCheck does not report IDLE_STALL with a VERIFYING run", async () => {
+  const result = await runWatchdogWithInFlightRuns({
+    queued: 1,
+    verifying: [
+      {
+        runId: "run_verifying",
+        agent: "dispatch@1",
+        state: "VERIFYING",
+        created_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      },
+    ],
+  });
+
+  expect(result.issues.some((issue) => issue.code === "IDLE_STALL")).toBe(
+    false,
+  );
 });
 
 test("runWatchdogCheck detects unreachable API as critical", async () => {


### PR DESCRIPTION
Fixes #1646

Use live attempt leases to prevent healthy VERIFYING runs from being flagged as wedges.

## Validation

| Check                | Command                                                                          | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/watchdog.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 163 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,087 pass; lint clean |
| UX critique          | factory-ux-critic                                                                | not run | internal watchdog surface     |

UX critique: skipped

run:4ef945ef (post-review fix, manual)


## Post-review
Reviewer verdict FIX, addressed in 4ef945ef (merged `origin/develop` — conflicts with #1631 resolved on this branch's side, which supersedes it):
- The fresh-lease exemption from `WEDGED_RUN` now applies only to `VERIFYING` runs (lease renewal is worker liveness, not progress in LEASED/RUNNING). An absolute ceiling flags any run older than `stuckMinutes * 3` regardless of lease.
- `inFlightRunDetails` wraps each `GET /runs/:id` in try/catch (falls back to `lease_expires_at: null`) and fetches in batches of 8, so one 404/timeout no longer drops the whole metrics block.
- Tests: RUNNING with fresh lease past `stuckMinutes` → wedged; VERIFYING with fresh lease → not wedged; VERIFYING past the 3× ceiling → wedged; stale VERIFYING without lease → wedged; one detail fetch failing while the rest still report.
- Verified: `bun test orchestrator/watchdog.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` (167 pass), `bun run lint`, `bun test event-runtime/lib` (2102 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
