### PR TITLE
fix(control-plane): order GitHub transition writes

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1777,7 +1777,7 @@ export function githubControlPlane(options = {}) {
     async transition(
       identifier,
       state,
-      { add = [], remove = [], unassign } = {},
+      { add = [], remove = [], unassign, demotionComment = null } = {},
     ) {
       if (!state && !add.length && !remove.length && !unassign)
         throw new ControlPlaneError(
@@ -1797,6 +1797,14 @@ export function githubControlPlane(options = {}) {
         );
       if (state)
         await setStatus(repo, number, issue.node_id ?? ticket.id, state);
+      let nextLabels;
+      if (add.length || remove.length) {
+        await requireLabelsExist(repo, add);
+        nextLabels = resolveLabelNames(currentNames, { add, remove });
+        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
+          body: { labels: nextLabels },
+        });
+      }
       const patch = {};
       if (unassign) patch.assignees = [];
       if (state)
@@ -1805,20 +1813,15 @@ export function githubControlPlane(options = {}) {
         await call("PATCH", `repos/${repo}/issues/${number}`, { body: patch });
       if (readyRemoval === "demotion") {
         const reason =
+          demotionComment ||
           `Removed \`${AGENT_READY_LABEL}\` after moving this ticket to \`${state}\`. ` +
-          `It is no longer eligible for dispatch.`;
+            `It is no longer eligible for dispatch.`;
         await call("POST", `repos/${repo}/issues/${number}/comments`, {
           body: { body: clampGithubBody(stampRun(reason)) },
         });
       }
-      if (add.length || remove.length) {
-        await requireLabelsExist(repo, add);
-        const nextLabels = resolveLabelNames(currentNames, { add, remove });
-        await call("PUT", `repos/${repo}/issues/${number}/labels`, {
-          body: { labels: nextLabels },
-        });
+      if (nextLabels)
         await maybeStampReadyPin(repo, number, add, issue.body ?? "");
-      }
     },
 
     async setLabels(identifier, { add = [], remove = [] } = {}) {

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1128,7 +1128,7 @@ export function githubControlPlane(options = {}) {
       updated?.updateProjectV2ItemFieldValue?.projectV2Item?.id;
     if (acknowledgedId !== item.id)
       throw new ControlPlaneError(
-        `GitHub did not acknowledge moving ${issueIdentifier(repo, number)} to ${stateName}; labels were not changed`,
+        `GitHub did not acknowledge moving ${issueIdentifier(repo, number)} to ${stateName}`,
       );
     projectCache = null;
     projectItemsCache = null;
@@ -1795,8 +1795,16 @@ export function githubControlPlane(options = {}) {
         throw new ControlPlaneError(
           `refusing to remove ${AGENT_READY_LABEL} from a Todo ticket without claim labels or a move to another state`,
         );
-      if (state)
-        await setStatus(repo, number, issue.node_id ?? ticket.id, state);
+      if (demotionComment && readyRemoval !== "demotion")
+        console.warn(
+          `[control-plane] dropping demotionComment for ${issueIdentifier(repo, number)}: ` +
+            `the write is not a demotion (${readyRemoval})`,
+        );
+      // Write order (#1695): labels first, then the demotion comment, then the
+      // project Status and the issue PATCH. Every step is a separate GitHub
+      // write, so a failure after the label PUT leaves the ticket wearing its
+      // new labels while its Status / state / assignees are untouched — never
+      // the reverse, which the reaper and queue views read as a live claim.
       let nextLabels;
       if (add.length || remove.length) {
         await requireLabelsExist(repo, add);
@@ -1805,12 +1813,6 @@ export function githubControlPlane(options = {}) {
           body: { labels: nextLabels },
         });
       }
-      const patch = {};
-      if (unassign) patch.assignees = [];
-      if (state)
-        patch.state = state.toLowerCase() === "done" ? "closed" : "open";
-      if (Object.keys(patch).length)
-        await call("PATCH", `repos/${repo}/issues/${number}`, { body: patch });
       if (readyRemoval === "demotion") {
         const reason =
           demotionComment ||
@@ -1820,6 +1822,14 @@ export function githubControlPlane(options = {}) {
           body: { body: clampGithubBody(stampRun(reason)) },
         });
       }
+      if (state)
+        await setStatus(repo, number, issue.node_id ?? ticket.id, state);
+      const patch = {};
+      if (unassign) patch.assignees = [];
+      if (state)
+        patch.state = state.toLowerCase() === "done" ? "closed" : "open";
+      if (Object.keys(patch).length)
+        await call("PATCH", `repos/${repo}/issues/${number}`, { body: patch });
       if (nextLabels)
         await maybeStampReadyPin(repo, number, add, issue.body ?? "");
     },

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1249,7 +1249,7 @@ describe("control-plane contract: github", () => {
     );
   });
 
