### PR TITLE
feat(label-guard): detect stale factory:ready-pin

### DIFF
--- a/lib/queue-summary.mjs
+++ b/lib/queue-summary.mjs
@@ -17,6 +17,7 @@ import {
 } from "../orchestrator/reply-detection.mjs";
 import { liveWorkerLeases } from "./worker-leases.mjs";
 import { openBlockers } from "../orchestrator/blockers.mjs";
+import { parseReadyPin, readyPinMarker } from "../event-runtime/lib/triage.mjs";
 
 /**
  * What the neutral contract still cannot answer (WM-1008).
@@ -55,6 +56,76 @@ export const STAGE_GATES = {
   dispatch: (s) => s.slotsFree > 0 && s.startable.length > 0,
   merge: (s) => s.openPRs > 0,
 };
+
+/**
+ * Whether the latest ready-pin comment still describes the ticket body.
+ *
+ * This deliberately uses the same marker factory as planner admission: a
+ * lookalike SHA-256 calculation here would make the queue disagree with the
+ * refusal it is meant to surface. No pin is not stale because pre-rollout
+ * ready tickets remain admissible; an unreadable comment feed is unknown and
+ * must not be advertised as ready.
+ */
+export function readyPinStatus(description = "", comments = []) {
+  let latest = null;
+  for (const [index, comment] of comments.entries()) {
+    const hash = parseReadyPin(comment?.body);
+    if (!hash) continue;
+    const createdAt = Date.parse(comment?.createdAt ?? "");
+    if (
+      !latest ||
+      (Number.isFinite(createdAt) &&
+        (!Number.isFinite(latest.createdAt) ||
+          createdAt >= latest.createdAt)) ||
+      (!Number.isFinite(createdAt) &&
+        !Number.isFinite(latest.createdAt) &&
+        index > latest.index)
+    ) {
+      latest = { hash, createdAt, index };
+    }
+  }
+  if (!latest) return "missing";
+  return parseReadyPin(readyPinMarker(description)) === latest.hash
+    ? "fresh"
+    : "stale";
+}
+
+async function readyPinStatuses(tickets, listComments) {
+  const statuses = await Promise.all(
+    tickets.map(async (ticket) => {
+      try {
+        return [
+          ticket.identifier,
+          readyPinStatus(
+            ticket.description,
+            await listComments(ticket.identifier),
+          ),
+        ];
+      } catch {
+        return [ticket.identifier, "unreadable"];
+      }
+    }),
+  );
+  return new Map(statuses);
+}
+
+/** Split nominally-ready tickets into planner-admissible and qualified groups. */
+export function qualifyReadyTickets(tickets, pinStatuses) {
+  const stale = tickets.filter(
+    (ticket) => pinStatuses.get(ticket.identifier) === "stale",
+  );
+  const unreadable = tickets.filter(
+    (ticket) => pinStatuses.get(ticket.identifier) === "unreadable",
+  );
+  return {
+    stale,
+    unreadable,
+    admissible: tickets.filter(
+      (ticket) =>
+        !["stale", "unreadable"].includes(pinStatuses.get(ticket.identifier)),
+    ),
+  };
+}
 
 export function loadQueueConfig(repoFilter = []) {
   const cfg = loadConfigYaml("repos");
@@ -159,12 +230,23 @@ export async function fetchQueueSummaries(repos, defaultCap) {
     const readyAll = nodes.filter(
       (i) => state(i) === "Todo" && labels(i).includes("ai:agent-ready"),
     );
+    // A stale pin is a real planner refusal, not dispatchable supply. Read
+    // comments only for ready candidates so the queue's cost remains bounded
+    // by the small set it might otherwise advertise for work.
+    const pinStatuses = await readyPinStatuses(readyAll, (identifier) =>
+      cp.listComments(identifier),
+    );
+    const {
+      stale: readyStale,
+      unreadable: readyUnreadable,
+      admissible: readyPinned,
+    } = qualifyReadyTickets(readyAll, pinStatuses);
     // "Ready" and "ready but waiting on another ticket" are different facts, and
     // folding them into one count hides the second entirely: a held ticket sits
     // in Todo consuming no slot and raising no error, so a wrong or forgotten
     // `blocked by` relation would starve it invisibly. Split the line instead.
-    const readyHeld = readyAll.filter((i) => openBlockers(i).length);
-    const ready = readyAll.filter((i) => !openBlockers(i).length);
+    const readyHeld = readyPinned.filter((i) => openBlockers(i).length);
+    const ready = readyPinned.filter((i) => !openBlockers(i).length);
     const notReady = nodes.filter(
       (i) => state(i) === "Todo" && !labels(i).includes("ai:agent-ready"),
     );
@@ -225,6 +307,13 @@ export async function fetchQueueSummaries(repos, defaultCap) {
       todoNotReady: notReady.length,
       answered: answered.length,
       ready: ready.length,
+      readyStale: readyStale.length,
+      readyStaleTickets: readyStale.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+      })),
+      readyUnreadable: readyUnreadable.length,
       // Held ≠ ready: dispatch will not touch these until the named blockers
       // finish. Surfaced separately so starvation from a stale relation is a
       // visible line in watch, not an empty queue.

