### PR TITLE
chore(evals): pin the grader in policy and ignore run results (#1090)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ graphify-out/
 
 # Event-runtime web bundle — built from source, never committed
 event-runtime/web/dist/
+
+# Eval run output — local timestamps, not repo content
+evals/.results/

--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -134,6 +134,20 @@ models:
     standard: cursor-grok-4.6-high
     light: cursor-grok-4.6-low-fast
 
+# Grader pin for `evals/run.mjs`. A real run refuses to start without this;
+# `--dry-run` still works so discovery stays testable. `grader.model` must
+# name a real model (`default` is refused) so a grader upgrade is reviewable.
+evals:
+  subject:
+    model: default
+  grader:
+    model: claude-sonnet-4-6
+  limits:
+    case_timeout_seconds: 300
+    case_budget_usd: 2.00
+    total_seconds: 3600
+    total_budget_usd: 20.00
+
 limits:
   max_run_minutes: 90
 


### PR DESCRIPTION
Fixes watt-mind/factory#1090

Pins claude-sonnet-4-6 as the eval grader in policy.example.yaml and ignores evals/.results/.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `node evals/run.mjs --dry-run --json \| node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>{const j=JSON.parse(s);if(!j.grader\|\|!j.grader.model){console.error("FAIL: grader unpinned — "+j.graderProblem);process.exit(1)}console.log("PASS: grader pinned as "+j.grader.model)})' && git check-ignore -q evals/.results/x.json && echo "PASS: evals/.results ignored"` | pass    | grader claude-sonnet-4-6; results ignored |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2142 pass, 0 fail; prettier clean; lint 0 errors |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_91725409-90a0-4189-93b6-b3ad2942bb6a

Made with [Cursor](https://cursor.com)