### PR TITLE
fix(ticket): accept configured GitHub repo refs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -37,7 +37,7 @@ tracker the factory cannot reach must never be silently read as "no tickets".
 
 | Protocol     | GitHub                                                                                        |
 | :----------- | :-------------------------------------------------------------------------------------------- |
-| `identifier` | `owner/repo#42`                                                                               |
+| `identifier` | `owner/repo#42` or `configured-repo-name#42`                                                  |
 | `team`       | Repository, via `controlPlane.github.teams` (or a key that already looks like `owner/name`)   |
 | `labels`     | Issue labels of the **same spelling**. Writes send the complete resulting set, never a delta. |
 | `assignee`   | Issue assignee. `claim` assigns the `gh` viewer, then **reads the assignee back**.            |
@@ -355,8 +355,11 @@ and its `claim` verb performs the advisory read-back. The authoritative
 concurrency control is the per-repository dispatch lock described in §7.
 
 ```bash
-# Read a ticket.
+# Read a ticket. GitHub Issues accept either the full slug or the configured
+# repository name; both spellings resolve to the full `owner/repo#N` form.
 factory ticket get CLNT-616
+factory ticket get watt-mind/factory#123
+factory ticket get factory#123
 # List its comments.
 factory ticket comments CLNT-616
 # Atomically claim a dispatchable ticket (`--agent` selects the harness).

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -409,8 +409,8 @@ function configuredGithubTicketRef(ticketArg, registry) {
   const full = ticketArg.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([0-9]+)$/);
   const short = ticketArg.match(/^([A-Za-z0-9_.-]+)#([0-9]+)$/);
   if (!full && !short) return null;
-  const name = (full?.[1] ?? short?.[1]).toLowerCase();
-  const number = full?.[2] ?? short?.[2];
+  const [, rawName, number] = full ?? short;
+  const name = rawName.toLowerCase();
   for (const repo of registry.values()) {
     const matches = full
       ? typeof repo.github === "string" && repo.github.toLowerCase() === name
@@ -422,7 +422,9 @@ function configuredGithubTicketRef(ticketArg, registry) {
 
 /** Return the full GitHub slug, or reject a miss before fallback routing. */
 export function normalizeTicketRef(ticketArg, repos) {
-  const registry = repos ?? getRepos();
+  // Same registry `controlPlane()` binds to, so the ref that passes here is
+  // the ref the adapter is built for.
+  const registry = repos ?? getRepos(instanceConfigRoot());
   const ref = configuredGithubTicketRef(ticketArg, registry);
   if (ref) return ref.identifier;
   if (typeof ticketArg === "string" && /^[^#\s]+#[0-9]+$/.test(ticketArg)) {
@@ -658,8 +660,8 @@ const VERBS = {
   },
 
   async comments() {
+    if (!positional[0]) throw new Error(`usage: comments <ISSUE-ID>`);
     const key = normalizeTicketRef(positional[0]);
-    if (!key) throw new Error(`usage: comments <ISSUE-ID>`);
     const nodes = await controlPlane(key).listComments(key);
     out(nodes, formatComments(nodes));
   },
@@ -680,8 +682,8 @@ const VERBS = {
   },
 
   async unclaim() {
+    if (!positional[0]) throw new Error(`usage: unclaim <ISSUE-ID>`);
     const key = normalizeTicketRef(positional[0]);
-    if (!key) throw new Error(`usage: unclaim <ISSUE-ID>`);
     const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
     const currentNames = (issue.labels ?? []).map((label) => label.name);
@@ -702,10 +704,10 @@ const VERBS = {
   },
 
   async triage() {
-    const key = normalizeTicketRef(positional[0]);
     const comment = flag("comment");
-    if (!key || comment === null)
+    if (!positional[0] || comment === null)
       throw new Error(`usage: triage <ISSUE-ID> --comment "<text>"`);
+    const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     await cp.transition(key, "Triage", { remove: ["ai:agent-ready"] });
     if (comment.trim()) await cp.comment(key, comment);
@@ -713,10 +715,10 @@ const VERBS = {
   },
 
   async answer() {
-    const key = normalizeTicketRef(positional[0]);
     const text = positional[1];
-    if (!key || !text)
+    if (!positional[0] || !text)
       throw new Error(`usage: answer <ISSUE-ID> [--] "<text>"`);
+    const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
     if (issue.state?.name?.toLowerCase() === "blocked")
@@ -726,10 +728,10 @@ const VERBS = {
   },
 
   async detail() {
-    const key = normalizeTicketRef(positional[0]);
     const rawDetail = positional[1];
-    if (!key || !rawDetail)
+    if (!positional[0] || !rawDetail)
       throw new Error(`usage: detail <ISSUE-ID> [--] "<markdown>"`);
+    const key = normalizeTicketRef(positional[0]);
     const { appended } = await controlPlane(key).appendDetail(key, rawDetail);
     if (!appended) {
       out(
@@ -745,11 +747,11 @@ const VERBS = {
   },
 
   async labels() {
-    const key = normalizeTicketRef(positional[0]);
-    if (!key)
+    if (!positional[0])
       throw new Error(
         `usage: labels <ISSUE-ID> [--add <label>] [--remove <label>]`,
       );
+    const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     const add = flagAll("add"),
       remove = flagAll("remove");
@@ -771,12 +773,11 @@ const VERBS = {
   },
 
   async state() {
-    const key = normalizeTicketRef(positional[0]);
     const wanted = positional[1];
     const add = flagAll("add"),
       remove = flagAll("remove");
     const comment = flag("comment");
-    if (!key)
+    if (!positional[0])
       throw new Error(
         `usage: state <ISSUE-ID> ["<State Name>"] [--add label] [--remove label] [--comment "<text>"]`,
       );
@@ -785,6 +786,7 @@ const VERBS = {
         `usage: state <ISSUE-ID> "<State Name>" [--add label] [--remove label] [--comment "<text>"]`,
       );
     }
+    const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
 

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -8,6 +8,7 @@
  * `tools/linear.mjs` remains as a deprecated shim.
  *
  *   bun tools/ticket.mjs get CLNT-616
+ *   bun tools/ticket.mjs get owner/repo#123  # or configured-repo-name#123
  *   bun tools/ticket.mjs comments CLNT-616
  *   bun tools/ticket.mjs claim CLNT-616 --agent claude
  *   bun tools/ticket.mjs unclaim CLNT-616
@@ -392,23 +393,46 @@ export function resolveRepoName({
 /**
  * When cwd identifies no repo (dispatched agents run from ephemeral runtime
  * workspaces under ~/.factory, matching neither `path` nor `worktree_root` —
- * GH-975), the ticket identifier itself still can: `owner/repo#N` names the
- * GitHub repo, and a registry entry whose `github:` matches decides the
- * plane. Without this, a workspace-run claim silently falls back to the
- * workspace-wide default plane and misreads or misses the ticket entirely.
+ * GH-975), the ticket identifier itself still can: `owner/repo#N` or a
+ * configured `repo-name#N` names the GitHub repo. Without this, a workspace-
+ * run claim silently falls back to the workspace-wide default plane and
+ * misreads or misses the ticket entirely.
  */
 export function resolveRepoNameFromTicket(ticketArg, repos) {
   const registry = repos ?? getRepos();
-  const m =
-    typeof ticketArg === "string" &&
-    ticketArg.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#[0-9]+/);
-  if (!m) return null;
-  const github = m[1].toLowerCase();
+  const ref = configuredGithubTicketRef(ticketArg, registry);
+  return ref?.repo.name ?? null;
+}
+
+function configuredGithubTicketRef(ticketArg, registry) {
+  if (typeof ticketArg !== "string") return null;
+  const full = ticketArg.match(/^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([0-9]+)$/);
+  const short = ticketArg.match(/^([A-Za-z0-9_.-]+)#([0-9]+)$/);
+  if (!full && !short) return null;
+  const name = (full?.[1] ?? short?.[1]).toLowerCase();
+  const number = full?.[2] ?? short?.[2];
   for (const repo of registry.values()) {
-    if (typeof repo.github === "string" && repo.github.toLowerCase() === github)
-      return repo.name;
+    const matches = full
+      ? typeof repo.github === "string" && repo.github.toLowerCase() === name
+      : typeof repo.name === "string" && repo.name.toLowerCase() === name;
+    if (matches) return { repo, identifier: `${repo.github}#${number}` };
   }
   return null;
+}
+
+/** Return the full GitHub slug, or reject a miss before fallback routing. */
+export function normalizeTicketRef(ticketArg, repos) {
+  const registry = repos ?? getRepos();
+  const ref = configuredGithubTicketRef(ticketArg, registry);
+  if (ref) return ref.identifier;
+  if (typeof ticketArg === "string" && /^[^#\s]+#[0-9]+$/.test(ticketArg)) {
+    const err = new Error(
+      `unrecognised ticket ref ${JSON.stringify(ticketArg)}: expected <owner>/<repo>#N or <repo-name>#N for a configured GitHub repo, or a Linear id like CLNT-616`,
+    );
+    err.exitCode = 2;
+    throw err;
+  }
+  return ticketArg;
 }
 
 /**
@@ -628,23 +652,24 @@ const out = (obj, text) =>
 
 const VERBS = {
   async get() {
-    const issue = await controlPlane().getTicket(positional[0]);
+    const key = normalizeTicketRef(positional[0]);
+    const issue = await controlPlane(key).getTicket(key);
     out(issue, formatTicket(issue));
   },
 
   async comments() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     if (!key) throw new Error(`usage: comments <ISSUE-ID>`);
-    const nodes = await controlPlane().listComments(key);
+    const nodes = await controlPlane(key).listComments(key);
     out(nodes, formatComments(nodes));
   },
 
   async claim() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const harness = flag("agent", "claude");
     // Linear has no compare-and-swap; the adapter's read-back IS the
     // concurrency control. `ok: false` is a lost race, not a transport error.
-    const result = await controlPlane().claim(key, { harness });
+    const result = await controlPlane(key).claim(key, { harness });
     out(
       result,
       result.ok
@@ -655,9 +680,9 @@ const VERBS = {
   },
 
   async unclaim() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     if (!key) throw new Error(`usage: unclaim <ISSUE-ID>`);
-    const cp = controlPlane();
+    const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
     const currentNames = (issue.labels ?? []).map((label) => label.name);
     const { add, remove } = releaseLabels(currentNames, { to: "Todo" });
@@ -669,30 +694,30 @@ const VERBS = {
   },
 
   async comment() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const body = positional[1];
     if (!body) throw new Error(`usage: comment <ISSUE-ID> [--] "<text>"`);
-    await controlPlane().comment(key, body);
+    await controlPlane(key).comment(key, body);
     out({ ok: true, identifier: key }, `commented on ${key}`);
   },
 
   async triage() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const comment = flag("comment");
     if (!key || comment === null)
       throw new Error(`usage: triage <ISSUE-ID> --comment "<text>"`);
-    const cp = controlPlane();
+    const cp = controlPlane(key);
     await cp.transition(key, "Triage", { remove: ["ai:agent-ready"] });
     if (comment.trim()) await cp.comment(key, comment);
     out({ ok: true, identifier: key }, `${key} -> Triage`);
   },
 
   async answer() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const text = positional[1];
     if (!key || !text)
       throw new Error(`usage: answer <ISSUE-ID> [--] "<text>"`);
-    const cp = controlPlane();
+    const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
     if (issue.state?.name?.toLowerCase() === "blocked")
       await cp.transition(key, "Todo");
@@ -701,11 +726,11 @@ const VERBS = {
   },
 
   async detail() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const rawDetail = positional[1];
     if (!key || !rawDetail)
       throw new Error(`usage: detail <ISSUE-ID> [--] "<markdown>"`);
-    const { appended } = await controlPlane().appendDetail(key, rawDetail);
+    const { appended } = await controlPlane(key).appendDetail(key, rawDetail);
     if (!appended) {
       out(
         { ok: true, identifier: key, appended: false },
@@ -720,12 +745,12 @@ const VERBS = {
   },
 
   async labels() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     if (!key)
       throw new Error(
         `usage: labels <ISSUE-ID> [--add <label>] [--remove <label>]`,
       );
-    const cp = controlPlane();
+    const cp = controlPlane(key);
     const add = flagAll("add"),
       remove = flagAll("remove");
     if (!add.length && !remove.length) {
@@ -746,7 +771,7 @@ const VERBS = {
   },
 
   async state() {
-    const key = positional[0];
+    const key = normalizeTicketRef(positional[0]);
     const wanted = positional[1];
     const add = flagAll("add"),
       remove = flagAll("remove");
@@ -760,7 +785,7 @@ const VERBS = {
         `usage: state <ISSUE-ID> "<State Name>" [--add label] [--remove label] [--comment "<text>"]`,
       );
     }
-    const cp = controlPlane();
+    const cp = controlPlane(key);
     const issue = await cp.getTicket(key);
 
     if (add.includes("ai:agent-ready")) {
@@ -921,7 +946,7 @@ export async function main() {
       process.exit(LINEAR_RATE_LIMIT_EXIT);
     }
     console.error(`ticket ${verb}: ${e.message}`);
-    process.exit(1);
+    process.exit(e.exitCode ?? 1);
   }
 }
 

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -34,6 +34,7 @@ import {
   closureCheckMessages,
   resolveRepoName,
   resolveRepoNameFromTicket,
+  normalizeTicketRef,
   resolveRepoNameForFile,
   instanceConfigRoot,
   InstanceConfigMissingError,
@@ -781,10 +782,25 @@ test("resolveRepoNameFromTicket: case-insensitive on the github slug", () => {
   );
 });
 
+test("resolveRepoNameFromTicket: configured repository names resolve case-insensitively", () => {
+  expect(resolveRepoNameFromTicket("factory#7", GH975_REPOS)).toBe("factory");
+  expect(resolveRepoNameFromTicket("Factory#7", GH975_REPOS)).toBe("factory");
+});
+
+test("normalizeTicketRef: both configured GitHub spellings use the full slug", () => {
+  expect(normalizeTicketRef("factory#7", GH975_REPOS)).toBe(
+    "watt-mind/factory#7",
+  );
+  expect(normalizeTicketRef("Watt-Mind/Factory#7", GH975_REPOS)).toBe(
+    "watt-mind/factory#7",
+  );
+});
+
 test("resolveRepoNameFromTicket: linear-style and bare ids resolve nothing", () => {
   expect(resolveRepoNameFromTicket("WM-123", GH975_REPOS)).toBeNull();
   expect(resolveRepoNameFromTicket("975", GH975_REPOS)).toBeNull();
   expect(resolveRepoNameFromTicket(undefined, GH975_REPOS)).toBeNull();
+  expect(resolveRepoNameFromTicket("nope#7", GH975_REPOS)).toBeNull();
 });
 
 test("resolveRepoNameForFile: --from chooses its GitHub repo and refuses an ambiguous workspace", () => {
@@ -840,7 +856,7 @@ test("resolveRepoNameForFile: a Linear-style --from falls through to cwd instead
  * Linear key leaks in: each route therefore ends in a deterministic, offline
  * failure that identifies which control plane was reached.
  */
-function spawnFileOutsideRepo(args, { controlPlane } = {}) {
+function spawnTicketOutsideRepo(args, { controlPlane } = {}) {
   const root = mkdtempSync(path.join(os.tmpdir(), "ticket-file-route-"));
   const workspace = path.join(root, "workspace");
   const bin = path.join(root, "bin");
@@ -887,7 +903,7 @@ function spawnFileOutsideRepo(args, { controlPlane } = {}) {
         delete env[name];
     }
     const result = Bun.spawnSync({
-      cmd: ["bun", path.join(cliRoot, "tools", "ticket.mjs"), "file", ...args],
+      cmd: ["bun", path.join(cliRoot, "tools", "ticket.mjs"), ...args],
       cwd: workspace,
       env,
       stdout: "pipe",
@@ -902,6 +918,9 @@ function spawnFileOutsideRepo(args, { controlPlane } = {}) {
     rmSync(root, { recursive: true, force: true });
   }
 }
+
+const spawnFileOutsideRepo = (args, options) =>
+  spawnTicketOutsideRepo(["file", ...args], options);
 
 test("file refuses an unresolvable workspace with both routing flags", () => {
   const result = spawnFileOutsideRepo(["--title", "finding"]);
@@ -943,6 +962,24 @@ test("file without --title reports usage before any routing", () => {
   expect(result.exitCode).toBe(1);
   expect(result.stderr).toContain("usage: file --title");
   expect(result.stderr).not.toContain("--repo <name> or --from <owner/repo#N>");
+});
+
+test("unknown GitHub-shaped ticket refs fail before a control-plane transport", () => {
+  const result = spawnTicketOutsideRepo(["labels", "nope#7", "--remove", "x"]);
+  expect(result.exitCode).toBe(2);
+  expect(result.stderr).toContain('unrecognised ticket ref "nope#7"');
+  expect(result.stderr).toContain("<owner>/<repo>#N or <repo-name>#N");
+  expect(result.ghCalls).toBe("");
+});
+
+test("short configured GitHub refs reach the adapter as full identifiers", () => {
+  const result = spawnTicketOutsideRepo(
+    ["labels", "factory#7", "--remove", "x"],
+    { controlPlane: "github" },
+  );
+  expect(result.exitCode).toBe(1);
+  expect(result.ghCalls).toContain("repos/watt-mind/factory/issues/7");
+  expect(result.ghCalls).not.toContain("factory#7");
 });
 
 // ----------------------------------- instance config resolution (GH-975) ---

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -972,6 +972,16 @@ test("unknown GitHub-shaped ticket refs fail before a control-plane transport", 
   expect(result.ghCalls).toBe("");
 });
 
+test("verbs missing the ticket argument report usage before ref normalisation", () => {
+  for (const verb of ["comments", "unclaim", "labels"]) {
+    const result = spawnTicketOutsideRepo([verb]);
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr).toContain(`usage: ${verb} <ISSUE-ID>`);
+    expect(result.stderr).not.toContain("unrecognised ticket ref");
+    expect(result.ghCalls).toBe("");
+  }
+});
+
 test("short configured GitHub refs reach the adapter as full identifiers", () => {
   const result = spawnTicketOutsideRepo(
     ["labels", "factory#7", "--remove", "x"],


### PR DESCRIPTION
Fixes watt-mind/factory#1660

Use configured GitHub repository names in ticket CLI refs without falling back to Linear.

## Validation

| Check                | Command                                                                          | Result  | Notes                    |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test tools/ticket.test.mjs --timeout 20000`                                 | pass    | 55 tests, 0 failures     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2112 pass, 10 skips      |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface   |

UX critique: skipped
run:run_bae879a0-363f-4d2b-82a4-ecc4ef1b80d8

## Post-review

- `normalizeTicketRef` now reads `getRepos(instanceConfigRoot())`, the same registry `controlPlane()` binds to.
- Verbs check the `<ISSUE-ID>` positional before normalising it, so a missing argument prints usage instead of a registry error; test added (`comments`/`unclaim`/`labels` with no arg).
- Replaced the `no-unsafe-optional-chaining` lint error in `configuredGithubTicketRef` with a destructure of `full ?? short`.
- Merged `origin/develop`; `bun test tools/ticket.test.mjs` 56 pass, `event-runtime/lib` 2108 pass, lint 0 errors, prettier/check clean.
