### PR TITLE
test(evals): cover grader process-group termination (#1107)

### DIFF
--- a/evals/lib/grader.test.mjs
+++ b/evals/lib/grader.test.mjs
@@ -1,6 +1,26 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, existsSync, readFileSync, rmSync } from "node:fs";
 import { EventEmitter } from "node:events";
+import { spawn } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
 import { callClaude } from "./grader.mjs";
+import {
+  registerTestProcessCleanup,
+  trackProcess,
+  trackProcessGroupForPid,
+} from "../../event-runtime/lib/test-helpers-process.mjs";
+
+registerTestProcessCleanup(import.meta.url);
+
+const temporaryDirectories = new Set();
+
+afterEach(() => {
+  for (const directory of temporaryDirectories) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+  temporaryDirectories.clear();
+});
 
 function fakeChild() {
   const child = new EventEmitter();
@@ -48,6 +68,91 @@ function graderCall(child, options = {}) {
   });
 }
 
+function processExists(pid) {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return error?.code !== "ESRCH";
+  }
+}
+
+async function waitForGrandchildPid(pidFile) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (existsSync(pidFile)) {
+      const pid = Number(readFileSync(pidFile, "utf8").trim());
+      expect(pid).toBeGreaterThan(0);
+      return pid;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error("fixture did not report its grandchild PID");
+}
+
+async function waitForProcessExit(pid) {
+  for (let attempt = 0; attempt < 500; attempt += 1) {
+    if (!processExists(pid)) return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  expect(processExists(pid)).toBe(false);
+}
+
+function realFixtureCall({ detached }) {
+  const directory = mkdtempSync(path.join(os.tmpdir(), "grader-process-"));
+  temporaryDirectories.add(directory);
+  const pidFile = path.join(directory, "grandchild.pid");
+  const fixture = `
+    const grandchild = Bun.spawn([process.execPath, "-e", "setInterval(() => {}, 10000)"], {
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    await Bun.write(${JSON.stringify(pidFile)}, String(grandchild.pid));
+    setInterval(() => {}, 10000);
+  `;
+
+  let child;
+  const spawnFn = (_command, _args, options) => {
+    child = spawn(process.execPath, ["-e", fixture], {
+      ...options,
+      detached,
+    });
+    if (detached) {
+      trackProcessGroupForPid(child.pid, { owner: import.meta.url });
+    } else {
+      // The control deliberately shares the test runner's process group, so
+      // track the child itself rather than ever registering that whole group.
+      trackProcess(child.pid, {
+        group: false,
+        owner: import.meta.url,
+      });
+    }
+    return child;
+  };
+
+  const killFn = detached
+    ? process.kill
+    : (_pid, _signal) => {
+        // Make killProcessGroup's direct-child fallback observable in the
+        // non-detached control without signalling the test runner's group.
+        throw new Error("force direct-child fallback");
+      };
+
+  return {
+    child,
+    pidFile,
+    pending: callClaude({
+      prompt: "grade this",
+      model: "test-model",
+      cwd: process.cwd(),
+      timeoutMs: 1000,
+      budgetUsd: 1,
+      killGraceMs: 100,
+      killFn,
+      spawnFn,
+    }),
+  };
+}
+
 describe("grader process termination", () => {
   test("sends TERM then KILL after the configured grace period", async () => {
     const child = fakeChild();
@@ -74,4 +179,33 @@ describe("grader process termination", () => {
     child.emit("close", 1);
     await pending;
   });
+
+  test(
+    "timeout kills a real detached process group without orphaning a grandchild",
+    async () => {
+      const run = realFixtureCall({ detached: true });
+      const grandchildPid = await waitForGrandchildPid(run.pidFile);
+      expect(processExists(grandchildPid)).toBe(true);
+
+      const outcome = await run.pending;
+      expect(outcome.timedOut).toBe(true);
+      await waitForProcessExit(grandchildPid);
+    },
+    { timeout: 10_000 },
+  );
+
+  test(
+    "non-detached control leaves the real grandchild alive",
+    async () => {
+      const run = realFixtureCall({ detached: false });
+      const grandchildPid = await waitForGrandchildPid(run.pidFile);
+      trackProcess(grandchildPid, { group: false, owner: import.meta.url });
+      expect(processExists(grandchildPid)).toBe(true);
+
+      const outcome = await run.pending;
+      expect(outcome.timedOut).toBe(true);
+      expect(processExists(grandchildPid)).toBe(true);
+    },
+    { timeout: 10_000 },
+  );
 });

--- a/evals/lib/grader.test.mjs
+++ b/evals/lib/grader.test.mjs
@@ -10,6 +10,7 @@ import {
   trackProcess,
   trackProcessGroupForPid,
 } from "../../event-runtime/lib/test-helpers-process.mjs";
+import { loadAdjustedTimeout } from "../../event-runtime/lib/test-helpers-timing.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -110,9 +111,8 @@ function realFixtureCall({ detached }) {
     setInterval(() => {}, 10000);
   `;
 
-  let child;
   const spawnFn = (_command, _args, options) => {
-    child = spawn(process.execPath, ["-e", fixture], {
+    const child = spawn(process.execPath, ["-e", fixture], {
       ...options,
       detached,
     });
@@ -138,13 +138,13 @@ function realFixtureCall({ detached }) {
       };
 
   return {
-    child,
     pidFile,
     pending: callClaude({
       prompt: "grade this",
       model: "test-model",
       cwd: process.cwd(),
-      timeoutMs: 1000,
+      // Two Bun cold starts race this deadline on a loaded runner.
+      timeoutMs: loadAdjustedTimeout(5000),
       budgetUsd: 1,
       killGraceMs: 100,
       killFn,
@@ -191,7 +191,7 @@ describe("grader process termination", () => {
       expect(outcome.timedOut).toBe(true);
       await waitForProcessExit(grandchildPid);
     },
-    { timeout: 10_000 },
+    { timeout: loadAdjustedTimeout(20_000) },
   );
 
   test(
@@ -206,6 +206,6 @@ describe("grader process termination", () => {
       expect(outcome.timedOut).toBe(true);
       expect(processExists(grandchildPid)).toBe(true);
     },
-    { timeout: 10_000 },
+    { timeout: loadAdjustedTimeout(20_000) },
   );
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1107

Review the real-process fixture and its cleanup tracking; the evals suite passed 10 consecutive runs.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 evals`    | pass    | 40 tests, 0 failures; 10 consecutive runs |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`  | pass    | unit, emit, format, and lint gates clean |
| UX critique          | factory-ux-critic                | not run | test-only change; no user-facing surface |

UX critique: skipped — test-only change with no user-facing surface


## Post-review

Reviewer verdict FIX, addressed in 9948c63e:
- The two real-process tests raced two Bun cold starts against a 1 s grader deadline on the loaded runner. The grader `timeoutMs` is now `loadAdjustedTimeout(5000)` and the per-test budget `loadAdjustedTimeout(20_000)` (from `event-runtime/lib/test-helpers-timing.mjs`); assertions unchanged (`timedOut: true`, grandchild dead in the detached case, non-detached fallback keeps it alive).
- Dropped the always-undefined `child` field returned by `realFixtureCall`.
- Merged `origin/develop`.

Verification: `bun test evals/lib/grader.test.mjs` 15/15 consecutive runs green (4 pass / 0 fail each); ticket command `bun test --timeout 20000 evals` 40 pass / 0 fail; `bun test event-runtime/lib --timeout 20000` 2134 pass / 0 fail; lint 0 errors; format:check clean; `bun run check` passes. `bun build/emit.mjs --check` reports the live checkout's AGENTS.md as stale (instance repos.yaml points at the operator's checkout), unrelated to this branch.
