### PR TITLE
fix(dispatch): verify operator authorisations in worker

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -280,7 +280,7 @@ On response the runtime records an authorisation:
 {
   "ticket": "WM-313",
   "repo": "factory",
-  "descriptionHash": "sha256:…", // of the Linear description at decision time
+  "descriptionHash": "sha256:…", // canonical hashBytes of the description at decision time
   "paths": ["…"], // scope.paths ∩ operator's multi-choice, if one was gated on this option
   "summary": "…",
   "insight": "…", // concatenated text fields, if any
@@ -292,13 +292,14 @@ On response the runtime records an authorisation:
 
 Two bindings make it safe:
 
-- **Bound to the ticket as written.** `descriptionHash` is taken from Linear
-  at decision time. When the re-dispatched run starts, the dispatch brief
-  compares it to the current description; a mismatch means the operator
-  approved different work, and the agent refuses again with a new decision
-  request whose context says the ticket changed. The runtime also checks at
-  emit time and raises a fresh `ESCALATED` item instead of dispatching if the
-  description already moved.
+- **Bound to the ticket as written.** `descriptionHash` is
+  `hashBytes(description)`: SHA-256 over the description's exact UTF-8 bytes,
+  with no trailing newline appended. At worker start, before the model runs,
+  the runtime applies the same canonical recipe to the ticket's current
+  description. A mismatch is refused as `authorisation_stale:description`;
+  matching authorisations are delivered with `verified: true`. The runtime
+  also checks at emit time and raises a fresh `ESCALATED` item instead of
+  dispatching if the description already moved.
 - **Bound to paths.** The re-dispatched agent may modify only
   `authorisation.paths` (∩ the ticket's Owned Paths); anything outside is the
   ordinary out-of-scope rule.
@@ -446,12 +447,12 @@ same way any input is. Two consequences fall out for free:
 The `dispatch` brief gains one clause, in the escalation-gate paragraph:
 
 > If the input carries `humanDecision.authorisation` for this ticket, the
-> operator has already seen the escalation. Compare
-> `authorisation.descriptionHash` to the ticket's current description; if it
-> matches, proceed, staying inside `authorisation.paths`, and quote the
-> authorisation (item id, decided-at) in the PR body. If it does not match,
-> refuse with a new decision request whose `context` says the ticket changed
-> after approval.
+> operator has already seen the escalation. The worker compares
+> `authorisation.descriptionHash` to canonical `hashBytes(description)` over
+> the ticket's exact current UTF-8 description bytes, with no trailing newline,
+> before the model runs. Trust `authorisation.verified: true`; do not recompute
+> the hash. Stay inside `authorisation.paths` and quote the authorisation (item
+> id, decided-at) in the PR body.
 
 Other agents that can be re-run after a decision (`triage-scan` after
 `answer`, a parked event after `requeue`) do not need the field: their

--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -302,7 +302,13 @@ Two bindings make it safe:
   dispatching if the description already moved.
 - **Bound to paths.** The re-dispatched agent may modify only
   `authorisation.paths` (∩ the ticket's Owned Paths); anything outside is the
-  ordinary out-of-scope rule.
+  ordinary out-of-scope rule. The operator may narrow the scope, so the worker
+  accepts `paths` as any non-empty subset of the ticket's current Owned Paths
+  and refuses `authorisation_stale:paths` only when the set is empty or names
+  a path outside Owned Paths. The worker also refuses
+  `authorisation_stale:ticket` when `authorisation.ticket`/`repo` differ from
+  the run input. Refusal evidence carries only
+  `{ descriptionHash, ownedPaths }`, never the raw ticket.
 
 An authorisation is single-use: it lives in one run's input. A second refusal
 raises a second item; the operator decides again. Blanket approval per ticket

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:4a60022dfd2bec82cc0dc4a24896d219be50fecf8117c6cf668cb287936cf963",
+    "agents/dispatch.md": "sha256:66fb358bd8f192a768fc0101923095b3164fdd2ce270af163c28b9c62c0ec3cb",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:6bf64383494b007b354f40bfaf208d3a2bfe181b40005529eaaa55793d8de7c9",
+    "agents/dispatch.md": "sha256:4a60022dfd2bec82cc0dc4a24896d219be50fecf8117c6cf668cb287936cf963",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -239,11 +239,14 @@ landed without a human.
 
 If the input carries `humanDecision.authorisation` for this ticket, the
 operator has already seen that escalation. The runtime verifies the live
-description and path scope before this agent runs, then sets
-`authorisation.verified: true`. Trust that flag and never recompute the hash
-yourself. Proceed only inside `authorisation.paths` (and the ticket's Owned
-Paths), and quote the authorisation's inbox item id and `decidedAt` in the PR
-body.
+description, the ticket/repo binding, and the path scope (`authorisation.paths`
+must be a non-empty subset of the ticket's Owned Paths) before this agent runs,
+then sets `authorisation.verified: true`. Trust that flag and never recompute
+the hash yourself. If `authorisation.verified` is absent or not exactly `true`,
+the authorisation is unverified: refuse (`reasonCode: "needs_human"`) and never
+proceed on it. When it is `true`, proceed only inside `authorisation.paths`
+(and the ticket's Owned Paths), and quote the authorisation's inbox item id and
+`decidedAt` in the PR body.
 
 If `memos.json` holds a `decision` memo on this subject, the operator has
 ruled on a related question before. **Cite it** — item id, decided-at,

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -238,13 +238,12 @@ the ticket, and refuse (`reasonCode: "needs_human"`). Those diffs are never
 landed without a human.
 
 If the input carries `humanDecision.authorisation` for this ticket, the
-operator has already seen that escalation. Compare
-`authorisation.descriptionHash` with the SHA-256 of the ticket's current
-description. If it matches, proceed only inside `authorisation.paths` (and the
-ticket's Owned Paths), and quote the authorisation's inbox item id and
-`decidedAt` in the PR body. If it does not match, refuse with a fresh decision
-request whose `context` says the ticket changed after approval; never reuse an
-authorisation for a different ticket description.
+operator has already seen that escalation. The runtime verifies the live
+description and path scope before this agent runs, then sets
+`authorisation.verified: true`. Trust that flag and never recompute the hash
+yourself. Proceed only inside `authorisation.paths` (and the ticket's Owned
+Paths), and quote the authorisation's inbox item id and `decidedAt` in the PR
+body.
 
 If `memos.json` holds a `decision` memo on this subject, the operator has
 ruled on a related question before. **Cite it** — item id, decided-at,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2733,7 +2733,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:e7c6ec68b91dc1fe02dcbfcbbd5ec662c47ef92e54656ed71b0e44a931621328","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5553c665cbd9578b9bf897b33092ad4bb28318bcf487f03cf6a71295d5a94e29","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2733,7 +2733,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5553c665cbd9578b9bf897b33092ad4bb28318bcf487f03cf6a71295d5a94e29","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:779fa866b66dd5422699118041cfa88e1545d4269468ad987d93e6db169265b7","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -394,7 +394,7 @@ describe("registry", () => {
     // canonical authorisation description hash and path scope before execution;
     // dispatch.md trusts the worker-authenticated verified flag.
     const expected =
-      "sha256:9b985da7b8c58e1f34e3507cd9dec779e11ec98371e8382edfc01f6fbe69195e";
+      "sha256:a3685bcb3f85cb09522de22654860620138003cc5d9fbec8e5fe0dc3349d009c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -682,7 +682,7 @@ describe("registry", () => {
     // Regenerated (#1337): dispatch trusts the worker-verified authorisation;
     // prompt pin only, `pack` remains non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:5553c665cbd9578b9bf897b33092ad4bb28318bcf487f03cf6a71295d5a94e29",
+      "sha256:779fa866b66dd5422699118041cfa88e1545d4269468ad987d93e6db169265b7",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -390,8 +390,11 @@ describe("registry", () => {
     // REST (`gh run list --workflow ci.yml --commit` + `gh run watch`) and
     // ship-apply's merge_rc_pr asserts every check-run is green before
     // merging; prompt pins and one argv template only.
+    // Regenerated (#1337): the worker, not the dispatch model, verifies the
+    // canonical authorisation description hash and path scope before execution;
+    // dispatch.md trusts the worker-authenticated verified flag.
     const expected =
-      "sha256:cf57efc93be0d488db8ff55b8c892d8c52d0da52d7a0112da82ac7596b4f4d3f";
+      "sha256:9b985da7b8c58e1f34e3507cd9dec779e11ec98371e8382edfc01f6fbe69195e";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -676,8 +679,10 @@ describe("registry", () => {
     // out-of-scope follow-ups; prompt pin only.
     // Regenerated (#1581): dispatch.md selects the CI run by workflow and
     // waits via REST; prompt pin only, `pack` remains non-enumerable.
+    // Regenerated (#1337): dispatch trusts the worker-verified authorisation;
+    // prompt pin only, `pack` remains non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:e7c6ec68b91dc1fe02dcbfcbbd5ec662c47ef92e54656ed71b0e44a931621328",
+      "sha256:5553c665cbd9578b9bf897b33092ad4bb28318bcf487f03cf6a71295d5a94e29",
     );
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2146,6 +2146,71 @@ export function claimedRetryFor(db, runId, attempt) {
   return { runId, priorAttempt, reasonCode: "lease_expired" };
 }
 
+/**
+ * Verify the operator authorisation against live ticket bytes before an agent
+ * can see it. Decision effects mint descriptionHash with hashBytes(description)
+ * (UTF-8, no appended newline); keeping the inverse here removes the model's
+ * former freedom to choose a different byte recipe.
+ *
+ * The returned input is an execution-only copy. The durable RunSpec remains
+ * immutable, while input.json and the adapter receive verified: true.
+ */
+export function humanDecisionAuthorisationGate(
+  input,
+  { fetchTicket = defaultFetchTicket } = {},
+) {
+  const authorisation = input?.humanDecision?.authorisation;
+  if (!authorisation) return { ok: true, input };
+
+  const ticket = fetchTicket(input.ticket, input.repo);
+  const description = ticket?.description;
+  if (
+    typeof description !== "string" ||
+    authorisation.descriptionHash !== hashBytes(description)
+  ) {
+    return {
+      ok: false,
+      refusal: {
+        decision: "noop",
+        reason: "authorisation_stale:description",
+        detail:
+          "humanDecision.authorisation.descriptionHash does not match the canonical hashBytes of the current ticket description",
+      },
+      evidence: { ticket },
+    };
+  }
+
+  const authorisedPaths = new Set(
+    Array.isArray(authorisation.paths) ? authorisation.paths : [],
+  );
+  const missingPaths = parseOwnedPaths(description).filter(
+    (ownedPath) => !authorisedPaths.has(ownedPath),
+  );
+  if (missingPaths.length > 0) {
+    return {
+      ok: false,
+      refusal: {
+        decision: "noop",
+        reason: "authorisation_stale:paths",
+        detail: `humanDecision.authorisation.paths does not cover Owned Paths: ${missingPaths.join(", ")}`,
+      },
+      evidence: { ticket, missingPaths },
+    };
+  }
+
+  return {
+    ok: true,
+    input: {
+      ...input,
+      humanDecision: {
+        ...input.humanDecision,
+        authorisation: { ...authorisation, verified: true },
+      },
+    },
+    evidence: { ticket },
+  };
+}
+
 function contradictsPlanTimeOwnedPaths(spec, gateResult) {
   const planned = spec?.approvalPolicy?.dispatchEvidence?.ticket;
   const current = gateResult?.evidence?.ticket;
@@ -3093,6 +3158,7 @@ export async function executeClaimed(
   const projectTierEscalationFn =
     dispatchOpts?.projectTierEscalation ?? defaultProjectTierEscalation;
   let handoffContext = null;
+  let executionInput = spec.input;
 
   const nowFn = typeof now === "function" ? now : () => now ?? Date.now();
 
@@ -3656,38 +3722,50 @@ export async function executeClaimed(
           if (worktreeHandoff?.projectionState === "pending") {
             return deferTransientGate("tier_escalation_projection_pending");
           }
-          gateResult = worktreeDispatchAutoEligibility(spec.input, {
-            ...(dispatchOpts ?? {}),
-            claimedRetry: claimedRetryFor(db, runId, attempt),
-            escalatedContinuation: worktreeHandoff,
-            hasTicketLease:
-              dispatchOpts?.hasTicketLease ??
-              ((repo, ticket) =>
-                liveWorkerLeases(repo, { dir: leasesDir }).some(
-                  (lease) => String(lease.ticket) === String(ticket),
-                )),
-            // Match the planner's operator-only bypass from the immutable
-            // proposal that admitted this run. Never trust caller options here:
-            // chain and schedule runs must keep the security/escalation gate.
-            //
-            // A spec field alone can never carry this authorisation: chain and
-            // schedule runs inherit approvalPolicy (dispatchEvidence included,
-            // via stableChainApprovalPolicyForHash) from the dispatch they
-            // descend from, so trusting `dispatchEvidence.checks
-            // .operator_authorized` would hand every descendant of one operator
-            // dispatch a permanent ai:escalated/security bypass. The escalation
-            // claim is only believed when the durable tier_escalations row read
-            // for THIS run authenticates it as the continuation of the exact
-            // failed run the spec names.
-            operatorAuthorized:
-              originatingEvent(db, runId)?.source === "operator" ||
-              (worktreeHandoff?.projectionState === "applied" &&
-                spec.approvalPolicy?.escalation?.operatorAuthorized === true &&
-                spec.approvalPolicy.escalation.failedRunId ===
-                  worktreeHandoff.failedRunId &&
-                spec.approvalPolicy.escalation.rootRunId ===
-                  worktreeHandoff.rootRunId),
+          const authorisationGate = humanDecisionAuthorisationGate(spec.input, {
+            fetchTicket: fetchTicketFn,
           });
+          if (!authorisationGate.ok) {
+            gateResult = authorisationGate;
+          } else {
+            executionInput = authorisationGate.input;
+            gateResult = worktreeDispatchAutoEligibility(spec.input, {
+              ...(dispatchOpts ?? {}),
+              ...(authorisationGate.evidence?.ticket
+                ? { fetchTicket: () => authorisationGate.evidence.ticket }
+                : {}),
+              claimedRetry: claimedRetryFor(db, runId, attempt),
+              escalatedContinuation: worktreeHandoff,
+              hasTicketLease:
+                dispatchOpts?.hasTicketLease ??
+                ((repo, ticket) =>
+                  liveWorkerLeases(repo, { dir: leasesDir }).some(
+                    (lease) => String(lease.ticket) === String(ticket),
+                  )),
+              // Match the planner's operator-only bypass from the immutable
+              // proposal that admitted this run. Never trust caller options here:
+              // chain and schedule runs must keep the security/escalation gate.
+              //
+              // A spec field alone can never carry this authorisation: chain and
+              // schedule runs inherit approvalPolicy (dispatchEvidence included,
+              // via stableChainApprovalPolicyForHash) from the dispatch they
+              // descend from, so trusting `dispatchEvidence.checks
+              // .operator_authorized` would hand every descendant of one operator
+              // dispatch a permanent ai:escalated/security bypass. The escalation
+              // claim is only believed when the durable tier_escalations row read
+              // for THIS run authenticates it as the continuation of the exact
+              // failed run the spec names.
+              operatorAuthorized:
+                originatingEvent(db, runId)?.source === "operator" ||
+                (worktreeHandoff?.projectionState === "applied" &&
+                  spec.approvalPolicy?.escalation?.operatorAuthorized ===
+                    true &&
+                  spec.approvalPolicy.escalation.failedRunId ===
+                    worktreeHandoff.failedRunId &&
+                  spec.approvalPolicy.escalation.rootRunId ===
+                    worktreeHandoff.rootRunId),
+            });
+          }
         }
       } catch (err) {
         if (
@@ -3908,7 +3986,7 @@ export async function executeClaimed(
         root: workspacesRoot,
         runId,
         attempt,
-        input: spec.input,
+        input: executionInput,
         workspace: spec.workspace,
         artifactStore,
         adapter: adapterKey,
@@ -4123,7 +4201,10 @@ export async function executeClaimed(
         repoName,
       });
       outcome = await adapter.execute({
-        spec,
+        spec:
+          executionInput === spec.input
+            ? spec
+            : { ...spec, input: executionInput },
         def,
         workspaceDir,
         timeoutMs: adapterExecuteTimeoutMs({

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2147,8 +2147,8 @@ export function claimedRetryFor(db, runId, attempt) {
 }
 
 /**
- * Verify the operator authorisation against live ticket bytes before an agent
- * can see it. Decision effects mint descriptionHash with hashBytes(description)
+ * Verify the operator authorisation against the run input and live ticket
+ * bytes before an agent can see it. Decision effects mint descriptionHash with hashBytes(description)
  * (UTF-8, no appended newline); keeping the inverse here removes the model's
  * former freedom to choose a different byte recipe.
  *
@@ -2162,11 +2162,37 @@ export function humanDecisionAuthorisationGate(
   const authorisation = input?.humanDecision?.authorisation;
   if (!authorisation) return { ok: true, input };
 
+  // The authorisation is single-use and bound to one ticket: decision effects
+  // mint it with the inbox item's issue/repo refs. A copy carried into another
+  // run's input must never authorise that run.
+  if (
+    String(authorisation.ticket ?? "") !== String(input?.ticket ?? "") ||
+    String(authorisation.repo ?? "") !== String(input?.repo ?? "")
+  ) {
+    return {
+      ok: false,
+      refusal: {
+        decision: "noop",
+        reason: "authorisation_stale:ticket",
+        detail:
+          "humanDecision.authorisation.ticket/repo do not match the run input ticket/repo",
+      },
+      evidence: { descriptionHash: null, ownedPaths: [] },
+    };
+  }
+
   const ticket = fetchTicket(input.ticket, input.repo);
   const description = ticket?.description;
+  const descriptionHash =
+    typeof description === "string" ? hashBytes(description) : null;
+  const ownedPaths =
+    typeof description === "string" ? parseOwnedPaths(description) : [];
+  // Refusal evidence is a fingerprint, never the raw ticket JSON.
+  const evidence = { descriptionHash, ownedPaths };
+
   if (
-    typeof description !== "string" ||
-    authorisation.descriptionHash !== hashBytes(description)
+    descriptionHash === null ||
+    authorisation.descriptionHash !== descriptionHash
   ) {
     return {
       ok: false,
@@ -2176,25 +2202,32 @@ export function humanDecisionAuthorisationGate(
         detail:
           "humanDecision.authorisation.descriptionHash does not match the canonical hashBytes of the current ticket description",
       },
-      evidence: { ticket },
+      evidence,
     };
   }
 
-  const authorisedPaths = new Set(
-    Array.isArray(authorisation.paths) ? authorisation.paths : [],
-  );
-  const missingPaths = parseOwnedPaths(description).filter(
-    (ownedPath) => !authorisedPaths.has(ownedPath),
-  );
-  if (missingPaths.length > 0) {
+  // The operator may narrow the scope (decision-effects authorisedPaths keeps
+  // only the chosen paths), so `paths` must be a non-empty subset of the
+  // ticket's current Owned Paths — "authorisation.paths ∩ Owned Paths" in
+  // docs/event-runtime-inbox.md §3.1. Anything outside Owned Paths means the
+  // ticket's scope moved after approval; an empty set authorises nothing.
+  const authorisedPaths = Array.isArray(authorisation.paths)
+    ? authorisation.paths.filter((entry) => typeof entry === "string")
+    : [];
+  const ownedSet = new Set(ownedPaths);
+  const foreignPaths = authorisedPaths.filter((entry) => !ownedSet.has(entry));
+  if (authorisedPaths.length === 0 || foreignPaths.length > 0) {
     return {
       ok: false,
       refusal: {
         decision: "noop",
         reason: "authorisation_stale:paths",
-        detail: `humanDecision.authorisation.paths does not cover Owned Paths: ${missingPaths.join(", ")}`,
+        detail:
+          authorisedPaths.length === 0
+            ? "humanDecision.authorisation.paths is empty; nothing is authorised"
+            : `humanDecision.authorisation.paths is not a subset of the ticket's Owned Paths: ${foreignPaths.join(", ")}`,
       },
-      evidence: { ticket, missingPaths },
+      evidence,
     };
   }
 
@@ -2207,7 +2240,7 @@ export function humanDecisionAuthorisationGate(
         authorisation: { ...authorisation, verified: true },
       },
     },
-    evidence: { ticket },
+    evidence: { ...evidence, ticket },
   };
 }
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -161,6 +161,8 @@ describe("worker", () => {
       humanDecision: {
         inboxItemId: "inbox_authorised",
         authorisation: {
+          ticket: "watt-mind/factory#1337",
+          repo: "factory",
           descriptionHash: hashBytes(description),
           paths: [
             "event-runtime/lib/worker.mjs",
@@ -191,6 +193,8 @@ describe("worker", () => {
         ticket: "watt-mind/factory#1337",
         humanDecision: {
           authorisation: {
+            ticket: "watt-mind/factory#1337",
+            repo: "factory",
             descriptionHash: hashBytes(`${description}\n`),
             paths: ["event-runtime/lib/worker.mjs"],
           },
@@ -205,7 +209,7 @@ describe("worker", () => {
     });
   });
 
-  test("authorisation paths must cover every parsed Owned Path", () => {
+  test("authorisation paths may narrow to a non-empty subset of Owned Paths", () => {
     const description =
       "## Owned Paths\n- event-runtime/lib/worker.mjs\n- docs/event-runtime-inbox.md\n";
     const result = humanDecisionAuthorisationGate(
@@ -214,6 +218,8 @@ describe("worker", () => {
         ticket: "watt-mind/factory#1337",
         humanDecision: {
           authorisation: {
+            ticket: "watt-mind/factory#1337",
+            repo: "factory",
             descriptionHash: hashBytes(description),
             paths: ["event-runtime/lib/worker.mjs"],
           },
@@ -223,9 +229,142 @@ describe("worker", () => {
     );
 
     expect(result).toMatchObject({
+      ok: true,
+      input: {
+        humanDecision: {
+          authorisation: {
+            verified: true,
+            paths: ["event-runtime/lib/worker.mjs"],
+          },
+        },
+      },
+    });
+  });
+
+  test("authorisation paths outside the ticket's Owned Paths are refused", () => {
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    const result = humanDecisionAuthorisationGate(
+      {
+        repo: "factory",
+        ticket: "watt-mind/factory#1337",
+        humanDecision: {
+          authorisation: {
+            ticket: "watt-mind/factory#1337",
+            repo: "factory",
+            descriptionHash: hashBytes(description),
+            paths: [
+              "event-runtime/lib/worker.mjs",
+              "event-runtime/lib/planner.mjs",
+            ],
+          },
+        },
+      },
+      { fetchTicket: () => ({ description }) },
+    );
+
+    expect(result).toMatchObject({
       ok: false,
       refusal: { reason: "authorisation_stale:paths" },
-      evidence: { missingPaths: ["docs/event-runtime-inbox.md"] },
+    });
+    expect(result.refusal.detail).toContain("event-runtime/lib/planner.mjs");
+    expect(result.evidence).toEqual({
+      descriptionHash: hashBytes(description),
+      ownedPaths: ["event-runtime/lib/worker.mjs"],
+    });
+  });
+
+  test("an empty authorisation path set is refused", () => {
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    for (const paths of [[], undefined]) {
+      const result = humanDecisionAuthorisationGate(
+        {
+          repo: "factory",
+          ticket: "watt-mind/factory#1337",
+          humanDecision: {
+            authorisation: {
+              ticket: "watt-mind/factory#1337",
+              repo: "factory",
+              descriptionHash: hashBytes(description),
+              ...(paths === undefined ? {} : { paths }),
+            },
+          },
+        },
+        { fetchTicket: () => ({ description }) },
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        refusal: { reason: "authorisation_stale:paths" },
+        evidence: { ownedPaths: ["event-runtime/lib/worker.mjs"] },
+      });
+    }
+  });
+
+  test("an authorisation minted for another ticket or repo is refused", () => {
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    let fetches = 0;
+    for (const binding of [
+      { ticket: "watt-mind/factory#1338", repo: "factory" },
+      { ticket: "watt-mind/factory#1337", repo: "other-repo" },
+      {},
+    ]) {
+      const result = humanDecisionAuthorisationGate(
+        {
+          repo: "factory",
+          ticket: "watt-mind/factory#1337",
+          humanDecision: {
+            authorisation: {
+              ...binding,
+              descriptionHash: hashBytes(description),
+              paths: ["event-runtime/lib/worker.mjs"],
+            },
+          },
+        },
+        {
+          fetchTicket: () => {
+            fetches += 1;
+            return { description };
+          },
+        },
+      );
+
+      expect(result).toMatchObject({
+        ok: false,
+        refusal: { reason: "authorisation_stale:ticket" },
+      });
+      expect(result.evidence).toEqual({
+        descriptionHash: null,
+        ownedPaths: [],
+      });
+    }
+    expect(fetches).toBe(0);
+  });
+
+  test("a stale description refusal carries a fingerprint, not the ticket", () => {
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    const result = humanDecisionAuthorisationGate(
+      {
+        repo: "factory",
+        ticket: "watt-mind/factory#1337",
+        humanDecision: {
+          authorisation: {
+            ticket: "watt-mind/factory#1337",
+            repo: "factory",
+            descriptionHash: hashBytes("something else"),
+            paths: ["event-runtime/lib/worker.mjs"],
+          },
+        },
+      },
+      { fetchTicket: () => ({ description, title: "secret title" }) },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      refusal: { reason: "authorisation_stale:description" },
+    });
+    expect(result.evidence).toEqual({
+      descriptionHash: hashBytes(description),
+      ownedPaths: ["event-runtime/lib/worker.mjs"],
     });
   });
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -99,6 +99,7 @@ import {
   expireRunDeadline,
   extendRunDeadline,
   forceFailRun,
+  humanDecisionAuthorisationGate,
   LEASE_GRACE_SECONDS,
   policyMaxRunMinutes,
   policyWorkspaceOnlyFallback,
@@ -151,6 +152,95 @@ registerTestProcessCleanup(import.meta.url);
 let seq = 0;
 
 describe("worker", () => {
+  test("canonical authorisation hash is verified before dispatch execution", () => {
+    const description =
+      "## Owned Paths\n- event-runtime/lib/worker.mjs\n- docs/event-runtime-inbox.md\n";
+    const input = {
+      repo: "factory",
+      ticket: "watt-mind/factory#1337",
+      humanDecision: {
+        inboxItemId: "inbox_authorised",
+        authorisation: {
+          descriptionHash: hashBytes(description),
+          paths: [
+            "event-runtime/lib/worker.mjs",
+            "docs/event-runtime-inbox.md",
+          ],
+        },
+      },
+    };
+
+    const result = humanDecisionAuthorisationGate(input, {
+      fetchTicket: () => ({ description }),
+    });
+
+    expect(result).toMatchObject({
+      ok: true,
+      input: {
+        humanDecision: { authorisation: { verified: true } },
+      },
+    });
+    expect(input.humanDecision.authorisation.verified).toBeUndefined();
+  });
+
+  test("trailing-newline authorisation hash is refused before dispatch execution", () => {
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    const result = humanDecisionAuthorisationGate(
+      {
+        repo: "factory",
+        ticket: "watt-mind/factory#1337",
+        humanDecision: {
+          authorisation: {
+            descriptionHash: hashBytes(`${description}\n`),
+            paths: ["event-runtime/lib/worker.mjs"],
+          },
+        },
+      },
+      { fetchTicket: () => ({ description }) },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      refusal: { reason: "authorisation_stale:description" },
+    });
+  });
+
+  test("authorisation paths must cover every parsed Owned Path", () => {
+    const description =
+      "## Owned Paths\n- event-runtime/lib/worker.mjs\n- docs/event-runtime-inbox.md\n";
+    const result = humanDecisionAuthorisationGate(
+      {
+        repo: "factory",
+        ticket: "watt-mind/factory#1337",
+        humanDecision: {
+          authorisation: {
+            descriptionHash: hashBytes(description),
+            paths: ["event-runtime/lib/worker.mjs"],
+          },
+        },
+      },
+      { fetchTicket: () => ({ description }) },
+    );
+
+    expect(result).toMatchObject({
+      ok: false,
+      refusal: { reason: "authorisation_stale:paths" },
+      evidence: { missingPaths: ["docs/event-runtime-inbox.md"] },
+    });
+  });
+
+  test("dispatch without an authorisation does not add a ticket read", () => {
+    const input = { repo: "factory", ticket: "watt-mind/factory#1337" };
+    let fetches = 0;
+
+    expect(
+      humanDecisionAuthorisationGate(input, {
+        fetchTicket: () => (fetches += 1),
+      }),
+    ).toEqual({ ok: true, input });
+    expect(fetches).toBe(0);
+  });
+
   test("materialized harness entries record hashes for every copied file", () => {
     const factoryRoot = tmpDir("evrt-harness-source-");
     const workspaceDir = tmpDir("evrt-harness-workspace-");


### PR DESCRIPTION
Fixes watt-mind/factory#1337

Review the worker-side authorisation gate that removes model-side hash recomputation.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/decision-effects.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000` | pass | 191 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,138 pass, 10 skip; emit/format/lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend/runtime and documentation contract only

run:run_c54b8772-8b8d-4b7a-86d4-5d713e8a0589

## Post-review

Amended semantics (ticket #1337 "AC amendment", 2026-08-30): `authorisation.paths` must be a NON-EMPTY SUBSET of the ticket's current Owned Paths (operator narrowing via `decision-effects.mjs authorisedPaths()` is legitimate); `authorisation_stale:paths` is raised only for an empty set or a path outside Owned Paths. The gate now also refuses `authorisation_stale:ticket` when `authorisation.ticket`/`repo` differ from the run input (checked before any ticket read). `dispatch.md` states that an absent/false `verified` flag means refuse, never proceed. Refusal evidence is trimmed to `{ descriptionHash, ownedPaths }` (no raw ticket JSON). Hermetic tests cover subset-accept, superset-refuse, empty-refuse, ticket/repo-mismatch-refuse and the trimmed evidence; dispatch.json pin, planner defHash fixture and registry digest baseline re-pinned together.
