### PR TITLE
fix(runtime): verify committed harness pins

### DIFF
--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -66,6 +66,8 @@ repos:
           requires:
             - dist/**
             - plugins/core/**
+            # Shared harness content must update its committed content pins.
+            - event-runtime/pins.json
       pin_manifests: # Pin manifests that must accompany matching path changes.
         - event-runtime/agents/*.json
       # Registry inputs change the tracked zero-pack digest baseline.

--- a/docs/kernel-and-packs.md
+++ b/docs/kernel-and-packs.md
@@ -140,6 +140,10 @@ validates a supplied `harnessRoots` array against this file at load time,
 failing closed exactly like the per-agent pin check, on either an unpinned
 file or content that has drifted from its pin:
 
+Adding or removing any file under `shared/` requires re-running
+`bun event-runtime/cli.mjs update-pins`. The repository verification gate
+enforces that the committed harness pins remain current.
+
 ```sh
 bun event-runtime/cli.mjs update-pins --check
 ```

--- a/event-runtime/lib/pins.test.mjs
+++ b/event-runtime/lib/pins.test.mjs
@@ -9,6 +9,8 @@ import {
   updateHarnessPins,
   verifyHarnessPins,
 } from "./pins.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
+import { collectHarnessRoots } from "./extensions.mjs";
 
 function makeRoot(dir, { plugin = "core", origin = "builtin" } = {}) {
   mkdirSync(path.join(dir, "commands"), { recursive: true });
@@ -49,6 +51,21 @@ describe("hashHarnessRoots", () => {
 });
 
 describe("updateHarnessPins / verifyHarnessPins", () => {
+  test("accepts the current built-in shared harness pins", () => {
+    const { roots, anomalies } = collectHarnessRoots({
+      root: FACTORY_ROOT,
+      builtin: path.join(FACTORY_ROOT, "shared"),
+      // Keep this regression test hermetic: local extension packs must not
+      // affect the committed built-in harness manifest.
+      policy: { extensions: [] },
+    });
+
+    expect(anomalies).toEqual([]);
+    expect(roots).toHaveLength(1);
+    expect(() => verifyHarnessPins(roots)).not.toThrow();
+    expect(updateHarnessPins({ roots, check: true })).toEqual([]);
+  });
+
   test("writes pins, then a second update reports no change", () => {
     withTmpDir("pins-update-", (dir) => {
       const root = makeRoot(dir);


### PR DESCRIPTION
Fixes watt-mind/factory#1164

Committed shared harness pins are now asserted by a hermetic regression test and enforced by ownership guidance.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Pin-probe falsification | `mkdir shared/skills/_pin-probe; bun test event-runtime/lib/pins.test.mjs --timeout 20000; rm -rf shared/skills/_pin-probe` | pass | failed as expected: has no pin; cleanup returned 8 passing tests |
| Verification Command | `bun test event-runtime/lib/pins.test.mjs --timeout 20000 && bun event-runtime/cli.mjs update-pins --check && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 8 pin tests; 2143 pass, 10 skipped, 0 failures; pins current |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2143 pass, 10 skipped, 0 failures; format and lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped

run:run_1415b6c7-0694-4f64-8dbd-48aab32ab211