### PR TITLE
fix(control-plane): prevent silent agent-ready removal

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -25,6 +25,7 @@ import {
   appendIssueDetail,
   BLOCKED_LABEL,
   clampGithubBody,
+  classifyAgentReadyRemoval,
   claimLabels,
   GITHUB_BODY_MAX_LENGTH,
   IN_PROGRESS_LABEL,
@@ -1112,7 +1113,7 @@ export function githubControlPlane(options = {}) {
   async function setStatus(repo, number, contentId, stateName) {
     const { project, item } = await ensureProjectItem(repo, number, contentId);
     const opt = optionFor(project, stateName);
-    await call("POST", "graphql", {
+    const updated = await call("POST", "graphql", {
       body: {
         query: SET_PROJECT_STATUS,
         variables: {
@@ -1123,6 +1124,12 @@ export function githubControlPlane(options = {}) {
         },
       },
     });
+    const acknowledgedId =
+      updated?.updateProjectV2ItemFieldValue?.projectV2Item?.id;
+    if (acknowledgedId !== item.id)
+      throw new ControlPlaneError(
+        `GitHub did not acknowledge moving ${issueIdentifier(repo, number)} to ${stateName}; labels were not changed`,
+      );
     projectCache = null;
     projectItemsCache = null;
     return opt;
@@ -1778,36 +1785,53 @@ export function githubControlPlane(options = {}) {
         );
       const { repo, number } = locate(identifier);
       const { issue, ticket } = await fetchIssue(repo, number);
+      const currentNames = (ticket.labels ?? []).map((label) => label.name);
+      const readyRemoval = classifyAgentReadyRemoval(currentNames, {
+        add,
+        remove,
+        state,
+      });
+      if (readyRemoval === "unsafe")
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} from a Todo ticket without claim labels or a move to another state`,
+        );
       if (state)
         await setStatus(repo, number, issue.node_id ?? ticket.id, state);
-      if (add.length || remove.length) {
-        await requireLabelsExist(repo, add);
-        const nextLabels = resolveLabelNames(
-          (ticket.labels ?? []).map((l) => l.name),
-          { add, remove },
-        );
-        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
-          body: { labels: nextLabels },
-        });
-        await maybeStampReadyPin(repo, number, add, issue.body ?? "");
-      }
       const patch = {};
       if (unassign) patch.assignees = [];
       if (state)
         patch.state = state.toLowerCase() === "done" ? "closed" : "open";
       if (Object.keys(patch).length)
         await call("PATCH", `repos/${repo}/issues/${number}`, { body: patch });
+      if (readyRemoval === "demotion") {
+        const reason =
+          `Removed \`${AGENT_READY_LABEL}\` after moving this ticket to \`${state}\`. ` +
+          `It is no longer eligible for dispatch.`;
+        await call("POST", `repos/${repo}/issues/${number}/comments`, {
+          body: { body: clampGithubBody(stampRun(reason)) },
+        });
+      }
+      if (add.length || remove.length) {
+        await requireLabelsExist(repo, add);
+        const nextLabels = resolveLabelNames(currentNames, { add, remove });
+        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+          body: { labels: nextLabels },
+        });
+        await maybeStampReadyPin(repo, number, add, issue.body ?? "");
+      }
     },
 
     async setLabels(identifier, { add = [], remove = [] } = {}) {
       const { repo, number } = locate(identifier);
       const { issue, ticket } = await fetchIssue(repo, number);
       if (!add.length && !remove.length) return;
+      const currentNames = (ticket.labels ?? []).map((label) => label.name);
+      if (classifyAgentReadyRemoval(currentNames, { add, remove }) === "unsafe")
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} without claim labels or a state transition`,
+        );
       await requireLabelsExist(repo, add);
-      const nextLabels = resolveLabelNames(
-        (ticket.labels ?? []).map((l) => l.name),
-        { add, remove },
-      );
+      const nextLabels = resolveLabelNames(currentNames, { add, remove });
       await call("PUT", `repos/${repo}/issues/${number}/labels`, {
         body: { labels: nextLabels },
       });

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1213,10 +1213,12 @@ describe("control-plane contract: github", () => {
     const names = (await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name);
     expect(names).toContain(AGENT_READY_LABEL);
     expect(names).toContain("type:bug");
-    await cp.setLabels(`${REPO}#1`, { remove: [AGENT_READY_LABEL] });
-    expect((await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name)).toEqual(
-      ["type:bug"],
-    );
+    await expect(
+      cp.setLabels(`${REPO}#1`, { remove: [AGENT_READY_LABEL] }),
+    ).rejects.toThrow(/refusing to remove ai:agent-ready/);
+    expect(
+      (await cp.getTicket(`${REPO}#1`)).labels.map((l) => l.name).sort(),
+    ).toEqual([AGENT_READY_LABEL, "type:bug"].sort());
   });
 
   test("setLabels rejects unknown type:* values before mutating", async () => {
@@ -1245,6 +1247,79 @@ describe("control-plane contract: github", () => {
     await expect(cp.transition(`${REPO}#2`, "DoesNotExist")).rejects.toThrow(
       ControlPlaneError,
     );
+  });
+
+  test("demotion records its reason before removing ai:agent-ready", async () => {
+    const { api, cp } = makePlane();
+    await cp.transition(`${REPO}#1`, "Triage", {
+      remove: [AGENT_READY_LABEL],
+    });
+
+    const ticket = await cp.getTicket(`${REPO}#1`);
+    expect(ticket.state.name).toBe("Triage");
+    expect(ticket.labels.map((label) => label.name)).not.toContain(
+      AGENT_READY_LABEL,
+    );
+    expect((await cp.listComments(`${REPO}#1`)).at(-1)?.body).toContain(
+      "after moving this ticket to `Triage`",
+    );
+
+    const commentIndex = api.calls.findIndex(
+      (call) =>
+        call.method === "POST" &&
+        call.pathName === `repos/${REPO}/issues/1/comments`,
+    );
+    const labelIndex = api.calls.findIndex(
+      (call) =>
+        call.method === "PUT" &&
+        call.pathName === `repos/${REPO}/issues/1/labels`,
+    );
+    expect(commentIndex).toBeGreaterThan(-1);
+    expect(labelIndex).toBeGreaterThan(commentIndex);
+  });
+
+  test("an unacknowledged status write cannot strip a ready Todo ticket", async () => {
+    const seed = contractSeed();
+    const baseApi = fakeApi(seed);
+    const api = (method, pathName, options = {}) => {
+      if (
+        pathName === "graphql" &&
+        options.body?.query?.includes("SetProjectStatus")
+      ) {
+        api.calls.push({ method, pathName, ...options });
+        return {
+          data: { updateProjectV2ItemFieldValue: null },
+        };
+      }
+      return baseApi(method, pathName, options);
+    };
+    api.calls = baseApi.calls;
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+
+    await expect(
+      cp.transition(`${REPO}#1`, "Triage", {
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).rejects.toThrow(/did not acknowledge moving/);
+
+    const ticket = await cp.getTicket(`${REPO}#1`);
+    expect(ticket.state.name).toBe("Todo");
+    expect(ticket.labels.map((label) => label.name)).toContain(
+      AGENT_READY_LABEL,
+    );
+    expect(await cp.listComments(`${REPO}#1`)).toEqual([]);
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "PUT" &&
+          call.pathName === `repos/${REPO}/issues/1/labels`,
+      ),
+    ).toBe(false);
   });
 
   test("file creates a ticket in Triage with the requested labels", async () => {

--- a/lib/control-plane/labels.mjs
+++ b/lib/control-plane/labels.mjs
@@ -238,6 +238,34 @@ export function claimLabels(currentNames, harness) {
 }
 
 /**
+ * Classify a complete-set label write that drops `ai:agent-ready`.
+ *
+ * A ready ticket may leave the queue in only two ways: a claim adds both
+ * lifecycle lock labels in the same label write, or a transition moves it to
+ * a non-Todo state before the label is removed. Everything else would create
+ * the silent, unclaimed Todo state that dispatch cannot see.
+ */
+export function classifyAgentReadyRemoval(
+  currentNames,
+  { add = [], remove = [], state = "" } = {},
+) {
+  const actuallyRemoved =
+    currentNames.includes(AGENT_READY_LABEL) &&
+    remove.includes(AGENT_READY_LABEL) &&
+    !add.includes(AGENT_READY_LABEL);
+  if (!actuallyRemoved) return "none";
+
+  const claimWrite =
+    add.includes(IN_PROGRESS_LABEL) &&
+    add.some((name) => name.startsWith("agent:"));
+  if (claimWrite) return "claim";
+
+  const target = String(state).trim().toLowerCase();
+  if (target && target !== "todo") return "demotion";
+  return "unsafe";
+}
+
+/**
  * The exact inverse of {@link claimLabels}: give the ticket back (WM-1024).
  *
  * `to: "Todo"` must produce a **dispatchable** ticket — `Todo` + no assignee

--- a/lib/control-plane/labels.test.mjs
+++ b/lib/control-plane/labels.test.mjs
@@ -1,0 +1,60 @@
+import { describe, expect, test } from "bun:test";
+import {
+  AGENT_READY_LABEL,
+  classifyAgentReadyRemoval,
+  IN_PROGRESS_LABEL,
+} from "./labels.mjs";
+
+describe("classifyAgentReadyRemoval", () => {
+  const current = [AGENT_READY_LABEL, "type:bug"];
+
+  test("allows a claim only when both claim labels share the write", () => {
+    expect(
+      classifyAgentReadyRemoval(current, {
+        add: [IN_PROGRESS_LABEL, "agent:claude-code"],
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).toBe("claim");
+    expect(
+      classifyAgentReadyRemoval(current, {
+        add: [IN_PROGRESS_LABEL],
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).toBe("unsafe");
+  });
+
+  test("allows removal after a move out of Todo", () => {
+    expect(
+      classifyAgentReadyRemoval(current, {
+        remove: [AGENT_READY_LABEL],
+        state: "Triage",
+      }),
+    ).toBe("demotion");
+  });
+
+  test("rejects bare and Todo removals", () => {
+    expect(
+      classifyAgentReadyRemoval(current, { remove: [AGENT_READY_LABEL] }),
+    ).toBe("unsafe");
+    expect(
+      classifyAgentReadyRemoval(current, {
+        remove: [AGENT_READY_LABEL],
+        state: "Todo",
+      }),
+    ).toBe("unsafe");
+  });
+
+  test("ignores no-op removals and an explicit re-add", () => {
+    expect(
+      classifyAgentReadyRemoval(["type:bug"], {
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).toBe("none");
+    expect(
+      classifyAgentReadyRemoval(current, {
+        add: [AGENT_READY_LABEL],
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).toBe("none");
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1635

Guards the offending `ticket labels` → GitHub `setLabels` bare-removal path and makes demotion failures leave ready tickets dispatchable.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs lib/control-plane/labels.test.mjs tools/ticket.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass | 174 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,118 tests; 0 lint errors |
| UX critique | `factory-ux-critic` | not run | skipped: backend-only invariant |

UX critique: skipped — backend control-plane change with no user-facing surface

run:run_becaf3f1-6f37-41fb-9743-79da90bb7950