### PR TITLE
fix(owned-paths): make duplicate sections deterministic

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -175,12 +175,18 @@ A ticket missing a load-bearing section (`Owned Paths` or `Verification
 Command`) is demoted to `Triage`; do not dispatch it. `factory label-guard`
 checks those two mechanically.
 
-When a §5 heading is duplicated, the **first** matching block is authoritative
-for every reader (dispatch, handoff verification, and the template guard).
-This keeps an already-corrupted ticket deterministic rather than silently
-using a later append. `factory ticket detail ISSUE -- "..."` appends an
-idempotent detail block; use `factory ticket detail ISSUE --replace -- "..."`
-to replace the complete description when re-specifying a ticket.
+When a §5 heading is duplicated (the usual cause: a respec appended with
+`ticket detail`), every reader **unions** the matching blocks in document
+order — dispatch, handoff verification, and the template guard alike, so they
+can never disagree about which copy counts. `Owned Paths` becomes the
+deduplicated union of all blocks (first occurrence keeps its position), so an
+appended respec widens scope to cover the old and the new block and is never
+silently narrower than either. `Verification Command` becomes the distinct
+commands joined with `&&` — all of them must pass. A first-match win is
+deliberately not what happens. `factory ticket detail ISSUE -- "..."` appends
+an idempotent detail block; use `factory ticket detail ISSUE --replace -- "..."`
+to replace the complete description when re-specifying a ticket, which is the
+only way to make a stale block stop counting.
 
 ## 6. Bundles
 

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -175,6 +175,13 @@ A ticket missing a load-bearing section (`Owned Paths` or `Verification
 Command`) is demoted to `Triage`; do not dispatch it. `factory label-guard`
 checks those two mechanically.
 
+When a §5 heading is duplicated, the **first** matching block is authoritative
+for every reader (dispatch, handoff verification, and the template guard).
+This keeps an already-corrupted ticket deterministic rather than silently
+using a later append. `factory ticket detail ISSUE -- "..."` appends an
+idempotent detail block; use `factory ticket detail ISSUE --replace -- "..."`
+to replace the complete description when re-specifying a ticket.
+
 ## 6. Bundles
 
 Bundling several tickets into one worktree is the **human's** call, never
@@ -369,8 +376,10 @@ factory ticket comment CLNT-616 "..."
 factory ticket triage CLNT-616 --comment "..."
 # Record an answer and return a blocked ticket to Todo when applicable.
 factory ticket answer CLNT-616 "..."
-# Append idempotent Markdown detail to a ticket.
+# Append idempotent Markdown detail to a ticket (the default never replaces).
 factory ticket detail CLNT-616 -- "..."
+# Replace the complete description when re-specifying a ticket.
+factory ticket detail CLNT-616 --replace -- "..."
 # Read or mutate labels (`label` is an alias for `labels`).
 factory ticket labels CLNT-616 --add ai:needs-review --remove ai:in-progress
 factory ticket label CLNT-616

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -27,25 +27,13 @@ import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
 import {
   parseOwnedPaths,
+  ticketSections,
   ownedPathsClosureGaps,
   readPinManifestRequirements,
   formatOwnedPathClosureGaps,
 } from "./owned-paths.mjs";
 
 const AI_AGENT_READY = "ai:agent-ready";
