### PR TITLE
feat(control-plane): bind organization project boards

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -601,9 +601,22 @@ async function ghJson(exec, args, input, { sleep = defaultSleep } = {}) {
       // still key rate-limit retries and named failures correctly.
       let apiStatus = response.httpStatus ?? status;
       let secondaryRateLimit = false;
+      let graphqlErrors = null;
       try {
         const parsed = JSON.parse(stdout);
         if (parsed?.message) message = `github api: ${parsed.message}`;
+        // `gh api graphql` exits non-zero on a GraphQL `errors[]` body and
+        // prints that body to stdout; surface the messages so callers can
+        // tell a NOT_FOUND (a login that is not an organization) from a
+        // permission failure instead of reading "failed (status 1)".
+        if (Array.isArray(parsed?.errors) && parsed.errors.length) {
+          graphqlErrors = parsed.errors;
+          const msgs = parsed.errors
+            .map((e) => e?.message)
+            .filter(Boolean)
+            .join("; ");
+          if (msgs) message = `github graphql: ${msgs}`;
+        }
         // `gh` reports the HTTP status as a string ("401"); a raw REST error
         // body may carry a number. Accept either — the claim path keys its
         // named failures off this value.
@@ -620,10 +633,12 @@ async function ghJson(exec, args, input, { sleep = defaultSleep } = {}) {
         await sleep(retryDelayMs(response.headers, attempt));
         continue;
       }
-      throw new ControlPlaneError(message, {
+      const failure = new ControlPlaneError(message, {
         status: apiStatus,
         cause: r.error,
       });
+      if (graphqlErrors) failure.graphqlErrors = graphqlErrors;
+      throw failure;
     }
     if (!stdout.trim()) return {};
     try {
@@ -871,10 +886,13 @@ export function githubControlPlane(options = {}) {
         pathName === "/graphql" ||
         method === "GRAPHQL";
       if (isGraphql) {
-        if (result?.errors?.length)
-          throw new ControlPlaneError(
+        if (result?.errors?.length) {
+          const failure = new ControlPlaneError(
             result.errors[0]?.message ?? "github graphql error",
           );
+          failure.graphqlErrors = result.errors;
+          throw failure;
+        }
         return result?.data ?? result;
       }
       return result;
@@ -2226,6 +2244,13 @@ async function provisionBoard(call, repo, { dryRun, project, statusField }) {
   // repository has no repository-scoped board yet, but must be linked to the
   // organization Factory board before the control plane can see its issues.
   // Prefer an already-linked board (above) so re-running init is a no-op.
+  //
+  // A user-owned repository has no organization at all: `organization(login:)`
+  // then answers `null` with a NOT_FOUND GraphQL error (which `gh api graphql`
+  // turns into a non-zero exit). That is not a permission problem and not a
+  // reason to abandon the labels already provisioned — it simply means there
+  // is no organization board to link, so fall through to the "absent board"
+  // report below.
   if (!found) {
     try {
       const d = await call("POST", "graphql", {
@@ -2234,11 +2259,13 @@ async function provisionBoard(call, repo, { dryRun, project, statusField }) {
           variables: { login: owner, title: project, statusField },
         },
       });
+      // A null organization (a seam that returns the NOT_FOUND body instead
+      // of throwing) reads the same way: nothing to link.
       found = (d?.data ?? d)?.organization?.projectsV2?.nodes?.find(
         (p) => p.title === project,
       );
     } catch (err) {
-      throw scopeHint(err, repo, "project");
+      if (!isOrganizationNotFound(err)) throw scopeHint(err, repo, "project");
     }
   }
 
@@ -2290,6 +2317,25 @@ async function provisionBoard(call, repo, { dryRun, project, statusField }) {
     throw scopeHint(err, repo, "project");
   }
   return { action: "linked", title: project, options };
+}
+
+/**
+ * Did an `organization(login:)` lookup fail only because the login is not an
+ * organization (a user-owned repository)? Reads the GraphQL `errors[]` when
+ * the transport preserved them, else the message GitHub uses for that case.
+ */
+function isOrganizationNotFound(errOrPayload) {
+  const errors = errOrPayload?.graphqlErrors ?? errOrPayload?.errors;
+  if (Array.isArray(errors) && errors.length) {
+    return errors.some(
+      (e) =>
+        e?.type === "NOT_FOUND" &&
+        (!Array.isArray(e.path) || e.path[0] === "organization"),
+    );
+  }
+  return /could not resolve to an organization/i.test(
+    String(errOrPayload?.message ?? ""),
+  );
 }
 
 /** Turn a permission failure into an error that names the scope needed. */

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -53,6 +53,25 @@ const DEFAULT_STATUS_FIELD = "Status";
 
 const FIND_REPO_PROJECT = `query FindRepoProject($owner: String!, $name: String!, $title: String!, $statusField: String!) {
   repository(owner: $owner, name: $name) {
+    id
+    projectsV2(first: 20, query: $title) {
+      nodes {
+        id
+        title
+        field(name: $statusField) {
+          ... on ProjectV2SingleSelectField {
+            id
+            name
+            options { id name }
+          }
+        }
+      }
+    }
+  }
+}`;
+
+const FIND_ORGANIZATION_PROJECT = `query FindOrganizationProject($login: String!, $title: String!, $statusField: String!) {
+  organization(login: $login) {
     projectsV2(first: 20, query: $title) {
       nodes {
         id
@@ -196,6 +215,12 @@ const ISSUE_CLOSING_PULL_REQUESTS = `query IssueClosingPullRequests($owner: Stri
 const ADD_PROJECT_ITEM = `mutation AddProjectItem($projectId: ID!, $contentId: ID!) {
   addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
     item { id }
+  }
+}`;
+
+const LINK_PROJECT_TO_REPOSITORY = `mutation LinkProjectV2ToRepository($projectId: ID!, $repositoryId: ID!) {
+  linkProjectV2ToRepository(input: { projectId: $projectId, repositoryId: $repositoryId }) {
+    repository { id }
   }
 }`;
 
@@ -2176,7 +2201,8 @@ export async function provisionGithubRepo(call, repo, opts = {}) {
  * than a setup mistake.
  */
 async function provisionBoard(call, repo, { dryRun, project, statusField }) {
-  const [owner] = repo.split("/");
+  const [owner, name] = repo.split("/");
+  let repository;
   let found;
   try {
     const d = await call("POST", "graphql", {
@@ -2184,17 +2210,36 @@ async function provisionBoard(call, repo, { dryRun, project, statusField }) {
         query: FIND_REPO_PROJECT,
         variables: {
           owner,
-          name: repo.split("/")[1],
+          name,
           title: project,
           statusField,
         },
       },
     });
-    found = (d?.data ?? d)?.repository?.projectsV2?.nodes?.find(
-      (p) => p.title === project,
-    );
+    repository = (d?.data ?? d)?.repository;
+    found = repository?.projectsV2?.nodes?.find((p) => p.title === project);
   } catch (err) {
     throw scopeHint(err, repo, "project");
+  }
+
+  // Projects v2 boards are commonly organization-owned. A newly onboarded
+  // repository has no repository-scoped board yet, but must be linked to the
+  // organization Factory board before the control plane can see its issues.
+  // Prefer an already-linked board (above) so re-running init is a no-op.
+  if (!found) {
+    try {
+      const d = await call("POST", "graphql", {
+        body: {
+          query: FIND_ORGANIZATION_PROJECT,
+          variables: { login: owner, title: project, statusField },
+        },
+      });
+      found = (d?.data ?? d)?.organization?.projectsV2?.nodes?.find(
+        (p) => p.title === project,
+      );
+    } catch (err) {
+      throw scopeHint(err, repo, "project");
+    }
   }
 
   if (!found) {
@@ -2220,7 +2265,31 @@ async function provisionBoard(call, repo, { dryRun, project, statusField }) {
       `project ${JSON.stringify(project)} field ${JSON.stringify(statusField)} is missing option(s): ${missing.join(", ")} — have: ${options.join(", ") || "(none)"}`,
     );
   }
-  return { action: "exists", title: project, options };
+
+  if (repository?.projectsV2?.nodes?.some((p) => p.id === found.id))
+    return { action: "exists", title: project, options };
+
+  if (!repository?.id)
+    throw new ControlPlaneError(
+      `repository ${repo} did not return a node id while linking project ${JSON.stringify(project)}`,
+    );
+  if (dryRun) return { action: "would-link", title: project, options };
+
+  try {
+    const d = await call("POST", "graphql", {
+      body: {
+        query: LINK_PROJECT_TO_REPOSITORY,
+        variables: { projectId: found.id, repositoryId: repository.id },
+      },
+    });
+    if (!(d?.data ?? d)?.linkProjectV2ToRepository?.repository?.id)
+      throw new ControlPlaneError(
+        `linking repository ${repo} to project ${JSON.stringify(project)} was not acknowledged`,
+      );
+  } catch (err) {
+    throw scopeHint(err, repo, "project");
+  }
+  return { action: "linked", title: project, options };
 }
 
 /** Turn a permission failure into an error that names the scope needed. */
@@ -2357,6 +2426,10 @@ export async function runGithubInit(argv, { cwd = process.cwd(), api } = {}) {
   if (report.created.length) print(`  ${report.created.join(", ")}`);
   if (report.board?.action === "exists")
     print(`Board ${JSON.stringify(project)}: present with all Status options.`);
+  else if (report.board?.action === "linked")
+    print(`Board ${JSON.stringify(project)}: linked to ${repo}.`);
+  else if (report.board?.action === "would-link")
+    print(`Board ${JSON.stringify(project)}: would link to ${repo} (dry run).`);
   else if (report.board?.action === "would-create")
     print(`Board ${JSON.stringify(project)}: missing (dry run).`);
   else if (report.board?.hint) print(`Board: ${report.board.hint}`);

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -2390,6 +2390,7 @@ describe("provisionGithubRepo", () => {
     project = null,
     repoProject = project,
     organizationProject = null,
+    organizationError = null,
     failList = null,
   } = {}) {
     const state = { labels: [...labels], created: [], calls: [], links: [] };
@@ -2413,6 +2414,7 @@ describe("provisionGithubRepo", () => {
       if (pathName === "graphql") {
         const query = body?.query ?? "";
         if (query.includes("FindOrganizationProject")) {
+          if (organizationError) throw organizationError;
           return {
             organization: {
               projectsV2: {
@@ -2627,6 +2629,84 @@ describe("provisionGithubRepo", () => {
     const second = await provisionGithubRepo(api, REPO2);
     expect(second.board.action).toBe("exists");
     expect(api.state.links).toHaveLength(1);
+  });
+
+  test("a user-owned repository (no organization) reports the board as absent, not as a failure", async () => {
+    // `organization(login:)` on a user login answers null + a NOT_FOUND
+    // GraphQL error; `gh api graphql` turns that into a non-zero exit. Before
+    // the fold this threw and init printed "Labels/board: not provisioned"
+    // even though every label had just been created.
+    const notFound = new ControlPlaneError(
+      "github graphql: Could not resolve to an Organization with the login of 'acme'.",
+      { status: 200 },
+    );
+    notFound.graphqlErrors = [
+      {
+        type: "NOT_FOUND",
+        path: ["organization"],
+        message:
+          "Could not resolve to an Organization with the login of 'acme'.",
+      },
+    ];
+    const api = provApi({ repoProject: null, organizationError: notFound });
+
+    const report = await provisionGithubRepo(api, REPO2);
+    expect(report.board.action).toBe("manual");
+    expect(report.created.length).toBeGreaterThan(0);
+    expect(api.state.links).toEqual([]);
+
+    const dry = await provisionGithubRepo(
+      provApi({ repoProject: null, organizationError: notFound }),
+      REPO2,
+      { dryRun: true },
+    );
+    expect(dry.board.action).toBe("would-create");
+
+    // Only the message survives some transports; that is enough.
+    const bare = new ControlPlaneError(
+      "Could not resolve to an Organization with the login of 'acme'.",
+    );
+    const viaMessage = await provisionGithubRepo(
+      provApi({ repoProject: null, organizationError: bare }),
+      REPO2,
+    );
+    expect(viaMessage.board.action).toBe("manual");
+
+    // A real permission failure on the organization lookup still fails loudly.
+    const forbidden = new ControlPlaneError("Forbidden", { status: 403 });
+    await expect(
+      provisionGithubRepo(
+        provApi({ repoProject: null, organizationError: forbidden }),
+        REPO2,
+      ),
+    ).rejects.toThrow(/'project' scope/);
+  });
+
+  test("dry run reports would-link without calling LinkProjectV2ToRepository", async () => {
+    const project = {
+      id: "PVT_1",
+      title: "Factory",
+      field: {
+        id: "PVTF_1",
+        name: "Status",
+        options: GITHUB_FACTORY_STATES.map((name, i) => ({
+          id: `o${i}`,
+          name,
+        })),
+      },
+    };
+    const api = provApi({ repoProject: null, organizationProject: project });
+
+    const report = await provisionGithubRepo(api, REPO2, { dryRun: true });
+
+    expect(report.board.action).toBe("would-link");
+    expect(report.board.title).toBe("Factory");
+    expect(api.state.links).toEqual([]);
+    expect(
+      api.state.calls.some((c) =>
+        String(c.body?.query ?? "").includes("LinkProjectV2ToRepository"),
+      ),
+    ).toBe(false);
   });
 
   test("a board MISSING a Status option fails loudly, naming it", async () => {
@@ -3049,6 +3129,41 @@ describe("Projects v2 board read is cached for a short TTL (WM-1067)", () => {
     // though it lands inside the TTL window. Without invalidation this would be
     // 1 (every read served from the pre-write memo).
     expect(api.state.boardReads).toBe(2);
+  });
+});
+
+describe("makeGhApi GraphQL error bodies (#1642)", () => {
+  test("a non-zero `gh api graphql` exit surfaces the errors[] messages and keeps them on the error", async () => {
+    const body = {
+      data: { organization: null },
+      errors: [
+        {
+          type: "NOT_FOUND",
+          path: ["organization"],
+          message:
+            "Could not resolve to an Organization with the login of 'acme'.",
+        },
+      ],
+    };
+    const exec = () => ({
+      status: 1,
+      stdout: `HTTP/2.0 200 OK\r\ncontent-type: application/json\r\n\r\n${JSON.stringify(body)}`,
+      stderr:
+        "gh: Could not resolve to an Organization with the login of 'acme'.",
+      error: null,
+    });
+    const api = makeGhApi(exec, { env: { PATH: "/usr/bin" } });
+    let caught;
+    try {
+      await api("POST", "graphql", { body: { query: "query { x }" } });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(ControlPlaneError);
+    expect(caught.message).toBe(
+      "github graphql: Could not resolve to an Organization with the login of 'acme'.",
+    );
+    expect(caught.graphqlErrors).toEqual(body.errors);
   });
 });
 

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -2385,8 +2385,14 @@ describe("provisionGithubRepo", () => {
   const REPO2 = "acme/widget";
 
   /** A gh api fake with a controllable label set and project. */
-  function provApi({ labels = [], project = null, failList = null } = {}) {
-    const state = { labels: [...labels], created: [], calls: [] };
+  function provApi({
+    labels = [],
+    project = null,
+    repoProject = project,
+    organizationProject = null,
+    failList = null,
+  } = {}) {
+    const state = { labels: [...labels], created: [], calls: [], links: [] };
     const api = async (method, pathName, { body, query } = {}) => {
       state.calls.push({ method, pathName, body, query });
       if (method === "GET" && pathName === `repos/${REPO2}/labels`) {
@@ -2405,8 +2411,28 @@ describe("provisionGithubRepo", () => {
         return { name: body.name };
       }
       if (pathName === "graphql") {
+        const query = body?.query ?? "";
+        if (query.includes("FindOrganizationProject")) {
+          return {
+            organization: {
+              projectsV2: {
+                nodes: organizationProject ? [organizationProject] : [],
+              },
+            },
+          };
+        }
+        if (query.includes("LinkProjectV2ToRepository")) {
+          state.links.push(body.variables);
+          repoProject = organizationProject;
+          return {
+            linkProjectV2ToRepository: { repository: { id: "R_1" } },
+          };
+        }
         return {
-          repository: { projectsV2: { nodes: project ? [project] : [] } },
+          repository: {
+            id: "R_1",
+            projectsV2: { nodes: repoProject ? [repoProject] : [] },
+          },
         };
       }
       throw new ControlPlaneError(`unexpected ${method} ${pathName}`, {
@@ -2574,6 +2600,33 @@ describe("provisionGithubRepo", () => {
     });
     const report = await provisionGithubRepo(api, REPO2);
     expect(report.board.action).toBe("exists");
+  });
+
+  test("links a repository to the organization's existing Factory board", async () => {
+    const project = {
+      id: "PVT_1",
+      title: "Factory",
+      field: {
+        id: "PVTF_1",
+        name: "Status",
+        options: GITHUB_FACTORY_STATES.map((name, i) => ({
+          id: `o${i}`,
+          name,
+        })),
+      },
+    };
+    const api = provApi({ repoProject: null, organizationProject: project });
+
+    const report = await provisionGithubRepo(api, REPO2);
+
+    expect(report.board.action).toBe("linked");
+    expect(api.state.links).toEqual([
+      { projectId: "PVT_1", repositoryId: "R_1" },
+    ]);
+
+    const second = await provisionGithubRepo(api, REPO2);
+    expect(second.board.action).toBe("exists");
+    expect(api.state.links).toHaveLength(1);
   });
 
   test("a board MISSING a Status option fails loudly, naming it", async () => {


### PR DESCRIPTION
Fixes #1642

Link newly provisioned repositories to the organization Factory Projects v2 board while preserving existing labels.

## Validation

| Check                | Command                                                                                                 | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs`                                                           | pass    | 123 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2148 pass, 0 failures; clean |
| UX critique          | factory-ux-critic                                                                                       | not run | backend control-plane change  |

UX critique: skipped

run:run_2009451c-47b8-435f-95f1-dd87d121ff96

## Post-review

Reviewer fold (head `fcf9eeb`): `provisionBoard`'s organization fallback no longer throws for a user-owned repository. `organization(login:)` answering null + a `NOT_FOUND` GraphQL error (a non-zero `gh api graphql` exit) is now read as "no organization board" and falls through to the existing absent-board report (`action:"manual"` / `would-create` on dry run); real permission failures still surface with the `project` scope hint. `ghJson` surfaces GraphQL `errors[]` messages (and keeps them on the `ControlPlaneError`) so the case is detectable through the raw `gh api` seam. Tests added: user-owned repo (thrown NOT_FOUND, message-only, and 403 still fails), `dryRun:true` asserting `would-link` with no `LinkProjectV2ToRepository` call, and the `ghJson` GraphQL error surface.

| Check | Command | Result |
| --- | --- | --- |
| Verification Command | `bun test lib/control-plane/github.test.mjs` | pass (126 tests) |
| Repo verify | `bun run lint && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` | pass (2164 tests, 0 fail; lint 0 errors; format clean) |
