### PR TITLE
fix(spend): fail closed on unreadable logs

### DIFF
--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -21,19 +21,50 @@
  * and labelled as the estimate they are. The point is not accuracy — these were
  * never dollars — it is that every run moves the number.
  */
-import { readFileSync } from "node:fs";
+import { readFileSync, statSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { parseRun, estimateUSD } from "./transcript.mjs";
 
 export const LOG_DIR = path.join(homedir(), ".factory/logs");
 
-/** {usd, reported, estimated, runs} — `estimated` is the non-Claude share. */
+/**
+ * {usd, reported, estimated, runs, scanned} — `estimated` is the non-Claude
+ * share. A missing log directory is a clean, empty scan; other scan failures
+ * are reported so callers can fail closed instead of mistaking them for zero.
+ */
 export function todaysSpendBreakdown(logDir = LOG_DIR) {
   const today = new Date().toISOString().slice(0, 10);
   let reported = 0,
     estimated = 0,
     runs = 0;
+
+  // Bun.Glob.scanSync() can represent a missing directory as an empty result,
+  // which is indistinguishable from an idle day. Check it explicitly first so
+  // ENOENT remains the one benign failure mode.
+  try {
+    statSync(logDir);
+  } catch (error) {
+    if (error?.code === "ENOENT")
+      return {
+        usd: 0,
+        reported: 0,
+        estimated: 0,
+        runs: 0,
+        scanned: false,
+        reason: "no log directory",
+      };
+
+    return {
+      usd: 0,
+      reported: 0,
+      estimated: 0,
+      runs: 0,
+      scanned: false,
+      error: errorMessage(error),
+    };
+  }
+
   try {
     for (const f of new Bun.Glob("*.jsonl").scanSync(logDir)) {
       const full = path.join(logDir, f);
@@ -47,10 +78,21 @@ export function todaysSpendBreakdown(logDir = LOG_DIR) {
       if (run.cost > 0) reported += run.cost;
       else estimated += estimateUSD(run);
     }
-  } catch {
-    /* no log dir yet — nothing spent */
+  } catch (error) {
+    return {
+      usd: reported + estimated,
+      reported,
+      estimated,
+      runs,
+      scanned: false,
+      error: errorMessage(error),
+    };
   }
-  return { usd: reported + estimated, reported, estimated, runs };
+  return { usd: reported + estimated, reported, estimated, runs, scanned: true };
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
 }
 
 export function todaysSpendUSD(logDir = LOG_DIR) {
@@ -61,7 +103,9 @@ export function todaysSpendUSD(logDir = LOG_DIR) {
 export function budgetExhausted(policy, logDir = LOG_DIR) {
   const perDay = policy?.budget?.per_day_usd;
   if (!perDay) return null;
-  const { usd, reported, estimated } = todaysSpendBreakdown(logDir);
+  const { usd, reported, estimated, error } = todaysSpendBreakdown(logDir);
+  if (error)
+    return `day budget unavailable — unreadable log directory (${error})`;
   if (usd < perDay) return null;
   const split =
     estimated > 0.005

--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -33,7 +33,10 @@ export const LOG_DIR = path.join(homedir(), ".factory/logs");
  * share. A missing log directory is a clean, empty scan; other scan failures
  * are reported so callers can fail closed instead of mistaking them for zero.
  */
-export function todaysSpendBreakdown(logDir = LOG_DIR) {
+export function todaysSpendBreakdown(
+  logDir = LOG_DIR,
+  { stat = statSync, readFile = readFileSync } = {},
+) {
   const today = new Date().toISOString().slice(0, 10);
   let reported = 0,
     estimated = 0,
@@ -43,7 +46,7 @@ export function todaysSpendBreakdown(logDir = LOG_DIR) {
   // which is indistinguishable from an idle day. Check it explicitly first so
   // ENOENT remains the one benign failure mode.
   try {
-    statSync(logDir);
+    stat(logDir);
   } catch (error) {
     if (error?.code === "ENOENT")
       return {
@@ -73,7 +76,7 @@ export function todaysSpendBreakdown(logDir = LOG_DIR) {
         today
       )
         continue;
-      const run = parseRun(f, readFileSync(full, "utf8"));
+      const run = parseRun(f, readFile(full, "utf8"));
       runs++;
       if (run.cost > 0) reported += run.cost;
       else estimated += estimateUSD(run);
@@ -106,10 +109,13 @@ export function todaysSpendUSD(logDir = LOG_DIR) {
 }
 
 /** null when under budget; a human-readable reason when the day is spent. */
-export function budgetExhausted(policy, logDir = LOG_DIR) {
+export function budgetExhausted(policy, logDir = LOG_DIR, scanOptions) {
   const perDay = policy?.budget?.per_day_usd;
   if (!perDay) return null;
-  const { usd, reported, estimated, error } = todaysSpendBreakdown(logDir);
+  const { usd, reported, estimated, error } = todaysSpendBreakdown(
+    logDir,
+    scanOptions,
+  );
   if (error)
     return `day budget unavailable — unreadable log directory (${error})`;
   if (usd < perDay) return null;

--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -88,7 +88,13 @@ export function todaysSpendBreakdown(logDir = LOG_DIR) {
       error: errorMessage(error),
     };
   }
-  return { usd: reported + estimated, reported, estimated, runs, scanned: true };
+  return {
+    usd: reported + estimated,
+    reported,
+    estimated,
+    runs,
+    scanned: true,
+  };
 }
 
 function errorMessage(error) {

--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -29,9 +29,12 @@ import { parseRun, estimateUSD } from "./transcript.mjs";
 export const LOG_DIR = path.join(homedir(), ".factory/logs");
 
 /**
- * {usd, reported, estimated, runs, scanned} — `estimated` is the non-Claude
- * share. A missing log directory is a clean, empty scan; other scan failures
- * are reported so callers can fail closed instead of mistaking them for zero.
+ * {usd, reported, estimated, runs, skipped, scanned} — `estimated` is the
+ * non-Claude share. A missing log directory is a clean, empty scan; other scan
+ * failures are reported so callers can fail closed instead of mistaking them
+ * for zero. A single log file that vanishes mid-scan (rotated or deleted
+ * between the directory listing and its stat/read) is not a scan failure: it
+ * is counted in `skipped` and the rest of the day still totals.
  */
 export function todaysSpendBreakdown(
   logDir = LOG_DIR,
@@ -40,7 +43,8 @@ export function todaysSpendBreakdown(
   const today = new Date().toISOString().slice(0, 10);
   let reported = 0,
     estimated = 0,
-    runs = 0;
+    runs = 0,
+    skipped = 0;
 
   // Bun.Glob.scanSync() can represent a missing directory as an empty result,
   // which is indistinguishable from an idle day. Check it explicitly first so
@@ -54,6 +58,7 @@ export function todaysSpendBreakdown(
         reported: 0,
         estimated: 0,
         runs: 0,
+        skipped: 0,
         scanned: false,
         reason: "no log directory",
       };
@@ -63,6 +68,7 @@ export function todaysSpendBreakdown(
       reported: 0,
       estimated: 0,
       runs: 0,
+      skipped: 0,
       scanned: false,
       error: errorMessage(error),
     };
@@ -71,12 +77,21 @@ export function todaysSpendBreakdown(
   try {
     for (const f of new Bun.Glob("*.jsonl").scanSync(logDir)) {
       const full = path.join(logDir, f);
-      if (
-        new Date(Bun.file(full).lastModified).toISOString().slice(0, 10) !==
-        today
-      )
+      const day = fileDay(full, stat);
+      if (day === null) {
+        skipped++;
         continue;
-      const run = parseRun(f, readFile(full, "utf8"));
+      }
+      if (day !== today) continue;
+      let text;
+      try {
+        text = readFile(full, "utf8");
+      } catch (error) {
+        if (error?.code !== "ENOENT") throw error;
+        skipped++;
+        continue;
+      }
+      const run = parseRun(f, text);
       runs++;
       if (run.cost > 0) reported += run.cost;
       else estimated += estimateUSD(run);
@@ -87,6 +102,7 @@ export function todaysSpendBreakdown(
       reported,
       estimated,
       runs,
+      skipped,
       scanned: false,
       error: errorMessage(error),
     };
@@ -96,8 +112,26 @@ export function todaysSpendBreakdown(
     reported,
     estimated,
     runs,
+    skipped,
     scanned: true,
   };
+}
+
+/**
+ * The YYYY-MM-DD a log file was last written, or null when the file cannot be
+ * dated on its own — gone (ENOENT) or carrying an unusable mtime. Any other
+ * stat failure propagates: it is the directory's problem, not one file's.
+ */
+function fileDay(full, stat) {
+  let mtimeMs;
+  try {
+    mtimeMs = stat(full).mtimeMs;
+  } catch (error) {
+    if (error?.code === "ENOENT") return null;
+    throw error;
+  }
+  if (!Number.isFinite(mtimeMs)) return null;
+  return new Date(mtimeMs).toISOString().slice(0, 10);
 }
 
 function errorMessage(error) {

--- a/lib/spend.test.mjs
+++ b/lib/spend.test.mjs
@@ -1,0 +1,123 @@
+import { test, expect } from "bun:test";
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { budgetExhausted, todaysSpendBreakdown } from "./spend.mjs";
+
+const jsonl = (...events) =>
+  events.map((event) => JSON.stringify(event)).join("\n") + "\n";
+
+const tempLogDir = () => mkdtempSync(path.join(tmpdir(), "factory-spend-"));
+
+const policy = (perDay) => ({ budget: { per_day_usd: perDay } });
+
+test("missing log directory is an empty, explicitly unscanned day", () => {
+  const logDir = path.join(tempLogDir(), "missing");
+  try {
+    expect(todaysSpendBreakdown(logDir)).toEqual({
+      usd: 0,
+      reported: 0,
+      estimated: 0,
+      runs: 0,
+      scanned: false,
+      reason: "no log directory",
+    });
+    expect(budgetExhausted(policy(1), logDir)).toBeNull();
+  } finally {
+    rmSync(path.dirname(logDir), { recursive: true, force: true });
+  }
+});
+
+test("an unreadable log directory surfaces an error and closes the budget gate", () => {
+  const root = tempLogDir();
+  const logDir = path.join(root, "not-a-directory");
+  writeFileSync(logDir, "not a directory", "utf8");
+  try {
+    const breakdown = todaysSpendBreakdown(logDir);
+    expect(breakdown).toMatchObject({
+      usd: 0,
+      reported: 0,
+      estimated: 0,
+      runs: 0,
+      scanned: false,
+    });
+    expect(breakdown.error).toContain("not a directory");
+    expect(budgetExhausted(policy(100), logDir)).toMatch(
+      /unreadable log directory/,
+    );
+    expect(budgetExhausted({}, logDir)).toBeNull();
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a file read failure is surfaced and closes the budget gate", () => {
+  const root = tempLogDir();
+  const logDir = path.join(root, "logs");
+  mkdirSync(logDir);
+  writeFileSync(
+    path.join(logDir, "z-good.jsonl"),
+    jsonl({
+      type: "result",
+      total_cost_usd: 1.25,
+      num_turns: 1,
+    }),
+    "utf8",
+  );
+  const unreadable = path.join(logDir, "a-unreadable.jsonl");
+  writeFileSync(unreadable, "not readable", "utf8");
+  chmodSync(unreadable, 0o000);
+  try {
+    const breakdown = todaysSpendBreakdown(logDir);
+    expect(breakdown.scanned).toBe(false);
+    expect(breakdown.error).toBeTruthy();
+    expect(breakdown.usd).toBeGreaterThanOrEqual(0);
+    expect(budgetExhausted(policy(100), logDir)).toMatch(
+      /unreadable log directory/,
+    );
+  } finally {
+    chmodSync(unreadable, 0o600);
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a clean fixture scan reports today's totals and scanned true", () => {
+  const root = tempLogDir();
+  const logDir = path.join(root, "logs");
+  mkdirSync(logDir);
+  writeFileSync(
+    path.join(logDir, "factory-CLNT-1-today.jsonl"),
+    jsonl(
+      {
+        type: "assistant",
+        message: {
+          usage: { input_tokens: 100, output_tokens: 50 },
+          content: [],
+        },
+      },
+      { type: "result", total_cost_usd: 1.25, num_turns: 2 },
+    ),
+    "utf8",
+  );
+  try {
+    expect(todaysSpendBreakdown(logDir)).toMatchObject({
+      usd: 1.25,
+      reported: 1.25,
+      estimated: 0,
+      runs: 1,
+      scanned: true,
+    });
+    expect(budgetExhausted(policy(2), logDir)).toBeNull();
+    expect(budgetExhausted(policy(1), logDir)).toBe(
+      "day budget spent (~$1.25 of $1 notional)",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/lib/spend.test.mjs
+++ b/lib/spend.test.mjs
@@ -1,8 +1,8 @@
 import { test, expect } from "bun:test";
 import {
-  chmodSync,
   mkdtempSync,
   mkdirSync,
+  readFileSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -16,6 +16,12 @@ const jsonl = (...events) =>
 const tempLogDir = () => mkdtempSync(path.join(tmpdir(), "factory-spend-"));
 
 const policy = (perDay) => ({ budget: { per_day_usd: perDay } });
+
+const permissionDenied = (target) => {
+  const error = new Error(`EACCES: permission denied, open '${target}'`);
+  error.code = "EACCES";
+  return error;
+};
 
 test("missing log directory is an empty, explicitly unscanned day", () => {
   const logDir = path.join(tempLogDir(), "missing");
@@ -36,10 +42,13 @@ test("missing log directory is an empty, explicitly unscanned day", () => {
 
 test("an unreadable log directory surfaces an error and closes the budget gate", () => {
   const root = tempLogDir();
-  const logDir = path.join(root, "not-a-directory");
-  writeFileSync(logDir, "not a directory", "utf8");
+  const logDir = path.join(root, "logs");
+  mkdirSync(logDir);
+  const stat = () => {
+    throw permissionDenied(logDir);
+  };
   try {
-    const breakdown = todaysSpendBreakdown(logDir);
+    const breakdown = todaysSpendBreakdown(logDir, { stat });
     expect(breakdown).toMatchObject({
       usd: 0,
       reported: 0,
@@ -47,8 +56,8 @@ test("an unreadable log directory surfaces an error and closes the budget gate",
       runs: 0,
       scanned: false,
     });
-    expect(breakdown.error).toContain("not a directory");
-    expect(budgetExhausted(policy(100), logDir)).toMatch(
+    expect(breakdown.error).toContain("permission denied");
+    expect(budgetExhausted(policy(100), logDir, { stat })).toMatch(
       /unreadable log directory/,
     );
     expect(budgetExhausted({}, logDir)).toBeNull();
@@ -62,7 +71,7 @@ test("a file read failure is surfaced and closes the budget gate", () => {
   const logDir = path.join(root, "logs");
   mkdirSync(logDir);
   writeFileSync(
-    path.join(logDir, "z-good.jsonl"),
+    path.join(logDir, "first.jsonl"),
     jsonl({
       type: "result",
       total_cost_usd: 1.25,
@@ -70,19 +79,38 @@ test("a file read failure is surfaced and closes the budget gate", () => {
     }),
     "utf8",
   );
-  const unreadable = path.join(logDir, "a-unreadable.jsonl");
-  writeFileSync(unreadable, "not readable", "utf8");
-  chmodSync(unreadable, 0o000);
+  writeFileSync(
+    path.join(logDir, "second.jsonl"),
+    jsonl({
+      type: "result",
+      total_cost_usd: 2.5,
+      num_turns: 1,
+    }),
+    "utf8",
+  );
+  let reads = 0;
+  const readFile = (...args) => {
+    if (reads++ === 1) throw permissionDenied(args[0]);
+    return readFileSync(...args);
+  };
   try {
-    const breakdown = todaysSpendBreakdown(logDir);
+    const breakdown = todaysSpendBreakdown(logDir, { readFile });
     expect(breakdown.scanned).toBe(false);
-    expect(breakdown.error).toBeTruthy();
-    expect(breakdown.usd).toBeGreaterThanOrEqual(0);
-    expect(budgetExhausted(policy(100), logDir)).toMatch(
+    expect(breakdown.error).toContain("permission denied");
+    expect(breakdown).toMatchObject({
+      estimated: 0,
+      runs: 1,
+    });
+    expect(breakdown.reported === 1.25 || breakdown.reported === 2.5).toBe(
+      true,
+    );
+    expect(breakdown.usd).toBe(breakdown.reported);
+
+    reads = 0;
+    expect(budgetExhausted(policy(100), logDir, { readFile })).toMatch(
       /unreadable log directory/,
     );
   } finally {
-    chmodSync(unreadable, 0o600);
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/lib/spend.test.mjs
+++ b/lib/spend.test.mjs
@@ -4,6 +4,7 @@ import {
   mkdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -31,6 +32,7 @@ test("missing log directory is an empty, explicitly unscanned day", () => {
       reported: 0,
       estimated: 0,
       runs: 0,
+      skipped: 0,
       scanned: false,
       reason: "no log directory",
     });
@@ -108,6 +110,69 @@ test("a file read failure is surfaced and closes the budget gate", () => {
 
     reads = 0;
     expect(budgetExhausted(policy(100), logDir, { readFile })).toMatch(
+      /unreadable log directory/,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("a log file that vanishes mid-scan is skipped, not a scan failure", () => {
+  const root = tempLogDir();
+  const logDir = path.join(root, "logs");
+  mkdirSync(logDir);
+  const result = (usd) =>
+    jsonl({ type: "result", total_cost_usd: usd, num_turns: 1 });
+  writeFileSync(path.join(logDir, "first.jsonl"), result(1.25), "utf8");
+  writeFileSync(path.join(logDir, "second.jsonl"), result(2.5), "utf8");
+  writeFileSync(path.join(logDir, "third.jsonl"), result(4), "utf8");
+  const gone = (target) => {
+    const error = new Error(
+      `ENOENT: no such file or directory, stat '${target}'`,
+    );
+    error.code = "ENOENT";
+    return error;
+  };
+  // The directory listing still names second.jsonl; it is rotated away before
+  // its stat, and third.jsonl loses its mtime.
+  const stat = (target) => {
+    if (target.endsWith("second.jsonl")) throw gone(target);
+    if (target.endsWith("third.jsonl")) return { mtimeMs: NaN };
+    return statSync(target);
+  };
+  try {
+    const breakdown = todaysSpendBreakdown(logDir, { stat });
+    expect(breakdown).toEqual({
+      usd: 1.25,
+      reported: 1.25,
+      estimated: 0,
+      runs: 1,
+      skipped: 2,
+      scanned: true,
+    });
+    expect(breakdown.error).toBeUndefined();
+    expect(budgetExhausted(policy(100), logDir, { stat })).toBeNull();
+
+    // Vanishing between stat and read is the same benign race.
+    const readFile = (target, ...rest) => {
+      if (String(target).endsWith("first.jsonl")) throw gone(target);
+      return readFileSync(target, ...rest);
+    };
+    expect(todaysSpendBreakdown(logDir, { readFile })).toEqual({
+      usd: 6.5,
+      reported: 6.5,
+      estimated: 0,
+      runs: 2,
+      skipped: 1,
+      scanned: true,
+    });
+
+    // A non-ENOENT stat failure on a file is still a closed gate.
+    const denied = (target) => {
+      if (target.endsWith("second.jsonl")) throw permissionDenied(target);
+      return statSync(target);
+    };
+    expect(budgetExhausted(policy(100), logDir, { stat: denied })).toMatch(
       /unreadable log directory/,
     );
   } finally {


### PR DESCRIPTION
Fixes watt-mind/factory#1111

Make unreadable spend-log failures deterministic and fail the daily budget gate closed.

## Validation

| Check                | Command                                                                                                           | Result  | Notes                                           |
| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------- |
| Verification Command | `bun test --timeout 20000 lib/spend.test.mjs orchestrator/ask.test.mjs event-runtime/lib/auto-approval.test.mjs` | pass    | 56 tests, 0 failures                            |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2127 pass, 10 skip; emit/format clean           |
| UX critique          | factory-ux-critic                                                                                                 | not run | no user-facing surface                          |

UX critique: skipped — backend-only spend accounting change

run:run_4937e037-10ff-4dec-a4b6-f55d19a18e21

## Post-review

Folded reviewer finding: the per-file `Bun.file(full).lastModified` in the scan loop was not injectable and threw `RangeError` (`new Date(NaN).toISOString()`) for a log file rotated/deleted mid-scan, closing the budget gate until the next tick. Files are now dated through the injectable `stat`; ENOENT (stat or read) and a non-finite mtime skip that single file and count it in a new `skipped` field, while any other stat failure (e.g. EACCES) and directory-level failures still fail closed with `error`. New test: one file vanishes mid-scan (plus one with NaN mtime) and the scan still succeeds with the other files' totals and no `error`; a non-ENOENT per-file stat failure still closes the gate. Verified: ticket Verification Command (57 pass), `bun run lint`, `bun test event-runtime/lib` (2144 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
