### PR TITLE
fix(worktree): stamp bun-lock-sha after locked_bun_install (#1694)

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -1060,6 +1060,31 @@ rename_dir_atomic() { # <src> <dst>
   fi
 }
 
+# Write node_modules/.bun-lock-sha as the lowercase hex sha256 of bun.lock
+# (same bytes preflightHandoffDependencies trims after sha256Hex(readFileSync)).
+# A matching stamp lets the handoff preflight skip a redundant frozen install
+# (gh-1694). Missing lockfile or hasher failure leaves no stamp.
+write_bun_lock_stamp() { # <dir>
+  local dir="$1"
+  local lockfile="$dir/bun.lock"
+  local stamp="$dir/node_modules/.bun-lock-sha"
+  local digest=""
+  if [[ ! -f "$lockfile" ]]; then
+    rm -f "$stamp"
+    return 0
+  fi
+  mkdir -p "$dir/node_modules"
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest=$(sha256sum -- "$lockfile") || return 1
+  elif command -v shasum >/dev/null 2>&1; then
+    digest=$(shasum -a 256 -- "$lockfile") || return 1
+  else
+    return 1
+  fi
+  digest=${digest%% *}
+  printf '%s\n' "${digest,,}" > "$stamp"
+}
+
 # File-locked bun install with retry on SQLITE_BUSY (OPS-322).
 # Prevents concurrent worktree bring-ups from racing on bun's global cache DB.
 locked_bun_install() { # <dir>
@@ -1164,7 +1189,10 @@ locked_bun_install() { # <dir>
   [[ -n "$previous_exit_trap" ]] && eval "$previous_exit_trap"
   [[ -n "$previous_int_trap" ]] && eval "$previous_int_trap"
   [[ -n "$previous_term_trap" ]] && eval "$previous_term_trap"
-  if [[ $code -ne 0 ]]; then
+  if [[ $code -eq 0 ]]; then
+    write_bun_lock_stamp "$target_dir"
+  else
+    rm -f "$target_dir/node_modules/.bun-lock-sha"
     printf '%s\n' "$out" >&2
   fi
   return $code

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -1086,15 +1086,23 @@ write_bun_lock_stamp() { # <dir>
     rm -f "$stamp"
     return 0
   fi
+  # A stale stamp must never survive a hasher/write failure: the preflight
+  # would otherwise trust it and skip a needed install. The non-zero status is
+  # advisory only (callers warn, never fail the install on it).
   if command -v sha256sum >/dev/null 2>&1; then
-    digest=$(sha256sum -- "$lockfile") || return 1
+    digest=$(sha256sum -- "$lockfile" 2>/dev/null) || { rm -f "$stamp"; return 1; }
   elif command -v shasum >/dev/null 2>&1; then
-    digest=$(shasum -a 256 -- "$lockfile") || return 1
+    digest=$(shasum -a 256 -- "$lockfile" 2>/dev/null) || { rm -f "$stamp"; return 1; }
   else
+    rm -f "$stamp"
     return 1
   fi
   digest=${digest%% *}
-  printf '%s\n' "${digest,,}" > "$stamp"
+  if [[ -z "$digest" ]] || ! printf '%s\n' "${digest,,}" > "$stamp" 2>/dev/null; then
+    rm -f "$stamp"
+    return 1
+  fi
+  return 0
 }
 
 # File-locked bun install with retry on SQLITE_BUSY (OPS-322).
@@ -1202,7 +1210,9 @@ locked_bun_install() { # <dir>
   [[ -n "$previous_int_trap" ]] && eval "$previous_int_trap"
   [[ -n "$previous_term_trap" ]] && eval "$previous_term_trap"
   if [[ $code -eq 0 ]]; then
-    write_bun_lock_stamp "$target_dir"
+    # Cosmetic: a missing hasher or unwritable stamp must not fail a
+    # successful install (set -e callers such as worktree-up.sh).
+    write_bun_lock_stamp "$target_dir" || warn "bun lock stamp skipped for $target_dir (no sha256 tool or unwritable node_modules)"
   else
     rm -f "$target_dir/node_modules/.bun-lock-sha"
     printf '%s\n' "$out" >&2

--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -1063,17 +1063,29 @@ rename_dir_atomic() { # <src> <dst>
 # Write node_modules/.bun-lock-sha as the lowercase hex sha256 of bun.lock
 # (same bytes preflightHandoffDependencies trims after sha256Hex(readFileSync)).
 # A matching stamp lets the handoff preflight skip a redundant frozen install
-# (gh-1694). Missing lockfile or hasher failure leaves no stamp.
+# (gh-1694). Never mkdir node_modules: an empty tree would shadow Bun's
+# resolver (WM-115 baseline-red stubs `bun install` as a no-op). Missing
+# lockfile, missing/empty node_modules, or hasher failure leaves no stamp.
 write_bun_lock_stamp() { # <dir>
   local dir="$1"
   local lockfile="$dir/bun.lock"
-  local stamp="$dir/node_modules/.bun-lock-sha"
-  local digest=""
-  if [[ ! -f "$lockfile" ]]; then
+  local nm="$dir/node_modules"
+  local stamp="$nm/.bun-lock-sha"
+  local digest="" entry populated=0
+  if [[ ! -f "$lockfile" || ! -d "$nm" ]]; then
     rm -f "$stamp"
     return 0
   fi
-  mkdir -p "$dir/node_modules"
+  for entry in "$nm"/* "$nm"/.[!.]*; do
+    [[ -e "$entry" || -L "$entry" ]] || continue
+    [[ "$(basename -- "$entry")" == ".bun-lock-sha" ]] && continue
+    populated=1
+    break
+  done
+  if [[ "$populated" -eq 0 ]]; then
+    rm -f "$stamp"
+    return 0
+  fi
   if command -v sha256sum >/dev/null 2>&1; then
     digest=$(sha256sum -- "$lockfile") || return 1
   elif command -v shasum >/dev/null 2>&1; then

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -3,6 +3,7 @@ import {
   cpSync,
   existsSync,
   mkdtempSync,
+  readFileSync,
   rmSync,
   mkdirSync,
   writeFileSync,
@@ -12,7 +13,9 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import { execFileSync } from "node:child_process";
 import { afterAll, expect, test } from "bun:test";
+import { sha256Hex } from "../event-runtime/lib/canonical.mjs";
 import { until } from "../event-runtime/lib/test-helpers-timing.mjs";
+import { preflightHandoffDependencies } from "../event-runtime/lib/verify.mjs";
 
 const COMMON = path.resolve(import.meta.dir, "worktree-common.sh");
 const WORKTREE_UP = path.resolve(import.meta.dir, "worktree-up.sh");
@@ -1227,5 +1230,121 @@ test("web_build_hash computes deterministic sha1 and changes on file rename or c
     );
   } finally {
     rmSync(mockWebDir, { recursive: true, force: true });
+  }
+});
+
+function mockBunInstallBin(succeed) {
+  const dir = mkdtempSync(path.join(tmpdir(), "mock-bun-install-"));
+  writeFileSync(
+    path.join(dir, "bun"),
+    succeed
+      ? `#!/usr/bin/env bash
+if [[ "$1" == "install" ]]; then
+  mkdir -p node_modules/placeholder
+  exit 0
+fi
+echo "unexpected bun invocation: $*" >&2
+exit 1
+`
+      : `#!/usr/bin/env bash
+if [[ "$1" == "install" ]]; then
+  echo "install failed" >&2
+  exit 1
+fi
+echo "unexpected bun invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(path.join(dir, "bun"), 0o755);
+  return dir;
+}
+
+function bunInstallFixture(lockContents = "fixture-lock\n") {
+  const dir = mkdtempSync(path.join(tmpdir(), "bun-lock-stamp-"));
+  writeFileSync(path.join(dir, "package.json"), '{"name":"fixture"}\n');
+  writeFileSync(path.join(dir, "bun.lock"), lockContents);
+  return dir;
+}
+
+test("locked_bun_install stamps node_modules/.bun-lock-sha after a successful install", () => {
+  const target = bunInstallFixture();
+  const mockBin = mockBunInstallBin(true);
+  const lockDir = path.join(tmpdir(), `bun-lock-${process.pid}-${Date.now()}`);
+  try {
+    const r = sh(`locked_bun_install "${target}"`, {
+      PATH: `${mockBin}:${TEST_PATH}`,
+      FACTORY_LOCK_DIR: lockDir,
+    });
+    expect(r.status).toBe(0);
+    const stamp = path.join(target, "node_modules", ".bun-lock-sha");
+    expect(existsSync(stamp)).toBe(true);
+    expect(readFileSync(stamp, "utf8").trim()).toBe(
+      sha256Hex(readFileSync(path.join(target, "bun.lock"))),
+    );
+  } finally {
+    rmSync(target, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+test("locked_bun_install removes a stale stamp when install fails", () => {
+  const lockContents = "fixture-lock\n";
+  const target = bunInstallFixture(lockContents);
+  mkdirSync(path.join(target, "node_modules"));
+  writeFileSync(
+    path.join(target, "node_modules", ".bun-lock-sha"),
+    `${sha256Hex(lockContents)}\n`,
+  );
+  const mockBin = mockBunInstallBin(false);
+  const lockDir = path.join(
+    tmpdir(),
+    `bun-lock-fail-${process.pid}-${Date.now()}`,
+  );
+  try {
+    const r = sh(`locked_bun_install "${target}"`, {
+      PATH: `${mockBin}:${TEST_PATH}`,
+      FACTORY_LOCK_DIR: lockDir,
+    });
+    expect(r.status).not.toBe(0);
+    expect(existsSync(path.join(target, "node_modules", ".bun-lock-sha"))).toBe(
+      false,
+    );
+  } finally {
+    rmSync(target, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+test("preflightHandoffDependencies reports installed:false for a shell-stamped directory", () => {
+  const target = bunInstallFixture();
+  const mockBin = mockBunInstallBin(true);
+  const lockDir = path.join(
+    tmpdir(),
+    `bun-lock-preflight-${process.pid}-${Date.now()}`,
+  );
+  try {
+    const r = sh(`locked_bun_install "${target}"`, {
+      PATH: `${mockBin}:${TEST_PATH}`,
+      FACTORY_LOCK_DIR: lockDir,
+    });
+    expect(r.status).toBe(0);
+
+    let installs = 0;
+    const result = preflightHandoffDependencies({
+      worktreePath: target,
+      installer: () => {
+        installs += 1;
+        return { passed: true, exitCode: 0, output: "unexpected" };
+      },
+    });
+    expect(result.passed).toBe(true);
+    expect(result.installed).toBe(false);
+    expect(installs).toBe(0);
+  } finally {
+    rmSync(target, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
   }
 });

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -1317,6 +1317,38 @@ test("locked_bun_install removes a stale stamp when install fails", () => {
   }
 });
 
+test("locked_bun_install does not create node_modules when install is a no-op success", () => {
+  const target = bunInstallFixture();
+  const mockBin = mkdtempSync(path.join(tmpdir(), "mock-bun-noop-"));
+  writeFileSync(
+    path.join(mockBin, "bun"),
+    `#!/usr/bin/env bash
+if [[ "$1" == "install" ]]; then
+  exit 0
+fi
+echo "unexpected bun invocation: $*" >&2
+exit 1
+`,
+  );
+  chmodSync(path.join(mockBin, "bun"), 0o755);
+  const lockDir = path.join(
+    tmpdir(),
+    `bun-lock-noop-${process.pid}-${Date.now()}`,
+  );
+  try {
+    const r = sh(`locked_bun_install "${target}"`, {
+      PATH: `${mockBin}:${TEST_PATH}`,
+      FACTORY_LOCK_DIR: lockDir,
+    });
+    expect(r.status).toBe(0);
+    expect(existsSync(path.join(target, "node_modules"))).toBe(false);
+  } finally {
+    rmSync(target, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
 test("preflightHandoffDependencies reports installed:false for a shell-stamped directory", () => {
   const target = bunInstallFixture();
   const mockBin = mockBunInstallBin(true);

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -8,6 +8,8 @@ import {
   mkdirSync,
   writeFileSync,
   renameSync,
+  readdirSync,
+  symlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -1345,6 +1347,73 @@ exit 1
   } finally {
     rmSync(target, { recursive: true, force: true });
     rmSync(mockBin, { recursive: true, force: true });
+    rmSync(lockDir, { recursive: true, force: true });
+  }
+});
+
+// PATH identical to TEST_PATH except that every sha256sum/shasum is hidden,
+// so write_bun_lock_stamp has no hasher to run.
+function pathWithoutShaTools() {
+  const dir = mkdtempSync(path.join(tmpdir(), "no-sha-path-"));
+  const seen = new Set();
+  for (const entry of TEST_PATH.split(":")) {
+    if (!entry || !existsSync(entry)) continue;
+    let names;
+    try {
+      names = readdirSync(entry);
+    } catch {
+      continue;
+    }
+    for (const name of names) {
+      if (name === "sha256sum" || name === "shasum" || seen.has(name)) continue;
+      seen.add(name);
+      try {
+        symlinkSync(path.join(entry, name), path.join(dir, name));
+      } catch {
+        // unreadable or racing entry: skip, first-wins semantics preserved
+      }
+    }
+  }
+  return dir;
+}
+
+test("locked_bun_install succeeds without a stamp when no sha256 tool is on PATH", () => {
+  const lockContents = "fixture-lock\n";
+  const target = bunInstallFixture(lockContents);
+  mkdirSync(path.join(target, "node_modules"));
+  // A stale stamp from a previous install must not survive a hasher-less run.
+  writeFileSync(
+    path.join(target, "node_modules", ".bun-lock-sha"),
+    `${sha256Hex("old-lock\n")}\n`,
+  );
+  const mockBin = mockBunInstallBin(true);
+  const noShaPath = pathWithoutShaTools();
+  const lockDir = path.join(
+    tmpdir(),
+    `bun-lock-nosha-${process.pid}-${Date.now()}`,
+  );
+  try {
+    const probe = sh("command -v sha256sum || command -v shasum", {
+      PATH: `${mockBin}:${noShaPath}`,
+    });
+    expect(probe.status).not.toBe(0);
+    const r = sh(`set -e; locked_bun_install "${target}"; echo installed-ok`, {
+      PATH: `${mockBin}:${noShaPath}`,
+      FACTORY_LOCK_DIR: lockDir,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("installed-ok");
+    expect(r.stderr).toContain("bun lock stamp skipped");
+    expect(existsSync(path.join(target, "node_modules", "placeholder"))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(target, "node_modules", ".bun-lock-sha"))).toBe(
+      false,
+    );
+  } finally {
+    rmSync(target, { recursive: true, force: true });
+    rmSync(mockBin, { recursive: true, force: true });
+    rmSync(noShaPath, { recursive: true, force: true });
     rmSync(lockDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1694

Stamp bun.lock sha after a successful locked_bun_install so handoff preflight skips a redundant frozen install.

## Validation

| Check                | Command                                                                 | Result  | Notes                                      |
| -------------------- | ----------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test bin/worktree-common.test.mjs --timeout 60000`                 | pass    | 46 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2142 pass, 0 fail; emit ok; lint 0 errors  |
| UX critique          | factory-ux-critic                                                       | not run | no user-facing surface                     |

UX critique: skipped

run:run_3b1f8395-10f2-44b3-9a3a-354dc55b347e

Made with [Cursor](https://cursor.com)

## Post-review

- Merged origin/develop (2 behind).
- Fold: `write_bun_lock_stamp` never propagates a non-zero status into the install result — a missing sha256sum/shasum or unwritable stamp removes any stale stamp and returns an advisory 1; `locked_bun_install` now calls it as `write_bun_lock_stamp "$target_dir" || warn "bun lock stamp skipped ..."`, so `set -e` callers (worktree-up.sh) no longer abort a successful install.
- New test: sha tools hidden from PATH under `set -e` → install succeeds, stale stamp removed, no new stamp, warn emitted.
- Verified: `bun test bin/worktree-common.test.mjs --timeout 60000` (47 pass), `bun run lint && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` (2142 pass, clean).
