### PR TITLE
fix(verify): preflight handoff dependencies

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -15,8 +15,8 @@ import {
   closeSync,
   existsSync,
   mkdtempSync,
-  mkdirSync,
   openSync,
+  readdirSync,
   readFileSync,
   realpathSync,
   rmSync,
@@ -1102,12 +1102,72 @@ function boundedTail(text, maxChars = HANDOFF_FAILURE_OUTPUT_MAX_CHARS) {
   return `…${text.slice(-(maxChars - 1))}`;
 }
 
-/** Missing modules in the guest prove the host worktree was not installable. */
-export function handoffFailureReasonCode(obs) {
-  const output = stripAnsi(obs?.output);
-  return /(?:Cannot find package ['"][^'"]+['"](?: from |$)|error:\s*Cannot find module\b)/i.test(
-    output,
-  )
+const MISSING_MODULE_RE = /Cannot find (?:package|module) ['"]([^'"\n]+)['"]/gi;
+
+/** The specifiers a Bun/Node resolver could not find in the guest. */
+export function missingModuleSpecifiers(output) {
+  const specifiers = [];
+  for (const match of stripAnsi(output).matchAll(MISSING_MODULE_RE))
+    specifiers.push(match[1]);
+  return specifiers;
+}
+
+/** `./x`, `../x`, `/x` and `file:` URLs resolve against the tree, not the registry. */
+function isBareSpecifier(specifier) {
+  return !(
+    specifier.startsWith(".") ||
+    specifier.startsWith("/") ||
+    /^(?:file|node|bun):/i.test(specifier)
+  );
+}
+
+/** `@scope/name/sub` -> `@scope/name`; `name/sub` -> `name`. */
+function packageNameOf(specifier) {
+  const parts = specifier.split("/");
+  return specifier.startsWith("@") && parts.length > 1
+    ? `${parts[0]}/${parts[1]}`
+    : parts[0];
+}
+
+/**
+ * The packages the worktree declares (dependencies + devDependencies), or
+ * null when there is no readable manifest to consult.
+ */
+function declaredPackages(worktreePath) {
+  if (!worktreePath) return null;
+  let manifest;
+  try {
+    manifest = JSON.parse(
+      readFileSync(path.join(worktreePath, "package.json"), "utf8"),
+    );
+  } catch {
+    return null;
+  }
+  return new Set([
+    ...Object.keys(manifest?.dependencies ?? {}),
+    ...Object.keys(manifest?.devDependencies ?? {}),
+  ]);
+}
+
+/**
+ * Missing modules in the guest prove the host worktree was not installable —
+ * but only when every missing specifier is a bare package the worktree's
+ * package.json declares. A relative import that does not resolve, or a bare
+ * package the branch forgot to add, is the agent's failure and stays
+ * `handoff_verification_failed`. Without a readable manifest the bare
+ * specifier alone decides, since there is nothing the branch could have
+ * declared it in.
+ */
+export function handoffFailureReasonCode(obs, { worktreePath } = {}) {
+  const specifiers = missingModuleSpecifiers(obs?.output);
+  if (specifiers.length === 0) return "handoff_verification_failed";
+  const declared = declaredPackages(worktreePath);
+  const environmental = specifiers.every(
+    (specifier) =>
+      isBareSpecifier(specifier) &&
+      (declared === null || declared.has(packageNameOf(specifier))),
+  );
+  return environmental
     ? HANDOFF_DEPENDENCIES_MISSING
     : "handoff_verification_failed";
 }
@@ -1154,6 +1214,15 @@ function defaultDependencyInstaller({ cwd, timeoutMs }) {
     timedOut: result.error?.code === "ETIMEDOUT",
     output: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim(),
   };
+}
+
+/** True when node_modules holds anything beyond the preflight's own stamp. */
+function nodeModulesPopulated(nodeModules) {
+  try {
+    return readdirSync(nodeModules).some((entry) => entry !== ".bun-lock-sha");
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -1231,10 +1300,12 @@ export function preflightHandoffDependencies({
       };
     }
 
-    // An installer can succeed without making node_modules itself (for
-    // example, a mocked no-op). The stamp is only meaningful alongside it.
-    mkdirSync(nodeModules, { recursive: true });
-    writeFileSync(stamp, `${lockHash}\n`, "utf8");
+    // An installer can exit 0 without populating node_modules (a mocked
+    // no-op, or a bun that silently skipped the install). A stamp on an
+    // empty tree would pin that tree as current and skip every later
+    // preflight, so only stamp what the install actually produced.
+    if (nodeModulesPopulated(nodeModules))
+      writeFileSync(stamp, `${lockHash}\n`, "utf8");
   }
 
   return {
@@ -1930,7 +2001,7 @@ function verifyCompleted({
       obs.source = "ticket";
       handoff.verification = obs;
       if (!obs.passed) {
-        const reasonCode = handoffFailureReasonCode(obs);
+        const reasonCode = handoffFailureReasonCode(obs, { worktreePath });
         refuse(
           reasonCode,
           `ticket_verify_failed: ${handoffWhy(obs)}; sandbox_limits: ${handoffSandboxLimits(obs.sandbox.tmpfsMb)}`,

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -15,10 +15,12 @@ import {
   closeSync,
   existsSync,
   mkdtempSync,
+  mkdirSync,
   openSync,
   readFileSync,
   realpathSync,
   rmSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -101,11 +103,14 @@ export class ContractViolation extends Error {
  * `event-runtime/web/src/**`, and compares the diff with the ticket's Owned
  * Paths — and authors the Verification line itself.
  */
+/** The host could not restore dependencies before entering the offline guest. */
+export const HANDOFF_DEPENDENCIES_MISSING = "handoff_dependencies_missing";
 export const HANDOFF_REASON_CODES = new Set([
   "handoff_verification_failed",
   "handoff_verification_unspecified",
   "handoff_owned_paths_violation",
   "handoff_pr_form_invalid",
+  HANDOFF_DEPENDENCIES_MISSING,
 ]);
 export const HANDOFF_TAIL_LINES = 40;
 /** reasonCode the worker stamps on a result.json it synthesized itself (#1592). */
@@ -130,6 +135,7 @@ export const HANDOFF_GUEST_PATH =
 /** Where the verified worktree is mounted inside the chroot. */
 export const HANDOFF_GUEST_WORKSPACE = "/workspace";
 export const DEFAULT_HANDOFF_SANDBOX_TMPFS_MB = 1024;
+export const DEFAULT_HANDOFF_DEPENDENCY_TIMEOUT_MS = 180_000;
 export const HANDOFF_SANDBOX_NAMESPACES = Object.freeze([
   "user",
   "mount",
@@ -1096,6 +1102,16 @@ function boundedTail(text, maxChars = HANDOFF_FAILURE_OUTPUT_MAX_CHARS) {
   return `…${text.slice(-(maxChars - 1))}`;
 }
 
+/** Missing modules in the guest prove the host worktree was not installable. */
+export function handoffFailureReasonCode(obs) {
+  const output = stripAnsi(obs?.output);
+  return /(?:Cannot find package ['"][^'"]+['"](?: from |$)|error:\s*Cannot find module\b)/i.test(
+    output,
+  )
+    ? HANDOFF_DEPENDENCIES_MISSING
+    : "handoff_verification_failed";
+}
+
 /**
  * Preserve enough of a handoff red for its one permitted continuation. Same
  * curated diagnostic as the repository verification reason (timeout, then
@@ -1110,6 +1126,123 @@ export function handoffFailureOutput(obs, { timeoutMs } = {}) {
     repoVerifyFailureExcerpt(obs?.output) ||
     stripAnsi(obs?.output).trimEnd().slice(-HANDOFF_FAILURE_OUTPUT_MAX_CHARS);
   return boundedTail(curated.trim()) || `exit ${obs?.exitCode ?? "unknown"}`;
+}
+
+function defaultDependencyInstaller({ cwd, timeoutMs }) {
+  // Source the worker checkout's helper, never the agent-writable worktree.
+  // This retains the same global Bun-cache lock and SQLITE_BUSY retry policy
+  // used while materializing worktrees without granting ticket code host-shell
+  // execution before the handoff sandbox is active.
+  const helper = path.resolve(import.meta.dir, "../../bin/worktree-common.sh");
+  const result = spawnSync(
+    "/bin/bash",
+    ["-c", 'source "$1"; locked_bun_install "$2"', "--", helper, cwd],
+    {
+      encoding: "utf8",
+      timeout: timeoutMs,
+      env: {
+        ...process.env,
+        FACTORY_LOCK_MAX_WAIT: String(
+          Math.min(120, Math.floor(timeoutMs / 1000)),
+        ),
+      },
+    },
+  );
+  return {
+    passed: result.status === 0 && !result.error,
+    exitCode: result.status,
+    timedOut: result.error?.code === "ETIMEDOUT",
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`.trim(),
+  };
+}
+
+/**
+ * Restore stale worktree dependencies before any handoff command enters the
+ * no-network namespace. The stamp is owned by this preflight: Bun itself does
+ * not provide a stable cross-version lockfile marker.
+ */
+export function preflightHandoffDependencies({
+  worktreePath,
+  needsWebBuild = false,
+  installer = defaultDependencyInstaller,
+  timeoutMs = DEFAULT_HANDOFF_DEPENDENCY_TIMEOUT_MS,
+}) {
+  const directories = [worktreePath];
+  if (needsWebBuild)
+    directories.push(path.join(worktreePath, HANDOFF_WEB_BUILD_DIR));
+  const details = [];
+  const started = Date.now();
+
+  for (const directory of directories) {
+    const packageJson = path.join(directory, "package.json");
+    const lockfile = path.join(directory, "bun.lock");
+    if (!existsSync(packageJson) || !existsSync(lockfile)) continue;
+
+    const nodeModules = path.join(directory, "node_modules");
+    const stamp = path.join(nodeModules, ".bun-lock-sha");
+    const lockHash = sha256Hex(readFileSync(lockfile));
+    let stampedHash = null;
+    try {
+      stampedHash = readFileSync(stamp, "utf8").trim();
+    } catch {
+      // Missing or unreadable stamps are stale dependencies, never a pass.
+    }
+    if (existsSync(nodeModules) && stampedHash === lockHash) {
+      details.push({
+        dir: path.relative(worktreePath, directory) || ".",
+        installed: false,
+        ms: 0,
+      });
+      continue;
+    }
+
+    const installStarted = Date.now();
+    let observation;
+    try {
+      observation = installer({
+        command: "bun install --frozen-lockfile",
+        cwd: directory,
+        timeoutMs,
+      });
+    } catch (err) {
+      observation = {
+        passed: false,
+        exitCode: null,
+        output: `installer error: ${err?.message ?? String(err)}`,
+      };
+    }
+    const ms = Date.now() - installStarted;
+    const detail = {
+      dir: path.relative(worktreePath, directory) || ".",
+      installed: Boolean(observation?.passed),
+      ms,
+    };
+    details.push(detail);
+    if (!observation?.passed) {
+      return {
+        passed: false,
+        installed: false,
+        ms: Date.now() - started,
+        dirs: details,
+        failed: {
+          ...detail,
+          output: handoffFailureOutput(observation, { timeoutMs }),
+        },
+      };
+    }
+
+    // An installer can succeed without making node_modules itself (for
+    // example, a mocked no-op). The stamp is only meaningful alongside it.
+    mkdirSync(nodeModules, { recursive: true });
+    writeFileSync(stamp, `${lockHash}\n`, "utf8");
+  }
+
+  return {
+    passed: true,
+    installed: details.some((detail) => detail.installed),
+    ms: Date.now() - started,
+    dirs: details,
+  };
 }
 
 /**
@@ -1170,6 +1303,8 @@ export function verifyResult({
   extraArtifacts = [],
   worktreeRecord = null,
   verifyTimeoutMs = repoVerifyTimeoutMs(),
+  runHandoffCommandFn = runHandoffCommand,
+  dependencyInstaller = defaultDependencyInstaller,
 }) {
   let raw;
   try {
@@ -1203,6 +1338,8 @@ export function verifyResult({
     extraArtifacts,
     worktreeRecord,
     verifyTimeoutMs,
+    runHandoffCommandFn,
+    dependencyInstaller,
   });
 }
 
@@ -1602,6 +1739,8 @@ function verifyCompleted({
   extraArtifacts = [],
   worktreeRecord = null,
   verifyTimeoutMs,
+  runHandoffCommandFn,
+  dependencyInstaller,
 }) {
   if (candidate.artifact === undefined)
     throw new ContractViolation(["missing_artifact"]);
@@ -1697,7 +1836,7 @@ function verifyCompleted({
     // PR or returns the ticket over it.
     const runHandoffStep = (options) => {
       try {
-        return runHandoffCommand(options);
+        return runHandoffCommandFn(options);
       } catch (err) {
         if (err instanceof SandboxUnavailable) {
           refuse(HANDOFF_SANDBOX_UNAVAILABLE, err.message);
@@ -1717,6 +1856,32 @@ function verifyCompleted({
       refuse(
         "handoff_verification_unspecified",
         "handoff_verification_unspecified: the ticket has no parseable `## Verification Command` and the repo declares no `verify:` command",
+      );
+    }
+
+    // The guest has no network and receives only this worktree as a mount.
+    // Compute the diff first so a pending web build gets its own dependency
+    // preflight, then restore both directories before any sandboxed command.
+    handoff.diff = changedFilesSince({
+      worktreePath,
+      base: worktreeRecord.base ?? null,
+    });
+    const files = handoff.diff.files ?? [];
+    const needsWebBuild =
+      files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
+      existsSync(
+        path.join(worktreePath, HANDOFF_WEB_BUILD_DIR, "package.json"),
+      );
+    handoff.dependencies = preflightHandoffDependencies({
+      worktreePath,
+      needsWebBuild,
+      installer: dependencyInstaller,
+    });
+    if (!handoff.dependencies.passed) {
+      const failed = handoff.dependencies.failed;
+      refuse(
+        HANDOFF_DEPENDENCIES_MISSING,
+        `${HANDOFF_DEPENDENCIES_MISSING}: ${failed.dir}: ${failed.output}`,
       );
     }
 
@@ -1765,8 +1930,9 @@ function verifyCompleted({
       obs.source = "ticket";
       handoff.verification = obs;
       if (!obs.passed) {
+        const reasonCode = handoffFailureReasonCode(obs);
         refuse(
-          "handoff_verification_failed",
+          reasonCode,
           `ticket_verify_failed: ${handoffWhy(obs)}; sandbox_limits: ${handoffSandboxLimits(obs.sandbox.tmpfsMb)}`,
         );
       }
@@ -1775,19 +1941,9 @@ function verifyCompleted({
       handoff.verification = handoff.repoVerify;
     }
 
-    // 3. What the PR actually carries.
-    handoff.diff = changedFilesSince({
-      worktreePath,
-      base: worktreeRecord.base ?? null,
-    });
-    const files = handoff.diff.files ?? [];
-
-    // 4. tsc + vite for anything under event-runtime/web/src/** — the check
+    // 3. tsc + vite for anything under event-runtime/web/src/** — the check
     //    #593 failed on, regardless of what the ticket's command covers.
-    if (
-      files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
-      existsSync(path.join(worktreePath, HANDOFF_WEB_BUILD_DIR, "package.json"))
-    ) {
+    if (needsWebBuild) {
       const obs = runHandoffStep({
         command: HANDOFF_WEB_BUILD_COMMAND,
         cwd: path.join(worktreePath, HANDOFF_WEB_BUILD_DIR),
@@ -1806,7 +1962,7 @@ function verifyCompleted({
       handoffChecks.push("web_build_passed");
     }
 
-    // 5. Owned Paths conformance: listed always; refused under strict.
+    // 4. Owned Paths conformance: listed always; refused under strict.
     if (handoff.diff.ok && ownedPathsKnown) {
       handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths);
       if (handoff.ownedPathsDeviations.length === 0) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -16,7 +16,10 @@ import { getAgent, loadRegistry } from "./registry.mjs";
 import { execFileSync } from "node:child_process";
 import {
   ContractViolation,
+  HANDOFF_DEPENDENCIES_MISSING,
   HANDOFF_FAILURE_OUTPUT_MAX_CHARS,
+  HANDOFF_REASON_CODES,
+  handoffFailureReasonCode,
   handoffFailureOutput,
   HANDOFF_HOST_ENV,
   HANDOFF_SANDBOX_INIT,
@@ -1320,6 +1323,156 @@ describe("worktree baseline verification (WM-334)", () => {
       "ticket_verify_covered_by_repo_verify",
     );
     expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
+  });
+
+  test("missing dependencies install before the injected step-1 sandbox runner", () => {
+    const { dir, record } = worktreeWorkspace("step-1", null);
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture"}\n',
+    );
+    writeFileSync(path.join(record.path, "bun.lock"), "fixture-lock\n");
+    const calls = [];
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      dependencyInstaller: (options) => {
+        calls.push({ kind: "install", ...options });
+        return { passed: true, exitCode: 0, output: "installed" };
+      },
+      runHandoffCommandFn: (options) => {
+        calls.push({ kind: "spawn", command: options.command });
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "ok",
+          sandbox: { tmpfsMb: 1024 },
+        };
+      },
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(calls).toEqual([
+      expect.objectContaining({
+        kind: "install",
+        command: "bun install --frozen-lockfile",
+        cwd: record.path,
+      }),
+      { kind: "spawn", command: "step-1" },
+    ]);
+    expect(out.handoff.dependencies).toMatchObject({ installed: true });
+  });
+
+  test("a failed dependency install refuses before either sandbox verification step", () => {
+    const { dir, record } = worktreeWorkspace("step-1", null);
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture"}\n',
+    );
+    writeFileSync(path.join(record.path, "bun.lock"), "fixture-lock\n");
+    let spawned = 0;
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        dependencyInstaller: () => ({
+          passed: false,
+          exitCode: 1,
+          output: "network unavailable",
+        }),
+        runHandoffCommandFn: () => {
+          spawned += 1;
+          return { passed: true, exitCode: 0, output: "unexpected" };
+        },
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe(HANDOFF_DEPENDENCIES_MISSING);
+      expect(err.violations[0]).toContain("network unavailable");
+    }
+    expect(spawned).toBe(0);
+  });
+
+  test("a matching node_modules lock stamp does not reinstall", () => {
+    const { dir, record } = worktreeWorkspace("step-1", null);
+    const lock = "fixture-lock\n";
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture"}\n',
+    );
+    writeFileSync(path.join(record.path, "bun.lock"), lock);
+    mkdirSync(path.join(record.path, "node_modules"));
+    writeFileSync(
+      path.join(record.path, "node_modules", ".bun-lock-sha"),
+      `${sha256Hex(lock)}\n`,
+    );
+    let installs = 0;
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      dependencyInstaller: () => {
+        installs += 1;
+        return { passed: true, exitCode: 0, output: "unexpected" };
+      },
+      runHandoffCommandFn: () => ({
+        passed: true,
+        exitCode: 0,
+        output: "ok",
+        sandbox: { tmpfsMb: 1024 },
+      }),
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(installs).toBe(0);
+    expect(out.handoff.dependencies).toMatchObject({ installed: false });
+  });
+
+  test("missing package output is an environment dependency failure", () => {
+    expect(HANDOFF_REASON_CODES.has(HANDOFF_DEPENDENCIES_MISSING)).toBe(true);
+    expect(
+      handoffFailureReasonCode({
+        output: "Cannot find package 'prettier' from registry.mjs",
+      }),
+    ).toBe(HANDOFF_DEPENDENCIES_MISSING);
+    expect(
+      handoffFailureReasonCode({ output: "error: Cannot find module 'x'" }),
+    ).toBe(HANDOFF_DEPENDENCIES_MISSING);
+
+    const { dir, record } = worktreeWorkspace(null, null);
+    record.handoff = { verificationCommand: "ticket-step" };
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: () => ({
+          passed: false,
+          exitCode: 1,
+          output: "Cannot find package 'prettier' from registry.mjs",
+          sandbox: { tmpfsMb: 1024 },
+        }),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err.reasonCode).toBe(HANDOFF_DEPENDENCIES_MISSING);
+    }
   });
 
   test("a ticket-step failure names its sandbox limits", () => {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -21,6 +21,8 @@ import {
   HANDOFF_REASON_CODES,
   handoffFailureReasonCode,
   handoffFailureOutput,
+  missingModuleSpecifiers,
+  preflightHandoffDependencies,
   HANDOFF_HOST_ENV,
   HANDOFF_SANDBOX_INIT,
   HANDOFF_SANDBOX_SETUP,
@@ -1473,6 +1475,162 @@ describe("worktree baseline verification (WM-334)", () => {
     } catch (err) {
       expect(err.reasonCode).toBe(HANDOFF_DEPENDENCIES_MISSING);
     }
+  });
+
+  test("a missing relative import stays the agent's verification failure", () => {
+    expect(
+      missingModuleSpecifiers(
+        'error: Cannot find module "./missing.mjs" from "/w/x.mjs"',
+      ),
+    ).toEqual(["./missing.mjs"]);
+    expect(
+      handoffFailureReasonCode({
+        output: 'error: Cannot find module "./missing.mjs" from "/w/x.mjs"',
+      }),
+    ).toBe("handoff_verification_failed");
+    expect(
+      handoffFailureReasonCode({
+        output: "Cannot find module '../lib/gone.mjs' from 'x.test.mjs'",
+      }),
+    ).toBe("handoff_verification_failed");
+    expect(
+      handoffFailureReasonCode({
+        output: "Cannot find module '/abs/gone.mjs' from 'x.test.mjs'",
+      }),
+    ).toBe("handoff_verification_failed");
+
+    const { dir, record } = worktreeWorkspace(null, null);
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture","dependencies":{"prettier":"^3"}}\n',
+    );
+    record.handoff = { verificationCommand: "ticket-step" };
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: () => ({
+          passed: false,
+          exitCode: 1,
+          output: 'error: Cannot find module "./missing.mjs" from "x.mjs"',
+          sandbox: { tmpfsMb: 1024 },
+        }),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+    }
+  });
+
+  test("a bare package the worktree never declared is a forgotten dependency, not an environment failure", () => {
+    const { dir, record } = worktreeWorkspace(null, null);
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture","dependencies":{"prettier":"^3"},"devDependencies":{"@scope/tool":"1"}}\n',
+    );
+    const output = "Cannot find package 'left-pad' from 'x.mjs'";
+    expect(
+      handoffFailureReasonCode({ output }, { worktreePath: record.path }),
+    ).toBe("handoff_verification_failed");
+    // Declared packages (including subpaths and scoped names) are the
+    // installer's problem.
+    expect(
+      handoffFailureReasonCode(
+        { output: "Cannot find package 'prettier' from registry.mjs" },
+        { worktreePath: record.path },
+      ),
+    ).toBe(HANDOFF_DEPENDENCIES_MISSING);
+    expect(
+      handoffFailureReasonCode(
+        { output: "error: Cannot find module '@scope/tool/sub' from 'x.mjs'" },
+        { worktreePath: record.path },
+      ),
+    ).toBe(HANDOFF_DEPENDENCIES_MISSING);
+    // One undeclared specifier among declared ones is still the branch's.
+    expect(
+      handoffFailureReasonCode(
+        {
+          output:
+            "Cannot find package 'prettier' from a.mjs\nCannot find package 'left-pad' from b.mjs",
+        },
+        { worktreePath: record.path },
+      ),
+    ).toBe("handoff_verification_failed");
+
+    record.handoff = { verificationCommand: "ticket-step" };
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: () => ({
+          passed: false,
+          exitCode: 1,
+          output,
+          sandbox: { tmpfsMb: 1024 },
+        }),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+    }
+  });
+
+  test("an installer that exits 0 without populating node_modules leaves no lock stamp", () => {
+    const { record } = worktreeWorkspace(null, null);
+    const lock = "fixture-lock\n";
+    writeFileSync(
+      path.join(record.path, "package.json"),
+      '{"name":"fixture"}\n',
+    );
+    writeFileSync(path.join(record.path, "bun.lock"), lock);
+    const stamp = path.join(record.path, "node_modules", ".bun-lock-sha");
+    let installs = 0;
+
+    const empty = preflightHandoffDependencies({
+      worktreePath: record.path,
+      installer: () => {
+        installs += 1;
+        return { passed: true, exitCode: 0, output: "" };
+      },
+    });
+    expect(empty.passed).toBe(true);
+    expect(installs).toBe(1);
+    expect(existsSync(stamp)).toBe(false);
+
+    // The next preflight reinstalls instead of trusting an empty tree, and
+    // stamps once the install actually produced packages.
+    const populated = preflightHandoffDependencies({
+      worktreePath: record.path,
+      installer: ({ cwd }) => {
+        installs += 1;
+        mkdirSync(path.join(cwd, "node_modules", "prettier"), {
+          recursive: true,
+        });
+        return { passed: true, exitCode: 0, output: "installed" };
+      },
+    });
+    expect(populated.passed).toBe(true);
+    expect(installs).toBe(2);
+    expect(readFileSync(stamp, "utf8").trim()).toBe(sha256Hex(lock));
+
+    preflightHandoffDependencies({
+      worktreePath: record.path,
+      installer: () => {
+        installs += 1;
+        return { passed: true, exitCode: 0, output: "unexpected" };
+      },
+    });
+    expect(installs).toBe(2);
   });
 
   test("a ticket-step failure names its sandbox limits", () => {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -65,6 +65,7 @@ import { traceRecorder } from "./trace.mjs";
 import {
   ContractViolation,
   composeHandoffVerification,
+  HANDOFF_DEPENDENCIES_MISSING,
   HANDOFF_REASON_CODES,
   HANDOFF_SANDBOX_UNAVAILABLE,
   normalizeFailureOutput,
@@ -911,11 +912,20 @@ const ENVIRONMENT_FAILURES = new Set([
   // agent's work is implicated, so this must never burn an agent attempt or
   // draft the PR — it is the worker host that needs attention.
   HANDOFF_SANDBOX_UNAVAILABLE,
+  // The offline sandbox cannot restore packages; this is a host fault rather
+  // than evidence that the agent's branch is red.
+  HANDOFF_DEPENDENCIES_MISSING,
 ]);
+const isAgentHandoffFailure = (reasonCode) =>
+  HANDOFF_REASON_CODES.has(reasonCode) &&
+  reasonCode !== HANDOFF_DEPENDENCIES_MISSING;
 // The handoff gate (WM-718) catching the agent's own red is an agent error:
 // bounded by maxAttempts like any contract violation, never an environment
 // retry and never fatal — the ticket is already back in Todo + agent-ready.
-const AGENT_FAILURES = new Set(["contract_violation", ...HANDOFF_REASON_CODES]);
+const AGENT_FAILURES = new Set([
+  "contract_violation",
+  ...[...HANDOFF_REASON_CODES].filter(isAgentHandoffFailure),
+]);
 const FATAL_FAILURES = new Set([
   "cli_not_found",
   "filesystem_confinement_unavailable",
@@ -953,7 +963,7 @@ export function tierEscalationEligibility(spec, reasonCode) {
   // (verify.mjs HANDOFF_REASON_CODES). Match the emitted codes only — a
   // reason code no producer writes is dead weight that reads as coverage.
   const eligibleReason =
-    HANDOFF_REASON_CODES.has(reasonCode) ||
+    isAgentHandoffFailure(reasonCode) ||
     reasonCode === "contract_violation" ||
     String(reasonCode).startsWith("agent_exit_");
   const eligible = Boolean(
@@ -4407,6 +4417,7 @@ export async function executeClaimed(
       const reasonCode =
         activeError.reasonCode === "baseline_red" ||
         activeError.reasonCode === HANDOFF_SANDBOX_UNAVAILABLE ||
+        activeError.reasonCode === HANDOFF_DEPENDENCIES_MISSING ||
         HANDOFF_REASON_CODES.has(activeError.reasonCode)
           ? activeError.reasonCode
           : "contract_violation";
@@ -4427,7 +4438,7 @@ export async function executeClaimed(
       // WM-718: the PR is the agent's, already opened; the structural hold is
       // to draft it and quote the observed failure where the reviewer looks.
       if (
-        HANDOFF_REASON_CODES.has(reasonCode) &&
+        isAgentHandoffFailure(reasonCode) &&
         handoff?.prNumber &&
         mayMutateClaimedTicket()
       ) {
@@ -4444,7 +4455,7 @@ export async function executeClaimed(
         }
       }
       if (mayMutateClaimedTicket() && !escalating) {
-        if (HANDOFF_REASON_CODES.has(reasonCode)) {
+        if (isAgentHandoffFailure(reasonCode)) {
           try {
             const returned = returnHandoffTicketFn({
               repo: repoName,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -21,6 +21,7 @@ const EXECUTE_SPAWN_TIMEOUT_MS = loadAdjustedTimeout(5_000);
 import {
   composeHandoffVerification,
   ContractViolation,
+  HANDOFF_DEPENDENCIES_MISSING,
   insideHandoffSandbox,
   verifyResult,
 } from "./verify.mjs";
@@ -2860,6 +2861,9 @@ sh -c 'sleep 5 & wait'
     expect(classifyFailureCause("lease_expired")).toBe("environment");
     expect(classifyFailureCause("linear_unconfigured")).toBe("environment");
     expect(classifyFailureCause("registry_stale")).toBe("environment");
+    expect(classifyFailureCause(HANDOFF_DEPENDENCIES_MISSING)).toBe(
+      "environment",
+    );
     expect(classifyFailureCause("agent_exit_1")).toBe("agent_error");
     expect(classifyFailureCause("contract_violation")).toBe("agent_error");
     for (const reason of [
@@ -2904,6 +2908,7 @@ sh -c 'sleep 5 & wait'
       "timeout",
       "lease_expired",
       "adapter_error",
+      HANDOFF_DEPENDENCIES_MISSING,
       "needs_human",
       "policy_denied:Bash",
       "cancelled",


### PR DESCRIPTION
Fixes watt-mind/factory#1658

Preflight offline handoff dependencies and route restore failures as worker environment faults.

## Validation

| Check                | Command | Result | Notes |
| -------------------- | ------- | ------ | ----- |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs --timeout 20000` | pass | 78 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 615 known warnings |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_299ef9f3-a104-4d6c-b9f7-f7b8bd7e8f69

## Post-review

Reviewer folds (d5690cf3, merged develop at 834046ba):

1. `handoffFailureReasonCode` now classifies `handoff_dependencies_missing` only when every unresolved specifier is a bare package declared in the worktree's `package.json` (`dependencies`/`devDependencies`). Relative/absolute imports and undeclared (forgotten) packages stay `handoff_verification_failed`. Tests cover `./`, `../`, `/abs`, undeclared bare, declared+subpath/scoped, and mixed output.
2. `preflightHandoffDependencies` writes `.bun-lock-sha` only when `node_modules` holds content after the install; an installer that exits 0 without populating the tree leaves no stamp and is retried on the next preflight (test added).

Verification: `bun test event-runtime/lib/verify.test.mjs --timeout 20000` (81 pass); `bun run lint && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` all green.
