### PR TITLE
fix(control-plane): guard agent-ready removal in all planes

### DIFF
--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -579,10 +579,12 @@ for (const [name, make] of IMPLEMENTATIONS) {
       const names = (await cp.getTicket("WM-1")).labels.map((l) => l.name);
       expect(names).toContain(AGENT_READY_LABEL);
       expect(names).toContain("type:bug");
-      await cp.setLabels("WM-1", { remove: [AGENT_READY_LABEL] });
-      expect((await cp.getTicket("WM-1")).labels.map((l) => l.name)).toEqual([
-        "type:bug",
-      ]);
+      await expect(
+        cp.setLabels("WM-1", { remove: [AGENT_READY_LABEL] }),
+      ).rejects.toThrow(/refusing to remove ai:agent-ready/);
+      expect(
+        (await cp.getTicket("WM-1")).labels.map((l) => l.name).sort(),
+      ).toEqual([AGENT_READY_LABEL, "type:bug"].sort());
     });
 
     test("setLabels rejects unknown type:* values before mutating", async () => {

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -16,6 +16,7 @@ import { byQueueOrder, ControlPlaneError, OPEN_STATE_TYPES } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
+  classifyAgentReadyRemoval,
   claimLabels,
   resolveLabelIds,
   stampRun,
@@ -397,6 +398,14 @@ export function linearControlPlane({
           `transition requires a state name or a label change`,
         );
       const issue = await issueByKey(identifier);
+      const readyRemoval = classifyAgentReadyRemoval(
+        (issue.labels ?? []).map((label) => label.name),
+        { add, remove, state },
+      );
+      if (readyRemoval === "unsafe")
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} from a Todo ticket without claim labels or a move to another state`,
+        );
       const input = {};
       if (state) {
         const teamKey = issue.team?.key ?? teamOf(identifier);
@@ -419,6 +428,15 @@ export function linearControlPlane({
     async setLabels(identifier, { add = [], remove = [] } = {}) {
       const issue = await issueByKey(identifier);
       if (!add.length && !remove.length) return;
+      if (
+        classifyAgentReadyRemoval(
+          (issue.labels ?? []).map((label) => label.name),
+          { add, remove },
+        ) === "unsafe"
+      )
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} without claim labels or a state transition`,
+        );
       await issueUpdate(issue.id, {
         labelIds: await labelIdsFor(issue, add, remove),
       });

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -1,6 +1,63 @@
 import { describe, expect, test } from "bun:test";
 import { linearControlPlane } from "./linear.mjs";
 import { ControlPlaneError } from "./types.mjs";
+import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
+
+const guardLabels = [
+  { id: "ready", name: AGENT_READY_LABEL },
+  { id: "progress", name: IN_PROGRESS_LABEL },
+  { id: "agent", name: "agent:claude-code" },
+];
+
+function guardPlane() {
+  const ticket = {
+    id: "issue-1",
+    identifier: "WM-1",
+    title: "Issue",
+    state: { id: "todo", name: "Todo", type: "unstarted" },
+    assignee: null,
+    team: { key: "WM" },
+    project: null,
+    labels: { nodes: [guardLabels[0]] },
+    comments: { nodes: [] },
+    inverseRelations: { nodes: [] },
+  };
+  const updates = [];
+  const cp = linearControlPlane({
+    gql: async (query, variables) => {
+      if (query.includes("issue(id:$k)")) return { issue: ticket };
+      if (query.includes("issueLabels")) {
+        return {
+          issueLabels: {
+            nodes: guardLabels,
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        };
+      }
+      if (query.includes("teams(filter")) {
+        return {
+          teams: {
+            nodes: [
+              {
+                id: "team-1",
+                states: {
+                  nodes: [{ id: "triage", name: "Triage" }],
+                  pageInfo: { hasNextPage: false, endCursor: null },
+                },
+              },
+            ],
+          },
+        };
+      }
+      if (query.includes("issueUpdate")) {
+        updates.push(variables.in);
+        return { issueUpdate: { success: true } };
+      }
+      throw new Error(`unexpected query: ${query}`);
+    },
+  });
+  return { cp, updates };
+}
 
 describe("Linear ControlPlane pagination (GH-1393)", () => {
   test("listTickets concatenates cursor-paginated issue results", async () => {
@@ -327,5 +384,31 @@ describe("Linear ControlPlane pagination (GH-1393)", () => {
     await expect(cp.raw("query { ping }")).rejects.toThrow(
       "linear graphql timed out after 1ms",
     );
+  });
+
+  test("refuses bare transition and label removals before updating", async () => {
+    for (const removeReady of [
+      (cp) => cp.transition("WM-1", undefined, { remove: [AGENT_READY_LABEL] }),
+      (cp) => cp.setLabels("WM-1", { remove: [AGENT_READY_LABEL] }),
+    ]) {
+      const { cp, updates } = guardPlane();
+      await expect(removeReady(cp)).rejects.toThrow(/refusing to remove/);
+      expect(updates).toEqual([]);
+    }
+  });
+
+  test("allows a claim write and a move out of Todo", async () => {
+    const claimed = guardPlane();
+    await claimed.cp.setLabels("WM-1", {
+      add: [IN_PROGRESS_LABEL, "agent:claude-code"],
+      remove: [AGENT_READY_LABEL],
+    });
+    expect(claimed.updates).toEqual([{ labelIds: ["progress", "agent"] }]);
+
+    const moved = guardPlane();
+    await moved.cp.transition("WM-1", "Triage", {
+      remove: [AGENT_READY_LABEL],
+    });
+    expect(moved.updates).toEqual([{ stateId: "triage", labelIds: [] }]);
   });
 });

--- a/lib/control-plane/memory.mjs
+++ b/lib/control-plane/memory.mjs
@@ -237,14 +237,6 @@ export function memoryControlPlane(seed = {}) {
       nextState,
       { add = [], remove = [], unassign } = {},
     ) {
-      calls.push({
-        op: "transition",
-        identifier,
-        state: nextState,
-        add,
-        remove,
-        unassign,
-      });
       if (!nextState && !add.length && !remove.length && !unassign)
         throw new ControlPlaneError(
           `transition requires a state name or a label change`,
@@ -258,6 +250,14 @@ export function memoryControlPlane(seed = {}) {
         throw new ControlPlaneError(
           `refusing to remove ${AGENT_READY_LABEL} from a Todo ticket without claim labels or a move to another state`,
         );
+      calls.push({
+        op: "transition",
+        identifier,
+        state: nextState,
+        add,
+        remove,
+        unassign,
+      });
       if (nextState) {
         const teamKey = ticket.team?.key ?? teamOf(identifier);
         ticket.state = { ...requireState(nextState, teamKey) };
@@ -267,7 +267,6 @@ export function memoryControlPlane(seed = {}) {
     },
 
     async setLabels(identifier, { add = [], remove = [] } = {}) {
-      calls.push({ op: "setLabels", identifier, add, remove });
       const ticket = requireTicket(identifier);
       if (!add.length && !remove.length) return;
       if (
@@ -279,6 +278,7 @@ export function memoryControlPlane(seed = {}) {
         throw new ControlPlaneError(
           `refusing to remove ${AGENT_READY_LABEL} without claim labels or a state transition`,
         );
+      calls.push({ op: "setLabels", identifier, add, remove });
       applyLabels(ticket, add, remove);
     },
 

--- a/lib/control-plane/memory.mjs
+++ b/lib/control-plane/memory.mjs
@@ -21,6 +21,7 @@ import { byQueueOrder, ControlPlaneError, OPEN_STATE_TYPES } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
   appendIssueDetail,
+  classifyAgentReadyRemoval,
   claimLabels,
   resolveLabelIds,
   stampRun,
@@ -249,6 +250,14 @@ export function memoryControlPlane(seed = {}) {
           `transition requires a state name or a label change`,
         );
       const ticket = requireTicket(identifier);
+      const readyRemoval = classifyAgentReadyRemoval(
+        (ticket.labels ?? []).map((label) => label.name),
+        { add, remove, state: nextState },
+      );
+      if (readyRemoval === "unsafe")
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} from a Todo ticket without claim labels or a move to another state`,
+        );
       if (nextState) {
         const teamKey = ticket.team?.key ?? teamOf(identifier);
         ticket.state = { ...requireState(nextState, teamKey) };
@@ -261,6 +270,15 @@ export function memoryControlPlane(seed = {}) {
       calls.push({ op: "setLabels", identifier, add, remove });
       const ticket = requireTicket(identifier);
       if (!add.length && !remove.length) return;
+      if (
+        classifyAgentReadyRemoval(
+          (ticket.labels ?? []).map((label) => label.name),
+          { add, remove },
+        ) === "unsafe"
+      )
+        throw new ControlPlaneError(
+          `refusing to remove ${AGENT_READY_LABEL} without claim labels or a state transition`,
+        );
       applyLabels(ticket, add, remove);
     },
 

--- a/lib/control-plane/memory.test.mjs
+++ b/lib/control-plane/memory.test.mjs
@@ -35,6 +35,11 @@ describe("memory ControlPlane agent-ready removal guard", () => {
       expect(ticket.labels.map((label) => label.name)).toEqual([
         AGENT_READY_LABEL,
       ]);
+      expect(
+        cp.calls.filter((call) =>
+          ["transition", "setLabels"].includes(call.op),
+        ),
+      ).toEqual([]);
     }
   });
 

--- a/lib/control-plane/memory.test.mjs
+++ b/lib/control-plane/memory.test.mjs
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { memoryControlPlane } from "./memory.mjs";
+import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
+
+const labels = [
+  { id: "ready", name: AGENT_READY_LABEL },
+  { id: "progress", name: IN_PROGRESS_LABEL },
+  { id: "agent", name: "agent:claude-code" },
+];
+
+function plane() {
+  const seed = {
+    labels,
+    tickets: [
+      {
+        id: "issue-1",
+        identifier: "WM-1",
+        state: { id: "todo", name: "Todo" },
+        labels: [labels[0]],
+      },
+    ],
+  };
+  return { cp: memoryControlPlane(seed), ticket: seed.tickets[0] };
+}
+
+describe("memory ControlPlane agent-ready removal guard", () => {
+  test("refuses bare transition and label removals without mutating", async () => {
+    for (const removeReady of [
+      (cp) => cp.transition("WM-1", undefined, { remove: [AGENT_READY_LABEL] }),
+      (cp) => cp.setLabels("WM-1", { remove: [AGENT_READY_LABEL] }),
+    ]) {
+      const { cp, ticket } = plane();
+      await expect(removeReady(cp)).rejects.toThrow(/refusing to remove/);
+      expect(ticket.state.name).toBe("Todo");
+      expect(ticket.labels.map((label) => label.name)).toEqual([
+        AGENT_READY_LABEL,
+      ]);
+    }
+  });
+
+  test("allows a claim write and a move out of Todo", async () => {
+    const claimed = plane();
+    await claimed.cp.setLabels("WM-1", {
+      add: [IN_PROGRESS_LABEL, "agent:claude-code"],
+      remove: [AGENT_READY_LABEL],
+    });
+    expect(claimed.ticket.labels.map((label) => label.name).sort()).toEqual([
+      "agent:claude-code",
+      IN_PROGRESS_LABEL,
+    ]);
+
+    const moved = plane();
+    await moved.cp.transition("WM-1", "Triage", {
+      remove: [AGENT_READY_LABEL],
+    });
+    expect(moved.ticket.state.name).toBe("Triage");
+    expect(moved.ticket.labels).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1696

Review cross-plane guard coverage before merging.

## Validation

| Check                | Command                          | Result  | Notes                         |
| -------------------- | -------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test lib/control-plane/linear.test.mjs lib/control-plane/labels.test.mjs lib/control-plane/memory.test.mjs --timeout 20000` | pass | 16 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,142 pass; emit, format, lint exit 0 |
| UX critique          | factory-ux-critic                | not run | no user-facing surface        |

UX critique: skipped

run:run_704d34e6-01d1-4f24-be9d-8c7e35d61ab1

## Post-review
- Merged origin/develop (11 behind).
- Fold: memory plane pushes `setLabels`/`transition` onto `plane.calls` only after the `classifyAgentReadyRemoval` guard, so a refused write is not logged; refusal test asserts no such call was recorded.
- Skipped optional shared error-string export: `lib/control-plane/labels.mjs` is not in Owned Paths.
- Verified: ticket Verification Command (16 pass), `bun run lint`, `bun test event-runtime/lib` (2154 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