-  test("demotion records its reason before removing ai:agent-ready", async () => {
+  test("demotion records its reason after removing ai:agent-ready", async () => {
     const { api, cp } = makePlane();
     await cp.transition(`${REPO}#1`, "Triage", {
       remove: [AGENT_READY_LABEL],
@@ -1275,7 +1275,68 @@ describe("control-plane contract: github", () => {
         call.pathName === `repos/${REPO}/issues/1/labels`,
     );
     expect(commentIndex).toBeGreaterThan(-1);
-    expect(labelIndex).toBeGreaterThan(commentIndex);
+    expect(labelIndex).toBeGreaterThan(-1);
+    expect(commentIndex).toBeGreaterThan(labelIndex);
+  });
+
+  test("demotion posts a caller-provided explanation exactly once", async () => {
+    const { api, cp } = makePlane();
+    const explanation =
+      "Demoted by the template guard because Owned Paths is missing.";
+    await cp.transition(`${REPO}#1`, "Triage", {
+      remove: [AGENT_READY_LABEL],
+      demotionComment: explanation,
+    });
+
+    const comments = api.calls.filter(
+      (call) =>
+        call.method === "POST" &&
+        call.pathName === `repos/${REPO}/issues/1/comments`,
+    );
+    expect(comments).toHaveLength(1);
+    expect(comments[0].body.body).toContain(explanation);
+  });
+
+  test("a failed demotion label write leaves issue state and assignees untouched", async () => {
+    const seed = contractSeed();
+    const baseApi = fakeApi(seed);
+    const api = (method, pathName, options = {}) => {
+      if (method === "PUT" && pathName === `repos/${REPO}/issues/1/labels`) {
+        api.calls.push({ method, pathName, ...options });
+        throw new ControlPlaneError("labels temporarily unavailable", {
+          status: 503,
+        });
+      }
+      return baseApi(method, pathName, options);
+    };
+    api.calls = baseApi.calls;
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+
+    await expect(
+      cp.transition(`${REPO}#1`, "Triage", {
+        remove: [AGENT_READY_LABEL],
+      }),
+    ).rejects.toThrow(/labels temporarily unavailable/);
+
+    const issue = seed.repos[REPO].issues.find(
+      (candidate) => candidate.number === 1,
+    );
+    expect(issue.state).toBe("open");
+    expect(issue.assignee).toBeNull();
+    expect(issue.labels.map((label) => label.name)).toContain(
+      AGENT_READY_LABEL,
+    );
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "PATCH" && call.pathName === `repos/${REPO}/issues/1`,
+      ),
+    ).toBe(false);
   });
 
   test("an unacknowledged status write cannot strip a ready Todo ticket", async () => {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1337,9 +1337,45 @@ describe("control-plane contract: github", () => {
           call.method === "PATCH" && call.pathName === `repos/${REPO}/issues/1`,
       ),
     ).toBe(false);
+    // The project Status write comes after the label PUT too, so a failed
+    // PUT never leaves the board moved while the labels still say otherwise.
+    expect(
+      api.calls.some(
+        (call) =>
+          call.pathName === "graphql" &&
+          call.body?.query?.includes("SetProjectStatus"),
+      ),
+    ).toBe(false);
+    expect((await cp.getTicket(`${REPO}#1`)).state.name).toBe("Todo");
+    expect(await cp.listComments(`${REPO}#1`)).toEqual([]);
   });
 
-  test("an unacknowledged status write cannot strip a ready Todo ticket", async () => {
+  test("a caller-supplied demotionComment is not posted when the write is not a demotion", async () => {
+    const { api, cp } = makePlane();
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    try {
+      await cp.transition(`${REPO}#3`, "Triage", {
+        remove: [AGENT_READY_LABEL],
+        demotionComment: "should not appear",
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "POST" &&
+          call.pathName === `repos/${REPO}/issues/3/comments`,
+      ),
+    ).toBe(false);
+    expect(warnings.some((line) => line.includes("demotionComment"))).toBe(
+      true,
+    );
+  });
+
+  test("an unacknowledged status write leaves issue state and assignees untouched", async () => {
     const seed = contractSeed();
     const baseApi = fakeApi(seed);
     const api = (method, pathName, options = {}) => {
@@ -1368,17 +1404,19 @@ describe("control-plane contract: github", () => {
       }),
     ).rejects.toThrow(/did not acknowledge moving/);
 
+    // Labels are written first (#1695): the ready label is already gone and
+    // the demotion reason recorded, but the board, issue state and assignees
+    // are untouched, so the ticket never reads as a live claim.
     const ticket = await cp.getTicket(`${REPO}#1`);
     expect(ticket.state.name).toBe("Todo");
-    expect(ticket.labels.map((label) => label.name)).toContain(
+    expect(ticket.labels.map((label) => label.name)).not.toContain(
       AGENT_READY_LABEL,
     );
-    expect(await cp.listComments(`${REPO}#1`)).toEqual([]);
+    expect(await cp.listComments(`${REPO}#1`)).toHaveLength(1);
     expect(
       api.calls.some(
         (call) =>
-          call.method === "PUT" &&
-          call.pathName === `repos/${REPO}/issues/1/labels`,
+          call.method === "PATCH" && call.pathName === `repos/${REPO}/issues/1`,
       ),
     ).toBe(false);
   });

--- a/orchestrator/label-guard.mjs
+++ b/orchestrator/label-guard.mjs
@@ -193,8 +193,8 @@ export async function demote(
   const cp = resolveControlPlane({ repoName: repo.name });
   await cp.transition(issue.identifier, "Triage", {
     remove: [AI_AGENT_READY],
+    demotionComment: body,
   });
-  await cp.comment(issue.identifier, body);
 }
 
 export function parseArgs(argv = process.argv.slice(2)) {

--- a/orchestrator/label-guard.test.mjs
+++ b/orchestrator/label-guard.test.mjs
@@ -126,8 +126,15 @@ test("listing and demotion select the control plane configured for the repo", as
       calls.push({ method: "listDispatchable", filters });
       return [{ identifier: "#1555" }];
     },
-    transition: async (...args) => calls.push({ method: "transition", args }),
-    comment: async (...args) => calls.push({ method: "comment", args }),
+    transition: async (...args) => {
+      calls.push({ method: "transition", args });
+      const [identifier, , options] = args;
+      if (options.demotionComment)
+        calls.push({
+          method: "comment",
+          args: [identifier, options.demotionComment],
+        });
+    },
   };
   const resolveControlPlane = (options) => {
     calls.push({ method: "loadControlPlane", options });
@@ -147,8 +154,15 @@ test("listing and demotion select the control plane configured for the repo", as
   });
   expect(calls).toContainEqual({
     method: "transition",
-    args: ["#1555", "Triage", { remove: ["ai:agent-ready"] }],
+    args: [
+      "#1555",
+      "Triage",
+      expect.objectContaining({ remove: ["ai:agent-ready"] }),
+    ],
   });
+  const comments = calls.filter((call) => call.method === "comment");
+  expect(comments).toHaveLength(1);
+  expect(comments[0].args[1]).toContain("Demoted by the `ai:agent-ready`");
 });
 
 test("a malformed registry digest policy is rendered as a guard message", () => {


### PR DESCRIPTION
Fixes #1695

Label writes now complete before issue PATCHes, and template demotions leave one detailed explanation.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | \`bun test lib/control-plane/github.test.mjs orchestrator/label-guard.test.mjs --timeout 20000\` | pass | 139 tests, 0 failures |
| Repo verify | \`bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint\` | pass | clean; 615 existing warnings |
| UX critique | factory-ux-critic | skipped | no user-facing surface |

UX critique: skipped — no user-facing surface

## Post-review
- Merged `origin/develop` into the branch.
- Fold: `setStatus()` (project Status) now runs **after** the label PUT, so a failed PUT leaves Status, issue state and assignees all untouched. Order is label PUT -> demotion comment -> Status -> issue PATCH.
- Extended the "PUT fails -> no PATCH" test to also assert no `SetProjectStatus` write, Status still Todo, no comment.
- The #1673 status-ack test now asserts the inverse invariant (labels already written, no PATCH, Status still Todo) because one of the two non-transactional writes has to go first; a Todo ticket without `ai:agent-ready` is simply undispatchable, whereas Triage + `ai:agent-ready` is the stale-pin state.
- `console.warn` (with test) when a caller-supplied `demotionComment` is dropped because the write is not a demotion; not thrown, so `demote()` on an already-demoted ticket stays idempotent.
- Verified: ticket command (140 pass), `bun run lint && bun test event-runtime/lib && bun build/emit.mjs --check && bun run format:check && bun run check` all green.