### PR TITLE
fix(worker): trap verifyResult throws that escaped executeClaimed (#1663)

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -903,6 +903,11 @@ function workerSubprocessTimeoutMs() {
     : DEFAULT_WORKER_SUBPROCESS_TIMEOUT_MS;
 }
 
+/** Worktree vanished between agent finish and handoff verify (`realpath` ENOENT). */
+const HANDOFF_WORKTREE_MISSING = "handoff_worktree_missing";
+/** Non-`ContractViolation` throw from `verifyResult` / `assertHandoffPullRequestBase`. */
+const VERIFICATION_INTERNAL_ERROR = "verification_internal_error";
+
 const ENVIRONMENT_FAILURES = new Set([
   "adapter_error",
   "lease_expired",
@@ -915,6 +920,9 @@ const ENVIRONMENT_FAILURES = new Set([
   // The offline sandbox cannot restore packages; this is a host fault rather
   // than evidence that the agent's branch is red.
   HANDOFF_DEPENDENCIES_MISSING,
+  // Same family: the worktree is gone, so continuation/retry must not treat
+  // the throw as an agent red (#1663).
+  HANDOFF_WORKTREE_MISSING,
 ]);
 const isAgentHandoffFailure = (reasonCode) =>
   HANDOFF_REASON_CODES.has(reasonCode) &&
@@ -934,6 +942,7 @@ const FATAL_FAILURES = new Set([
   "unknown_adapter",
   "agent_definition_mismatch",
   "workspace_integrity_violation",
+  VERIFICATION_INTERNAL_ERROR,
 ]);
 
 /** Closed failure taxonomy: unknown reasons fail safe as fatal and never retry. */
@@ -953,6 +962,19 @@ export function classifyFailureCause(reasonCode) {
     return "fatal";
   }
   return "fatal";
+}
+
+function verificationInternalReasonCode(err) {
+  return err?.code === "ENOENT"
+    ? HANDOFF_WORKTREE_MISSING
+    : VERIFICATION_INTERNAL_ERROR;
+}
+
+function verificationInternalErrorPayload(err) {
+  return {
+    code: err?.code ?? err?.name ?? null,
+    message: err?.message ?? String(err),
+  };
 }
 
 /** Closed eligibility predicate; a continuation can never escalate again. */
@@ -3042,6 +3064,7 @@ export async function executeClaimed(
     resolveLinearKey = resolveLinearApiKey,
     policyRoot = FACTORY_ROOT,
     sandboxAvailability,
+    verifyResult: verifyResultFn = verifyResult,
   } = {},
 ) {
   const { runId, attempt, fencingToken, spec } = claim;
@@ -3451,6 +3474,82 @@ export async function executeClaimed(
       );
       return { ok: true, receipt };
     });
