### PR TITLE
fix(worktree): reclaim exhausted failed owners

### DIFF
--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -1303,7 +1303,12 @@ test("worktree-down --prune recognizes merged GitHub worktrees and preserves dir
     );
     writeFileSync(
       path.join(mockBin, "gh"),
-      "#!/usr/bin/env bash\nprintf '1\\n'\n",
+      `#!/usr/bin/env bash\n${branches
+        .map(
+          (branch) =>
+            `[[ "$*" == *"--head ${branch}"* ]] && { printf '1\\n'; exit 0; }`,
+        )
+        .join("\n")}\nprintf '0\\n'\n`,
       { mode: 0o755 },
     );
     const pruned = Bun.spawnSync({

--- a/bin/worktree-checkout.test.mjs
+++ b/bin/worktree-checkout.test.mjs
@@ -1267,7 +1267,7 @@ test("worktree-down --prune removes only clean terminal worktrees and preserves 
   }
 });
 
-test("worktree-down --prune recognizes a merged PR for the worktree branch", () => {
+test("worktree-down --prune recognizes merged GitHub worktrees and preserves dirty ones", () => {
   if (handoffSandbox) return;
   const tempWtRoot = mkdtempSync(
     path.join(tmpdir(), "factory-wt-prune-merged-"),
@@ -1275,17 +1275,26 @@ test("worktree-down --prune recognizes a merged PR for the worktree branch", () 
   const mockBin = mkdtempSync(
     path.join(tmpdir(), "factory-wt-prune-merged-bin-"),
   );
-  const ticketId = makeTestTicket("MERGED");
-  const branch = `feat/${ticketId}`;
+  const ticketNumber = (Date.now() % 1_000_000_000) + process.pid;
+  const cleanTicket = `gh-${ticketNumber}`;
+  const dirtyTicket = `gh-${ticketNumber + 1}`;
+  const tickets = [cleanTicket, dirtyTicket];
+  const branches = tickets.map((ticket) => `feat/${ticket}`);
 
   try {
-    const up = Bun.spawnSync({
-      cmd: ["bash", UP, ticketId, "--checkout-only", "--no-fetch"],
-      stdout: "pipe",
-      stderr: "pipe",
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
-    });
-    expect(up.exitCode).toBe(0);
+    for (const ticket of tickets) {
+      const up = Bun.spawnSync({
+        cmd: ["bash", UP, ticket, "--checkout-only", "--no-fetch"],
+        stdout: "pipe",
+        stderr: "pipe",
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      });
+      expect(up.exitCode).toBe(0);
+    }
+    writeFileSync(
+      path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"),
+      "do not remove\n",
+    );
 
     writeFileSync(
       path.join(mockBin, "bun"),
@@ -1294,7 +1303,7 @@ test("worktree-down --prune recognizes a merged PR for the worktree branch", () 
     );
     writeFileSync(
       path.join(mockBin, "gh"),
-      `#!/usr/bin/env bash\n[[ "$*" == *"--head ${branch}"* ]] && printf '1\\n' || printf '0\\n'\n`,
+      "#!/usr/bin/env bash\nprintf '1\\n'\n",
       { mode: 0o755 },
     );
     const pruned = Bun.spawnSync({
@@ -1308,16 +1317,22 @@ test("worktree-down --prune recognizes a merged PR for the worktree branch", () 
       },
     });
     expect(pruned.exitCode).toBe(0);
-    expect(existsSync(path.join(tempWtRoot, ticketId))).toBe(false);
+    expect(existsSync(path.join(tempWtRoot, cleanTicket))).toBe(false);
+    expect(existsSync(path.join(tempWtRoot, dirtyTicket))).toBe(true);
   } finally {
-    Bun.spawnSync({
-      cmd: ["bash", DOWN, ticketId, "--force"],
-      env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+    rmSync(path.join(tempWtRoot, dirtyTicket, "uncommitted.txt"), {
+      force: true,
     });
+    for (const ticket of tickets) {
+      Bun.spawnSync({
+        cmd: ["bash", DOWN, ticket, "--force"],
+        env: { ...process.env, FACTORY_WT_ROOT: tempWtRoot },
+      });
+    }
     rmSync(tempWtRoot, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
     Bun.spawnSync({
-      cmd: ["git", "branch", "-D", branch],
+      cmd: ["git", "branch", "-D", ...branches],
       cwd: path.resolve(import.meta.dir, ".."),
     });
   }

--- a/bin/worktree-down.sh
+++ b/bin/worktree-down.sh
@@ -104,7 +104,8 @@ if [[ "$PRUNE" -eq 1 ]]; then
   for WT in "$WT_ROOT"/*; do
     [[ -d "$WT" ]] || continue
     ticket=$(basename "$WT")
-    [[ "$ticket" =~ ^[A-Z]+-[0-9]+(-[A-Za-z0-9][A-Za-z0-9-]*)?$ ]] || continue
+    ticket_is_valid "$ticket" || continue
+    [[ "$(ticket_slug "$ticket")" == "$ticket" ]] || continue
 
     status=$(git -C "$WT" status --porcelain 2>/dev/null) || {
       warn "skipping $ticket — cannot inspect worktree status"

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -361,6 +361,8 @@ export function detectWorktreeOwnershipConflict({
   databasePath = dbPath(),
   leasesDir,
   leases = liveWorkerLeases(repo, { dir: leasesDir }),
+  staleOwnerLog = (staleRunId) =>
+    console.warn(`worktree_owner_stale:${staleRunId}`),
 } = {}) {
   const runs = [];
   if (existsSync(databasePath)) {
@@ -368,18 +370,27 @@ export function detectWorktreeOwnershipConflict({
     try {
       db = new Database(databasePath, { readonly: true });
       for (const row of db
-        .query(`SELECT run_id, state, spec_json FROM runs`)
+        .query(`SELECT run_id, state, spec_json, attempts FROM runs`)
         .all()) {
         if (row.run_id === runId || TERMINAL_STATES.has(row.state)) continue;
+        let spec;
         let input;
         try {
-          input = JSON.parse(row.spec_json)?.input;
+          spec = JSON.parse(row.spec_json);
+          input = spec?.input;
         } catch {
           continue;
         }
-        if (input?.repo === repo && input?.ticket === ticket) {
-          runs.push({ runId: row.run_id, state: row.state });
+        if (input?.repo !== repo || input?.ticket !== ticket) continue;
+        if (
+          row.state === "FAILED" &&
+          spec?.maxAttempts != null &&
+          row.attempts >= spec.maxAttempts
+        ) {
+          staleOwnerLog(row.run_id);
+          continue;
         }
+        runs.push({ runId: row.run_id, state: row.state });
       }
     } catch (err) {
       return {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -365,6 +365,7 @@ export function detectWorktreeOwnershipConflict({
     console.warn(`worktree_owner_stale:${staleRunId}`),
 } = {}) {
   const runs = [];
+  const staleOwners = [];
   if (existsSync(databasePath)) {
     let db;
     try {
@@ -387,7 +388,7 @@ export function detectWorktreeOwnershipConflict({
           spec?.maxAttempts != null &&
           row.attempts >= spec.maxAttempts
         ) {
-          staleOwnerLog(row.run_id);
+          staleOwners.push(row.run_id);
           continue;
         }
         runs.push({ runId: row.run_id, state: row.state });
@@ -424,7 +425,12 @@ export function detectWorktreeOwnershipConflict({
       return tokenSeparator <= 0 || identity.slice(0, tokenSeparator) !== runId;
     })
     .map((lease) => ({ owner: lease.owner, pid: lease.pid }));
-  if (runs.length === 0 && competingLeases.length === 0) return null;
+  if (runs.length === 0 && competingLeases.length === 0) {
+    // Only announce a release once nothing else still holds the ticket; an
+    // exhausted owner next to a live one is not stale ownership being reclaimed.
+    for (const staleRunId of staleOwners) staleOwnerLog(staleRunId);
+    return null;
+  }
   return {
     reason: "ticket has a non-terminal run or live worker lease",
     runs,

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -109,16 +109,16 @@ test("detectWorktreeOwnershipConflict identifies the current run's compound leas
   const databasePath = path.join(root, "runtime.db");
   const db = new Database(databasePath);
   db.exec(`
-    CREATE TABLE runs (run_id TEXT, state TEXT, spec_json TEXT);
+    CREATE TABLE runs (run_id TEXT, state TEXT, spec_json TEXT, attempts INTEGER NOT NULL DEFAULT 0);
     CREATE TABLE attempts (run_id TEXT, attempt INTEGER, lease_owner TEXT);
   `);
   const spec = JSON.stringify({ input: { repo: "factory", ticket: "WM-627" } });
-  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run(
+  db.query(`INSERT INTO runs (run_id, state, spec_json) VALUES (?, ?, ?)`).run(
     "run_self",
     "RUNNING",
     spec,
   );
-  db.query(`INSERT INTO runs VALUES (?, ?, ?)`).run(
+  db.query(`INSERT INTO runs (run_id, state, spec_json) VALUES (?, ?, ?)`).run(
     "run_done",
     "COMPLETED",
     spec,
@@ -183,7 +183,7 @@ test("detectWorktreeOwnershipConflict identifies the current run's compound leas
 
   const competingDb = new Database(databasePath);
   competingDb
-    .query(`INSERT INTO runs VALUES (?, ?, ?)`)
+    .query(`INSERT INTO runs (run_id, state, spec_json) VALUES (?, ?, ?)`)
     .run("run_other", "FAILED", spec);
   competingDb.close();
   const conflict = detectWorktreeOwnershipConflict({
@@ -198,6 +198,70 @@ test("detectWorktreeOwnershipConflict identifies the current run's compound leas
     runs: [{ runId: "run_other", state: "FAILED" }],
     leases: [],
   });
+});
+
+test("detectWorktreeOwnershipConflict releases only attempts-exhausted FAILED owners", () => {
+  const root = tmpRoot();
+  const databasePath = path.join(root, "runtime.db");
+  const db = new Database(databasePath);
+  db.exec(`
+    CREATE TABLE runs (
+      run_id TEXT,
+      state TEXT,
+      spec_json TEXT,
+      attempts INTEGER NOT NULL DEFAULT 0
+    );
+  `);
+  const repo = "factory";
+  const insert = (runId, ticket, state, attempts, maxAttempts) =>
+    db.query(`INSERT INTO runs VALUES (?, ?, ?, ?)`).run(
+      runId,
+      state,
+      JSON.stringify({
+        input: { repo, ticket },
+        ...(maxAttempts === undefined ? {} : { maxAttempts }),
+      }),
+      attempts,
+    );
+  insert("run_exhausted", "WM-EXHAUSTED", "FAILED", 3, 3);
+  insert("run_retryable", "WM-RETRYABLE", "FAILED", 2, 3);
+  insert("run_unbounded", "WM-UNBOUNDED", "FAILED", 3, undefined);
+  insert("run_running", "WM-RUNNING", "RUNNING", 1, 3);
+  insert("run_dead", "WM-DEAD", "COMPLETED", 1, 3);
+  db.close();
+
+  const staleOwners = [];
+  const detect = (ticket, leases = []) =>
+    detectWorktreeOwnershipConflict({
+      repo,
+      ticket,
+      runId: "run_new",
+      databasePath,
+      leases,
+      staleOwnerLog: (staleRunId) => staleOwners.push(staleRunId),
+    });
+
+  expect(detect("WM-EXHAUSTED")).toBeNull();
+  expect(staleOwners).toEqual(["run_exhausted"]);
+  expect(detect("WM-RETRYABLE")?.runs).toEqual([
+    { runId: "run_retryable", state: "FAILED" },
+  ]);
+  expect(detect("WM-UNBOUNDED")?.runs).toEqual([
+    { runId: "run_unbounded", state: "FAILED" },
+  ]);
+  expect(detect("WM-RUNNING")?.runs).toEqual([
+    { runId: "run_running", state: "RUNNING" },
+  ]);
+
+  const liveLease = {
+    repo,
+    ticket: "WM-DEAD",
+    owner: "worker_dead_run",
+    pid: process.pid + 1,
+  };
+  expect(detect("WM-DEAD", [liveLease])?.leases).toEqual([
+    { owner: "worker_dead_run", pid: process.pid + 1 },
+  ]);
 });
 
 describe("createWorkspace / destroyWorkspace", () => {

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -228,6 +228,8 @@ test("detectWorktreeOwnershipConflict releases only attempts-exhausted FAILED ow
   insert("run_unbounded", "WM-UNBOUNDED", "FAILED", 3, undefined);
   insert("run_running", "WM-RUNNING", "RUNNING", 1, 3);
   insert("run_dead", "WM-DEAD", "COMPLETED", 1, 3);
+  insert("run_mixed_exhausted", "WM-MIXED", "FAILED", 3, 3);
+  insert("run_mixed_live", "WM-MIXED", "RUNNING", 1, 3);
   db.close();
 
   const staleOwners = [];
@@ -252,6 +254,12 @@ test("detectWorktreeOwnershipConflict releases only attempts-exhausted FAILED ow
   expect(detect("WM-RUNNING")?.runs).toEqual([
     { runId: "run_running", state: "RUNNING" },
   ]);
+  // An exhausted owner beside a live one is not released, so nothing is
+  // announced as stale.
+  expect(detect("WM-MIXED")?.runs).toEqual([
+    { runId: "run_mixed_live", state: "RUNNING" },
+  ]);
+  expect(staleOwners).toEqual(["run_exhausted"]);
 
   const liveLease = {
     repo,


### PR DESCRIPTION
Fixes watt-mind/factory#1469

Review the exhausted-FAILED ownership log path; end-to-end redispatch against a live runtime DB remains the declared gate blind spot.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/workspace.test.mjs bin/worktree-checkout.test.mjs --timeout 60000` | pass | 73 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; 0 lint errors |
| UX critique | factory-ux-critic | not run | backend worktree lifecycle only |

UX critique: skipped — no user-facing surface

run:run_beb62e3f-ff39-4312-89b4-f71f8730a74c

## Post-review

Folded reviewer findings (6ebbb5e1, merged with origin/develop):
- `detectWorktreeOwnershipConflict` now buffers exhausted-FAILED owners and emits `worktree_owner_stale:<id>` only when the ticket is actually released (function returns `null`); added a mixed exhausted+live case to `workspace.test.mjs`.
- `worktree-checkout.test.mjs` prune test: `gh` mock restored to per-branch matching (`--head <branch>`), so `ticket_is_terminal` is asserted against each worktree's own branch.

Verification: ticket command 73 pass / 0 fail; `bun test event-runtime/lib` 2122 pass; lint 0 errors; format:check clean; `bun run check` clean.
