### PR TITLE
fix(proposals): replan stale registry versions

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -241,9 +241,10 @@ single rule.
 wastes an approval, the same reason the planner refuses on a missing artifact
 before the operator decides rather than after. And re-checked at execute:
 an approval may sit for its whole TTL, and within the TTL it executes as-is
-(event-runtime.md §12) — the world the operator approved against has had
-minutes to fill the cap. The plan-time check keeps the inbox honest; the
-execute-time check is the one that holds.
+(event-runtime.md §12) unless its prompt or policy registry version is stale,
+in which case approval re-plans it first — the world the operator approved
+against has had minutes to fill the cap. The plan-time check keeps the inbox
+honest; the execute-time check is the one that holds.
 
 **The usage window: a static split, not dynamic observation.** Every
 claude-adapter run draws on the same subscription usage window as interactive

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -83,7 +83,7 @@ function loadEnvelope(db, proposal) {
 
 /**
  * Plan-time-only values are not recoverable from the event envelope. Keep the
- * values recorded in the approved proposal when TTL expiry rebuilds its spec.
+ * values recorded in the approved proposal when a replan rebuilds its spec.
  */
 function ttlReplanOptions(spec) {
   return {
@@ -96,6 +96,22 @@ function ttlReplanOptions(spec) {
       ? { configSnapshot: spec.configSnapshot }
       : {}),
   };
+}
+
+/**
+ * A registry-version refresh changes the full spec hash even when the runnable
+ * intent is unchanged. Compare that intent after replacing only the two
+ * version pins — no authorization, routing, or other plan-time value may be
+ * normalized away.
+ */
+function matchesAfterRegistryVersionRefresh(storedSpec, freshSpec) {
+  return (
+    hashJson({
+      ...storedSpec,
+      promptVersion: freshSpec.promptVersion,
+      policyVersion: freshSpec.policyVersion,
+    }) === hashJson(freshSpec)
+  );
 }
 
 function approveRun(
@@ -124,10 +140,11 @@ function approveRun(
 
 /**
  * Approve an open 'run' proposal. Within TTL the recorded spec executes
- * as-is. After expiry the spec is rebuilt against current state under the
- * same runId: identical → approved (reason 'approved_after_ttl_replan');
- * different → the stale proposal is superseded, the still-PROPOSED run gets
- * the fresh spec, and a new open proposal is returned instead (§12).
+ * as-is only while its registry-version pins still match. After expiry or a
+ * stale registry pin, the spec is rebuilt against current state under the
+ * same runId: equivalent → approved; different → the stale proposal is
+ * superseded, the still-PROPOSED run gets the fresh spec, and a new open
+ * proposal is returned instead (§12).
  *
  * @returns {{ approved: true, runId: string }
  *         | { approved: false, replanned: true, proposal: object }}
@@ -176,6 +193,11 @@ export function approveProposal(
     const recordedSpec = proposal.spec_json
       ? JSON.parse(proposal.spec_json)
       : null;
+    const registryVersionMismatch =
+      recordedSpec !== null &&
+      policyVersion !== "unknown" &&
+      (recordedSpec.promptVersion !== policyVersion ||
+        recordedSpec.policyVersion !== policyVersion);
     let registryReloadMismatch = false;
     if (recordedSpec?.defHash) {
       try {
@@ -186,7 +208,11 @@ export function approveProposal(
         registryReloadMismatch = true;
       }
     }
-    if (!registryReloadMismatch && !isExpired(proposal, now)) {
+    if (
+      !registryReloadMismatch &&
+      !registryVersionMismatch &&
+      !isExpired(proposal, now)
+    ) {
       return approveRun(db, proposal, envelope, {
         actor,
         now,
@@ -195,12 +221,13 @@ export function approveProposal(
       });
     }
 
-    // Expired or definition-stale: re-plan against current registry state,
-    // reusing the runId.  A defHash mismatch is checked even inside the TTL:
-    // approval names an immutable definition, not merely an unexpired row.
+    // Expired, version-stale, or definition-stale: re-plan against current
+    // registry state, reusing the runId. A defHash mismatch is checked even
+    // inside the TTL: approval names an immutable definition, not merely an
+    // unexpired row.
     if (!mapping)
       throw new Error(
-        `proposal ${id} expired and event type ${envelope.type} is no longer registered`,
+        `proposal ${id} requires re-planning but event type ${envelope.type} is no longer registered`,
       );
     const storedSpec = recordedSpec ?? JSON.parse(proposal.spec_json);
     const built = {
@@ -232,12 +259,35 @@ export function approveProposal(
         }
       : built;
     const freshHash = hashJson(fresh);
-    if (!registryReloadMismatch && freshHash === proposal.spec_hash) {
+    const versionRefreshMatches =
+      registryVersionMismatch &&
+      !registryReloadMismatch &&
+      matchesAfterRegistryVersionRefresh(storedSpec, fresh);
+    if (
+      !registryReloadMismatch &&
+      (freshHash === proposal.spec_hash || versionRefreshMatches)
+    ) {
+      if (versionRefreshMatches) {
+        const freshJson = canonicalJson(fresh);
+        db.query(
+          `UPDATE runs SET spec_json = ?, spec_hash = ?, updated_at = ? WHERE run_id = ?`,
+        ).run(
+          freshJson,
+          freshHash,
+          new Date(now).toISOString(),
+          proposal.run_id,
+        );
+        db.query(
+          `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+        ).run(freshJson, freshHash, proposal.id);
+      }
       return approveRun(db, proposal, envelope, {
         actor,
         now,
         policyVersion,
-        reason: "approved_after_ttl_replan",
+        reason: versionRefreshMatches
+          ? "approved_after_registry_replan"
+          : "approved_after_ttl_replan",
       });
     }
 
@@ -254,7 +304,9 @@ export function approveProposal(
       actor,
       registryReloadMismatch
         ? "superseded_by_registry_reload"
-        : "superseded_by_ttl_replan",
+        : registryVersionMismatch
+          ? "superseded_by_registry_replan"
+          : "superseded_by_ttl_replan",
       id,
     );
     const freshJson = canonicalJson(fresh);
@@ -277,7 +329,9 @@ export function approveProposal(
       fresh.idempotencyKey,
       registryReloadMismatch
         ? "replanned_after_registry_reload"
-        : "replanned_after_ttl",
+        : registryVersionMismatch
+          ? "replanned_after_registry_replan"
+          : "replanned_after_ttl",
       at,
       mapping.proposalTtlSeconds ?? DEFAULT_PROPOSAL_TTL_SECONDS,
     );

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -17,6 +17,7 @@ import {
   rejectProposal,
 } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
+import { claimNext } from "./worker.mjs";
 
 const registry = loadRegistry();
 const NOW = Date.parse("2026-08-12T10:30:02Z");
@@ -191,6 +192,90 @@ describe("approveProposal within TTL", () => {
     ]);
     expect(journal[1].actor).toBe("operator");
     expect(journal[1].correlation_id).toBe("workflow-01");
+    expect(journal.at(-1).reason).toBe("approved");
+  });
+
+  test("re-plans a stale registry version, then queues the refreshed spec when only its versions changed", () => {
+    const { db, proposal, runId } = planned({}, { policyVersion: "new" });
+    const staleSpec = {
+      ...getProposal(db, proposal.id).spec,
+      promptVersion: "old",
+      policyVersion: "new",
+    };
+    const staleJson = canonicalJson(staleSpec);
+    const staleHash = hashJson(staleSpec);
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(staleJson, staleHash, proposal.id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(staleJson, staleHash, runId);
+
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + 1000,
+      policyVersion: "new",
+    });
+
+    expect(result).toEqual({ approved: true, runId });
+    expect(runState(db, runId)).toBe("QUEUED");
+    expect(lifecycleOf(db, runId).at(-1).reason).toBe(
+      "approved_after_registry_replan",
+    );
+    for (const specJson of [
+      db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId)
+        .spec_json,
+      getProposal(db, proposal.id).spec_json,
+    ]) {
+      expect(JSON.parse(specJson)).toMatchObject({
+        promptVersion: "new",
+        policyVersion: "new",
+      });
+    }
+    expect(
+      claimNext(db, {
+        owner: "fresh-worker",
+        now: NOW + 2000,
+        policyVersion: "new",
+        registryVersion: "new",
+      })?.runId,
+    ).toBe(runId);
+  });
+
+  test("supersedes a stale registry version when re-planning changes another field", () => {
+    const { db, proposal, runId } = planned({}, { policyVersion: "new" });
+    const staleSpec = {
+      ...getProposal(db, proposal.id).spec,
+      promptVersion: "new",
+      policyVersion: "old",
+    };
+    const staleJson = canonicalJson(staleSpec);
+    const staleHash = hashJson(staleSpec);
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(staleJson, staleHash, proposal.id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(staleJson, staleHash, runId);
+
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + 1000,
+      policyVersion: "new",
+      adapterOverride: "claude",
+    });
+
+    expect(result).toMatchObject({ approved: false, replanned: true });
+    expect(result.proposal).toMatchObject({
+      status: "open",
+      reason: "replanned_after_registry_replan",
+      spec: { promptVersion: "new", policyVersion: "new", adapter: "claude" },
+    });
+    expect(getProposal(db, proposal.id)).toMatchObject({
+      status: "superseded",
+      reason: "superseded_by_registry_replan",
+    });
+    expect(runState(db, runId)).toBe("PROPOSED");
   });
 
   test("a registry defHash change supersedes and creates one fresh open proposal", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1659

Refresh within-TTL approved run specs when registry versions drift, so current workers can claim them.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs --timeout 20000`                                             | pass    | 15 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2123 pass; emit, format, lint clean        |
| UX critique          | factory-ux-critic                                                                                            | not run | no user-facing surface                     |

UX critique: skipped

run:run_dcc55049-1395-4bd6-b091-ad6332dcda00