+
+  /** Convert a non-ContractViolation verify throw into a terminal FAILED summary. */
+  const failVerificationInternal = (err) => {
+    const reasonCode = verificationInternalReasonCode(err);
+    const error = verificationInternalErrorPayload(err);
+    const journalReason = `${reasonCode}: ${error.message}`;
+    if (mayMutateClaimedTicket()) {
+      try {
+        unclaimTicketFn({
+          repo: repoName,
+          ticket: ticketId,
+          why: journalReason,
+          log: null,
+        });
+      } catch {
+        /* intentionally ignored */
+      }
+    }
+    const result = {
+      schemaVersion: "factory.run-result/v1",
+      runId,
+      attempt,
+      terminalState: "failed",
+      reasonCode,
+      outputContract: spec.outputContract,
+      error,
+      verification: {
+        status: "failed",
+        stage: "verification",
+        checks: [],
+      },
+      artifacts: [],
+    };
+    let res;
+    let terminalError;
+    try {
+      res = failTerminal("FAILED", journalReason, reasonCode, (currentNow) => {
+        const receipt = receiptWithDeadlineExtensions(db, runId, {
+          runId,
+          spec,
+          def,
+          artifactHash: null,
+          evidenceSetHash: null,
+          journalHead: latestJournalHash(db, runId),
+          verificationStatus: "failed",
+          extraReceipt: filesystemConfinementReceipt,
+          harnessPins: materializedHarnessPins,
+        });
+        db.query(
+          `INSERT INTO results (run_id, attempt, result_json, artifact_hash, evidence_set_hash, verification_json, receipt_json, accepted_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+        ).run(
+          runId,
+          attempt,
+          canonicalJson(result),
+          "none",
+          null,
+          canonicalJson(result.verification),
+          canonicalJson(receipt),
+          iso(currentNow),
+        );
+      });
+    } catch (failErr) {
+      terminalError = recordTerminalError("failTerminal", failErr);
+    }
+    cleanupWorkspace({ retainWorkspace: retain });
+    if (res?.fenced) return { fenced: true };
+    return {
+      runId,
+      attempt,
+      terminalState: "FAILED",
+      reasonCode,
+      error,
+      ...(terminalError ? { terminalError } : {}),
+    };
+  };
 
   try {
     const started = txImmediate(db, () => {
@@ -4330,7 +4429,7 @@ export async function executeClaimed(
       // worktree command verification until after the fenced VERIFYING
       // transition below. The normal verifier then runs again in full.
       try {
-        verifyResult({
+        verifyResultFn({
           spec,
           def,
           registry,
@@ -4341,7 +4440,9 @@ export async function executeClaimed(
         });
         lateCompletion = true;
       } catch (err) {
-        if (!(err instanceof ContractViolation)) throw err;
+        if (!(err instanceof ContractViolation)) {
+          return failVerificationInternal(err);
+        }
       }
 
       if (!lateCompletion) {
@@ -4469,7 +4570,7 @@ export async function executeClaimed(
 
     let verified;
     verificationAttempt: try {
-      verified = verifyResult({
+      verified = verifyResultFn({
         spec,
         def,
         registry,
@@ -4489,7 +4590,9 @@ export async function executeClaimed(
         });
       }
     } catch (err) {
-      if (!(err instanceof ContractViolation)) throw err;
+      if (!(err instanceof ContractViolation)) {
+        return failVerificationInternal(err);
+      }
       let activeError = err;
       const recovered = recoverMissingDispatchResult({
         error: err,
@@ -4504,7 +4607,7 @@ export async function executeClaimed(
       });
       if (recovered) {
         try {
-          verified = verifyResult({
+          verified = verifyResultFn({
             spec,
             def,
             registry,
@@ -4523,8 +4626,9 @@ export async function executeClaimed(
           verified.result.reasonCode = RECOVERED_RESULT_REASON;
           break verificationAttempt;
         } catch (recoveryError) {
-          if (!(recoveryError instanceof ContractViolation))
-            throw recoveryError;
+          if (!(recoveryError instanceof ContractViolation)) {
+            return failVerificationInternal(recoveryError);
+          }
           activeError = recoveryError;
         }
       }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -964,10 +964,26 @@ export function classifyFailureCause(reasonCode) {
   return "fatal";
 }
 
-function verificationInternalReasonCode(err) {
-  return err?.code === "ENOENT"
-    ? HANDOFF_WORKTREE_MISSING
-    : VERIFICATION_INTERNAL_ERROR;
+/**
+ * Only an ENOENT whose target lies inside the run's own workspace (the
+ * delegated worktree or the workspace dir `verifyResult` realpaths) is the
+ * vanished-worktree environment failure. An ENOENT elsewhere — a missing
+ * verifier binary or config — is a harness defect and must not draw on the
+ * environment retry budget.
+ */
+function verificationInternalReasonCode(err, roots = []) {
+  if (err?.code !== "ENOENT") return VERIFICATION_INTERNAL_ERROR;
+  const target = err.path ?? err.dest ?? null;
+  if (typeof target !== "string" || !target) return VERIFICATION_INTERNAL_ERROR;
+  const resolved = path.resolve(target);
+  for (const root of roots) {
+    if (typeof root !== "string" || !root) continue;
+    const rel = path.relative(path.resolve(root), resolved);
+    if (rel === "" || (!rel.startsWith("..") && !path.isAbsolute(rel))) {
+      return HANDOFF_WORKTREE_MISSING;
+    }
+  }
+  return VERIFICATION_INTERNAL_ERROR;
 }
 
 function verificationInternalErrorPayload(err) {
@@ -3477,7 +3493,10 @@ export async function executeClaimed(
 
   /** Convert a non-ContractViolation verify throw into a terminal FAILED summary. */
   const failVerificationInternal = (err) => {
-    const reasonCode = verificationInternalReasonCode(err);
+    const reasonCode = verificationInternalReasonCode(err, [
+      worktreePath,
+      workspaceDir,
+    ]);
     const error = verificationInternalErrorPayload(err);
     const journalReason = `${reasonCode}: ${error.message}`;
     if (mayMutateClaimedTicket()) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1714,6 +1714,100 @@ sh -c 'sleep 5 & wait'
     expect(summary.reasonCode).toBe("contract_violation");
   });
 
+  test("verifyResult ENOENT on a vanished worktree is FAILED/handoff_worktree_missing, not a LEASED leftover (#1663)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        verifyResult: () => {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        },
+      }),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "handoff_worktree_missing",
+    });
+    expect(summary.error).toEqual({ code: "ENOENT", message: "ENOENT" });
+    expect(runState(db, spec.runId)).not.toBe("LEASED");
+    const attemptRow = db
+      .query(
+        `SELECT terminal_state, reason_code, finished_at FROM attempts WHERE run_id = ? AND attempt = 1`,
+      )
+      .get(spec.runId);
+    expect(attemptRow.terminal_state).toBe("FAILED");
+    expect(attemptRow.reason_code).toBe("handoff_worktree_missing");
+    expect(attemptRow.finished_at).toBeTruthy();
+    const stored = JSON.parse(
+      db
+        .query(
+          `SELECT result_json, verification_json FROM results WHERE run_id = ?`,
+        )
+        .get(spec.runId).result_json,
+    );
+    expect(stored.error).toEqual({ code: "ENOENT", message: "ENOENT" });
+    expect(stored.verification).toMatchObject({
+      status: "failed",
+      stage: "verification",
+    });
+  });
+
+  test("verifyResult TypeError is FAILED/verification_internal_error with the message recorded (#1663)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        verifyResult: () => {
+          throw new TypeError("cannot read property of undefined");
+        },
+      }),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "verification_internal_error",
+    });
+    expect(summary.error.message).toBe("cannot read property of undefined");
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    const stored = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(spec.runId).result_json,
+    );
+    expect(stored.reasonCode).toBe("verification_internal_error");
+    expect(stored.error).toEqual({
+      code: "TypeError",
+      message: "cannot read property of undefined",
+    });
+    expect(stored.verification.stage).toBe("verification");
+  });
+
+  test("verifyResult ContractViolation still follows the existing handoff-failure path (#1663)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        verifyResult: () => {
+          throw new ContractViolation(["missing_result"]);
+        },
+      }),
+    );
+    expect(summary.terminalState).toBe("FAILED");
+    expect(summary.reasonCode).toBe("contract_violation");
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    expect(
+      db.query(`SELECT * FROM results WHERE run_id = ?`).get(spec.runId),
+    ).toBeNull();
+  });
+
   test("a trace recorder that cannot be prepared degrades to a no-op instead of throwing out of executeClaimed (#1330)", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec());
@@ -3093,6 +3187,9 @@ sh -c 'sleep 5 & wait'
     expect(classifyFailureCause(HANDOFF_DEPENDENCIES_MISSING)).toBe(
       "environment",
     );
+    expect(classifyFailureCause("handoff_worktree_missing")).toBe(
+      "environment",
+    );
     expect(classifyFailureCause("agent_exit_1")).toBe("agent_error");
     expect(classifyFailureCause("contract_violation")).toBe("agent_error");
     for (const reason of [
@@ -3104,6 +3201,7 @@ sh -c 'sleep 5 & wait'
       "agent_definition_mismatch",
       "policy_denied:Bash",
       "workspace_integrity_violation",
+      "verification_internal_error",
     ]) {
       expect(classifyFailureCause(reason)).toBe("fatal");
     }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1722,8 +1722,12 @@ sh -c 'sleep 5 & wait'
       registry,
       adapters,
       opts({
-        verifyResult: () => {
-          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        verifyResult: ({ workspaceDir }) => {
+          throw Object.assign(new Error("ENOENT"), {
+            code: "ENOENT",
+            syscall: "realpath",
+            path: path.join(workspaceDir, "worktree"),
+          });
         },
       }),
     );
@@ -1752,6 +1756,62 @@ sh -c 'sleep 5 & wait'
     expect(stored.verification).toMatchObject({
       status: "failed",
       stage: "verification",
+    });
+  });
+
+  test("verifyResult ENOENT outside the run workspace (missing verifier binary) is verification_internal_error, not the environment budget (#1663)", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const missingBinary = path.join(
+      path.sep,
+      "nonexistent-gh-1663",
+      "bin",
+      "verifier",
+    );
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        verifyResult: () => {
+          throw Object.assign(new Error(`ENOENT: ${missingBinary}`), {
+            code: "ENOENT",
+            syscall: "realpath",
+            path: missingBinary,
+          });
+        },
+      }),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "verification_internal_error",
+    });
+    expect(summary.error.code).toBe("ENOENT");
+    expect(runState(db, spec.runId)).toBe("FAILED");
+    const attemptRow = db
+      .query(
+        `SELECT reason_code FROM attempts WHERE run_id = ? AND attempt = 1`,
+      )
+      .get(spec.runId);
+    expect(attemptRow.reason_code).toBe("verification_internal_error");
+  });
+
+  test("verifyResult ENOENT without a path is verification_internal_error (#1663)", async () => {
+    const db = openDb(":memory:");
+    queueRun(db, makeSpec());
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        verifyResult: () => {
+          throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+        },
+      }),
+    );
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "verification_internal_error",
     });
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1663

Non-ContractViolation throws from verifyResult (ENOENT on a vanished worktree, TypeError) now fail the run with a typed reason instead of leaving it LEASED.

## Validation

| Check                | Command                                                                 | Result  | Notes                                  |
| -------------------- | ----------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000`            | pass    | 133 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2145 pass, emit/format/lint clean      |
| UX critique          | factory-ux-critic                                                       | not run | no user-facing surface                 |

UX critique: skipped

run:run_0ab2658a-de11-4544-96ae-1a5388ec568c

Made with [Cursor](https://cursor.com)

## Post-review

- Reviewer fold (f9b14ff): `verificationInternalReasonCode` now maps ENOENT to `handoff_worktree_missing` only when `err.path` lies inside the delegated worktree or the run workspace dir (the path `verifyResult` realpaths); any other ENOENT (missing verifier binary/config, or no path) is `verification_internal_error` so it does not draw on the environment retry budget. `mayMutateClaimedTicket()` gate (#1337) and #1658 routing untouched.
- Tests: ENOENT inside workspace -> `handoff_worktree_missing`; ENOENT outside (`/nonexistent-gh-1663/bin/verifier`) -> `verification_internal_error`; ENOENT without path -> `verification_internal_error`.
- Verified: `bun test event-runtime/lib/worker.test.mjs --timeout 20000` (135 pass), `bun run lint`, `bun test event-runtime/lib` (2153 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