-
-/** Split markdown heading sections (levels 2-4), keyed by heading text and trimmed body. */
-function sections(description = "") {
-  return description
-    .split(/^#{2,4}\s+/m)
-    .slice(1)
-    .map((s) => {
-      const nl = s.indexOf("\n");
-      const heading = (nl === -1 ? s : s.slice(0, nl)).trim();
-      const body = (nl === -1 ? "" : s.slice(nl + 1)).trim();
-      return { heading, body };
-    });
-}
 
 /**
  * Which linear.md §5 sections a description is missing. [] means it passes.
@@ -81,14 +69,18 @@ const NOT_APPLICABLE =
  * variation.
  */
 export function templateGaps(description = "") {
-  const secs = sections(description);
+  // Same duplicate-heading rule as parseOwnedPaths: every matching block
+  // counts, so an appended respec cannot disagree with dispatch about which
+  // copy is authoritative.
+  const secs = ticketSections(description);
   const gaps = [];
 
   // A non-code ticket (deploy/env-var/business change) legitimately has no
   // repo paths -- linear.md's non-code exception applies here too. Accept an
   // explicit "not applicable" declaration in the section body.
-  const owned = secs.find((s) => /\bowned\s+paths\b/i.test(s.heading));
-  const ownedNA = owned && NOT_APPLICABLE.test(owned.body);
+  const ownedNA = secs.some(
+    (s) => /\bowned\s+paths\b/i.test(s.heading) && NOT_APPLICABLE.test(s.body),
+  );
   if (!parseOwnedPaths(description).length && !ownedNA)
     gaps.push("Owned Paths");
 
@@ -101,7 +93,9 @@ export function templateGaps(description = "") {
     return (
       (/\bverification\s+command\b/i.test(s.heading) ||
         /\bevidence\b.*\b(required|line)\b/i.test(s.heading)) &&
-      s.body.length > 0
+      // ticketSections leaves bodies untrimmed; a heading followed only by
+      // blank lines is still a gap.
+      s.body.trim().length > 0
     );
   });
   if (!verified) gaps.push("Verification Command");

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -33,6 +33,35 @@ test("a real §5 spec passes with no gaps", () => {
   expect(templateGaps(FULL_SPEC)).toEqual([]);
 });
 
+test("a Verification Command heading with only blank lines under it is a gap", () => {
+  const desc = `## Owned Paths
+
+- \`app/services/api.ts\`
+
+## Verification Command
+
+`;
+  expect(templateGaps(desc)).toEqual(["Verification Command"]);
+});
+
+test("duplicate §5 headings are unioned, so an appended respec fills the gap", () => {
+  const desc = `## Owned Paths
+
+None — deploy-only change.
+
+## Verification Command
+
+## Owned Paths
+
+None
+
+## Verification Command
+
+    npm test
+`;
+  expect(templateGaps(desc)).toEqual([]);
+});
+
 test("a malformed registry digest policy is rendered as a guard message", () => {
   const result = ownedPathsClosureGuard("", {
     name: "factory",

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -38,10 +38,15 @@ export const REGISTRY_DIGEST_BASELINE_PATH =
 /**
  * Split level 2–4 Markdown headings into their sections.
  *
- * Every §5 reader treats the first matching duplicate heading as
- * authoritative. This keeps already-corrupted tickets deterministic until a
- * triage agent explicitly rewrites the description with `ticket detail
- * --replace`.
+ * Bodies are returned untrimmed (an indented Owned Paths code block must keep
+ * its leading whitespace); callers that gate on "has content" must trim.
+ *
+ * Duplicate headings are UNIONED, never first-match. `ticket detail` appends
+ * by default, so a respec through the CLI leaves two copies of a §5 section
+ * in the body; every §5 reader (dispatch, handoff verification, the template
+ * guard) reads all matching blocks in document order so the appended copy
+ * takes effect instead of being silently ignored. See {@link parseOwnedPaths}
+ * and {@link parseVerificationCommand}.
  */
 export function ticketSections(description = "") {
   return String(description ?? "")
@@ -58,26 +63,31 @@ export function ticketSections(description = "") {
     });
 }
 
-/** Return the authoritative (first) ticket section whose heading matches. */
-export function firstTicketSection(description = "", matchesHeading) {
-  return ticketSections(description).find((section) =>
+/** Every ticket section whose heading matches, in document order. */
+export function matchingTicketSections(description = "", matchesHeading) {
+  return ticketSections(description).filter((section) =>
     matchesHeading(section.heading),
   );
 }
 
 /**
  * Extract the Owned Paths bullet list (levels 2-4) from a Linear issue description.
- * If a ticket has more than one Owned Paths heading, only the first is
- * authoritative; see {@link firstTicketSection}.
+ *
+ * Duplicate `Owned Paths` headings are unioned: every matching block is read,
+ * the paths are deduplicated, and order is first occurrence in the body. A
+ * respec appended with `ticket detail` therefore widens scope to cover both
+ * the old and the new block — never silently narrower than either. With a
+ * single heading the result is byte-identical to reading that block alone.
  * Returns [] when the section is missing or fails to parse — for dispatch,
  * use `effectiveOwnedPaths`, which turns that into "collides with
  * everything" rather than "not dispatchable".
  */
 export function parseOwnedPaths(description = "") {
-  const section = firstTicketSection(description, (heading) =>
+  const sections = matchingTicketSections(description, (heading) =>
     /\bOwned Paths\b/i.test(heading),
   );
-  if (!section) return [];
+  if (!sections.length) return [];
+  const body = sections.map((section) => section.body).join("\n");
 
   // Real tickets write this section three different ways — bullet lists, fenced
   // code blocks, and indented code — often mixing them with prose ("Plus, only
@@ -88,7 +98,7 @@ export function parseOwnedPaths(description = "") {
   const out = [];
   let inFence = false;
 
-  for (const raw of section.body.split("\n")) {
+  for (const raw of body.split("\n")) {
     if (/^\s*```/.test(raw)) {
       inFence = !inFence;
       continue;
@@ -125,6 +135,9 @@ export function parseOwnedPaths(description = "") {
           !/\s/.test(s) &&
           (s.includes("/") || s.includes("*") || /\.[a-z0-9]+$/i.test(s)),
       )
+      // Union semantics: a path repeated across duplicate blocks counts once,
+      // keeping its first position.
+      .filter((s, i, all) => all.indexOf(s) === i)
   );
 }
 
@@ -159,14 +172,28 @@ export function effectiveOwnedPaths(description = "") {
  * Returns null when the section is missing or holds nothing runnable; the
  * worker's handoff gate then falls back to the repo's `verify:` command and,
  * absent both, refuses the handoff (fail-closed).
+ *
+ * Duplicate headings follow the same union rule as {@link parseOwnedPaths}:
+ * each block's command is read, duplicates are dropped, and the distinct
+ * commands are joined with ` && ` in document order — "all of these must
+ * pass". A single heading behaves exactly as before.
  */
 export function parseVerificationCommand(description = "") {
-  const section = firstTicketSection(description, (heading) =>
+  const sections = matchingTicketSections(description, (heading) =>
     /^Verification(\s+Command)?\s*:?\s*$/i.test(heading.trim()),
   );
-  if (!section) return null;
+  if (!sections.length) return null;
+  const commands = [];
+  for (const section of sections) {
+    const command = parseVerificationSection(section.body);
+    if (command && !commands.includes(command)) commands.push(command);
+  }
+  if (!commands.length) return null;
+  return commands.length === 1 ? commands[0] : commands.join(" && ");
+}
 
-  const body = section.body.split("\n");
+function parseVerificationSection(sectionBody) {
+  const body = sectionBody.split("\n");
   const fenced = [];
   let inFence = false;
   let sawFence = false;

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -36,21 +36,47 @@ export const REGISTRY_DIGEST_BASELINE_PATH =
   "event-runtime/lib/registry.test.mjs";
 
 /**
+ * Split level 2–4 Markdown headings into their sections.
+ *
+ * Every §5 reader treats the first matching duplicate heading as
+ * authoritative. This keeps already-corrupted tickets deterministic until a
+ * triage agent explicitly rewrites the description with `ticket detail
+ * --replace`.
+ */
+export function ticketSections(description = "") {
+  return String(description ?? "")
+    .split(/^#{2,4}\s+/m)
+    .slice(1)
+    .map((section) => {
+      const nl = section.indexOf("\n");
+      return {
+        heading: (nl === -1 ? section : section.slice(0, nl)).trim(),
+        // Preserve leading indentation: an Owned Paths block may be an
+        // indented Markdown code block, which would stop parsing if trimmed.
+        body: nl === -1 ? "" : section.slice(nl + 1),
+      };
+    });
+}
+
+/** Return the authoritative (first) ticket section whose heading matches. */
+export function firstTicketSection(description = "", matchesHeading) {
+  return ticketSections(description).find((section) =>
+    matchesHeading(section.heading),
+  );
+}
+
+/**
  * Extract the Owned Paths bullet list (levels 2-4) from a Linear issue description.
+ * If a ticket has more than one Owned Paths heading, only the first is
+ * authoritative; see {@link firstTicketSection}.
  * Returns [] when the section is missing or fails to parse — for dispatch,
  * use `effectiveOwnedPaths`, which turns that into "collides with
  * everything" rather than "not dispatchable".
  */
 export function parseOwnedPaths(description = "") {
-  // `split` retains the pre-heading prose as index 0. It cannot be a section,
-  // even when it mentions "Owned Paths", so only inspect heading-led chunks.
-  const section = description
-    .split(/^#{2,4}\s+/m)
-    .slice(1)
-    .find((s) => {
-      const heading = s.split("\n")[0];
-      return /\bOwned Paths\b/i.test(heading);
-    });
+  const section = firstTicketSection(description, (heading) =>
+    /\bOwned Paths\b/i.test(heading),
+  );
   if (!section) return [];
 
   // Real tickets write this section three different ways — bullet lists, fenced
@@ -62,7 +88,7 @@ export function parseOwnedPaths(description = "") {
   const out = [];
   let inFence = false;
 
-  for (const raw of section.split("\n").slice(1)) {
+  for (const raw of section.body.split("\n")) {
     if (/^\s*```/.test(raw)) {
       inFence = !inFence;
       continue;
@@ -135,15 +161,12 @@ export function effectiveOwnedPaths(description = "") {
  * absent both, refuses the handoff (fail-closed).
  */
 export function parseVerificationCommand(description = "") {
-  const section = String(description ?? "")
-    .split(/^#{2,4}\s+/m)
-    .find((s) => {
-      const heading = s.split("\n")[0];
-      return /^Verification(\s+Command)?\s*:?\s*$/i.test(heading.trim());
-    });
+  const section = firstTicketSection(description, (heading) =>
+    /^Verification(\s+Command)?\s*:?\s*$/i.test(heading.trim()),
+  );
   if (!section) return null;
 
-  const body = section.split("\n").slice(1);
+  const body = section.body.split("\n");
   const fenced = [];
   let inFence = false;
   let sawFence = false;

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -71,10 +71,11 @@ Something is broken.
   ]);
 });
 
-test("duplicate §5 headings keep the first Owned Paths and Verification Command blocks authoritative", () => {
+test("duplicate §5 headings are unioned: Owned Paths deduped in first-occurrence order, Verification Commands joined", () => {
   const desc = `## Owned Paths
 
 - \`orchestrator/owned-paths.mjs\`
+- \`docs/protocol.md\`
 
 ## Verification Command
 
@@ -83,13 +84,42 @@ test("duplicate §5 headings keep the first Owned Paths and Verification Command
 ## Owned Paths
 
 - \`docs/protocol.md\`
+- \`tools/ticket.mjs\`
 
 ## Verification Command
 
-\`bun test stale-appended.mjs\``;
+\`bun test appended.mjs\``;
 
-  expectEqual(parseOwnedPaths(desc), ["orchestrator/owned-paths.mjs"]);
-  expectEqual(parseVerificationCommand(desc), "bun test first.mjs");
+  expectEqual(parseOwnedPaths(desc), [
+    "orchestrator/owned-paths.mjs",
+    "docs/protocol.md",
+    "tools/ticket.mjs",
+  ]);
+  expectEqual(
+    parseVerificationCommand(desc),
+    "bun test first.mjs && bun test appended.mjs",
+  );
+});
+
+test("an identical appended Verification Command does not repeat itself", () => {
+  const desc = `## Verification Command
+
+\`bun test a.mjs\`
+
+## Verification Command
+
+\`bun test a.mjs\``;
+  expectEqual(parseVerificationCommand(desc), "bun test a.mjs");
+});
+
+test("an empty Verification Command section is not a command", () => {
+  expectEqual(parseVerificationCommand("## Verification Command\n\n"), null);
+  expectEqual(
+    parseVerificationCommand(
+      "## Verification Command\n\n## Verification Command\n\n`bun test a.mjs`",
+    ),
+    "bun test a.mjs",
+  );
 });
 
 test("missing section yields no paths (caller decides what that means)", () => {

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -71,6 +71,27 @@ Something is broken.
   ]);
 });
 
+test("duplicate §5 headings keep the first Owned Paths and Verification Command blocks authoritative", () => {
+  const desc = `## Owned Paths
+
+- \`orchestrator/owned-paths.mjs\`
+
+## Verification Command
+
+\`bun test first.mjs\`
+
+## Owned Paths
+
+- \`docs/protocol.md\`
+
+## Verification Command
+
+\`bun test stale-appended.mjs\``;
+
+  expectEqual(parseOwnedPaths(desc), ["orchestrator/owned-paths.mjs"]);
+  expectEqual(parseVerificationCommand(desc), "bun test first.mjs");
+});
+
 test("missing section yields no paths (caller decides what that means)", () => {
   expectEqual(parseOwnedPaths("## Problem\n\nno paths here"), []);
 });

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -549,33 +549,51 @@ export function closureCheckMessages(issue) {
   return formatOwnedPathClosureGaps(gaps);
 }
 
+/** A Linear issue key: team prefix, dash, number (`CLNT-616`, `WM-1007`). */
+const LINEAR_KEY = /^[A-Z][A-Z0-9]*-\d+$/;
+
 /**
  * Build the tracker-native escape-hatch mutation for `detail --replace`.
  *
  * The replacement stays in the ticket CLI's declared surface while adapters
- * grow a first-class replacement verb (see #1666). GitHub issue identifiers
- * are owner/repo#N; Linear identifiers are team keys such as CLNT-616.
+ * grow a first-class replacement verb (see #1666). The control plane's own
+ * `kind` decides the tracker; without one, a Linear key shape (`CLNT-616`)
+ * selects Linear and everything else — `owner/repo#N`, `#N`, bare `N`, all of
+ * which the GitHub adapter accepts — selects GitHub.
  */
-export function descriptionReplacementRequest(identifier, id, description) {
-  if (String(identifier).includes("/")) {
+export function descriptionReplacementRequest(
+  identifier,
+  id,
+  description,
+  { kind } = {},
+) {
+  const linear =
+    kind === "linear" ||
+    (kind == null && LINEAR_KEY.test(String(identifier).trim()));
+  if (linear) {
     return {
       query:
-        "mutation($id:ID!,$body:String!){updateIssue(input:{id:$id,body:$body}){issue{id}}}",
-      variables: { id, body: description },
-      resultAt: ["updateIssue", "issue", "id"],
+        "mutation($id:String!,$description:String!){issueUpdate(id:$id,input:{description:$description}){success}}",
+      variables: { id, description },
+      resultAt: ["issueUpdate", "success"],
     };
   }
   return {
     query:
-      "mutation($id:String!,$description:String!){issueUpdate(id:$id,input:{description:$description}){success}}",
-    variables: { id, description },
-    resultAt: ["issueUpdate", "success"],
+      "mutation($id:ID!,$body:String!){updateIssue(input:{id:$id,body:$body}){issue{id}}}",
+    variables: { id, body: description },
+    resultAt: ["updateIssue", "issue", "id"],
   };
 }
 
-function replacementSucceeded(result, resultAt) {
+/**
+ * Did the replacement mutation take? The tail of `resultAt` is either a
+ * boolean (`success`) or an id; both must be truthy — `success: false` is a
+ * failure, not "a value came back".
+ */
+export function replacementSucceeded(result, resultAt) {
   const payload = result?.data ?? result;
-  return resultAt.reduce((value, key) => value?.[key], payload) !== undefined;
+  return Boolean(resultAt.reduce((value, key) => value?.[key], payload));
 }
 
 const teamOf = (key) => String(key).split("-")[0];
@@ -747,7 +765,12 @@ const VERBS = {
         );
         return;
       }
-      const request = descriptionReplacementRequest(key, issue.id, description);
+      const request = descriptionReplacementRequest(
+        key,
+        issue.id,
+        description,
+        { kind: cp.kind },
+      );
       const result = await cp.raw(request.query, request.variables);
       if (!replacementSucceeded(result, request.resultAt))
         throw new Error(`detail replacement failed for ${key}`);

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -14,7 +14,8 @@
  *   bun tools/ticket.mjs comment CLNT-616 "verified: 42 tests pass"
  *   bun tools/ticket.mjs triage CLNT-616 --comment "Owned Paths need revision"
  *   bun tools/ticket.mjs answer CLNT-616 "Use the existing token cache"
- *   bun tools/ticket.mjs detail CLNT-616 -- "## Acceptance criteria\n- [ ] ..."
+ *   bun tools/ticket.mjs detail CLNT-616 -- "## Acceptance criteria\n- [ ] ..." # append
+ *   bun tools/ticket.mjs detail CLNT-616 --replace -- "## Acceptance criteria\n- [ ] ..."
  *   bun tools/ticket.mjs labels CLNT-616 --add ai:needs-review --remove ai:in-progress
  *   bun tools/ticket.mjs state CLNT-616 "In Review" --add ai:needs-review
  *   bun tools/ticket.mjs file --team CLNT --title "..." --body "..." --type bug --dedupe-key "..."
@@ -548,6 +549,35 @@ export function closureCheckMessages(issue) {
   return formatOwnedPathClosureGaps(gaps);
 }
 
+/**
+ * Build the tracker-native escape-hatch mutation for `detail --replace`.
+ *
+ * The replacement stays in the ticket CLI's declared surface while adapters
+ * grow a first-class replacement verb (see #1666). GitHub issue identifiers
+ * are owner/repo#N; Linear identifiers are team keys such as CLNT-616.
+ */
+export function descriptionReplacementRequest(identifier, id, description) {
+  if (String(identifier).includes("/")) {
+    return {
+      query:
+        "mutation($id:ID!,$body:String!){updateIssue(input:{id:$id,body:$body}){issue{id}}}",
+      variables: { id, body: description },
+      resultAt: ["updateIssue", "issue", "id"],
+    };
+  }
+  return {
+    query:
+      "mutation($id:String!,$description:String!){issueUpdate(id:$id,input:{description:$description}){success}}",
+    variables: { id, description },
+    resultAt: ["issueUpdate", "success"],
+  };
+}
+
+function replacementSucceeded(result, resultAt) {
+  const payload = result?.data ?? result;
+  return resultAt.reduce((value, key) => value?.[key], payload) !== undefined;
+}
+
 const teamOf = (key) => String(key).split("-")[0];
 
 // ------------------------------------------------------------------ verbs ---
@@ -704,8 +734,30 @@ const VERBS = {
     const key = positional[0];
     const rawDetail = positional[1];
     if (!key || !rawDetail)
-      throw new Error(`usage: detail <ISSUE-ID> [--] "<markdown>"`);
-    const { appended } = await controlPlane().appendDetail(key, rawDetail);
+      throw new Error(`usage: detail <ISSUE-ID> [--replace] [--] "<markdown>"`);
+    const cp = controlPlane();
+    if (has("replace")) {
+      const issue = await cp.getTicket(key);
+      const description = String(rawDetail).trim();
+      const current = String(issue.description ?? "").trim();
+      if (description === current) {
+        out(
+          { ok: true, identifier: key, replaced: false },
+          `${key} detail already matches`,
+        );
+        return;
+      }
+      const request = descriptionReplacementRequest(key, issue.id, description);
+      const result = await cp.raw(request.query, request.variables);
+      if (!replacementSucceeded(result, request.resultAt))
+        throw new Error(`detail replacement failed for ${key}`);
+      out(
+        { ok: true, identifier: key, replaced: true },
+        `${key} detail replaced`,
+      );
+      return;
+    }
+    const { appended } = await cp.appendDetail(key, rawDetail);
     if (!appended) {
       out(
         { ok: true, identifier: key, appended: false },

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -32,6 +32,7 @@ import {
   transitionThenComment,
   fileTicket,
   closureCheckMessages,
+  descriptionReplacementRequest,
   resolveRepoName,
   resolveRepoNameFromTicket,
   resolveRepoNameForFile,
@@ -506,6 +507,27 @@ test("the end-of-options sentinel preserves arbitrary leading dashes", () => {
   expect(
     parsePositionalArgs(["comment", "WM-316", "--", "---\n\n## Heading"]),
   ).toEqual(["WM-316", "---\n\n## Heading"]);
+});
+
+test("detail --replace keeps its Markdown body positional", () => {
+  expect(
+    parsePositionalArgs(["detail", "WM-318", "--replace", "## Heading"]),
+  ).toEqual(["WM-318", "## Heading"]);
+});
+
+test("detail --replace uses each tracker's body replacement mutation", () => {
+  expect(
+    descriptionReplacementRequest("watt-mind/factory#42", "issue-id", "new"),
+  ).toMatchObject({
+    variables: { id: "issue-id", body: "new" },
+    resultAt: ["updateIssue", "issue", "id"],
+  });
+  expect(
+    descriptionReplacementRequest("CLNT-42", "issue-id", "new"),
+  ).toMatchObject({
+    variables: { id: "issue-id", description: "new" },
+    resultAt: ["issueUpdate", "success"],
+  });
 });
 
 test("unknown flags remain flags instead of becoming positional bodies", () => {

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -33,6 +33,7 @@ import {
   fileTicket,
   closureCheckMessages,
   descriptionReplacementRequest,
+  replacementSucceeded,
   resolveRepoName,
   resolveRepoNameFromTicket,
   resolveRepoNameForFile,
@@ -528,6 +529,43 @@ test("detail --replace uses each tracker's body replacement mutation", () => {
     variables: { id: "issue-id", description: "new" },
     resultAt: ["issueUpdate", "success"],
   });
+});
+
+test("detail --replace routes bare and #-prefixed GitHub numbers to GitHub, not Linear", () => {
+  for (const identifier of ["1564", "#1564", " 1564 "]) {
+    expect(
+      descriptionReplacementRequest(identifier, "I_1", "new").resultAt,
+    ).toEqual(["updateIssue", "issue", "id"]);
+  }
+});
+
+test("detail --replace lets the control plane's kind override the identifier shape", () => {
+  expect(
+    descriptionReplacementRequest("CLNT-42", "I_1", "new", { kind: "github" })
+      .resultAt,
+  ).toEqual(["updateIssue", "issue", "id"]);
+  expect(
+    descriptionReplacementRequest("42", "lin-id", "new", { kind: "linear" })
+      .resultAt,
+  ).toEqual(["issueUpdate", "success"]);
+});
+
+test("replacementSucceeded treats success:false as a failure", () => {
+  const at = ["issueUpdate", "success"];
+  expect(replacementSucceeded({ issueUpdate: { success: false } }, at)).toBe(
+    false,
+  );
+  expect(replacementSucceeded({ issueUpdate: { success: true } }, at)).toBe(
+    true,
+  );
+  expect(replacementSucceeded({ data: { issueUpdate: {} } }, at)).toBe(false);
+  expect(
+    replacementSucceeded({ updateIssue: { issue: { id: "I_1" } } }, [
+      "updateIssue",
+      "issue",
+      "id",
+    ]),
+  ).toBe(true);
 });
 
 test("unknown flags remain flags instead of becoming positional bodies", () => {
@@ -1043,4 +1081,152 @@ test("instanceConfigRoot throws instance_config_missing when no instance config 
   } finally {
     rmSync(checkoutRoot, { recursive: true, force: true });
   }
+});
+
+/**
+ * Run `ticket.mjs detail <n> --replace` from inside a GitHub-plane repository
+ * against a stub `gh` on PATH that answers the reads the adapter makes and
+ * records every call (arguments and stdin) so the test can see which
+ * mutation the CLI actually issued.
+ */
+function spawnDetailReplaceAgainstStubGh(args, { body }) {
+  const root = mkdtempSync(path.join(os.tmpdir(), "ticket-detail-replace-"));
+  const repoDir = path.join(root, "repo");
+  const bin = path.join(root, "bin");
+  const ghLog = path.join(root, "gh.log");
+  const stdinLog = path.join(root, "gh-stdin.log");
+  const cliRoot = path.resolve(
+    path.dirname(fileURLToPath(import.meta.url)),
+    "..",
+  );
+  const issue = JSON.stringify({
+    number: 1564,
+    node_id: "I_1564",
+    title: "respec me",
+    body: "## Owned Paths\n\n- old/path.mjs\n",
+    state: "open",
+    html_url: "https://github.com/watt-mind/factory/issues/1564",
+    labels: [],
+    user: { login: "owner" },
+    author_association: "OWNER",
+  });
+  const project = JSON.stringify({
+    data: {
+      repository: {
+        projectsV2: {
+          nodes: [
+            {
+              id: "P_1",
+              title: "Factory",
+              field: {
+                id: "F_1",
+                options: [{ id: "o_todo", name: "Todo" }],
+              },
+            },
+          ],
+        },
+      },
+    },
+  });
+  try {
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    mkdirSync(repoDir);
+    mkdirSync(bin);
+    writeFileSync(
+      path.join(bin, "gh"),
+      [
+        "#!/bin/sh",
+        'input=""',
+        'for a in "$@"; do [ "$a" = "-" ] && input=$(cat); done',
+        `printf '%s\n' "$*" >> "${ghLog}"`,
+        `printf '%s\n' "$input" >> "${stdinLog}"`,
+        'case "$*" in',
+        "  *graphql*)",
+        '    case "$input" in',
+        `      *updateIssue*) printf '%s\\n' '{"data":{"updateIssue":{"issue":{"id":"I_1564"}}}}' ;;`,
+        `      *FindRepoProject*) printf '%s\\n' '${project}' ;;`,
+        `      *ProjectItems*) printf '%s\\n' '{"data":{"node":{"items":{"nodes":[],"pageInfo":{"hasNextPage":false,"endCursor":null}}}}}' ;;`,
+        `      *) printf '%s\\n' '{"data":{}}' ;;`,
+        "    esac ;;",
+        `  *issues/1564/comments*) printf '%s\\n' '[]' ;;`,
+        `  *issues/1564*) printf '%s\\n' '${issue}' ;;`,
+        `  *) printf '%s\\n' '{}' ;;`,
+        "esac",
+        "",
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    writeFileSync(
+      path.join(root, "config", "policy.yaml"),
+      "controlPlane:\n  kind: github\n",
+    );
+    writeFileSync(
+      path.join(root, "config", "repos.yaml"),
+      `repos:\n  - name: factory\n    path: ${repoDir}\n    github: watt-mind/factory\n    control_plane: github\n`,
+    );
+    const env = { ...process.env, FACTORY_REPOS_ROOT: root, HOME: root };
+    env.PATH = `${bin}${path.delimiter}${env.PATH ?? ""}`;
+    for (const name of Object.keys(env)) {
+      if (
+        name === "LINEAR_API_KEY" ||
+        name === "GH_TOKEN" ||
+        name === "GITHUB_TOKEN" ||
+        name.startsWith("FACTORY_GH_APP_")
+      )
+        delete env[name];
+    }
+    const result = Bun.spawnSync({
+      cmd: [
+        "bun",
+        path.join(cliRoot, "tools", "ticket.mjs"),
+        "detail",
+        ...args,
+        "--",
+        body,
+      ],
+      cwd: repoDir,
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    return {
+      exitCode: result.exitCode,
+      stdout: result.stdout.toString(),
+      stderr: result.stderr.toString(),
+      ghCalls: existsSync(ghLog) ? readFileSync(ghLog, "utf8") : "",
+      ghStdin: existsSync(stdinLog) ? readFileSync(stdinLog, "utf8") : "",
+    };
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+}
+
+test("detail <bare number> --replace on a GitHub repo issues the GitHub updateIssue mutation", () => {
+  const result = spawnDetailReplaceAgainstStubGh(["1564", "--replace"], {
+    body: "## Owned Paths\n\n- new/path.mjs\n",
+  });
+  expect(result.stderr).toBe("");
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("detail replaced");
+  expect(result.ghCalls).toContain("repos/watt-mind/factory/issues/1564");
+  const mutations = result.ghStdin
+    .split("\n")
+    .filter((line) => line.includes("mutation"));
+  expect(mutations).toHaveLength(1);
+  expect(mutations[0]).toContain("updateIssue");
+  expect(mutations[0]).not.toContain("issueUpdate");
+  expect(JSON.parse(mutations[0]).variables).toEqual({
+    id: "I_1564",
+    body: "## Owned Paths\n\n- new/path.mjs",
+  });
+});
+
+test("detail --replace with an unchanged body issues no mutation", () => {
+  const result = spawnDetailReplaceAgainstStubGh(["#1564", "--replace"], {
+    body: "## Owned Paths\n\n- old/path.mjs\n",
+  });
+  expect(result.stderr).toBe("");
+  expect(result.exitCode).toBe(0);
+  expect(result.stdout).toContain("already matches");
+  expect(result.ghStdin).not.toContain("mutation");
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1564

Use the first §5 block consistently and provide `ticket detail --replace` for re-specifying a ticket.

## Validation

| Check                | Command                                                                                          | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------------------------------------- |
| Verification Command | `bun test orchestrator/owned-paths.test.mjs tools/ticket.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass    | 96 tests, 0 failures; emit check passed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 0 errors; 616 existing lint warnings   |
| UX critique          | factory-ux-critic                                                                                | not run | no user-facing surface                 |

UX critique: skipped

run:run_febfa56a-e834-4952-bcc6-30b762e862fb


## Post-review

Reviewer verdict FIX (4 items), all addressed in 038f2cb4:

1. **Duplicate `## Owned Paths` / `## Verification Command` headings are now UNIONED, not first-match.** `parseOwnedPaths` reads every matching block in document order and returns the deduplicated union (first occurrence keeps its position); `parseVerificationCommand` joins the distinct per-block commands with ` && `. `templateGaps` (label-guard) shares `ticketSections`, so the three readers cannot disagree about which copy counts. A single heading behaves byte-identically to before. Documented in the JSDoc and `docs/protocol.md` §5.
   Real duplicated-section body, before vs after:
   ```
   before: ["orchestrator/owned-paths.mjs","docs/protocol.md"]
   after:  ["orchestrator/owned-paths.mjs","docs/protocol.md","tools/ticket.mjs"]
   verify: "bun test first.mjs && bun test appended.mjs"
   ```
2. **Empty `## Verification Command` body no longer counts as verified** — `templateGaps` gates on `body.trim().length > 0` (bodies stay untrimmed for `parseOwnedPaths`); `parseVerificationCommand` returns null for it. Tests added in `owned-paths.test.mjs` and `label-guard.test.mjs`.
3. **`detail --replace` tracker routing** — `descriptionReplacementRequest` branches on the control plane's `kind` (falling back to the Linear key shape `/^[A-Z][A-Z0-9]*-\d+$/`), default GitHub, so bare `1564` / `#1564` reach GitHub's `updateIssue`. New end-to-end test runs `ticket.mjs detail 1564 --replace` against a stub `gh` on PATH and asserts the single mutation issued is `updateIssue` with `{id, body}`; a second test asserts an unchanged body issues no mutation.
4. **`replacementSucceeded`** now requires a truthy tail (`success: false` is a failure). Unit test added.

Verification: `bun test orchestrator/owned-paths.test.mjs tools/ticket.test.mjs --timeout 20000 && bun build/emit.mjs --check` (118 pass), `bun run lint` (0 errors), `bun test event-runtime/lib --timeout 20000` (2115 pass), `bun run format:check`, `bun run check` — all green.
