### PR TITLE
fix(spend): surface scan failures in watch instead of $0.00 (#1693)

### DIFF
--- a/lib/spend.mjs
+++ b/lib/spend.mjs
@@ -138,8 +138,31 @@ function errorMessage(error) {
   return error instanceof Error ? error.message : String(error);
 }
 
-export function todaysSpendUSD(logDir = LOG_DIR) {
-  return todaysSpendBreakdown(logDir).usd;
+/**
+ * Today's notional spend, or `null` when the scan failed.
+ *
+ * A missing log directory is still `$0` (an empty day), matching
+ * `budgetExhausted`. Any other scan failure used to collapse to `0` here
+ * while the gate returned "budget unavailable" — watch then painted `$0.00`.
+ */
+export function todaysSpendUSD(logDir = LOG_DIR, scanOptions) {
+  const breakdown = todaysSpendBreakdown(logDir, scanOptions);
+  if (breakdown.error) return null;
+  return breakdown.usd;
+}
+
+/**
+ * Watch footer spend cell. Same breakdown `budgetExhausted` reads, so an
+ * unreadable log dir never renders as `$0.00` while the gate refuses dispatch.
+ */
+export function formatWatchSpend(breakdown, perDay) {
+  if (breakdown?.error) return "unavailable (unreadable log dir)";
+  const usd = breakdown?.usd ?? 0;
+  const cap = perDay ?? 0;
+  const amount = `$${usd.toFixed(2)} / $${cap.toFixed(2)}`;
+  const skipped = breakdown?.skipped ?? 0;
+  if (skipped > 0) return `~${amount} (${skipped} skipped)`;
+  return amount;
 }
 
 /** null when under budget; a human-readable reason when the day is spent. */

--- a/lib/spend.test.mjs
+++ b/lib/spend.test.mjs
@@ -9,7 +9,12 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { budgetExhausted, todaysSpendBreakdown } from "./spend.mjs";
+import {
+  budgetExhausted,
+  formatWatchSpend,
+  todaysSpendBreakdown,
+  todaysSpendUSD,
+} from "./spend.mjs";
 
 const jsonl = (...events) =>
   events.map((event) => JSON.stringify(event)).join("\n") + "\n";
@@ -36,6 +41,10 @@ test("missing log directory is an empty, explicitly unscanned day", () => {
       scanned: false,
       reason: "no log directory",
     });
+    expect(todaysSpendUSD(logDir)).toBe(0);
+    expect(formatWatchSpend(todaysSpendBreakdown(logDir), 40)).toBe(
+      "$0.00 / $40.00",
+    );
     expect(budgetExhausted(policy(1), logDir)).toBeNull();
   } finally {
     rmSync(path.dirname(logDir), { recursive: true, force: true });
@@ -59,6 +68,10 @@ test("an unreadable log directory surfaces an error and closes the budget gate",
       scanned: false,
     });
     expect(breakdown.error).toContain("permission denied");
+    expect(todaysSpendUSD(logDir, { stat })).toBeNull();
+    expect(formatWatchSpend(breakdown, 100)).toBe(
+      "unavailable (unreadable log dir)",
+    );
     expect(budgetExhausted(policy(100), logDir, { stat })).toMatch(
       /unreadable log directory/,
     );
@@ -109,6 +122,11 @@ test("a file read failure is surfaced and closes the budget gate", () => {
     expect(breakdown.usd).toBe(breakdown.reported);
 
     reads = 0;
+    expect(todaysSpendUSD(logDir, { readFile })).toBeNull();
+    expect(formatWatchSpend(breakdown, 100)).toBe(
+      "unavailable (unreadable log dir)",
+    );
+    reads = 0;
     expect(budgetExhausted(policy(100), logDir, { readFile })).toMatch(
       /unreadable log directory/,
     );
@@ -151,6 +169,10 @@ test("a log file that vanishes mid-scan is skipped, not a scan failure", () => {
       scanned: true,
     });
     expect(breakdown.error).toBeUndefined();
+    expect(todaysSpendUSD(logDir, { stat })).toBe(1.25);
+    expect(formatWatchSpend(breakdown, 100)).toBe(
+      "~$1.25 / $100.00 (2 skipped)",
+    );
     expect(budgetExhausted(policy(100), logDir, { stat })).toBeNull();
 
     // Vanishing between stat and read is the same benign race.
@@ -172,6 +194,10 @@ test("a log file that vanishes mid-scan is skipped, not a scan failure", () => {
       if (target.endsWith("second.jsonl")) throw permissionDenied(target);
       return statSync(target);
     };
+    expect(todaysSpendUSD(logDir, { stat: denied })).toBeNull();
+    expect(
+      formatWatchSpend(todaysSpendBreakdown(logDir, { stat: denied }), 100),
+    ).toBe("unavailable (unreadable log dir)");
     expect(budgetExhausted(policy(100), logDir, { stat: denied })).toMatch(
       /unreadable log directory/,
     );
@@ -206,6 +232,10 @@ test("a clean fixture scan reports today's totals and scanned true", () => {
       runs: 1,
       scanned: true,
     });
+    expect(todaysSpendUSD(logDir)).toBe(1.25);
+    expect(formatWatchSpend(todaysSpendBreakdown(logDir), 40)).toBe(
+      "$1.25 / $40.00",
+    );
     expect(budgetExhausted(policy(2), logDir)).toBeNull();
     expect(budgetExhausted(policy(1), logDir)).toBe(
       "day budget spent (~$1.25 of $1 notional)",

--- a/orchestrator/watch.jsx
+++ b/orchestrator/watch.jsx
@@ -46,14 +46,13 @@ import { homedir } from "node:os";
 import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import { ROOT } from "../lib/schedule.mjs";
-import { todaysSpendUSD } from "../lib/spend.mjs";
+import { formatWatchSpend, todaysSpendBreakdown } from "../lib/spend.mjs";
 import {
   buildTicketRows,
   latestLogForTicket,
   tailEntries,
   entryTone,
   formatEntry,
-  formatSpend,
   formatIssueCounts,
   parseReaperOutput,
   linearDeepLink,
@@ -839,7 +838,7 @@ function App() {
   const [logEntries, setLogEntries] = useState([]);
   const [scrollOffset, setScrollOffset] = useState(0); // rows back from live; 0 = following
   const [logMode, setLogMode] = useState("messages");
-  const [spend, setSpend] = useState(0);
+  const [spend, setSpend] = useState({ usd: 0, skipped: 0 });
   const [lastPollMs, setLastPollMs] = useState(null);
   const [nowTick, setNowTick] = useState(Date.now());
   const [reaper, setReaper] = useState(null); // { phase, team, lines, stale }
@@ -892,10 +891,10 @@ function App() {
 
   useEffect(() => {
     const id = setInterval(
-      () => setSpend(todaysSpendUSD(LOG_DIR)),
+      () => setSpend(todaysSpendBreakdown(LOG_DIR)),
       LOG_POLL_MS,
     );
-    setSpend(todaysSpendUSD(LOG_DIR));
+    setSpend(todaysSpendBreakdown(LOG_DIR));
     return () => clearInterval(id);
   }, []);
 
@@ -958,7 +957,9 @@ function App() {
     return () => clearInterval(id);
   }, [summary]);
 
-  const budgetTone = spendTone(spend, PER_DAY_USD);
+  const spendUsd = spend?.error != null ? null : (spend?.usd ?? 0);
+  const budgetTone =
+    spendUsd == null ? undefined : spendTone(spendUsd, PER_DAY_USD);
   const quietTickets = rows.filter(
     (t) =>
       t.status === "running" &&
@@ -1314,7 +1315,7 @@ function App() {
     if (key.escape) process.exit(0);
     if (input === "r") {
       pollRef.current?.();
-      setSpend(todaysSpendUSD(LOG_DIR));
+      setSpend(todaysSpendBreakdown(LOG_DIR));
     }
     if (input === "v")
       setLogMode((mode) => (mode === "messages" ? "tools" : "messages"));
@@ -1478,8 +1479,13 @@ function App() {
       </Box>
       <Box justifyContent="space-between">
         <Text dimColor>
-          spend {formatSpend(spend, PER_DAY_USD)}
-          {spendPct(spend, PER_DAY_USD) != null && (
+          spend{" "}
+          {spend?.error ? (
+            <Text color="red">{formatWatchSpend(spend, PER_DAY_USD)}</Text>
+          ) : (
+            formatWatchSpend(spend, PER_DAY_USD)
+          )}
+          {spendUsd != null && spendPct(spendUsd, PER_DAY_USD) != null && (
             <Text
               color={
                 budgetTone === "bad"
@@ -1490,7 +1496,7 @@ function App() {
               }
             >
               {" "}
-              ({spendPct(spend, PER_DAY_USD)}%)
+              ({spendPct(spendUsd, PER_DAY_USD)}%)
             </Text>
           )}{" "}
           today


### PR DESCRIPTION
Fixes watt-mind/factory#1693

Watch no longer paints $0.00 when the day-budget scan failed — it shows unavailable / skipped, matching the gate.

## Validation

| Check                | Command                                                                                                              | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test lib/spend.test.mjs --timeout 20000`                                                                        | pass    | 5 tests, 0 failures                        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`   | pass    | 2142 pass, 0 fail                          |
| UX critique          | factory-ux-critic                                                                                                    | not run | operator TUI spend cell; no browser surface |

UX critique: skipped

run:run_9136c54d-526c-4170-bed1-869c22269a03

Made with [Cursor](https://cursor.com)