### PR TITLE
fix(proposals): treat unknown policyVersion as a registry mismatch (#1697)

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -10,7 +10,10 @@ import path from "node:path";
 import { budgetExhausted } from "../../lib/spend.mjs";
 import { buildChainInput } from "./chain.mjs";
 import { hashJson } from "./canonical.mjs";
-import { resolveConfigPath } from "./config.mjs";
+import {
+  policyVersion as factoryPolicyVersion,
+  resolveConfigPath,
+} from "./config.mjs";
 import { defaultHookRegistry } from "./hooks.mjs";
 import { approveProposal } from "./proposals.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
@@ -960,6 +963,12 @@ export function autoApproveChains(db, registry, options = {}) {
   return pass;
 }
 
+function resolvePolicyVersion(value) {
+  return typeof value === "string" && value !== "" && value !== "unknown"
+    ? value
+    : factoryPolicyVersion();
+}
+
 /**
  * The pass itself. `marker.settled` is set in a `finally` inside this async
  * frame: if no `await` was reached (every hook answered synchronously) it is
@@ -981,6 +990,7 @@ async function runPass(
   } = {},
   marker = { settled: false },
 ) {
+  const resolvedPolicyVersion = resolvePolicyVersion(policyVersion);
   try {
     const approved = [];
     const open = [];
@@ -1057,7 +1067,7 @@ async function runPass(
               ? HANDOFF_AUTO_APPROVAL_REASON
               : CHAIN_AUTO_APPROVAL_REASON,
             now,
-            policyVersion,
+            policyVersion: resolvedPolicyVersion,
           });
           if (outcome.approved)
             approved.push({ proposalId: row.id, runId: outcome.runId });

--- a/event-runtime/lib/decision-effects.mjs
+++ b/event-runtime/lib/decision-effects.mjs
@@ -4,10 +4,19 @@ import { promisify } from "node:util";
 import path from "node:path";
 
 import { hashBytes } from "./canonical.mjs";
-import { FACTORY_ROOT } from "./config.mjs";
+import {
+  FACTORY_ROOT,
+  policyVersion as factoryPolicyVersion,
+} from "./config.mjs";
 import { admitExternalEvent } from "./intake.mjs";
 import { requeueEvent } from "./planner.mjs";
 import { approveProposal, rejectProposal } from "./proposals.mjs";
+
+function resolvePolicyVersion(value) {
+  return typeof value === "string" && value !== "" && value !== "unknown"
+    ? value
+    : factoryPolicyVersion();
+}
 
 const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
 const execFileAsync = promisify(execFile);
@@ -48,8 +57,9 @@ export const linearDecisionTransport = {
 /** Bind runtime operations that need the loaded registry. */
 export function decisionEffectPlanner(
   registry,
-  { onEvent = () => {}, policyVersion = "unknown" } = {},
+  { onEvent = () => {}, policyVersion } = {},
 ) {
+  const resolvedPolicyVersion = resolvePolicyVersion(policyVersion);
   return {
     admit(db, envelope, { now } = {}) {
       const outcome = admitExternalEvent(db, registry, envelope, { now });
@@ -64,11 +74,14 @@ export function decisionEffectPlanner(
     approveProposal(db, id, options) {
       return approveProposal(db, registry, id, {
         ...options,
-        policyVersion,
+        policyVersion: resolvedPolicyVersion,
       });
     },
     rejectProposal(db, id, options) {
-      return rejectProposal(db, id, { ...options, policyVersion });
+      return rejectProposal(db, id, {
+        ...options,
+        policyVersion: resolvedPolicyVersion,
+      });
     },
   };
 }

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -33,6 +33,19 @@ function isExpired(proposal, now) {
   return now - Date.parse(proposal.created_at) > proposal.ttl_seconds * 1000;
 }
 
+/** A pin that can be compared. `"unknown"` is the no-registry sentinel, not a version. */
+function isKnownPolicyVersion(value) {
+  return typeof value === "string" && value !== "" && value !== "unknown";
+}
+
+function recordedSpecPinsVersion(spec) {
+  return (
+    spec != null &&
+    (isKnownPolicyVersion(spec.promptVersion) ||
+      isKnownPolicyVersion(spec.policyVersion))
+  );
+}
+
 function withSpec(row) {
   return { ...row, spec: row.spec_json ? JSON.parse(row.spec_json) : null };
 }
@@ -140,9 +153,13 @@ function approveRun(
 
 /**
  * Approve an open 'run' proposal. Within TTL the recorded spec executes
- * as-is only while its registry-version pins still match. After expiry or a
- * stale registry pin, the spec is rebuilt against current state under the
- * same runId: equivalent → approved; different → the stale proposal is
+ * as-is only while its registry-version pins still match a *known* caller
+ * `policyVersion`. `"unknown"` (the parameter default) is treated as a
+ * mismatch when the recorded spec pins a version, so the spec is replanned
+ * rather than approved as-is. Specs that predate version pins remain
+ * approvable without a known policyVersion. After expiry or a stale
+ * registry pin, the spec is rebuilt against current state under the same
+ * runId: equivalent → approved; different → the stale proposal is
  * superseded, the still-PROPOSED run gets the fresh spec, and a new open
  * proposal is returned instead (§12).
  *
@@ -193,10 +210,13 @@ export function approveProposal(
     const recordedSpec = proposal.spec_json
       ? JSON.parse(proposal.spec_json)
       : null;
+    // Fail-closed: an unknown/omitted caller version is *not equal* to a
+    // recorded pin. Skipping the comparison here used to approve the
+    // recorded spec as-is whenever a caller forwarded the default.
     const registryVersionMismatch =
-      recordedSpec !== null &&
-      policyVersion !== "unknown" &&
-      (recordedSpec.promptVersion !== policyVersion ||
+      recordedSpecPinsVersion(recordedSpec) &&
+      (!isKnownPolicyVersion(policyVersion) ||
+        recordedSpec.promptVersion !== policyVersion ||
         recordedSpec.policyVersion !== policyVersion);
     let registryReloadMismatch = false;
     if (recordedSpec?.defHash) {
@@ -259,8 +279,12 @@ export function approveProposal(
         }
       : built;
     const freshHash = hashJson(fresh);
+    // Refresh-and-approve only when the caller named a real current version.
+    // Replanning with `"unknown"` must not stamp that sentinel onto the
+    // recorded spec and queue it.
     const versionRefreshMatches =
       registryVersionMismatch &&
+      isKnownPolicyVersion(policyVersion) &&
       !registryReloadMismatch &&
       matchesAfterRegistryVersionRefresh(storedSpec, fresh);
     if (

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -175,6 +175,7 @@ describe("approveProposal within TTL", () => {
     const result = approveProposal(db, registry, proposal.id, {
       actor: "operator",
       now: NOW + 60_000,
+      policyVersion: "git:test",
     });
     expect(result).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");
@@ -278,6 +279,83 @@ describe("approveProposal within TTL", () => {
     expect(runState(db, runId)).toBe("PROPOSED");
   });
 
+  test.each([
+    ["omitted", undefined],
+    ["unknown", "unknown"],
+  ])(
+    "a version-pinned spec is replanned when policyVersion is %s, not approved as-is",
+    (_label, policyVersion) => {
+      const { db, proposal, runId } = planned();
+      const recorded = getProposal(db, proposal.id).spec;
+      expect(recorded.promptVersion).toBe("git:test");
+      expect(recorded.policyVersion).toBe("git:test");
+
+      const result = approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        now: NOW + 1000,
+        ...(policyVersion === undefined ? {} : { policyVersion }),
+      });
+
+      expect(result).toMatchObject({ approved: false, replanned: true });
+      expect(result.proposal.id).not.toBe(proposal.id);
+      expect(result.proposal.status).toBe("open");
+      expect(result.proposal.reason).toBe("replanned_after_registry_replan");
+      expect(getProposal(db, proposal.id)).toMatchObject({
+        status: "superseded",
+        reason: "superseded_by_registry_replan",
+      });
+      expect(runState(db, runId)).toBe("PROPOSED");
+      expect(
+        JSON.parse(
+          db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId)
+            .spec_json,
+        ),
+      ).not.toMatchObject({
+        promptVersion: "git:test",
+        policyVersion: "git:test",
+      });
+    },
+  );
+
+  test.each([
+    ["omitted", undefined],
+    ["unknown", "unknown"],
+  ])(
+    "a spec without version pins remains approvable when policyVersion is %s",
+    (_label, policyVersion) => {
+      const { db, proposal, runId } = planned();
+      const recorded = getProposal(db, proposal.id).spec;
+      const legacySpec = { ...recorded };
+      delete legacySpec.promptVersion;
+      delete legacySpec.policyVersion;
+      const legacyJson = canonicalJson(legacySpec);
+      const legacyHash = hashJson(legacySpec);
+      db.query(
+        `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+      ).run(legacyJson, legacyHash, proposal.id);
+      db.query(
+        `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+      ).run(legacyJson, legacyHash, runId);
+
+      const result = approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        now: NOW + 1000,
+        ...(policyVersion === undefined ? {} : { policyVersion }),
+      });
+
+      expect(result).toEqual({ approved: true, runId });
+      expect(runState(db, runId)).toBe("QUEUED");
+      expect(getProposal(db, proposal.id).status).toBe("approved");
+      expect(lifecycleOf(db, runId).at(-1).reason).toBe("approved");
+      expect(
+        JSON.parse(
+          db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId)
+            .spec_json,
+        ),
+      ).toEqual(legacySpec);
+    },
+  );
+
   test("a registry defHash change supersedes and creates one fresh open proposal", () => {
     const { db, proposal, runId } = planned();
     const stored = getProposal(db, proposal.id);
@@ -323,11 +401,16 @@ describe("approveProposal within TTL", () => {
 
   test("only open 'run' proposals are approvable", () => {
     const { db, proposal } = planned();
-    approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW });
+    approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(() =>
       approveProposal(db, registry, proposal.id, {
         actor: "operator",
         now: NOW,
+        policyVersion: "git:test",
       }),
     ).toThrow(/not open/);
     expect(() =>
@@ -379,7 +462,11 @@ describe("closeOpenProposalForRun", () => {
 
   test("no-op when the run has no open proposal", () => {
     const { db, proposal, runId } = planned();
-    approveProposal(db, registry, proposal.id, { actor: "operator", now: NOW });
+    approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW,
+      policyVersion: "git:test",
+    });
     expect(
       closeOpenProposalForRun(db, runId, { actor: "operator", now: NOW }),
     ).toEqual({ closed: false });


### PR DESCRIPTION
Fixes watt-mind/factory#1697

approveProposal no longer skips the registry-staleness check when policyVersion is omitted or "unknown".

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs event-runtime/lib/decision-effects.test.mjs event-runtime/lib/auto-approval.test.mjs --timeout 60000` | pass    | 64 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2146 pass, format clean, lint 0 errors |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_2e216895-6062-4ddd-a269-646b9c3fd0bc

Made with [Cursor](https://cursor.com)