### PR TITLE
feat(metrics): add agent refusal and timeout breakdowns

### DIFF
--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -35,9 +35,12 @@ export const VALID_BREAKDOWN_DIMENSIONS = Object.freeze([
 export const VALID_BREAKDOWN_METRICS = Object.freeze([
   "runs",
   "failures",
+  "refusals",
+  "timeouts",
   "cost",
   "tokens",
   "p95_execution",
+  "last_run_at",
 ]);
 
 export const MAX_METRIC_BUCKETS = 500;
@@ -431,17 +434,33 @@ function factKeys(row, dimension) {
 }
 
 function breakdownFacts(db, metric, range) {
-  if (metric === "runs" || metric === "failures") {
-    const failures =
-      metric === "failures"
-        ? "AND r.state IN ('FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED')"
-        : "";
-    const time = metric === "failures" ? "r.updated_at" : "r.created_at";
+  if (
+    metric === "runs" ||
+    metric === "failures" ||
+    metric === "refusals" ||
+    metric === "timeouts"
+  ) {
+    const states = {
+      failures: "'FAILED', 'REFUSED', 'TIMED_OUT', 'CANCELLED'",
+      refusals: "'REFUSED'",
+      timeouts: "'TIMED_OUT'",
+    };
+    const state = states[metric];
+    const time = state ? "r.updated_at" : "r.created_at";
     return db
       .query(
         `${RUN_FACTS_SELECT}, 1 AS value
        FROM runs r ${RUN_FACTS_JOINS}
-       WHERE ${time} >= ? AND ${time} < ? ${failures}`,
+       WHERE ${time} >= ? AND ${time} < ? ${state ? `AND r.state IN (${state})` : ""}`,
+      )
+      .all(range.startIso, range.endIso);
+  }
+  if (metric === "last_run_at") {
+    return db
+      .query(
+        `${RUN_FACTS_SELECT}, r.created_at AS last_run_at
+       FROM runs r ${RUN_FACTS_JOINS}
+       WHERE r.created_at >= ? AND r.created_at < ?`,
       )
       .all(range.startIso, range.endIso);
   }
@@ -604,7 +623,11 @@ export function modelTierEconomicsView(
     .sort((a, b) => a.key.localeCompare(b.key));
 }
 
-/** Top-N operational dimensions used by GET /metrics/breakdown. */
+/**
+ * Top-N operational dimensions used by GET /metrics/breakdown. `last_run_at`
+ * is the only timestamp metric: its row value is epoch milliseconds, with the
+ * corresponding ISO-8601 timestamp exposed as `at`.
+ */
 export function metricsBreakdownView(
   db,
   { now, window = "24h", by, metric, limit } = {},
@@ -658,12 +681,18 @@ export function metricsBreakdownView(
         const samples = grouped.get(key) ?? [];
         samples.push(durationMs);
         grouped.set(key, samples);
+      } else if (metric === "last_run_at") {
+        const value = Date.parse(fact.last_run_at);
+        const current = grouped.get(key);
+        if (!current || value > current.value)
+          grouped.set(key, { value, at: fact.last_run_at });
       } else {
         grouped.set(key, (grouped.get(key) ?? 0) + Number(fact.value ?? 0));
       }
     }
   }
   let rows = [...grouped.entries()].map(([key, value]) => {
+    if (metric === "last_run_at") return { key, ...value };
     if (metric !== "p95_execution") return { key, value };
     value.sort((a, b) => a - b);
     return { key, value: percentile(value, 0.95) };

--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -683,6 +683,7 @@ export function metricsBreakdownView(
         grouped.set(key, samples);
       } else if (metric === "last_run_at") {
         const value = Date.parse(fact.last_run_at);
+        if (!Number.isFinite(value)) continue;
         const current = grouped.get(key);
         if (!current || value > current.value)
           grouped.set(key, { value, at: fact.last_run_at });

--- a/event-runtime/lib/metrics.test.mjs
+++ b/event-runtime/lib/metrics.test.mjs
@@ -493,6 +493,17 @@ describe("metrics breakdowns (WM-281)", () => {
       createdAt: at(25 * 60 * 60_000),
       updatedAt: at(25 * 60 * 60_000),
     });
+    // Seen first for delta@1: sorts inside the SQL window but Date.parse()
+    // returns NaN, which must not pin the key ahead of the parsable run.
+    insertRun(db, "delta-unparsable", {
+      agent: "delta@1",
+      createdAt: "2026-08-15T11:3x:00.000Z",
+      updatedAt: at(1 * 60_000),
+    });
+    insertRun(db, "delta-parsable", {
+      agent: "delta@1",
+      createdAt: at(20 * 60_000),
+    });
 
     const options = { now: NOW, window: "24h", by: "agent" };
     expect(
@@ -513,6 +524,7 @@ describe("metrics breakdowns (WM-281)", () => {
     ).toEqual([
       { key: "gamma@1", value: NOW - 5 * 60_000, at: at(5 * 60_000) },
       { key: "alpha@1", value: NOW - 15 * 60_000, at: at(15 * 60_000) },
+      { key: "delta@1", value: NOW - 20 * 60_000, at: at(20 * 60_000) },
       { key: "beta@1", value: NOW - 25 * 60_000, at: at(25 * 60_000) },
     ]);
 

--- a/event-runtime/lib/metrics.test.mjs
+++ b/event-runtime/lib/metrics.test.mjs
@@ -463,6 +463,76 @@ describe("metrics breakdowns (WM-281)", () => {
     db.close();
   });
 
+  test("agent terminal outcomes and newest run timestamps share breakdown facts", () => {
+    const db = openDb(":memory:");
+    insertRun(db, "refused", {
+      agent: "alpha@1",
+      state: "REFUSED",
+      createdAt: at(15 * 60_000),
+      updatedAt: at(12 * 60_000),
+    });
+    insertRun(db, "timed-out", {
+      agent: "beta@1",
+      state: "TIMED_OUT",
+      createdAt: at(25 * 60_000),
+      updatedAt: at(11 * 60_000),
+    });
+    insertRun(db, "failed", {
+      agent: "gamma@1",
+      state: "FAILED",
+      createdAt: at(40 * 60_000),
+      updatedAt: at(10 * 60_000),
+    });
+    insertRun(db, "gamma-newest", {
+      agent: "gamma@1",
+      createdAt: at(5 * 60_000),
+    });
+    insertRun(db, "outside-window", {
+      agent: "outside@1",
+      state: "REFUSED",
+      createdAt: at(25 * 60 * 60_000),
+      updatedAt: at(25 * 60 * 60_000),
+    });
+
+    const options = { now: NOW, window: "24h", by: "agent" };
+    expect(
+      metricsBreakdownView(db, { ...options, metric: "failures" }).rows,
+    ).toEqual([
+      { key: "alpha@1", value: 1 },
+      { key: "beta@1", value: 1 },
+      { key: "gamma@1", value: 1 },
+    ]);
+    expect(
+      metricsBreakdownView(db, { ...options, metric: "refusals" }).rows,
+    ).toEqual([{ key: "alpha@1", value: 1 }]);
+    expect(
+      metricsBreakdownView(db, { ...options, metric: "timeouts" }).rows,
+    ).toEqual([{ key: "beta@1", value: 1 }]);
+    expect(
+      metricsBreakdownView(db, { ...options, metric: "last_run_at" }).rows,
+    ).toEqual([
+      { key: "gamma@1", value: NOW - 5 * 60_000, at: at(5 * 60_000) },
+      { key: "alpha@1", value: NOW - 15 * 60_000, at: at(15 * 60_000) },
+      { key: "beta@1", value: NOW - 25 * 60_000, at: at(25 * 60_000) },
+    ]);
+
+    try {
+      metricsBreakdownView(db, { ...options, metric: "unknown" });
+      throw new Error("expected invalid metric error");
+    } catch (err) {
+      expect(err).toBeInstanceOf(MetricsQueryError);
+      expect(err.body).toMatchObject({
+        error: "invalid_metric",
+        validMetrics: expect.arrayContaining([
+          "refusals",
+          "timeouts",
+          "last_run_at",
+        ]),
+      });
+    }
+    db.close();
+  });
+
   test("modelTier cohorts use dispatch pins, merged events, and every ticket run cost", () => {
     const db = openDb(":memory:");
     insertRun(db, "standard-dispatch", {

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -280,7 +280,19 @@ export interface MetricsBreakdownView {
   by: string;
   metric: string;
   limit: number | null;
-  rows: Array<{ key: string; value: number }>;
+  rows: Array<{ key: string; value: number; at?: string }>;
+}
+
+/** Per-agent usage values joined from metrics breakdowns by the registry view. */
+export interface RegistryAgentUsage {
+  runs: number | null;
+  failures: number | null;
+  refusals: number | null;
+  timeouts: number | null;
+  p95_execution: number | null;
+  cost: number | null;
+  tokens: number | null;
+  last_run_at: string | null;
 }
 
 /** One append-only journal row (GET /journal) — the runtime's activity feed. */


### PR DESCRIPTION
Fixes watt-mind/factory#1174

Expose refusal, timeout, and newest-run agent metrics for #1075.

## Validation

| Check                | Command                                                                                          | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `bun test --timeout 20000 event-runtime/lib/metrics.test.mjs event-runtime/lib/api-metrics.test.mjs && bun run lint` | pass    | exit 0; tests and lint completed  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | exit 0; clean                     |
| Web TypeScript       | `cd event-runtime/web && bun x tsc --noEmit`                                                    | pass    | no diagnostics                     |
| UX critique          | factory-ux-critic                                                                                | not run | skipped; no user-facing surface   |

UX critique: skipped — shared metrics and type-contract changes only

run:run_e9c47bc4-0bc6-4049-a9b2-4a15dffe2ffc

## Post-review

- Reviewer fold (a1915ac8): `metricsBreakdownView` `last_run_at` reduction now skips `created_at` values where `!Number.isFinite(Date.parse(...))`, so an unparsable timestamp seen first for a key can no longer pin that key to `NaN`. Covered by a `delta@1` fixture in `metrics.test.mjs` (fails without the guard, passes with it).
- Verified: ticket Verification Command, `bun run lint`, `bun test event-runtime/lib` (2143 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
