### PR TITLE
fix(ci): await agy trace consumer close

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -425,8 +425,15 @@ export async function execute({
     }
 
     let finalUsage = null;
+    // `close` on the child only guarantees that its stdout fd closed. The
+    // readline consumer has its own close lifecycle, and its final line event
+    // can otherwise still be queued when `execute()` resolves. Keep the
+    // transcript and trace consumers in lockstep so callers can safely read
+    // both the artifact and emitted usage/trace state after awaiting execute.
+    let linesClosed = Promise.resolve();
     if (child.stdout) {
       const lines = createInterface({ input: child.stdout });
+      linesClosed = new Promise((done) => lines.once("close", done));
       lines.on("line", (line) => {
         let parsed;
         try {
@@ -485,7 +492,7 @@ export async function execute({
       cancelTermination?.();
       abortSignal?.removeEventListener("abort", cancel);
       signal?.removeEventListener("abort", cancel);
-      await transcriptClosed;
+      await Promise.all([transcriptClosed, linesClosed]);
       if (exitCode !== 0 && stderrBuf) {
         try {
           writeFileSync(


### PR DESCRIPTION
Fixes watt-mind/factory#1104

Await the readline trace consumer after child stdout closes; the existing parser already accepts the reported `(fail)` line, while the CI warning results from stderr not being captured by the workflow's stdout-only `tee`.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `for i in $(seq 1 20); do bun test --timeout 20000 --max-concurrency=4 event-runtime/lib/adapters/agy.test.mjs || exit 1; done && bun test --timeout 20000 event-runtime/lib/test-helpers-timing.test.mjs` | pass | 20 × 27 adapter tests; 9 parser tests |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; existing lint warnings only |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_f7194133-07a4-4382-8065-92fa3247a2b7
