### PR TITLE
fix(evals): fail closed on malformed policy subset

### DIFF
--- a/evals/lib/policy.mjs
+++ b/evals/lib/policy.mjs
@@ -132,7 +132,20 @@ export function parseIndentedMap(text) {
     ) {
       continue;
     }
-    if (/^\s*-/.test(line)) continue;
+    if (/^\s*-/.test(line)) {
+      // A sequence directly under a map key turns that key into a list, so
+      // callers expecting a map can tell "sequence" apart from "empty map".
+      const top = stack[stack.length - 1];
+      if (
+        top.key !== undefined &&
+        !top.blockScalar &&
+        Object.keys(top.node).length === 0 &&
+        raw.search(/\S|$/) > top.indent
+      ) {
+        top.parent[top.key] = [];
+      }
+      continue;
+    }
     const match = /^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
     if (!match) continue;
     const [, pad, key, rest] = match;
@@ -143,10 +156,12 @@ export function parseIndentedMap(text) {
     if (rest.trim() === "") {
       const node = {};
       parent[key] = node;
-      stack.push({ indent, node });
+      stack.push({ indent, node, key, parent });
     } else {
       parent[key] = unquote(rest);
-      if (/^[|>][+-]?$/.test(rest.trim())) {
+      // Block scalar header: `|`/`>` with optional chomping (`+`/`-`) and
+      // explicit indentation (`|2`, `>2-`, `|-2`) indicators, either order.
+      if (/^[|>](?:[+-]?\d?|\d?[+-]?)$/.test(rest.trim())) {
         stack.push({ indent, node: parent, blockScalar: true });
       }
     }
@@ -192,7 +207,9 @@ function readLimits(stanza, file) {
     stanza?.limits !== undefined &&
     !recognizedKeys.some((key) => limits[key] !== undefined)
   ) {
-    throw new EvalConfigError(`${file}: evals.limits must be a map`);
+    throw new EvalConfigError(
+      `${file}: evals.limits has no recognized keys (expected: ${recognizedKeys.join(", ")})`,
+    );
   }
   const pick = (key, fallback) =>
     limits[key] === undefined

--- a/evals/lib/policy.mjs
+++ b/evals/lib/policy.mjs
@@ -126,6 +126,12 @@ export function parseIndentedMap(text) {
   for (const raw of String(text ?? "").split(/\r?\n/)) {
     const line = stripComment(raw);
     if (line.trim() === "") continue;
+    if (
+      stack[stack.length - 1].blockScalar &&
+      raw.search(/\S|$/) > stack[stack.length - 1].indent
+    ) {
+      continue;
+    }
     if (/^\s*-/.test(line)) continue;
     const match = /^(\s*)([A-Za-z0-9_.-]+):\s*(.*)$/.exec(line);
     if (!match) continue;
@@ -140,6 +146,9 @@ export function parseIndentedMap(text) {
       stack.push({ indent, node });
     } else {
       parent[key] = unquote(rest);
+      if (/^[|>][+-]?$/.test(rest.trim())) {
+        stack.push({ indent, node: parent, blockScalar: true });
+      }
     }
   }
   return root;
@@ -171,6 +180,18 @@ function positiveNumber(raw, where) {
 function readLimits(stanza, file) {
   const limits = stanza?.limits ?? {};
   if (typeof limits !== "object" || Array.isArray(limits)) {
+    throw new EvalConfigError(`${file}: evals.limits must be a map`);
+  }
+  const recognizedKeys = [
+    "case_timeout_seconds",
+    "case_budget_usd",
+    "total_seconds",
+    "total_budget_usd",
+  ];
+  if (
+    stanza?.limits !== undefined &&
+    !recognizedKeys.some((key) => limits[key] !== undefined)
+  ) {
     throw new EvalConfigError(`${file}: evals.limits must be a map`);
   }
   const pick = (key, fallback) =>
@@ -237,25 +258,28 @@ export function loadEvalPolicy({
         : DEFAULT_MODEL,
   };
   const graderModel = stanza?.grader?.model;
-  if (typeof graderModel !== "string" || graderModel.trim() === "") {
+  const normalizedGraderModel =
+    typeof graderModel === "string" ? graderModel.trim() : "";
+  if (
+    normalizedGraderModel === "" ||
+    normalizedGraderModel === DEFAULT_MODEL ||
+    normalizedGraderModel === "null" ||
+    normalizedGraderModel === "~"
+  ) {
+    const reason =
+      normalizedGraderModel === ""
+        ? "is not set"
+        : `is ${JSON.stringify(normalizedGraderModel)} — the grader must name a model, so that changing it is reviewable`;
     return {
       ...base,
       subject,
       limits,
-      problem: `${policyFile}: evals.grader.model is not set`,
-    };
-  }
-  if (graderModel.trim() === DEFAULT_MODEL) {
-    return {
-      ...base,
-      subject,
-      limits,
-      problem: `${policyFile}: evals.grader.model is "${DEFAULT_MODEL}" — the grader must name a model, so that changing it is reviewable`,
+      problem: `${policyFile}: evals.grader.model ${reason}`,
     };
   }
   return {
     file: policyFile,
-    grader: { model: graderModel.trim() },
+    grader: { model: normalizedGraderModel },
     subject,
     limits,
     problem: null,

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -20,7 +20,7 @@ import {
   parseCliJson,
   parseVerdict,
 } from "./lib/grader.mjs";
-import { loadEvalPolicy } from "./lib/policy.mjs";
+import { loadEvalPolicy, requirePin } from "./lib/policy.mjs";
 import { compareRuns } from "./lib/results.mjs";
 
 const EVALS_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -652,6 +652,49 @@ describe("the grader pin", () => {
     expect(policy.grader).toBeNull();
     expect(policy.problem).toContain("must name a model");
   });
+
+  test("block-scalar bodies are skipped instead of becoming policy keys", () => {
+    const policy = loadEvalPolicy({
+      root: "/nowhere",
+      file: "/nowhere/config/policy.yaml",
+      text: `evals:
+  note: |
+    grader:
+      model: evil-judge
+`,
+    });
+    expect(policy.grader).toBeNull();
+    expect(policy.problem).toContain("evals.grader.model is not set");
+  });
+
+  test("a limits sequence is rejected instead of falling back to defaults", () => {
+    expect(() =>
+      loadEvalPolicy({
+        root: "/nowhere",
+        file: "/nowhere/config/policy.yaml",
+        text: `evals:
+  grader:
+    model: claude-sonnet-4-6
+  limits:
+    - case_timeout_seconds: 10
+`,
+      }),
+    ).toThrow("/nowhere/config/policy.yaml: evals.limits must be a map");
+  });
+
+  test.each(["null", "~"])(
+    "YAML %s is not accepted as a grader model",
+    (model) => {
+      const policy = loadEvalPolicy({
+        root: "/nowhere",
+        file: "/nowhere/config/policy.yaml",
+        text: `evals:\n  grader:\n    model: ${model}\n`,
+      });
+      expect(policy.grader).toBeNull();
+      expect(policy.problem).toContain("must name a model");
+      expect(() => requirePin(policy)).toThrow(/Add this stanza/);
+    },
+  );
 
   test("an absent stanza is reported, never guessed at", () => {
     const policy = loadEvalPolicy({

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -667,6 +667,41 @@ describe("the grader pin", () => {
     expect(policy.problem).toContain("evals.grader.model is not set");
   });
 
+  test("block scalars with explicit indentation indicators are skipped too", () => {
+    const policy = loadEvalPolicy({
+      root: "/nowhere",
+      file: "/nowhere/config/policy.yaml",
+      text: `evals:
+  note: |2
+    grader:
+      model: evil-judge
+  other: >2-
+    limits:
+      case_timeout_seconds: 1
+`,
+    });
+    expect(policy.grader).toBeNull();
+    expect(policy.problem).toContain("evals.grader.model is not set");
+    expect(policy.limits.caseTimeoutSeconds).not.toBe(1);
+  });
+
+  test("a limits map with no recognized keys is named as such", () => {
+    expect(() =>
+      loadEvalPolicy({
+        root: "/nowhere",
+        file: "/nowhere/config/policy.yaml",
+        text: `evals:
+  grader:
+    model: claude-sonnet-4-6
+  limits:
+    case_timeout_secs: 10
+`,
+      }),
+    ).toThrow(
+      "/nowhere/config/policy.yaml: evals.limits has no recognized keys (expected: case_timeout_seconds, case_budget_usd, total_seconds, total_budget_usd)",
+    );
+  });
+
   test("a limits sequence is rejected instead of falling back to defaults", () => {
     expect(() =>
       loadEvalPolicy({


### PR DESCRIPTION
Fixes watt-mind/factory#1108

Harden eval policy parsing so malformed limits and grader pins fail closed.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 evals/run.test.mjs`    | pass    | 40 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 0 errors, 615 warnings                  |
| UX critique          | factory-ux-critic                | not run | backend parser and tests only; no user-facing surface |

UX critique: skipped — backend parser and test-only change; no user-facing surface


## Post-review

Reviewer verdict: MERGE with two folds, applied as "honour block-scalar indent indicators" (now 9b0a29aa after the merge-fix loop rebased the branch onto develop):

1. `evals/lib/policy.mjs` — block-scalar header regex now accepts explicit indentation indicators (`|2`, `>2-`, `|-2`) so those bodies are skipped too; test added with `|2` / `>2-`.
2. `evals/lib/policy.mjs` — a `limits:` map with only unrecognized (or no) keys now throws `evals.limits has no recognized keys (expected: …)` instead of `must be a map`; a sequence under `limits:` still reports `must be a map` (the parser now yields a list for it). Test added.

Re-verified: `bun test --timeout 20000 evals/run.test.mjs` (42 pass), `bun run lint` (0 errors), `bun test event-runtime/lib` (0 fail), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` — all pass.

