### PR TITLE
fix(label-guard): resolve control plane per repo

### DIFF
--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -156,14 +156,23 @@ export function ownedPathsClosureGuard(
   }
 }
 
-export async function fetchReadyIssues(repo) {
-  return loadControlPlane().listDispatchable({
+export async function fetchReadyIssues(
+  repo,
+  resolveControlPlane = loadControlPlane,
+) {
+  return resolveControlPlane({ repoName: repo.name }).listDispatchable({
     team: repo.team,
     project: repo.project,
   });
 }
 
-export async function demote(issue, _triageStateId, gaps, apply) {
+export async function demote(
+  issue,
+  repo,
+  gaps,
+  apply,
+  resolveControlPlane = loadControlPlane,
+) {
   if (!apply) return;
 
   const body =
@@ -174,7 +183,7 @@ export async function demote(issue, _triageStateId, gaps, apply) {
     `\n\nMoved back to \`Triage\` and the label was removed so it isn't picked up for dispatch. ` +
     `A triage pass needs to add the missing section(s) before re-labeling \`ai:agent-ready\`.`;
 
-  const cp = loadControlPlane();
+  const cp = resolveControlPlane({ repoName: repo.name });
   await cp.transition(issue.identifier, "Triage", {
     remove: [AI_AGENT_READY],
   });
@@ -253,7 +262,7 @@ export async function main(argv = process.argv.slice(2)) {
 
       if (args.apply) {
         try {
-          await demote(issue, null, gaps, true);
+          await demote(issue, repo, gaps, true);
           console.log(`      -> demoted to Triage, ai:agent-ready removed`);
         } catch (err) {
           console.log(`      ! failed: ${err.message || err}`);

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -11,7 +11,13 @@
  * genuine catch (CLNT-871/872's shape) and the false positives that got cut.
  */
 import { test, expect } from "bun:test";
-import { ownedPathsClosureGuard, templateGaps } from "./label-guard.mjs";
+import { controlPlaneKindFromRepo } from "../lib/control-plane/index.mjs";
+import {
+  demote,
+  fetchReadyIssues,
+  ownedPathsClosureGuard,
+  templateGaps,
+} from "./label-guard.mjs";
 
 const FULL_SPEC = `## Problem & Context
 
@@ -31,6 +37,40 @@ Something is broken and it matters.
 
 test("a real §5 spec passes with no gaps", () => {
   expect(templateGaps(FULL_SPEC)).toEqual([]);
+});
+
+test("listing and demotion select the control plane configured for the repo", async () => {
+  const repo = { name: "factory", team: "WM", project: "Factory" };
+  expect(controlPlaneKindFromRepo(repo.name)).toBe("github");
+  const calls = [];
+  const cp = {
+    listDispatchable: async (filters) => {
+      calls.push({ method: "listDispatchable", filters });
+      return [{ identifier: "#1555" }];
+    },
+    transition: async (...args) => calls.push({ method: "transition", args }),
+    comment: async (...args) => calls.push({ method: "comment", args }),
+  };
+  const resolveControlPlane = (options) => {
+    calls.push({ method: "loadControlPlane", options });
+    return cp;
+  };
+
+  const issues = await fetchReadyIssues(repo, resolveControlPlane);
+  await demote(issues[0], repo, ["Owned Paths"], true, resolveControlPlane);
+
+  expect(calls.filter((call) => call.method === "loadControlPlane")).toEqual([
+    { method: "loadControlPlane", options: { repoName: "factory" } },
+    { method: "loadControlPlane", options: { repoName: "factory" } },
+  ]);
+  expect(calls).toContainEqual({
+    method: "listDispatchable",
+    filters: { team: "WM", project: "Factory" },
+  });
+  expect(calls).toContainEqual({
+    method: "transition",
+    args: ["#1555", "Triage", { remove: ["ai:agent-ready"] }],
+  });
 });
 
 test("a malformed registry digest policy is rendered as a guard message", () => {

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -11,7 +11,6 @@
  * genuine catch (CLNT-871/872's shape) and the false positives that got cut.
  */
 import { test, expect } from "bun:test";
-import { controlPlaneKindFromRepo } from "../lib/control-plane/index.mjs";
 import {
   demote,
   fetchReadyIssues,
@@ -41,7 +40,6 @@ test("a real §5 spec passes with no gaps", () => {
 
 test("listing and demotion select the control plane configured for the repo", async () => {
   const repo = { name: "factory", team: "WM", project: "Factory" };
-  expect(controlPlaneKindFromRepo(repo.name)).toBe("github");
   const calls = [];
   const cp = {
     listDispatchable: async (filters) => {


### PR DESCRIPTION
Fixes watt-mind/factory#1555

Route label-guard listing and demotion through each configured repository control plane.

## Validation

| Check                | Command                                                                                         | Result  | Notes                         |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/label-guard.test.mjs --timeout 20000 && bun build/emit.mjs --check`     | pass    | 14 tests; generated files match |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2102 pass, 10 skip; lint clean |
| UX critique          | factory-ux-critic                                                                               | not run | no user-facing surface        |

UX critique: skipped

run:run_80aad8fe-74d8-4f00-bae9-942061a5930e

## Post-review

- Merged `origin/develop` into the branch.
- Removed `label-guard.test.mjs`'s `controlPlaneKindFromRepo(repo.name)` assertion (and its import): it read the ambient `config/repos.yaml` from CWD and failed as `null` in CI. The `resolveControlPlane` call assertions already prove per-repo plane selection hermetically.
- Note: `demote()`'s 2nd parameter is now `repo` (the per-repo object from `main()`), so listing and demotion resolve the same plane via `loadControlPlane({ repoName })`.
- Verified: `bun test orchestrator/label-guard.test.mjs` (14 pass), `bun build/emit.mjs --check`, lint, `bun test event-runtime/lib` (2114 pass), format:check, `bun run check`. `./bin/factory label-guard --repo factory` (dry run, real repos.yaml): `factory  WM / Factory  --  32 ai:agent-ready ticket(s), 2 failing §5`, exit 0, no Linear call.
