### PR TITLE
fix(control-plane): use Linear IssueSortInput

### DIFF
--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -303,13 +303,16 @@ export function linearControlPlane({
       const decl = states?.length ? ", $s:[String!]" : "";
       const vars = {
         t: team,
-        orderBy: "createdAt",
+        // Linear removed IssueOrderByInput. Its live schema now exposes a
+        // list of IssueSortInput values through `sort`; retain ascending
+        // creation order so cursor pagination remains deterministic.
+        sort: [{ createdAt: { order: "Ascending" } }],
         ...(project ? { p: project } : {}),
       };
       if (states?.length) vars.s = states;
       const query = project
-        ? `query($t:String!,$p:String!${decl},$after:String,$orderBy:IssueOrderByInput){ issues(first:250,after:$after,orderBy:$orderBy, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`
-        : `query($t:String!${decl},$after:String,$orderBy:IssueOrderByInput){ issues(first:250,after:$after,orderBy:$orderBy, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`;
+        ? `query($t:String!,$p:String!${decl},$after:String,$sort:[IssueSortInput!]){ issues(first:250,after:$after,sort:$sort, filter:{ team:{key:{eq:$t}}, project:{name:{eq:$p}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`
+        : `query($t:String!${decl},$after:String,$sort:[IssueSortInput!]){ issues(first:250,after:$after,sort:$sort, filter:{ team:{key:{eq:$t}}, ${stateClause} }){ nodes{ ${ISSUE_FIELDS} } pageInfo{ hasNextPage endCursor } } }`;
       return (
         await Promise.all(
           (await collectPages(query, vars, (d) => d?.issues, "issues")).map(

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -43,7 +43,12 @@ describe("Linear ControlPlane pagination (GH-1393)", () => {
       "cursor-1",
     ]);
     expect(calls[0].query).toContain("pageInfo{ hasNextPage endCursor }");
-    expect(calls[0].variables.orderBy).toBe("createdAt");
+    expect(calls[0].query).toContain("$sort:[IssueSortInput!]");
+    expect(calls[0].query).toContain("sort:$sort");
+    expect(calls[0].query).not.toContain("IssueOrderByInput");
+    expect(calls[0].variables.sort).toEqual([
+      { createdAt: { order: "Ascending" } },
+    ]);
   });
 
   test("passes an abort signal to gql and aborts it on the request timeout", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1554

Restore Linear-plane ticket listing by using schema-supported `IssueSortInput`; ascending creation ordering is preserved.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/linear.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass | 8 tests, emit clean |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2102 passed, 10 skipped, lint warnings only |
| Live Linear listing  | `./bin/factory ticket queue --repo legalease` | pass | returned CLNT queue rows |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped

run:run_bc54cc31-f6a9-4f0a-9d1d-872072a1c22c


## Live Linear listing

Run 2026-08-30T11:35:33Z from the PR head (62aea410, merged with origin/develop) against the real Linear API, using the operator Linear key and `FACTORY_REPOS_ROOT=/opt/factory/current` for instance config. Both entry points exit 0 and return 21 rows (no HTTP 400 / `IssueOrderByInput` error), so the `IssueSortInput` shape validates live. Read-only listing; no ticket was claimed or edited.

```
$ ./bin/factory ticket queue --repo legalease   # exit 0, 21 rows
$ bun tools/ticket.mjs queue --repo legalease  # exit 0, 21 rows (identical)
CLNT-1479  Prevent automatic disk desync in promote_base_template_to_system and promote_clause_to_system
CLNT-1483  Add GenericRelation on contract models to prevent orphaned Case and Note records
CLNT-1487  Fix Hungarian honorific 'id.' mangled into Roman numeral all-caps 'ID.' and hyphenated names in TitleCaseFixer
CLNT-1490  Fix production settings invariant check bypass in settings_prod.py
CLNT-1505  Fix repeatable formset management form placement breaking dynamic row addition in questionnaire templates
CLNT-1507  Fix payment schedule omitting cash/CSOK/Babaváró/LTP installments and truncating multi-loan amounts
CLNT-1510  Convert send_data_request_email to POST-only endpoint to prevent unsolicited mail on link prefetch
CLNT-1511  Configure EMAIL_TIMEOUT setting to prevent indefinite worker thread hangs on SMTP outage
CLNT-993  Agent API still accepts and returns vetelar on gift contracts after CLNT-872
CLNT-1408  Harden quick-create card next URL normalization and cover transaction edit link
...
```
