### PR TITLE
fix(ask): clarify queue eligibility

### DIFF
--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -669,11 +669,11 @@ export function formatAsk(doc) {
   if (doc.queue) {
     const repoW = columnWidth(doc.queue.rows, "repo", 6, 16);
     const idW = columnWidth(doc.queue.rows, "identifier", 8, 26);
-    lines.push(`\nQUEUE — dispatchable now (${count(doc.queue)})`);
+    lines.push(`\nQUEUE — eligible (${count(doc.queue)})`);
     renderRows(
       lines,
       doc.queue,
-      "no dispatchable tickets",
+      "no eligible tickets",
       (r) =>
         `  ${pad(r.repo, repoW)}  ${pad(r.identifier, idW)}  ${pad(r.priority == null ? "p-" : `p${r.priority}`, 3)}  ${oneLine(r.title, 60)}`,
     );

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -617,7 +617,7 @@ test("a failing section carries its error and never renders as empty", async () 
 
   const text = formatAsk(doc);
   expect(text).toContain("unavailable — factory: control plane unreachable");
-  expect(text).not.toContain("no dispatchable tickets");
+  expect(text).not.toContain("no eligible tickets");
   expect(text).not.toContain("nothing claimed");
   expect(text).not.toContain("nothing held");
 });
@@ -727,7 +727,7 @@ test("--section returns only the named sections", async () => {
   for (const absent of ["inflight", "recent", "noop", "spend"])
     expect(doc[absent]).toBeUndefined();
   const text = formatAsk(doc);
-  expect(text).toContain("QUEUE");
+  expect(text).toContain("QUEUE — eligible (1)");
   expect(text).not.toContain("RECENT RUNS");
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1112

Use eligible wording for tracker queue rows so capacity and path gating are not implied.

## Validation

| Check                | Command                                                                                      | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 orchestrator/ask.test.mjs`                                           | pass    | 13 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2134 passed, 10 skipped, 0 failures        |
| UX critique          | factory-ux-critic                                                                             | not run | no user-facing flow; CLI wording only      |

UX critique: skipped

run:run_9fd07d07-e5fd-43bd-a36f-6701f537c8e2