### PR TITLE
fix(ask): expose section completeness

### DIFF
--- a/orchestrator/ask.mjs
+++ b/orchestrator/ask.mjs
@@ -28,6 +28,10 @@
  *   never an empty list, while every other section still returns. The command
  *   exits 0 — a partial answer is the point.
  *
+ * JSON consumers must check each section's `complete` field. It is true only
+ * when `error` is null and `errors` is empty; `error === null` alone is not
+ * enough because a section can contain a partial answer and still have rows.
+ *
  * The JSON is the source; the text is rendered from it by `formatAsk`, so the
  * two cannot disagree.
  */
@@ -205,6 +209,17 @@ export function openRuntimeDb(file = dbPath()) {
 }
 
 const emptySection = (extra = {}) => ({ error: null, errors: [], ...extra });
+
+/** Add the final JSON completeness signal after every section has been built. */
+const finalizeSections = (doc) => {
+  for (const name of doc.sections) {
+    const section = doc[name];
+    if (section)
+      section.complete =
+        section.error === null && (section.errors?.length ?? 0) === 0;
+  }
+  return doc;
+};
 
 /**
  * Run `fn` for each repo, collecting rows and per-repo failures.
@@ -589,7 +604,7 @@ export async function gatherAsk({
     if (ownsDb && handle) handle.close();
   }
 
-  return doc;
+  return finalizeSections(doc);
 }
 
 // ---------------------------------------------------------------- render ----

--- a/orchestrator/ask.test.mjs
+++ b/orchestrator/ask.test.mjs
@@ -320,6 +320,11 @@ test("every section is present and typed on a seeded fixture", async () => {
   expect(doc.sections).toEqual([...SECTIONS]);
   for (const name of SECTIONS) expect(doc[name]).toBeDefined();
   expect(doc.repos).toEqual(["factory"]);
+  for (const name of SECTIONS) expect(doc[name].complete).toBe(true);
+  for (const name of SECTIONS)
+    expect(doc[name].complete).toBe(
+      doc[name].error === null && doc[name].errors.length === 0,
+    );
 
   // queue — dispatchable only, as typed rows
   expect(doc.queue.error).toBeNull();
@@ -639,6 +644,99 @@ test("runtime-database sections fail independently of the tracker", async () => 
   expect(doc.spend.today.runs).toBe(1);
   expect(doc.spend.errors[0]).toMatchObject({ source: "runtime.db" });
   expect(formatAsk(doc)).toContain("partial — runtime.db");
+});
+
+test("per-repo completeness distinguishes healthy, partial, and unavailable", async () => {
+  const repos = [REPO, { ...REPO, name: "other" }];
+  const healthy = {
+    async listDispatchable() {
+      return [{ identifier: "WM-10", title: "Healthy row" }];
+    },
+  };
+  const failing = {
+    async listDispatchable() {
+      throw new Error("tracker unavailable");
+    },
+  };
+
+  const partial = await gatherAsk({
+    ...askArgs(),
+    repos,
+    sections: ["queue"],
+    controlPlaneFor: (repo) => (repo.name === "factory" ? healthy : failing),
+  });
+  expect(partial.queue).toMatchObject({
+    complete: false,
+    error: null,
+    rows: [{ identifier: "WM-10" }],
+  });
+  expect(partial.queue.errors).toHaveLength(1);
+
+  const allFailed = await gatherAsk({
+    ...askArgs(),
+    repos,
+    sections: ["queue"],
+    controlPlaneFor: () => failing,
+  });
+  expect(allFailed.queue.complete).toBe(false);
+  expect(allFailed.queue.error).toContain("tracker unavailable");
+  expect(allFailed.queue.errors).toHaveLength(2);
+
+  const allHealthy = await gatherAsk({
+    ...askArgs(),
+    repos: [REPO],
+    sections: ["queue"],
+    controlPlaneFor: () => healthy,
+  });
+  expect(allHealthy.queue).toMatchObject({
+    complete: true,
+    error: null,
+    errors: [],
+  });
+});
+
+test("a section with no configured repos is incomplete", async () => {
+  const doc = await gatherAsk({
+    ...askArgs(),
+    repos: [],
+    sections: ["queue"],
+  });
+
+  expect(doc.queue).toMatchObject({
+    complete: false,
+    error: "no repositories configured (config/repos.yaml)",
+    errors: [],
+  });
+});
+
+test("runtime sections without a database are incomplete", async () => {
+  const doc = await gatherAsk({
+    ...askArgs(),
+    db: null,
+    sections: ["recent", "noop", "spend"],
+  });
+
+  expect(doc.recent.complete).toBe(false);
+  expect(doc.noop.complete).toBe(false);
+  expect(doc.spend.complete).toBe(false);
+  for (const name of ["recent", "noop", "spend"])
+    expect(doc[name].complete).toBe(
+      doc[name].error === null && doc[name].errors.length === 0,
+    );
+});
+
+test("every emitted section obeys the complete invariant", async () => {
+  const doc = await gatherAsk(
+    askArgs({ controlPlaneFor: () => seedPlane(), db: null }),
+  );
+
+  for (const name of doc.sections) {
+    const section = doc[name];
+    expect(typeof section.complete).toBe("boolean");
+    expect(section.complete).toBe(
+      section.error === null && (section.errors?.length ?? 0) === 0,
+    );
+  }
 });
 
 /**


### PR DESCRIPTION
Fixes watt-mind/factory#1110

Consumers can now reject partial ask sections via the final `complete` flag.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 orchestrator/ask.test.mjs`    | pass    | 17 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`  | pass    | clean                  |
| UX critique          | factory-ux-critic                | not run | backend-only JSON contract change; no user-facing surface |

UX critique: skipped — backend-only JSON contract change; no user-facing surface

run:run_37dc785e-4077-403e-bbf9-58d393525a45