### PR TITLE
fix(evals): enforce per-case budget across subject and grader

### DIFF
--- a/evals/lib/case-run.mjs
+++ b/evals/lib/case-run.mjs
@@ -82,14 +82,25 @@ export async function runCase({
     return record(FAIL, `case not runnable: ${evalCase.problem}`);
 
   let spent = 0;
+  const hasCaseBudget =
+    typeof budgetUsd === "number" &&
+    Number.isFinite(budgetUsd) &&
+    budgetUsd > 0;
   const outcome = await withDeadline(timeoutMs, async (signal) => {
     const response = await runSkill({ evalCase, timeoutMs, budgetUsd, signal });
     spent += Number(response?.costUsd) || 0;
+    const remaining = budgetUsd - spent;
+    if (hasCaseBudget && remaining <= 0) {
+      return {
+        pass: false,
+        reason: "case budget exhausted by the subject run",
+      };
+    }
     const verdict = await grade({
       evalCase,
       response,
       timeoutMs,
-      budgetUsd,
+      budgetUsd: hasCaseBudget ? remaining : budgetUsd,
       signal,
     });
     spent += Number(verdict?.costUsd) || 0;

--- a/evals/lib/case-run.test.mjs
+++ b/evals/lib/case-run.test.mjs
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { runCase, runSuite } from "./case-run.mjs";
+
+function evalCase(id = "skill/example") {
+  const [candidateName, name] = id.split("/");
+  return {
+    id,
+    candidateName,
+    name,
+    candidateSource: null,
+    problem: null,
+  };
+}
+
+describe("case budgets", () => {
+  test("gives the grader only the subject's remaining budget", async () => {
+    let graderBudget;
+    const result = await runCase({
+      evalCase: evalCase(),
+      timeoutMs: 1_000,
+      budgetUsd: 5,
+      runSkill: async () => ({ costUsd: 1.75 }),
+      grade: async ({ budgetUsd }) => {
+        graderBudget = budgetUsd;
+        return { pass: true, reason: "ok", costUsd: 0.5 };
+      },
+    });
+
+    expect(graderBudget).toBe(3.25);
+    expect(result).toMatchObject({ status: "pass", costUsd: 2.25 });
+  });
+
+  test("does not grade when the subject exhausts the case budget", async () => {
+    let gradeCalls = 0;
+    const result = await runCase({
+      evalCase: evalCase(),
+      timeoutMs: 1_000,
+      budgetUsd: 2,
+      runSkill: async () => ({ costUsd: 2 }),
+      grade: async () => {
+        gradeCalls += 1;
+        return { pass: true, reason: "unexpected" };
+      },
+    });
+
+    expect(gradeCalls).toBe(0);
+    expect(result).toMatchObject({
+      status: "fail",
+      reason: "case budget exhausted by the subject run",
+      costUsd: 2,
+    });
+  });
+
+  test("preserves unbounded budget values for the grader", async () => {
+    for (const budgetUsd of [undefined, Infinity, 0, -1]) {
+      let graderBudget = Symbol("not-called");
+      await runCase({
+        evalCase: evalCase(),
+        timeoutMs: 1_000,
+        budgetUsd,
+        runSkill: async () => ({ costUsd: 2 }),
+        grade: async ({ budgetUsd: receivedBudget }) => {
+          graderBudget = receivedBudget;
+          return { pass: true, reason: "ok" };
+        },
+      });
+      expect(graderBudget).toBe(budgetUsd);
+    }
+  });
+});
+
+test("suite case spending stays within each allocated case budget", async () => {
+  const budgets = [];
+  const suite = await runSuite({
+    cases: [evalCase("skill/one"), evalCase("skill/two")],
+    limits: {
+      caseTimeoutSeconds: 1,
+      caseBudgetUsd: 2,
+      totalSeconds: 10,
+      totalBudgetUsd: 3,
+    },
+    runSkill: async () => ({ costUsd: 1 }),
+    grade: async ({ budgetUsd }) => {
+      budgets.push(budgetUsd);
+      return { pass: true, reason: "ok", costUsd: budgetUsd };
+    },
+  });
+
+  expect(budgets).toEqual([1]);
+  expect(suite.cases.map(({ costUsd }) => costUsd)).toEqual([2, 1]);
+  expect(suite.totals.costUsd).toBe(3);
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1106

Keep each eval case within its configured budget by limiting grading to the subject run's remainder and skipping grading when the subject exhausts it.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 evals`    | pass    | 42 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`  | pass    | clean; 615 existing warnings  |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_dbb5928f-1774-4676-ab31-a72253b0c0ed