### PR TITLE
docs(security): record GitHub App grant decision

### DIFF
--- a/docs/event-runtime-github-app.md
+++ b/docs/event-runtime-github-app.md
@@ -8,31 +8,94 @@ cache for each `gh api` child process.
 
 ## Installation permissions
 
-Install the App on every repository managed by the GitHub control plane and
-grant this complete permission set:
+The `watt-mind-factory` App is installed on the `watt-mind` organization with
+`repository_selection: all`. This is the complete live grant read on
+2026-08-30 from installation `157493110`:
 
-| Scope        | Permission    | Access         | Used for                                                        |
-| ------------ | ------------- | -------------- | --------------------------------------------------------------- |
-| Repository   | Metadata      | Read-only      | Repository, collaborator-permission, and project linkage reads  |
-| Repository   | Issues        | Read and write | Tickets, labels, comments, assignment, and open/close mutations |
-| Repository   | Pull requests | Read-only      | Closing-PR references used by the duplicate-work claim guard    |
-| Organization | Projects      | Read and write | Projects v2 items and the `Status` field                        |
+| GitHub permission key   | Access | Currently used by Factory                                 |
+| ----------------------- | ------ | --------------------------------------------------------- |
+| `actions`               | Read   | No                                                        |
+| `checks`                | Write  | No                                                        |
+| `contents`              | Write  | No                                                        |
+| `issues`                | Write  | Yes — tickets, labels, comments, assignment, and state    |
+| `metadata`              | Read   | Yes — repository, collaborator, and project linkage reads |
+| `organization_projects` | Write  | Yes — Projects v2 items and the `Status` field            |
+| `pull_requests`         | Write  | Read-only closing-PR lookup only; write is unused         |
+| `statuses`              | Read   | No                                                        |
+
+The grant and the runtime's use are different contracts. The GitHub control
+plane in `lib/control-plane/github.mjs` is the only App-token consumer. It uses
+Issues, organization Projects, Metadata, and a read-only pull-request lookup.
+The forge in `lib/forge/` still uses the operator's ambient `gh` PAT for pull
+requests, merges, CI reads, and Git pushes. In particular, the App's
+`contents:write`, `pull_requests:write`, and `checks:write` grants do not move
+forge operations off the PAT.
+
+The broad grant is deliberate but temporary; see [the recorded product
+decision](product-decisions.md#github-app-installation-grant-gh-1594). Only
+the `factory` entry in `config/repos.yaml` currently selects the GitHub control
+plane, and no client-repository dispatch through this App is authorized.
 
 Read the grant that an installation actually carries with the App JWT (no
 token is minted, nothing is written):
 
 ```
-GET /app/installations/{installation_id}   ->  .permissions
+GET /app/installations/{installation_id}
+  -> { permissions: .permissions, repository_selection: .repository_selection }
 ```
 
-The `watt-mind` installation was read this way on 2026-08-29 and already
-carries `issues: write` and `organization_projects: write`. No permission
-change was needed to fix the claim failure — see the note below on `GET
-/user`, which is not grantable to an installation at any permission level.
+The expected response for installation `157493110` is:
+
+```json
+{
+  "permissions": {
+    "checks": "write",
+    "issues": "write",
+    "actions": "read",
+    "contents": "write",
+    "metadata": "read",
+    "statuses": "read",
+    "pull_requests": "write",
+    "organization_projects": "write"
+  },
+  "repository_selection": "all"
+}
+```
+
+The repository operator must repeat this read monthly and after every App
+configuration change. Compare both fields with the JSON and table above and
+open a security ticket for any difference before updating this document. The
+next scheduled review is 2026-09-30 and its owner is `hdkiller`. This periodic
+read is the drift check; it is intentionally read-only and does not mint an
+installation token.
+
+No permission change was needed to fix the earlier claim failure — see the
+note below on `GET /user`, which is not grantable to an installation at any
+permission level.
 
 Changing App permissions requires the organization owner to approve the new
 installation permissions. Re-mint the installation token after approval; an
 already-cached token retains its old grants until it expires or is replaced.
+
+### Narrowing runbook
+
+Narrowing remains the preferred fallback if the planned forge migration does
+not justify the broad grant at review time. It is a human operation:
+
+1. Confirm the repositories that actually select the GitHub control plane and
+   the permissions used by `lib/control-plane/github.mjs`.
+2. In the GitHub App settings, remove unused Actions, Checks, Contents,
+   Statuses, and Pull requests write access; retain only the minimum access
+   required by the confirmed consumers (Pull requests read is sufficient for
+   the current closing-PR lookup).
+3. Change the organization installation from **All repositories** to **Only
+   select repositories**, selecting only repositories confirmed in step 1.
+4. Have the organization owner approve the revised grant, then re-mint the
+   installation token so the cache does not retain the old permissions.
+5. Repeat `GET /app/installations/{installation_id}`, update the expected JSON
+   and table above field for field, and record the new decision and evidence.
+6. Run one real dispatch and confirm that claim succeeds and the run reaches
+   `RUNNING`; unit tests cannot prove live installation grants.
 
 Claims deliberately use one additional credential: the ambient `gh` user
 login. A GitHub App installation is not a user, `GET /user` always returns

--- a/docs/product-decisions.md
+++ b/docs/product-decisions.md
@@ -4,6 +4,31 @@ Recorded so the next agent does not re-litigate them. The webui spec
 (`docs/event-runtime-webui.md`) is the view-level contract; this file is the
 cross-cutting calls that several tickets share.
 
+## GitHub App installation grant (gh-1594)
+
+Decided 2026-08-30: deliberately retain the current `watt-mind-factory` App
+installation grant through the next review rather than narrowing it now. The
+live installation has `repository_selection: all` and eight permissions:
+Actions read, Checks write, Contents write, Issues write, Metadata read, Pull
+requests write, Statuses read, and organization Projects write. The complete
+field-level grant and drift procedure are recorded in
+[`docs/event-runtime-github-app.md`](event-runtime-github-app.md#installation-permissions).
+
+This is a time-bounded exception, not a claim that Factory currently needs the
+whole grant. The App token is used only by the GitHub control plane; the forge
+still uses the operator PAT, and several App permissions are unused. Retention
+keeps the planned #1136 phase 3 path open to move forge operations onto the App
+without another immediate organization approval. The present blast radius is
+accepted because `watt-mind` is a single-operator organization and no
+client-repository dispatch through this App is authorized.
+
+Owner: repository operator `hdkiller`. Review date: 2026-09-30. At that review,
+either give #1136 phase 3 a concrete migration target with permissions derived
+from its implementation, or use the documented human-operated narrowing
+runbook to select only active GitHub-control-plane repositories and remove
+unused scopes. Any live grant change requires a fresh installation read and a
+real dispatch reaching `RUNNING`.
+
 ## Operator context tabs (OPS-356)
 
 The Linear-style strip above the inverted-L is a **filter context**, not a


### PR DESCRIPTION
Fixes watt-mind/factory#1594

Review the time-bounded retained grant and 2026-09-30 narrowing decision; authorised by inbox_d65e28d0-a7f4-40db-8aef-196d95ebe159 at 2026-08-30T11:17:20.563Z.

## Validation

| Check                | Command                                                                                                                   | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun run format:check`                                                                                                    | pass    | all matched files use Prettier style   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`        | pass    | 2,134 pass; 10 skip; 0 errors          |
| UX critique          | factory-ux-critic                                                                                                         | not run | documentation-only; no user-facing UI |

UX critique: skipped — documentation-only; no user-facing surface

run:run_bdb9a9b1-5741-436b-b8ca-10578d93e913
