### PR TITLE
fix(work): surface queued-run skip reasons

### DIFF
--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -25,6 +25,7 @@ import {
   deregisterWorker,
   heartbeat,
   registerWorker,
+  satisfiesPlacement,
 } from "../lib/workers.mjs";
 import { fail, flagValue, log } from "./shared.mjs";
 
@@ -40,6 +41,7 @@ import { fail, flagValue, log } from "./shared.mjs";
  * claiming correct; Postgres is what remote nodes need, not this.
  *
  *   bun event-runtime/cli.mjs work [--label k=v ...] [--adapter-override fake] [--poll-ms 500]
+ *                                 [--skip-report-ms 60000]
  *                                 [--reload-on-change]
  */
 export default async function work(args) {
@@ -47,6 +49,14 @@ export default async function work(args) {
   const pollMs = Number(flagValue(args, "--poll-ms") ?? 500);
   if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
+  }
+  const skipReportMs = Number(
+    flagValue(args, "--skip-report-ms") ??
+      process.env.FACTORY_WORKER_SKIP_REPORT_MS ??
+      60_000,
+  );
+  if (!Number.isInteger(skipReportMs) || skipReportMs < pollMs) {
+    fail("work: --skip-report-ms must be an integer no smaller than --poll-ms");
   }
   const drainTimeoutSeconds = Number(flagValue(args, "--drain-timeout") ?? 60);
   if (
@@ -129,6 +139,106 @@ export default async function work(args) {
 
   let draining = false;
   let inFlight = null;
+  let idleSince = null;
+  let lastSkipInspectionAt = null;
+  const reportedSkips = new Map();
+
+  // Keep this exactly aligned with claimNext: a run in this window is QUEUED
+  // but intentionally not available to this worker yet. This poll-loop query
+  // is diagnostic only, so the claim transaction stays cheap under a queue of
+  // unsatisfiable placements.
+  const claimBackoff =
+    /^(?:claim_lock_contention:\d+|dispatch_gate_transient:[^:]+:\d+):backoff_(\d+)ms$/;
+
+  function inspectSkippedQueuedRuns(now) {
+    const candidates = db
+      .query(
+        `SELECT r.run_id, r.spec_json, le.reason AS queue_reason, le.at AS queued_at
+           FROM runs r
+           JOIN lifecycle_events le ON le.seq = (
+             SELECT MAX(latest.seq) FROM lifecycle_events latest WHERE latest.run_id = r.run_id
+           )
+          WHERE r.state = 'QUEUED'
+          ORDER BY r.created_at, r.run_id`,
+      )
+      .all();
+    const checkoutVersion = checkoutPolicyVersion();
+
+    return candidates.flatMap((candidate) => {
+      const spec = JSON.parse(candidate.spec_json);
+      const backoff = claimBackoff.exec(candidate.queue_reason ?? "");
+      if (backoff) {
+        const until = Date.parse(candidate.queued_at) + Number(backoff[1]);
+        if (until > now) {
+          return [
+            {
+              runId: candidate.run_id,
+              definition: spec.agent,
+              reason: `backoff_until:${new Date(until).toISOString()}`,
+            },
+          ];
+        }
+      }
+
+      if (!satisfiesPlacement(labels, spec.placement)) {
+        const [key, value] = Object.entries(spec.placement).find(
+          ([placementKey, placementValue]) =>
+            String(labels[placementKey]) !== String(placementValue),
+        );
+        return [
+          {
+            runId: candidate.run_id,
+            definition: spec.agent,
+            reason: `placement_unsatisfied:${key}=${value}`,
+          },
+        ];
+      }
+
+      // An adapter allow-list is not a reported reason in this ticket, but
+      // preserve claimNext's ordering so an unavailable adapter is not
+      // misdiagnosed as a registry mismatch below.
+      if (!adapterOverride && !adapterNames.includes(spec.adapter)) return [];
+
+      if (pv && (spec.promptVersion !== pv || spec.policyVersion !== pv)) {
+        return [
+          {
+            runId: candidate.run_id,
+            definition: spec.agent,
+            reason: `registry_stale:spec=${spec.promptVersion}/${spec.policyVersion}:worker=${pv}:checkout=${checkoutVersion}`,
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  function reportSkippedQueuedRuns(now) {
+    const skipped = inspectSkippedQueuedRuns(now);
+    lastSkipInspectionAt = now;
+    const present = new Set(
+      skipped.map(({ runId, reason }) => `${runId}\u0000${reason}`),
+    );
+    for (const key of reportedSkips.keys()) {
+      if (!present.has(key)) reportedSkips.delete(key);
+    }
+    for (const entry of skipped) {
+      const key = `${entry.runId}\u0000${entry.reason}`;
+      if (now - (reportedSkips.get(key) ?? -Infinity) < skipReportMs) continue;
+      log(`skipped ${JSON.stringify(entry)}`);
+      reportedSkips.set(key, now);
+    }
+  }
+
+  function reportSkipsWhenDue(now) {
+    idleSince ??= now;
+    if (
+      now - idleSince >= pollMs &&
+      (lastSkipInspectionAt === null ||
+        now - lastSkipInspectionAt >= skipReportMs)
+    ) {
+      reportSkippedQueuedRuns(now);
+    }
+  }
 
   // Dev live-reload (WM-213). Off unless asked for: a production worker must
   // never decide on its own that it is out of date.
@@ -220,19 +330,26 @@ export default async function work(args) {
           ...(adapterOverride ? { adapterOverride } : {}),
         });
         if (!claim) {
+          reportSkipsWhenDue(Date.now());
           await new Promise((resolve) => setTimeout(resolve, pollMs));
           continue;
         }
         if (claim.refused) {
-          log(
-            `refused ${claim.runId} (${claim.reasonCode}, retryable): worker registry ${claim.workerRegistryVersion}, checkout registry ${claim.checkoutRegistryVersion}, run prompt ${claim.spec.promptVersion}, run policy ${claim.spec.policyVersion}`,
-          );
+          if (claim.reloadRequired)
+            log(
+              `refused ${claim.runId} (${claim.reasonCode}, retryable): worker registry ${claim.workerRegistryVersion}, checkout registry ${claim.checkoutRegistryVersion}, run prompt ${claim.spec.promptVersion}, run policy ${claim.spec.policyVersion}`,
+            );
           if (claim.reloadRequired)
             return finish("registry_stale", CODE_RELOAD_EXIT);
+          reportSkipsWhenDue(Date.now());
           await new Promise((resolve) => setTimeout(resolve, pollMs));
           continue;
         }
         inFlight = claim.runId;
+        idleSince = null;
+        for (const key of reportedSkips.keys()) {
+          if (key.startsWith(`${claim.runId}\u0000`)) reportedSkips.delete(key);
+        }
         workerHeartbeat({ state: "busy", runId: claim.runId });
         log(
           `claimed ${claim.runId} attempt ${claim.attempt} (${claim.spec.agent})`,

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -39,6 +39,52 @@ registerTestProcessCleanup(import.meta.url);
 const WORKER_POLICY_VERSION = policyVersion();
 const LIVE_STACK = path.resolve(import.meta.dir, "../../bin/live-stack.sh");
 
+async function seedSkippedRun(
+  home,
+  { runId, placement, promptVersion = WORKER_POLICY_VERSION, queuedReason },
+) {
+  const { createRun, transition } = await import("../lib/lifecycle.mjs");
+  const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");
+  const db = openDb(path.join(home, "runtime.db"));
+  const input = { repos: ["ok"] };
+  const spec = {
+    schemaVersion: "factory.run-spec/v1",
+    runId,
+    agent: "factory-status-report@1",
+    input,
+    inputHash: hashJson(input),
+    workspace: { type: "ephemeral", retainOnFailure: false },
+    adapter: "fake",
+    promptVersion,
+    policyVersion: promptVersion,
+    ...(placement ? { placement } : {}),
+    outputContract: "factory.status-report/v1",
+    capabilities: ["linear:read"],
+    timeoutSeconds: 5,
+    maxAttempts: 1,
+    idempotencyKey: `idem_${runId}`,
+  };
+  createRun(db, {
+    runId,
+    idempotencyKey: spec.idempotencyKey,
+    spec,
+    specJson: canonicalJson(spec),
+    specHash: hashJson(spec),
+    actor: "test",
+    policyVersion: "test",
+    now: Date.now(),
+  });
+  transition(db, { runId, to: "APPROVED", actor: "test", now: Date.now() });
+  transition(db, {
+    runId,
+    to: "QUEUED",
+    actor: "test",
+    ...(queuedReason ? { reason: queuedReason } : {}),
+    now: Date.now(),
+  });
+  db.close();
+}
+
 /** Capture the shell supervisor's restart events, not just its worker's logs. */
 function spawnReloadSupervisor(args, env) {
   const child = spawnTracked(
@@ -83,6 +129,109 @@ describe("work command", () => {
     expect(r.status).not.toBe(0);
     expect(r.all).toContain('work: unknown --adapter-override "nonexistent"');
   });
+
+  test(
+    "reports an unsatisfied queued placement once per skip-report interval",
+    async () => {
+      const home = tmpDir("evrt-work-placement-skip-");
+      await seedSkippedRun(home, {
+        runId: "run_placement_skip",
+        placement: { node: "gpu" },
+      });
+      const box = spawnWorker(
+        [
+          "--adapter-override",
+          "fake",
+          "--label",
+          "node=cpu",
+          "--poll-ms",
+          "25",
+          "--skip-report-ms",
+          "1000",
+        ],
+        { FACTORY_EVENT_HOME: home },
+      );
+      try {
+        await waitFor(box, '"runId":"run_placement_skip"');
+        await Bun.sleep(100); // at least three more 25ms polls
+        expect(box.out.match(/"runId":"run_placement_skip"/g)).toHaveLength(1);
+        expect(box.out).toContain('"definition":"factory-status-report@1"');
+        expect(box.out).toContain("placement_unsatisfied:node=gpu");
+      } finally {
+        box.child.kill("SIGTERM");
+        await exitOf(box.child);
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    loadAdjustedTimeout(30_000),
+  );
+
+  test(
+    "folds stale registry refusals into the rate-limited skip report",
+    async () => {
+      const home = tmpDir("evrt-work-registry-skip-");
+      await seedSkippedRun(home, {
+        runId: "run_registry_skip",
+        promptVersion: "git:older-registry",
+      });
+      const box = spawnWorker(
+        [
+          "--adapter-override",
+          "fake",
+          "--poll-ms",
+          "25",
+          "--skip-report-ms",
+          "1000",
+        ],
+        { FACTORY_EVENT_HOME: home },
+      );
+      try {
+        await waitFor(box, '"runId":"run_registry_skip"');
+        await Bun.sleep(100); // at least three more 25ms polls
+        expect(box.out.match(/"runId":"run_registry_skip"/g)).toHaveLength(1);
+        expect(box.out).toMatch(
+          /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
+        );
+        expect(box.out).not.toContain("refused run_registry_skip");
+      } finally {
+        box.child.kill("SIGTERM");
+        await exitOf(box.child);
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    loadAdjustedTimeout(30_000),
+  );
+
+  test(
+    "reports a queued claim backoff with its retry time",
+    async () => {
+      const home = tmpDir("evrt-work-backoff-skip-");
+      await seedSkippedRun(home, {
+        runId: "run_backoff_skip",
+        queuedReason: "claim_lock_contention:1:backoff_10000ms",
+      });
+      const box = spawnWorker(
+        [
+          "--adapter-override",
+          "fake",
+          "--poll-ms",
+          "25",
+          "--skip-report-ms",
+          "1000",
+        ],
+        { FACTORY_EVENT_HOME: home },
+      );
+      try {
+        await waitFor(box, '"runId":"run_backoff_skip"');
+        expect(box.out).toMatch(/"reason":"backoff_until:\d{4}-\d{2}-\d{2}T/);
+      } finally {
+        box.child.kill("SIGTERM");
+        await exitOf(box.child);
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    loadAdjustedTimeout(30_000),
+  );
 
   test("executeClaimed respects adapterOverride option", async () => {
     const { openDb } = await import("../lib/db.mjs");


### PR DESCRIPTION
Fixes watt-mind/factory#1661

Review the idle-worker skip diagnostics and their per-run rate limiting; no registry storage or schema changed.

## Validation

| Check                | Command                                                                                                                     | Result  | Notes                               |
| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------- |
| Verification Command | `bun test event-runtime/cli/work.test.mjs --timeout 20000`                                                                  | pass    | 19 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`           | pass    | 2,127 pass; emit/format/lint clean  |
| UX critique          | factory-ux-critic                                                                                                           | not run | backend worker CLI diagnostics only |

UX critique: skipped — no user-facing surface

run:run_aa1f0bba-60e9-4b2a-84b2-e4747a063182