### PR TITLE
feat(doctor): report per-repo toolchain status (#1097)

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -4,6 +4,7 @@ import {
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-registry-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
+  CONTROL_TOKEN,
   GH_SECRET,
   PV,
   SECRET,
@@ -54,7 +55,7 @@ const makeServer = async (...args) => {
 describe("agent and repository registry surfacing (OPS-212)", () => {
   test("GET /agents exposes definitions, prompt text, schemas, pins, and routing", async () => {
     const { server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       const { agents: defs, contracts } = await client.agents();
       const def = defs.find((d) => d.ref === "factory-status-report@1");
@@ -107,7 +108,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
     const { server, port, close } = await makeServer({
       repos: () => loadRepos({ root }),
     });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       const { repos: rows } = await client.repos();
       expect(rows.map((r) => r.name)).toEqual(["dispatchable", "watched"]);
@@ -148,6 +149,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         hasWorktreeDown: true,
         hasWorktreeWarm: false,
         verify: null,
+        toolchain: null,
       });
       expect(rows[1]).toMatchObject({
         reportOnly: true,
@@ -234,7 +236,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         };
       },
     });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       const body = await client.janitor("dispatchable");
       expect(body.actor).toBe("operator");
@@ -274,7 +276,7 @@ describe("agent and repository registry surfacing (OPS-212)", () => {
         };
       },
     });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       const body = await client.janitor("dispatchable", { apply: true });
       expect(body.apply).toBe(true);

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -278,7 +278,7 @@ export function isToolchainConstraint(constraint) {
  * Absent/null returns null — "not declared" — which is what keeps this change
  * additive for every repo that has no block.
  */
-function normalizeToolchain(raw, repoName, file) {
+export function normalizeToolchain(raw, repoName, file) {
   if (raw === undefined || raw === null) return null;
 
   /** @type {Array<[unknown, unknown]>} */
@@ -599,7 +599,7 @@ export function repoReadiness({
           // Must be runnable: `bin/factory` has no `repo` subcommand, so the
           // repo-scoped `factory repo doctor <name>` the design sketches does
           // not exist yet. Name what exists and what is pending.
-          action: `re-run toolchain preflight for repo ${repo.name} on ${node} — \`factory doctor\` reports it once #1097 lands`,
+          action: `re-run toolchain preflight for repo ${repo.name} on ${node} — \`factory doctor\` reports the mismatch`,
         },
       ],
       refusal: `repo ${repo.name} has no current toolchain attestation on ${node} (${detail})`,
@@ -950,12 +950,9 @@ export function reposView(repos) {
     hasWorktreeDown: repo.worktreeDown !== null,
     hasWorktreeWarm: repo.worktreeWarm !== null,
     verify: repo.verify,
-    // `toolchain` is deliberately NOT published here yet. Adding a field to
-    // this projection changes /repos and the config view in the same commit,
-    // and both are asserted exactly in files outside gh-1076's Owned Paths
-    // (api-registry.test.mjs, api-config.test.mjs). Issue #1097 — teach
-    // `factory doctor` to report toolchain status — publishes it and updates
-    // those assertions alongside.
+    // Declared constraints only — observed versions belong to a node's
+    // attestation, not the registry projection.
+    toolchain: repo.toolchain ?? null,
   }));
 }
 

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -515,6 +515,7 @@ describe("reposView is what the control API serves", () => {
         "smokeUrl",
         "smokeWorkflow",
         "team",
+        "toolchain",
         "verify",
         "worktreeRoot",
       ]);
@@ -799,14 +800,16 @@ describe("toolchain: declaration parsing and validation", () => {
     ).toThrow(/declares toolchain executable "bun" twice/);
   });
 
-  test("the registry projection does not publish toolchain yet (removed by #1097)", () => {
-    // Not an oversight: /repos and the config view assert this projection
-    // exactly, in api-registry.test.mjs and api-config.test.mjs, both outside
-    // gh-1076's Owned Paths. Issue #1097 — toolchain status in `factory
-    // doctor` — publishes the field and updates those assertions in the same
-    // commit, and deletes this pin.
+  test("the registry projection publishes declared toolchain constraints, never observed versions", () => {
     const rows = reposView(loadRepos({ root: factoryRoot(YAML) }));
-    expect(rows[0]).not.toHaveProperty("toolchain");
+    expect(rows[0].toolchain).toEqual([
+      { executable: "bun", constraint: ">=1.3 <2" },
+      { executable: "node", constraint: ">=22 <25" },
+    ]);
+    expect(rows[1].toolchain).toBeNull();
+    expect(JSON.stringify(rows[0].toolchain)).not.toMatch(
+      /observed|resolved|satisfied/,
+    );
   });
 });
 

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -218,7 +218,8 @@ export function ossOnboardingDiagnostics({
  * pass, mismatch, and the undeclared no-block case without touching the
  * host. Repos may be raw YAML entries (map-form `toolchain:`) or
  * `loadRepos()` records; the helper always normalizes first so iterating a
- * map cannot throw.
+ * map cannot throw, and a malformed block becomes a red `toolchain` check
+ * instead of an exception.
  */
 export async function repoToolchainDiagnostics({
   repos = [],
@@ -233,7 +234,21 @@ export async function repoToolchainDiagnostics({
   if (typeof spawn === "function") preflightOpts.spawn = spawn;
 
   for (const repo of repos) {
-    const toolchain = normalizeToolchain(repo?.toolchain, repo?.name, file);
+    // A malformed `toolchain:` block is itself the diagnosis — surface it as
+    // a red check and keep going rather than letting the RepoError kill
+    // doctor with a stack trace before the remaining repos are examined.
+    let toolchain;
+    try {
+      toolchain = normalizeToolchain(repo?.toolchain, repo?.name, file);
+    } catch (err) {
+      diagnostics.push({
+        ok: false,
+        label: "toolchain",
+        detail: err?.message ?? String(err),
+        fix: `fix the toolchain: block for ${repo?.name ?? "this repo"} in ${file}`,
+      });
+      continue;
+    }
     if (!toolchain?.length) continue;
     const attestation = await preflightToolchain(
       { ...repo, toolchain },

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -30,6 +30,10 @@ import {
 } from "../lib/control-plane/index.mjs";
 import { harnessGitignoreIsCurrent } from "../lib/factory-gitignore.mjs";
 import {
+  normalizeToolchain,
+  preflightToolchain,
+} from "../event-runtime/lib/repos.mjs";
+import {
   browserLaunchCheck,
   piChromeDevtoolsCheck,
 } from "./doctor-browser.mjs";
@@ -206,6 +210,53 @@ export function ossOnboardingDiagnostics({
   return diagnostics;
 }
 
+/**
+ * Per-repo toolchain status for `factory doctor` (WM-316 / #1097).
+ *
+ * Pure except for the injectable `which`/`spawn` probes — the same
+ * injection `preflightToolchain` uses — so doctor.test.mjs can cover
+ * pass, mismatch, and the undeclared no-block case without touching the
+ * host. Repos may be raw YAML entries (map-form `toolchain:`) or
+ * `loadRepos()` records; the helper always normalizes first so iterating a
+ * map cannot throw.
+ */
+export async function repoToolchainDiagnostics({
+  repos = [],
+  file = "config/repos.yaml",
+  node = "local",
+  which,
+  spawn,
+} = {}) {
+  const diagnostics = [];
+  const preflightOpts = { node };
+  if (typeof which === "function") preflightOpts.which = which;
+  if (typeof spawn === "function") preflightOpts.spawn = spawn;
+
+  for (const repo of repos) {
+    const toolchain = normalizeToolchain(repo?.toolchain, repo?.name, file);
+    if (!toolchain?.length) continue;
+    const attestation = await preflightToolchain(
+      { ...repo, toolchain },
+      preflightOpts,
+    );
+    for (const tool of attestation.tools) {
+      const reason = attestation.reasons.find(
+        (r) => r.executable === tool.executable,
+      );
+      const observed = tool.observed ?? tool.observedRaw ?? null;
+      diagnostics.push({
+        ok: tool.satisfied,
+        label: `toolchain ${tool.executable}`,
+        detail: observed
+          ? `${tool.constraint}  observed ${observed}`
+          : `${tool.constraint}  missing`,
+        fix: reason?.action ?? null,
+      });
+    }
+  }
+  return diagnostics;
+}
+
 const ROOT = factoryRoot();
 installLinearBudgetCapture();
 const argv = process.argv.slice(2);
@@ -350,6 +401,13 @@ if (import.meta.main) {
     console.log(
       c.bold(`\n${repo.name}`) + c.dim(`  ${repo.team} / ${repo.project}`),
     );
+
+    // Node-local: independent of whether the checkout exists. A mismatch is
+    // diagnosable here instead of only as a dispatch refusal.
+    for (const row of await repoToolchainDiagnostics({ repos: [repo] })) {
+      check(row.ok, row.label, row.detail, row.fix);
+    }
+
     const p = expand(repo.path);
 
     const cloned = existsSync(p) && existsSync(path.join(p, ".git"));

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -213,6 +213,27 @@ describe("repo toolchain diagnostics (#1097)", () => {
     expect(emptyBlock).toEqual([]);
     expect(probes).toBe(0);
   });
+
+  test("malformed block: yields a red toolchain check instead of throwing", async () => {
+    let probes = 0;
+    const rows = await repoToolchainDiagnostics({
+      repos: [
+        { name: "broken", toolchain: "bun>=1.3" },
+        { name: "fine", toolchain: { bun: ">=1.0" } },
+      ],
+      which: async () => "/opt/bun",
+      spawn: async () => {
+        probes += 1;
+        return { exitCode: 0, stdout: "1.3.14\n", stderr: "" };
+      },
+    });
+    expect(rows[0]).toMatchObject({ ok: false, label: "toolchain" });
+    expect(rows[0].detail).toContain("repo broken toolchain must be a map");
+    expect(rows[0].fix).toContain("broken");
+    // Doctor keeps going: the next repo is still probed.
+    expect(rows[1]).toMatchObject({ ok: true, label: "toolchain bun" });
+    expect(probes).toBe(1);
+  });
 });
 
 describe("bin/chrome-headless.sh", () => {

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -33,6 +33,7 @@ import {
   MIN_GIT_VERSION,
   ossOnboardingDiagnostics,
   parseCliVersion,
+  repoToolchainDiagnostics,
 } from "./doctor.mjs";
 
 const HERE = path.dirname(new URL(import.meta.url).pathname);
@@ -124,6 +125,93 @@ describe("OSS onboarding diagnostics (WM-957)", () => {
     expect(diagnostics.find((d) => d.label === "worktree isolation")?.ok).toBe(
       "warn",
     );
+  });
+});
+
+describe("repo toolchain diagnostics (#1097)", () => {
+  test("declared-and-passing: map-form toolchain prints constraint and observed version", async () => {
+    let probes = 0;
+    const rows = await repoToolchainDiagnostics({
+      repos: [{ name: "demo", toolchain: { bun: ">=1.3 <2", git: ">=2.40" } }],
+      which: async (executable) => {
+        probes += 1;
+        return { bun: "/opt/bun", git: "/usr/bin/git" }[executable] ?? null;
+      },
+      spawn: async ([resolved]) => {
+        probes += 1;
+        return {
+          exitCode: 0,
+          stdout:
+            {
+              "/opt/bun": "1.3.14\n",
+              "/usr/bin/git": "git version 2.45.1\n",
+            }[resolved] ?? "",
+          stderr: "",
+        };
+      },
+    });
+    expect(probes).toBeGreaterThan(0);
+    expect(rows).toEqual([
+      {
+        ok: true,
+        label: "toolchain bun",
+        detail: ">=1.3 <2  observed 1.3.14",
+        fix: null,
+      },
+      {
+        ok: true,
+        label: "toolchain git",
+        detail: ">=2.40  observed 2.45.1",
+        fix: null,
+      },
+    ]);
+  });
+
+  test("declared-and-mismatched: missing and out-of-range are doctor problems with the reason's action", async () => {
+    const rows = await repoToolchainDiagnostics({
+      repos: [{ name: "demo", toolchain: { bun: ">=1.3 <2", uv: ">=0.5" } }],
+      which: async (executable) => (executable === "bun" ? "/opt/bun" : null),
+      spawn: async () => ({ exitCode: 0, stdout: "1.1.45\n", stderr: "" }),
+    });
+    expect(rows).toHaveLength(2);
+    const bun = rows.find((r) => r.label === "toolchain bun");
+    const uv = rows.find((r) => r.label === "toolchain uv");
+    expect(bun).toMatchObject({
+      ok: false,
+      detail: ">=1.3 <2  observed 1.1.45",
+    });
+    expect(bun.fix).toContain("make bun >=1.3 <2");
+    expect(uv).toMatchObject({
+      ok: false,
+      label: "toolchain uv",
+      detail: ">=0.5  missing",
+    });
+    expect(uv.fix).toContain("install uv >=0.5");
+  });
+
+  test("not-declared: no new rows and no probe is spawned", async () => {
+    let probes = 0;
+    const counted = {
+      which: async () => {
+        probes += 1;
+        return "/opt/bun";
+      },
+      spawn: async () => {
+        probes += 1;
+        return { exitCode: 0, stdout: "1.3.14\n", stderr: "" };
+      },
+    };
+    const absent = await repoToolchainDiagnostics({
+      repos: [{ name: "bare", path: "/tmp/bare" }],
+      ...counted,
+    });
+    const emptyBlock = await repoToolchainDiagnostics({
+      repos: [{ name: "empty", toolchain: {} }],
+      ...counted,
+    });
+    expect(absent).toEqual([]);
+    expect(emptyBlock).toEqual([]);
+    expect(probes).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1097

factory doctor reports per-repo toolchain status; reposView publishes declared constraints.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 orchestrator/doctor.test.mjs event-runtime/lib/repos.test.mjs event-runtime/lib/api-registry.test.mjs event-runtime/lib/api-config.test.mjs` | pass    | 128 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2142 pass, 0 fail; emit; format; lint 0 errors |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_216d27d3-d5e5-4b1b-83ff-9b4d2905bcfe

Made with [Cursor](https://cursor.com)

## Post-review

Reviewer fold (MERGE with one fold): `repoToolchainDiagnostics` now wraps `normalizeToolchain` — a malformed `toolchain:` block yields a red `toolchain` check carrying the `RepoError` message and doctor continues with the remaining repos, instead of dying with a stack trace. Added `malformed block: yields a red toolchain check instead of throwing` to `orchestrator/doctor.test.mjs`. Merged `origin/develop`. Verified: ticket command 129/0, `bun run lint`, `bun test event-runtime/lib` 2143/0, `bun build/emit.mjs --check`, `bun run format:check`, `bun run check` all green.
