### PR TITLE
chore(evals): pin compare-removed and policy-error contracts (#1109)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -71,7 +71,7 @@ evals:
 
 ### Runs are recorded, and drops are what you compare
 
-Two runs of the same cases on the same models can disagree, so an absolute score cannot tell you whether a prompt edit made things worse. The diff can. Every run writes `evals/.results/<timestamp>.json` — the models, the case set, and per-case pass/fail with the grader's reason — and `--compare <file>` reports the transitions against an earlier one: `pass -> fail` is a **regression** and exits non-zero; a grader change is flagged, because runs judged by different models are not a comparable measurement.
+Two runs of the same cases on the same models can disagree, so an absolute score cannot tell you whether a prompt edit made things worse. The diff can. Every run writes `evals/.results/<timestamp>.json` — the models, the case set, and per-case pass/fail with the grader's reason — and `--compare <file>` reports the transitions against an earlier one: `pass -> fail` is a **regression** and exits non-zero; a case present in the previous run and absent from the current one is reported as removed and does not fail the run, because case sets legitimately differ across branches; a grader change is flagged, because runs judged by different models are not a comparable measurement.
 
 `evals/.results/` is local run output, not repo content. Add it to `.gitignore` (tracked in [#1090](https://github.com/watt-mind/factory/issues/1090), together with the policy stanza above) or pass `--no-results`.
 

--- a/evals/lib/results.mjs
+++ b/evals/lib/results.mjs
@@ -42,6 +42,10 @@ function byId(run) {
 }
 
 /**
+ * Diff two recorded runs. `removed` is reported so the operator can see the
+ * case-set delta; it does not fail the run (case sets legitimately differ
+ * across branches). A `pass` -> not-`pass` transition is a regression.
+ *
  * @returns {{regressions: Array, fixes: Array, added: Array<string>, removed: Array<string>, graderChanged: boolean, previousGrader: string|null, currentGrader: string|null, previousAt: string|null}}
  */
 export function compareRuns(previous, current) {

--- a/evals/run.mjs
+++ b/evals/run.mjs
@@ -174,6 +174,7 @@ export async function main({
   evalsDir = EVALS_DIR,
   deps = null,
   policy: injectedPolicy = null,
+  loadPolicy = loadEvalPolicy,
   now = () => Date.now(),
   date = () => new Date(),
 } = {}) {
@@ -192,8 +193,9 @@ export async function main({
 
   let policy;
   try {
-    policy = injectedPolicy ?? loadEvalPolicy({ root: repoRoot });
+    policy = injectedPolicy ?? loadPolicy({ root: repoRoot });
   } catch (error) {
+    if (!(error instanceof EvalConfigError)) throw error;
     writeLine(stderr, `evals: ${error.message}`);
     return EXIT_USAGE;
   }
@@ -318,8 +320,12 @@ export async function main({
     writeLine(stdout, formatRun({ run, comparison, repoRoot }));
   }
 
+  // status is "pass" | "fail" only (see evals/lib/case-run.mjs), so a
+  // pass -> fail regression always increments totals.failed — one condition
+  // covers both. A removed case is reported in the comparison (and the JSON)
+  // but does not fail the run: case sets legitimately differ across branches,
+  // so a --compare against a run from a different branch must stay usable.
   if (run.totals.failed > 0) return EXIT_FAILED;
-  if (comparison && comparison.regressions.length > 0) return EXIT_FAILED;
   return EXIT_OK;
 }
 

--- a/evals/run.test.mjs
+++ b/evals/run.test.mjs
@@ -20,7 +20,7 @@ import {
   parseCliJson,
   parseVerdict,
 } from "./lib/grader.mjs";
-import { loadEvalPolicy, requirePin } from "./lib/policy.mjs";
+import { EvalConfigError, loadEvalPolicy, requirePin } from "./lib/policy.mjs";
 import { compareRuns } from "./lib/results.mjs";
 
 const EVALS_DIR = path.dirname(fileURLToPath(import.meta.url));
@@ -548,6 +548,33 @@ describe("--compare", () => {
       expect(report.comparison.added).toEqual(["ticket-spec/green-but-empty"]);
     }));
 
+  test("a passing case present in the previous run and absent from the current one is reported and does not fail the run", () =>
+    withTmpDir("evals-compare-removed-", async (dir) => {
+      const fixture = buildFixture(dir, { cases: twoCases() });
+      const previous = path.join(dir, "previous.json");
+      writeFileSync(
+        previous,
+        JSON.stringify({
+          startedAt: "2026-08-01T00:00:00.000Z",
+          grader: { model: "claude-sonnet-4-6" },
+          cases: [
+            { id: "ticket-spec/hidden-decision", status: "pass" },
+            { id: "ticket-spec/green-but-empty", status: "pass" },
+            { id: "ticket-spec/deleted-case", status: "pass" },
+          ],
+        }),
+      );
+      const result = await run({
+        argv: ["--json", "--compare", previous, "--no-results"],
+        deps: fakeDeps(),
+        ...fixture,
+      });
+      expect(result.code).toBe(EXIT_OK);
+      const report = JSON.parse(result.stdout);
+      expect(report.comparison.removed).toEqual(["ticket-spec/deleted-case"]);
+      expect(report.comparison.regressions).toEqual([]);
+    }));
+
   test("a missing or malformed comparison file is a usage error", () =>
     withTmpDir("evals-compare-bad-", async (dir) => {
       const fixture = buildFixture(dir, { cases: twoCases() });
@@ -739,6 +766,32 @@ describe("the grader pin", () => {
     });
     expect(policy.grader).toBeNull();
     expect(policy.problem).toContain("no `evals:` stanza");
+  });
+
+  test("an EvalConfigError from the policy loader is a usage error", async () => {
+    const result = await run({
+      argv: [],
+      policy: null,
+      deps: fakeDeps(),
+      loadPolicy: () => {
+        throw new EvalConfigError("bad limits");
+      },
+    });
+    expect(result.code).toBe(EXIT_USAGE);
+    expect(result.stderr).toContain("evals: bad limits");
+  });
+
+  test("a non-EvalConfigError from the policy loader is rethrown, not reported as exit 2", async () => {
+    await expect(
+      main({
+        argv: [],
+        stdout: sink(),
+        stderr: sink(),
+        loadPolicy: () => {
+          throw new TypeError("parser exploded");
+        },
+      }),
+    ).rejects.toBeInstanceOf(TypeError);
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1109

Pin the eval runner's --compare removed-case exit-0 contract, drop the unreachable regression-exit branch, and rethrow non-EvalConfigError from loadEvalPolicy.

## Validation

| Check                | Command                                                                                                              | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test --timeout 20000 evals/run.test.mjs`                                                                        | pass    | 45 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2142 pass, format clean, lint 0 errors     |
| UX critique          | factory-ux-critic                                                                                                    | not run | no user-facing surface                     |

UX critique: skipped

run:run_c4500440-a2b2-445d-bd0e-6e84de0f19ae

Made with [Cursor](https://cursor.com)