--- a/lib/queue-summary.mjs
+++ b/lib/queue-summary.mjs
@@ -62,9 +62,13 @@ export const STAGE_GATES = {
  *
  * This deliberately uses the same marker factory as planner admission: a
  * lookalike SHA-256 calculation here would make the queue disagree with the
- * refusal it is meant to surface. No pin is not stale because pre-rollout
- * ready tickets remain admissible; an unreadable comment feed is unknown and
- * must not be advertised as ready.
+ * refusal it is meant to surface. Returns one of "fresh", "stale", or
+ * "missing". Missing is kept distinct from stale: a stale pin means the body
+ * changed after a human approved it, while a missing pin means nothing was
+ * ever stamped. Whether missing is admissible depends on the control plane
+ * (see `qualifyReadyTickets`); this function only classifies. An unreadable
+ * comment feed is the caller's fourth state ("unreadable") and must not be
+ * advertised as ready.
  */
 export function readyPinStatus(description = "", comments = []) {
   let latest = null;
@@ -90,40 +94,75 @@ export function readyPinStatus(description = "", comments = []) {
     : "stale";
 }
 
-async function readyPinStatuses(tickets, listComments) {
-  const statuses = await Promise.all(
-    tickets.map(async (ticket) => {
-      try {
-        return [
-          ticket.identifier,
-          readyPinStatus(
-            ticket.description,
-            await listComments(ticket.identifier),
-          ),
-        ];
-      } catch {
-        return [ticket.identifier, "unreadable"];
-      }
-    }),
-  );
-  return new Map(statuses);
+/** Comment feeds read per ready ticket at once; bounds tracker fan-out. */
+export const READY_PIN_CONCURRENCY = 5;
+
+/**
+ * Classify every ready ticket's pin, reading comment feeds in bounded
+ * batches so a large ready queue does not open one tracker request per
+ * ticket simultaneously. Exported for tests; `listComments` is injected.
+ */
+export async function readyPinStatuses(
+  tickets,
+  listComments,
+  concurrency = READY_PIN_CONCURRENCY,
+) {
+  const statuses = new Map();
+  const width = Math.max(1, concurrency | 0);
+  for (let start = 0; start < tickets.length; start += width) {
+    const batch = tickets.slice(start, start + width);
+    const results = await Promise.all(
+      batch.map(async (ticket) => {
+        try {
+          return [
+            ticket.identifier,
+            readyPinStatus(
+              ticket.description,
+              await listComments(ticket.identifier),
+            ),
+          ];
+        } catch {
+          return [ticket.identifier, "unreadable"];
+        }
+      }),
+    );
+    for (const [identifier, status] of results)
+      statuses.set(identifier, status);
+  }
+  return statuses;
 }
 
-/** Split nominally-ready tickets into planner-admissible and qualified groups. */
-export function qualifyReadyTickets(tickets, pinStatuses) {
-  const stale = tickets.filter(
-    (ticket) => pinStatuses.get(ticket.identifier) === "stale",
-  );
+/**
+ * Split nominally-ready tickets into planner-admissible and qualified groups.
+ *
+ * `missingAdmissible` mirrors the planner: under a GitHub control plane an
+ * absent pin is refused outright (`ticket_ready_pin_missing`,
+ * event-runtime/lib/planner.mjs), so it must not be counted as dispatchable
+ * supply there. Linear/memory tickets carry no pin check at admission, so a
+ * missing pin stays admissible for them. Missing is never folded into stale:
+ * the two have different remedies (re-stamp vs. review the body change).
+ */
+export function qualifyReadyTickets(
+  tickets,
+  pinStatuses,
+  { missingAdmissible = true } = {},
+) {
+  const status = (ticket) => pinStatuses.get(ticket.identifier);
+  const stale = tickets.filter((ticket) => status(ticket) === "stale");
   const unreadable = tickets.filter(
-    (ticket) => pinStatuses.get(ticket.identifier) === "unreadable",
+    (ticket) => status(ticket) === "unreadable",
+  );
+  const missing = missingAdmissible
+    ? []
+    : tickets.filter((ticket) => status(ticket) === "missing");
+  const excluded = new Set(
+    [...stale, ...unreadable, ...missing].map((t) => t.identifier),
   );
   return {
     stale,
     unreadable,
-    admissible: tickets.filter(
-      (ticket) =>
-        !["stale", "unreadable"].includes(pinStatuses.get(ticket.identifier)),
-    ),
+    missing,
+    admissible: tickets.filter((ticket) => !excluded.has(ticket.identifier)),
   };
 }
 
@@ -239,8 +278,13 @@ export async function fetchQueueSummaries(repos, defaultCap) {
     const {
       stale: readyStale,
       unreadable: readyUnreadable,
+      missing: readyMissingPin,
       admissible: readyPinned,
-    } = qualifyReadyTickets(readyAll, pinStatuses);
+    } = qualifyReadyTickets(readyAll, pinStatuses, {
+      // The planner refuses a pin-less GitHub ticket outright; only the
+      // Linear/memory planes admit one.
+      missingAdmissible: cp.kind !== "github",
+    });
     // "Ready" and "ready but waiting on another ticket" are different facts, and
     // folding them into one count hides the second entirely: a held ticket sits
     // in Todo consuming no slot and raising no error, so a wrong or forgotten
@@ -314,6 +358,15 @@ export async function fetchQueueSummaries(repos, defaultCap) {
         url: t.url,
       })),
       readyUnreadable: readyUnreadable.length,
+      // GitHub-plane tickets with no pin at all: refused as
+      // ticket_ready_pin_missing, fixed by re-promoting (remove/add the
+      // label) rather than by reviewing a body change.
+      readyMissingPin: readyMissingPin.length,
+      readyMissingPinTickets: readyMissingPin.map((t) => ({
+        identifier: t.identifier,
+        title: t.title,
+        url: t.url,
+      })),
       // Held ≠ ready: dispatch will not touch these until the named blockers
       // finish. Surfaced separately so starvation from a stale relation is a
       // visible line in watch, not an empty queue.

--- a/lib/queue-summary.test.mjs
+++ b/lib/queue-summary.test.mjs
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { readyPinMarker } from "../event-runtime/lib/triage.mjs";
+import { qualifyReadyTickets, readyPinStatus } from "./queue-summary.mjs";
+
+test("ready-pin status agrees with the planner marker for fresh and edited bodies", () => {
+  const approved = "approved ticket body";
+  const comments = [
+    { body: readyPinMarker(approved), createdAt: "2026-08-30T10:00:00Z" },
+  ];
+
+  expect(readyPinStatus(approved, comments)).toBe("fresh");
+  expect(readyPinStatus("edited after promotion", comments)).toBe("stale");
+  expect(readyPinStatus(approved, [])).toBe("missing");
+});
+
+test("the latest ready pin wins when an older pin is stale", () => {
+  const approved = "current approved body";
+  expect(
+    readyPinStatus(approved, [
+      { body: readyPinMarker("old body"), createdAt: "2026-08-30T09:00:00Z" },
+      { body: readyPinMarker(approved), createdAt: "2026-08-30T10:00:00Z" },
+    ]),
+  ).toBe("fresh");
+});
+
+test("stale ready tickets are qualified out of dispatchable supply", () => {
+  const tickets = [{ identifier: "WM-1" }, { identifier: "WM-2" }];
+  const groups = qualifyReadyTickets(
+    tickets,
+    new Map([
+      ["WM-1", "stale"],
+      ["WM-2", "fresh"],
+    ]),
+  );
+
+  expect(groups.admissible.map((ticket) => ticket.identifier)).toEqual([
+    "WM-2",
+  ]);
+  expect(groups.stale.map((ticket) => ticket.identifier)).toEqual(["WM-1"]);
+});

--- a/lib/queue-summary.test.mjs
+++ b/lib/queue-summary.test.mjs
@@ -1,6 +1,10 @@
 import { expect, test } from "bun:test";
 import { readyPinMarker } from "../event-runtime/lib/triage.mjs";
-import { qualifyReadyTickets, readyPinStatus } from "./queue-summary.mjs";
+import {
+  qualifyReadyTickets,
+  readyPinStatus,
+  readyPinStatuses,
+} from "./queue-summary.mjs";
 
 test("ready-pin status agrees with the planner marker for fresh and edited bodies", () => {
   const approved = "approved ticket body";
@@ -37,4 +41,72 @@ test("stale ready tickets are qualified out of dispatchable supply", () => {
     "WM-2",
   ]);
   expect(groups.stale.map((ticket) => ticket.identifier)).toEqual(["WM-1"]);
+});
+
+test("a missing pin is admissible on Linear but refused on GitHub, and never counted as stale", () => {
+  const tickets = [
+    { identifier: "#1" },
+    { identifier: "#2" },
+    { identifier: "#3" },
+  ];
+  const statuses = new Map([
+    ["#1", "missing"],
+    ["#2", "fresh"],
+    ["#3", "stale"],
+  ]);
+
+  const linear = qualifyReadyTickets(tickets, statuses);
+  expect(linear.admissible.map((t) => t.identifier)).toEqual(["#1", "#2"]);
+  expect(linear.missing).toEqual([]);
+  expect(linear.stale.map((t) => t.identifier)).toEqual(["#3"]);
+
+  // Mirrors planner.mjs ticket_ready_pin_missing: not dispatchable supply,
+  // but reported apart from stale because the remedy differs.
+  const github = qualifyReadyTickets(tickets, statuses, {
+    missingAdmissible: false,
+  });
+  expect(github.admissible.map((t) => t.identifier)).toEqual(["#2"]);
+  expect(github.missing.map((t) => t.identifier)).toEqual(["#1"]);
+  expect(github.stale.map((t) => t.identifier)).toEqual(["#3"]);
+});
+
+test("an unreadable comment feed is qualified out, not advertised as ready", async () => {
+  const statuses = await readyPinStatuses(
+    [
+      { identifier: "#1", description: "ok" },
+      { identifier: "#2", description: "ok" },
+    ],
+    async (id) => {
+      if (id === "#2") throw new Error("tracker down");
+      return [
+        { body: readyPinMarker("ok"), createdAt: "2026-08-30T10:00:00Z" },
+      ];
+    },
+  );
+  expect(statuses.get("#1")).toBe("fresh");
+  expect(statuses.get("#2")).toBe("unreadable");
+});
+
+test("comment feeds are read in bounded batches", async () => {
+  const tickets = Array.from({ length: 12 }, (_, i) => ({
+    identifier: `#${i}`,
+    description: "body",
+  }));
+  let inFlight = 0;
+  let peak = 0;
+  const statuses = await readyPinStatuses(
+    tickets,
+    async () => {
+      inFlight += 1;
+      peak = Math.max(peak, inFlight);
+      await new Promise((resolve) => setTimeout(resolve, 2));
+      inFlight -= 1;
+      return [];
+    },
+    5,
+  );
+  expect(statuses.size).toBe(12);
+  expect(peak).toBeLessThanOrEqual(5);
+  expect(peak).toBeGreaterThan(1);
+  for (const status of statuses.values()) expect(status).toBe("missing");
 });

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -25,6 +25,7 @@
  */
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
+import { readyPinStatus } from "../lib/queue-summary.mjs";
 import {
   parseOwnedPaths,
   ticketSections,
@@ -160,6 +161,18 @@ export async function fetchReadyIssues(
   });
 }
 
+/** Read and classify a ready pin without turning a tracker outage into stale. */
+export async function readyPinGuard(issue, listComments) {
+  try {
+    return readyPinStatus(
+      issue.description ?? "",
+      await listComments(issue.identifier),
+    );
+  } catch {
+    return "unreadable";
+  }
+}
+
 export async function demote(
   issue,
   repo,
@@ -227,34 +240,49 @@ export async function main(argv = process.argv.slice(2)) {
 
   for (const repo of repos) {
     const issues = await fetchReadyIssues(repo);
+    const controlPlane = loadControlPlane({ repoName: repo.name });
     const closureRequirements = new Map();
-    const bad = issues
-      .map((issue) => {
-        const gapNames = [...templateGaps(issue.description ?? "")];
-        const closure = ownedPathsClosureGuard(
-          issue.description ?? "",
-          repo,
-          closureRequirements,
-        );
-        gapNames.push(...closure.messages);
-        return { issue, gaps: gapNames };
-      })
-      .filter((r) => r.gaps.length);
+    const bad = (
+      await Promise.all(
+        issues.map(async (issue) => {
+          const gapNames = [...templateGaps(issue.description ?? "")];
+          const closure = ownedPathsClosureGuard(
+            issue.description ?? "",
+            repo,
+            closureRequirements,
+          );
+          gapNames.push(...closure.messages);
+          return {
+            issue,
+            gaps: gapNames,
+            pinStatus: await readyPinGuard(
+              issue,
+              controlPlane.listComments.bind(controlPlane),
+            ),
+          };
+        }),
+      )
+    ).filter(({ gaps, pinStatus }) => gaps.length || pinStatus === "stale");
 
     console.log(
-      `${repo.name}  ${repo.team} / ${repo.project}  --  ${issues.length} ai:agent-ready ticket(s), ${bad.length} failing §5`,
+      `${repo.name}  ${repo.team} / ${repo.project}  --  ${issues.length} ai:agent-ready ticket(s), ${bad.length} guard finding(s)`,
     );
 
     if (!bad.length) continue;
     violations += bad.length;
 
-    for (const { issue, gaps } of bad) {
+    for (const { issue, gaps, pinStatus } of bad) {
       console.log(
         `  ${issue.identifier.padEnd(10)} ${issue.title.slice(0, 60)}`,
       );
       for (const g of gaps) console.log(`      missing: ${g}`);
+      if (pinStatus === "stale")
+        console.log("      stale: Ready Pin (body changed after promotion)");
 
-      if (args.apply) {
+      // `--apply` retains its existing structural-template demotion behavior,
+      // but a stale pin is reported only. Re-stamping it automatically would
+      // erase the approval-boundary signal the pin was introduced to keep.
+      if (args.apply && gaps.length) {
         try {
           await demote(issue, repo, gaps, true);
           console.log(`      -> demoted to Triage, ai:agent-ready removed`);
@@ -265,11 +293,11 @@ export async function main(argv = process.argv.slice(2)) {
     }
   }
 
-  console.log(
-    `\n=== ${args.apply ? "Demoted" : "Would demote"}: ${violations} ===`,
-  );
+  console.log(`\n=== Guard findings: ${violations} ===`);
   if (!args.apply && violations)
-    console.log("Run again with --apply to demote these.");
+    console.log(
+      "Run with --apply to demote structural gaps; re-promote stale pins after review.",
+    );
 }
 
 if (import.meta.main || process.argv[1]?.endsWith("label-guard.mjs")) {

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -210,9 +210,15 @@ export function parseArgs(argv = process.argv.slice(2)) {
   return { apply, repos };
 }
 
-export async function main(argv = process.argv.slice(2)) {
+export async function main(
+  argv = process.argv.slice(2),
+  {
+    resolveControlPlane = loadControlPlane,
+    resolveRepos = () => [...loadRepos().values()],
+  } = {},
+) {
   const args = parseArgs(argv);
-  const allRepos = [...loadRepos().values()].filter(
+  const allRepos = resolveRepos().filter(
     (r) => !args.repos.length || args.repos.includes(r.name),
   );
   const repos = allRepos.map((r) => ({
@@ -239,8 +245,8 @@ export async function main(argv = process.argv.slice(2)) {
   let violations = 0;
 
   for (const repo of repos) {
-    const issues = await fetchReadyIssues(repo);
-    const controlPlane = loadControlPlane({ repoName: repo.name });
+    const issues = await fetchReadyIssues(repo, resolveControlPlane);
+    const controlPlane = resolveControlPlane({ repoName: repo.name });
     const closureRequirements = new Map();
     const bad = (
       await Promise.all(
@@ -262,7 +268,10 @@ export async function main(argv = process.argv.slice(2)) {
           };
         }),
       )
-    ).filter(({ gaps, pinStatus }) => gaps.length || pinStatus === "stale");
+    ).filter(
+      ({ gaps, pinStatus }) =>
+        gaps.length || pinStatus === "stale" || pinStatus === "unreadable",
+    );
 
     console.log(
       `${repo.name}  ${repo.team} / ${repo.project}  --  ${issues.length} ai:agent-ready ticket(s), ${bad.length} guard finding(s)`,
@@ -278,13 +287,19 @@ export async function main(argv = process.argv.slice(2)) {
       for (const g of gaps) console.log(`      missing: ${g}`);
       if (pinStatus === "stale")
         console.log("      stale: Ready Pin (body changed after promotion)");
+      // A comment feed that could not be read is neither fresh nor stale;
+      // say so rather than silently passing the ticket as clean.
+      if (pinStatus === "unreadable")
+        console.log(
+          "      unreadable: Ready Pin (comment feed could not be read; re-run)",
+        );
 
       // `--apply` retains its existing structural-template demotion behavior,
       // but a stale pin is reported only. Re-stamping it automatically would
       // erase the approval-boundary signal the pin was introduced to keep.
       if (args.apply && gaps.length) {
         try {
-          await demote(issue, repo, gaps, true);
+          await demote(issue, repo, gaps, true, resolveControlPlane);
           console.log(`      -> demoted to Triage, ai:agent-ready removed`);
         } catch (err) {
           console.log(`      ! failed: ${err.message || err}`);

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -16,6 +16,7 @@ import {
   fetchReadyIssues,
   ownedPathsClosureGuard,
   readyPinGuard,
+  main,
   templateGaps,
 } from "./label-guard.mjs";
 import { readyPinMarker } from "../event-runtime/lib/triage.mjs";
@@ -84,6 +85,37 @@ None
     npm test
 `;
   expect(templateGaps(desc)).toEqual([]);
+});
+
+test("main reports an unreadable ready pin instead of passing the ticket as clean", async () => {
+  const cp = {
+    listDispatchable: async () => [
+      { identifier: "#1", title: "unreadable feed", description: FULL_SPEC },
+      { identifier: "#2", title: "clean", description: FULL_SPEC },
+    ],
+    listComments: async (id) => {
+      if (id === "#1") throw new Error("comments 502");
+      return [
+        { body: readyPinMarker(FULL_SPEC), createdAt: "2026-08-30T10:00:00Z" },
+      ];
+    },
+  };
+  const lines = [];
+  const log = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    await main(["--repo", "factory"], {
+      resolveControlPlane: () => cp,
+      resolveRepos: () => [{ name: "factory", team: "WM", project: "Factory" }],
+    });
+  } finally {
+    console.log = log;
+  }
+  const out = lines.join("\n");
+  expect(out).toContain("#1");
+  expect(out).toContain("unreadable: Ready Pin");
+  expect(out).not.toMatch(/#2 .*clean/);
+  expect(out).toContain("Guard findings: 1");
 });
 
 test("listing and demotion select the control plane configured for the repo", async () => {

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -15,8 +15,10 @@ import {
   demote,
   fetchReadyIssues,
   ownedPathsClosureGuard,
+  readyPinGuard,
   templateGaps,
 } from "./label-guard.mjs";
+import { readyPinMarker } from "../event-runtime/lib/triage.mjs";
 
 const FULL_SPEC = `## Problem & Context
 
@@ -36,6 +38,23 @@ Something is broken and it matters.
 
 test("a real §5 spec passes with no gaps", () => {
   expect(templateGaps(FULL_SPEC)).toEqual([]);
+});
+
+test("a stale ready pin is reported without treating an absent pin as stale", async () => {
+  const promoted = "original approved body";
+  const changed = "body edited after approval";
+  const stale = await readyPinGuard(
+    { identifier: "WM-1574", description: changed },
+    async () => [
+      { body: readyPinMarker(promoted), createdAt: "2026-08-30T10:00:00Z" },
+    ],
+  );
+  const missing = await readyPinGuard(
+    { identifier: "WM-1574", description: changed },
+    async () => [],
+  );
+  expect(stale).toBe("stale");
+  expect(missing).toBe("missing");
 });
 
 test("a Verification Command heading with only blank lines under it is a gap", () => {

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -78,6 +78,9 @@ for (const repo of repos) {
   if (s.answered) line("Held, reply received", s.answered, c.green);
   line("Todo, not ready", s.todoNotReady);
   line("READY to dispatch", s.ready, s.ready ? c.green : c.red);
+  if (s.readyStale) line("READY, stale pin", s.readyStale, c.yellow);
+  if (s.readyUnreadable)
+    line("READY, pin unreadable", s.readyUnreadable, c.yellow);
   if (s.readyHeld) line("READY, held by blocker", s.readyHeld, c.yellow);
   line("In Progress", s.inProgress);
   line("In Review", s.inReview, s.inReview ? c.cyan : (x) => x);
@@ -132,6 +135,12 @@ for (const repo of repos) {
         `\n  nothing startable — all ready tickets collide with running or with each other's unparseable Owned Paths`,
       ),
     );
+  } else if (s.readyStale || s.readyUnreadable) {
+    console.log(
+      c.dim(
+        `\n  nothing startable — ${s.readyStale} ready ticket(s) have stale pins and ${s.readyUnreadable} pin feed(s) could not be read`,
+      ),
+    );
   } else if (s.readyHeld) {
     // Not "queue empty": there IS specified work, it is waiting on its
     // blockers, and if those never finish this line is the only symptom.
@@ -157,6 +166,15 @@ for (const repo of repos) {
       console.log(
         `    ${c.yellow(t.identifier.padEnd(10))} blocked by ${t.blockedBy.join(", ")}  ${c.dim(t.title.slice(0, 45))}`,
       );
+  }
+  if (s.readyStale) {
+    console.log(
+      c.yellow(
+        `\n  ready pin stale — re-promote after reviewing the body change:`,
+      ),
+    );
+    for (const t of s.readyStaleTickets)
+      console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}`);
   }
   if (s.inReview) {
     console.log(c.dim(`\n  awaiting review/merge:`));

--- a/orchestrator/queue.mjs
+++ b/orchestrator/queue.mjs
@@ -81,6 +81,7 @@ for (const repo of repos) {
   if (s.readyStale) line("READY, stale pin", s.readyStale, c.yellow);
   if (s.readyUnreadable)
     line("READY, pin unreadable", s.readyUnreadable, c.yellow);
+  if (s.readyMissingPin) line("READY, no pin", s.readyMissingPin, c.yellow);
   if (s.readyHeld) line("READY, held by blocker", s.readyHeld, c.yellow);
   line("In Progress", s.inProgress);
   line("In Review", s.inReview, s.inReview ? c.cyan : (x) => x);
@@ -135,12 +136,15 @@ for (const repo of repos) {
         `\n  nothing startable — all ready tickets collide with running or with each other's unparseable Owned Paths`,
       ),
     );
-  } else if (s.readyStale || s.readyUnreadable) {
-    console.log(
-      c.dim(
-        `\n  nothing startable — ${s.readyStale} ready ticket(s) have stale pins and ${s.readyUnreadable} pin feed(s) could not be read`,
-      ),
-    );
+  } else if (s.readyStale || s.readyUnreadable || s.readyMissingPin) {
+    // Only name the counts that are non-zero; "0 pin feed(s) could not be
+    // read" is noise that hides the one line that matters.
+    const reasons = [
+      s.readyStale && `${s.readyStale} ready ticket(s) have stale pins`,
+      s.readyMissingPin && `${s.readyMissingPin} ready ticket(s) have no pin`,
+      s.readyUnreadable && `${s.readyUnreadable} pin feed(s) could not be read`,
+    ].filter(Boolean);
+    console.log(c.dim(`\n  nothing startable — ${reasons.join(", ")}`));
   } else if (s.readyHeld) {
     // Not "queue empty": there IS specified work, it is waiting on its
     // blockers, and if those never finish this line is the only symptom.
@@ -174,6 +178,15 @@ for (const repo of repos) {
       ),
     );
     for (const t of s.readyStaleTickets)
+      console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}`);
+  }
+  if (s.readyMissingPin) {
+    console.log(
+      c.yellow(
+        `\n  ${s.readyMissingPin} ready ticket(s) have no ready-pin — re-promote (remove/add ai:agent-ready) to stamp one:`,
+      ),
+    );
+    for (const t of s.readyMissingPinTickets)
       console.log(`    ${t.identifier.padEnd(10)} ${t.title.slice(0, 60)}`);
   }
   if (s.inReview) {

--- a/orchestrator/queue.test.mjs
+++ b/orchestrator/queue.test.mjs
@@ -1,0 +1,29 @@
+import { expect, test } from "bun:test";
+import { readyPinMarker } from "../event-runtime/lib/triage.mjs";
+import { qualifyReadyTickets, readyPinStatus } from "../lib/queue-summary.mjs";
+
+test("queue admission qualifies fresh, stale, and missing ready pins", () => {
+  const approved = "approved queue ticket";
+  const comments = [
+    { body: readyPinMarker(approved), createdAt: "2026-08-30T10:00:00Z" },
+  ];
+
+  expect(readyPinStatus(approved, comments)).toBe("fresh");
+  expect(readyPinStatus("edited queue ticket", comments)).toBe("stale");
+  expect(readyPinStatus(approved, [])).toBe("missing");
+});
+
+test("queue excludes stale pins from the dispatchable group", () => {
+  const groups = qualifyReadyTickets(
+    [{ identifier: "WM-1" }, { identifier: "WM-2" }],
+    new Map([
+      ["WM-1", "stale"],
+      ["WM-2", "fresh"],
+    ]),
+  );
+
+  expect(groups.admissible.map((ticket) => ticket.identifier)).toEqual([
+    "WM-2",
+  ]);
+  expect(groups.stale.map((ticket) => ticket.identifier)).toEqual(["WM-1"]);
+});

--- a/orchestrator/queue.test.mjs
+++ b/orchestrator/queue.test.mjs
@@ -27,3 +27,18 @@ test("queue excludes stale pins from the dispatchable group", () => {
   ]);
   expect(groups.stale.map((ticket) => ticket.identifier)).toEqual(["WM-1"]);
 });
+
+test("queue reports a pin-less GitHub ticket separately from stale, not as dispatchable", () => {
+  const groups = qualifyReadyTickets(
+    [{ identifier: "#1" }, { identifier: "#2" }],
+    new Map([
+      ["#1", "missing"],
+      ["#2", "fresh"],
+    ]),
+    { missingAdmissible: false },
+  );
+
+  expect(groups.admissible.map((t) => t.identifier)).toEqual(["#2"]);
+  expect(groups.missing.map((t) => t.identifier)).toEqual(["#1"]);
+  expect(groups.stale).toEqual([]);
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1574

Review stale ready-pin qualification before enabling queue dispatch.

## Validation

| Check                | Command                                                                                              | Result  | Notes                              |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test orchestrator/label-guard.test.mjs orchestrator/queue.test.mjs --timeout 20000 && bun build/emit.mjs --check` | pass    | 19 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2134 pass, 10 skipped, 0 failures  |
| UX critique          | factory-ux-critic                                                                                    | not run | skipped: no user-facing surface    |

UX critique: skipped — backend/operator queue and guard behavior only.

run:run_3b41754c-0a88-44cb-979a-67e38e2b7692

## Post-review

- `lib/queue-summary.mjs`: a MISSING ready-pin is no longer admissible under a GitHub control plane (mirrors `ticket_ready_pin_missing` in planner.mjs); reported as `readyMissingPin`/`readyMissingPinTickets`, kept distinct from stale (AC4 preserved); docstring corrected; comment feeds read in batches of 5 (`readyPinStatuses` exported, concurrency bounded).
- `orchestrator/queue.mjs`: new `READY, no pin` line with the re-promote hint; the nothing-startable reason names only non-zero counts.
- `orchestrator/label-guard.mjs`: `main` prints `unreadable: Ready Pin` (previously silently passed) and keeps `resolveControlPlane`/`resolveRepos` injectable.
- Tests: missing-vs-stale on Linear/GitHub, unreadable feed, bounded batching, label-guard `main` unreadable note (all hermetic, injected `listComments`).
- Verified: ticket Verification Command, `bun run lint`, `bun test event-runtime/lib` (2134 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
