### PR TITLE
fix(proposals): re-resolve models after adapter changes

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -114,6 +114,20 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
 }
 
 /**
+ * A RunSpec's concrete model must be one of the configured values for its
+ * adapter. Model tiers are portable intent; model names are not. Keep this at
+ * the planning boundary so a bad runtime overlay or carried-forward pin parks
+ * the event rather than producing a QUEUED run the adapter will reject.
+ */
+function modelAdapterMismatch(spec, modelTiers, adapter) {
+  if (spec?.model == null) return null;
+  const allowed = Object.values(modelTiers?.[adapter] ?? {});
+  return allowed.includes(spec.model)
+    ? null
+    : `model_adapter_mismatch: model ${JSON.stringify(spec.model)} is not configured for adapter ${JSON.stringify(adapter)}`;
+}
+
+/**
  * Per-agent repo scoping (WM-64), the repo analogue of the actions adapter's
  * host allowlist: a definition that declares `repos` may only run over those
  * repos. Applies to any input carrying a `repo` field, whatever the workspace
@@ -2660,6 +2674,13 @@ export function planEvent(
       }),
       idempotencyKey,
     };
+    const modelMismatch = modelAdapterMismatch(
+      spec,
+      registry.modelTiers,
+      mapping.adapter,
+    );
+    if (modelMismatch)
+      return humanNeeded(db, event, modelMismatch, at, ttlSeconds);
     const specJson = canonicalJson(spec);
     const specHash = hashJson(spec);
     try {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -52,6 +52,7 @@ import {
 import {
   getAgent,
   getEventType,
+  MODEL_ADAPTERS,
   MODEL_TIERS,
   resolveModel,
 } from "./registry.mjs";
@@ -114,17 +115,42 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
 }
 
 /**
- * A RunSpec's concrete model must be one of the configured values for its
- * adapter. Model tiers are portable intent; model names are not. Keep this at
- * the planning boundary so a bad runtime overlay or carried-forward pin parks
- * the event rather than producing a QUEUED run the adapter will reject.
+ * A tier-resolved model must be one of the configured values for its adapter.
+ * Model tiers are portable intent; model names are not. Keep this at the
+ * planning boundary so a bad runtime overlay or carried-forward pin parks the
+ * event rather than producing a QUEUED run the adapter will reject.
+ *
+ * Explicit pins — a definition's `model:` or an agent overlay `model` — are
+ * operator intent: `resolveModel` returns them verbatim and no adapter
+ * publishes a known-model list to check them against, so they are accepted
+ * as-is. `explicitPin` states that provenance when the caller knows it. When
+ * it does not (a stored spec being approved as recorded), a model outside the
+ * adapter's map is refused only when it is a tier value of some *other*
+ * adapter — the signature of a pin carried across an adapter change — and is
+ * otherwise treated as a pin.
+ *
+ * An adapter that takes no model (`fake`, actions) cannot mismatch one: a
+ * model on such a spec is the registered route's pin carried across a
+ * process-wide `--adapter-override`, and that adapter ignores it.
  */
-function modelAdapterMismatch(spec, modelTiers, adapter) {
-  if (spec?.model == null) return null;
+export function modelAdapterMismatch(
+  spec,
+  modelTiers,
+  adapter,
+  { explicitPin } = {},
+) {
+  if (spec?.model == null || explicitPin === true) return null;
+  if (!MODEL_ADAPTERS.has(adapter)) return null;
   const allowed = Object.values(modelTiers?.[adapter] ?? {});
-  return allowed.includes(spec.model)
-    ? null
-    : `model_adapter_mismatch: model ${JSON.stringify(spec.model)} is not configured for adapter ${JSON.stringify(adapter)}`;
+  if (allowed.includes(spec.model)) return null;
+  if (explicitPin === undefined) {
+    const foreignTierValue = Object.entries(modelTiers ?? {}).some(
+      ([name, tiers]) =>
+        name !== adapter && Object.values(tiers ?? {}).includes(spec.model),
+    );
+    if (!foreignTierValue) return null;
+  }
+  return `model_adapter_mismatch: model ${JSON.stringify(spec.model)} is not configured for adapter ${JSON.stringify(adapter)}`;
 }
 
 /**
@@ -2678,6 +2704,12 @@ export function planEvent(
       spec,
       registry.modelTiers,
       mapping.adapter,
+      {
+        explicitPin:
+          plannedDef(getAgent(registry, mapping.agent), {
+            modelOverride: overlayModel,
+          }).model !== undefined,
+      },
     );
     if (modelMismatch)
       return humanNeeded(db, event, modelMismatch, at, ttlSeconds);

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -23,6 +23,7 @@ import {
   buildEscalatedContinuationSpec,
   buildRunSpec,
   createLinearReadCache,
+  modelAdapterMismatch,
   DEFAULT_MAX_IN_FLIGHT as PLANNER_DEFAULT_MAX_IN_FLIGHT,
   idempotencyKeyFor,
   pinMemos,
@@ -1222,6 +1223,51 @@ describe("planEvent worktree gate (WM-108)", () => {
         expect(spec.model).toBe(item.model);
       }
     });
+  });
+
+  test("escalated continuation resolves the strong model for the failed spec's own adapter (gh-1704 AC3)", () => {
+    const base = {
+      schemaVersion: "factory.run-spec/v1",
+      runId: "run_light_failed_pi",
+      agent: "dispatch@1",
+      input: { repo: "tiered", ticket: "WM-694", modelTier: "light" },
+      inputHash: hashJson({
+        repo: "tiered",
+        ticket: "WM-694",
+        modelTier: "light",
+      }),
+      workspace: { type: "worktree", checkoutDir: "repo" },
+      adapter: "pi",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+      outputContract: "factory.dispatch-result/v1",
+      capabilities: ["tracker:write", "repo:write", "github:write"],
+      modelTier: "light",
+      model: "openai-codex/gpt-5.6-luna",
+      timeoutSeconds: 5400,
+      maxAttempts: 1,
+      idempotencyKey: "dispatch-light-pi",
+    };
+    for (const [adapter, strong] of [
+      ["pi", "openai-codex/gpt-5.6-sol"],
+      ["cursor", "cursor-grok-4.6-high"],
+    ]) {
+      const continuation = buildEscalatedContinuationSpec(
+        registry,
+        { ...base, adapter },
+        { runId: `run_strong_${adapter}` },
+      );
+      expect(continuation).toMatchObject({
+        adapter,
+        modelTier: "strong",
+        model: strong,
+      });
+      expect(
+        modelAdapterMismatch(continuation, registry.modelTiers, adapter, {
+          explicitPin: false,
+        }),
+      ).toBeNull();
+    }
   });
 
   test("escalated continuation pins a fresh strong-tier spec and authenticated claim proof", () => {
@@ -2650,30 +2696,140 @@ describe("planEvent model pinning (WM-135)", () => {
     const ref = admit(db, tieredEnvelope());
     const outcome = planEvent(
       db,
-      tieredRegistry({ modelTier: "standard", model: "default" }),
+      tieredRegistry({ modelTier: "standard", model: "claude-opus-4-1" }),
       ref,
       { now: NOW, policyVersion: "git:test" },
     );
     const spec = JSON.parse(outcome.proposal.spec_json);
-    expect(spec.model).toBe("default");
+    expect(spec.model).toBe("claude-opus-4-1");
     expect(spec.modelTier).toBe("standard");
   });
 
-  test("refuses a model override that is not configured for the selected adapter", () => {
+  test("an agent overlay model pin outside the tier map is an explicit pin — planned verbatim, not parked (gh-1704)", () => {
     const db = openDb(":memory:");
+    putOverride(db, {
+      kind: KIND_AGENT,
+      key: "test-tiered@1",
+      patch: { model: "claude-opus-4-1" },
+    });
     const ref = admit(db, tieredEnvelope());
     const outcome = planEvent(
       db,
-      tieredRegistry({
-        modelTier: "standard",
-        model: "openai-codex/gpt-5.6-terra",
-      }),
+      tieredRegistry({ modelTier: "standard" }),
       ref,
       { now: NOW, policyVersion: "git:test" },
     );
-    expect(outcome).toMatchObject({ decision: "human_needed" });
-    expect(outcome.reason).toStartWith("model_adapter_mismatch:");
-    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    expect(outcome.decision).toBe("run");
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec).toMatchObject({
+      adapter: "claude",
+      modelTier: "standard",
+      model: "claude-opus-4-1",
+    });
+  });
+
+  test("a tier-resolved model follows an adapter overlay flip and is consistent with that adapter's map (gh-1704)", () => {
+    const db = openDb(":memory:");
+    const modelTiers = {
+      claude: { strong: "default", standard: "sonnet", light: "haiku" },
+      pi: {
+        strong: "openai-codex/gpt-5.6-sol",
+        standard: "openai-codex/gpt-5.6-terra",
+        light: "openai-codex/gpt-5.6-luna",
+      },
+    };
+    putOverride(db, {
+      kind: KIND_EVENT_TYPE,
+      key: "test.tiered.requested",
+      patch: { adapter: "pi" },
+    });
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(
+      db,
+      tieredRegistry({ modelTier: "standard", modelTiers }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
+    expect(outcome.decision).toBe("run");
+    const spec = JSON.parse(outcome.proposal.spec_json);
+    expect(spec).toMatchObject({
+      adapter: "pi",
+      modelTier: "standard",
+      model: "openai-codex/gpt-5.6-terra",
+    });
+    expect(modelAdapterMismatch(spec, modelTiers, spec.adapter)).toBeNull();
+    expect(
+      modelAdapterMismatch(spec, modelTiers, spec.adapter, {
+        explicitPin: false,
+      }),
+    ).toBeNull();
+  });
+
+  describe("modelAdapterMismatch (gh-1704)", () => {
+    const modelTiers = {
+      claude: { strong: "default", standard: "sonnet", light: "haiku" },
+      pi: { standard: "openai-codex/gpt-5.6-terra" },
+    };
+
+    test("a tier-resolved model outside its adapter's map is a mismatch", () => {
+      expect(
+        modelAdapterMismatch(
+          { model: "openai-codex/gpt-5.6-terra" },
+          modelTiers,
+          "claude",
+          { explicitPin: false },
+        ),
+      ).toStartWith("model_adapter_mismatch:");
+    });
+
+    test("an explicit pin is accepted as-is whatever the map says", () => {
+      expect(
+        modelAdapterMismatch(
+          { model: "openai-codex/gpt-5.6-terra" },
+          modelTiers,
+          "claude",
+          { explicitPin: true },
+        ),
+      ).toBeNull();
+    });
+
+    test("unknown provenance: another adapter's tier value is a mismatch, any other value is a pin", () => {
+      expect(
+        modelAdapterMismatch(
+          { model: "openai-codex/gpt-5.6-terra" },
+          modelTiers,
+          "claude",
+        ),
+      ).toStartWith("model_adapter_mismatch:");
+      expect(
+        modelAdapterMismatch(
+          { model: "claude-opus-4-1" },
+          modelTiers,
+          "claude",
+        ),
+      ).toBeNull();
+      expect(
+        modelAdapterMismatch({ model: "sonnet" }, modelTiers, "claude"),
+      ).toBeNull();
+    });
+
+    test("an adapter that takes no model never mismatches one", () => {
+      expect(
+        modelAdapterMismatch(
+          { model: "openai-codex/gpt-5.6-terra" },
+          modelTiers,
+          "fake",
+          { explicitPin: false },
+        ),
+      ).toBeNull();
+    });
+
+    test("a spec without a model is never a mismatch", () => {
+      expect(modelAdapterMismatch({}, modelTiers, "claude")).toBeNull();
+      expect(
+        modelAdapterMismatch({ model: null }, modelTiers, "pi"),
+      ).toBeNull();
+    });
   });
 
   test("a definition declaring nothing produces a spec without model fields — today's behavior (regression)", () => {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2650,13 +2650,30 @@ describe("planEvent model pinning (WM-135)", () => {
     const ref = admit(db, tieredEnvelope());
     const outcome = planEvent(
       db,
-      tieredRegistry({ modelTier: "standard", model: "claude-opus-4-1" }),
+      tieredRegistry({ modelTier: "standard", model: "default" }),
       ref,
       { now: NOW, policyVersion: "git:test" },
     );
     const spec = JSON.parse(outcome.proposal.spec_json);
-    expect(spec.model).toBe("claude-opus-4-1");
+    expect(spec.model).toBe("default");
     expect(spec.modelTier).toBe("standard");
+  });
+
+  test("refuses a model override that is not configured for the selected adapter", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, tieredEnvelope());
+    const outcome = planEvent(
+      db,
+      tieredRegistry({
+        modelTier: "standard",
+        model: "openai-codex/gpt-5.6-terra",
+      }),
+      ref,
+      { now: NOW, policyVersion: "git:test" },
+    );
+    expect(outcome).toMatchObject({ decision: "human_needed" });
+    expect(outcome.reason).toStartWith("model_adapter_mismatch:");
+    expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
   });
 
   test("a definition declaring nothing produces a spec without model fields — today's behavior (regression)", () => {

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -5,7 +5,8 @@
  * a proposal that sat past its TTL is never executed as-is. Approval after
  * expiry re-plans against current state: an identical fresh spec runs, a
  * different one supersedes the stale proposal with a new open one. The
- * re-plan carries the stored approvalPolicy, modelTier, model,
+ * re-plan carries the stored approvalPolicy and modelTier, plus a model pin
+ * only when it belongs to the adapter selected for the fresh spec,
  * configSnapshot (when present), and idempotencyKey, so expiry cannot shed
  * plan-time dispatch authorization, model routing, or a run generation key.
  * Stale intent can therefore never execute silently, which is the §15 exit
@@ -98,17 +99,34 @@ function loadEnvelope(db, proposal) {
  * Plan-time-only values are not recoverable from the event envelope. Keep the
  * values recorded in the approved proposal when a replan rebuilds its spec.
  */
-function ttlReplanOptions(spec) {
+function ttlReplanOptions(spec, adapter) {
   return {
     approvalPolicy: spec.approvalPolicy ?? null,
     ...(Object.hasOwn(spec, "modelTier")
       ? { modelTierOverride: spec.modelTier }
       : {}),
-    ...(Object.hasOwn(spec, "model") ? { modelOverride: spec.model } : {}),
+    // A concrete model is adapter-specific. Retaining a pi pin while the
+    // current registry routes the re-plan to cursor produces a RunSpec that
+    // the cursor CLI cannot execute. The tier is portable intent, so let the
+    // planner resolve it through the fresh adapter's policy map instead.
+    ...(spec.adapter === adapter && Object.hasOwn(spec, "model")
+      ? { modelOverride: spec.model }
+      : {}),
     ...(Object.hasOwn(spec, "configSnapshot")
       ? { configSnapshot: spec.configSnapshot }
       : {}),
   };
+}
+
+function assertModelMatchesAdapter(spec, registry, adapter) {
+  if (spec?.model == null) return;
+  const allowed = Object.values(registry.modelTiers?.[adapter] ?? {});
+  if (allowed.includes(spec.model)) return;
+  const err = new Error(
+    `model_adapter_mismatch: model ${JSON.stringify(spec.model)} is not configured for adapter ${JSON.stringify(adapter)}`,
+  );
+  err.code = "model_adapter_mismatch";
+  throw err;
 }
 
 /**
@@ -233,6 +251,11 @@ export function approveProposal(
       !registryVersionMismatch &&
       !isExpired(proposal, now)
     ) {
+      assertModelMatchesAdapter(
+        recordedSpec,
+        registry,
+        mapping?.adapter ?? recordedSpec.adapter,
+      );
       return approveRun(db, proposal, envelope, {
         actor,
         now,
@@ -256,7 +279,7 @@ export function approveProposal(
         policyVersion,
         adapterOverride,
         now,
-        ...ttlReplanOptions(storedSpec),
+        ...ttlReplanOptions(storedSpec, mapping.adapter),
       }),
       // configSnapshot can affect planning and is itself part of specs that
       // explicitly pin it. Keep the pin in the rebuilt spec as well as
@@ -279,6 +302,7 @@ export function approveProposal(
         }
       : built;
     const freshHash = hashJson(fresh);
+    assertModelMatchesAdapter(fresh, registry, mapping.adapter);
     // Refresh-and-approve only when the caller named a real current version.
     // Replanning with `"unknown"` must not stamp that sentinel onto the
     // recorded spec and queue it.

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -17,7 +17,8 @@ import { DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
 import { txImmediate } from "./db.mjs";
 import { newProposalId } from "./ids.mjs";
 import { runState, transition } from "./lifecycle.mjs";
-import { buildRunSpec } from "./planner.mjs";
+import { buildRunSpec, modelAdapterMismatch } from "./planner.mjs";
+import { plannedDef } from "./runtime-overrides.mjs";
 import { getAgent, getEventType } from "./registry.mjs";
 import { computeDefHash } from "./receipts.mjs";
 
@@ -118,13 +119,20 @@ function ttlReplanOptions(spec, adapter) {
   };
 }
 
-function assertModelMatchesAdapter(spec, registry, adapter) {
-  if (spec?.model == null) return;
-  const allowed = Object.values(registry.modelTiers?.[adapter] ?? {});
-  if (allowed.includes(spec.model)) return;
-  const err = new Error(
-    `model_adapter_mismatch: model ${JSON.stringify(spec.model)} is not configured for adapter ${JSON.stringify(adapter)}`,
+/**
+ * Refuse to queue a spec whose concrete model cannot run on its adapter (a
+ * pi model carried onto a cursor route). `explicitPin` is the provenance of
+ * the model when the caller knows it; see `modelAdapterMismatch`.
+ */
+function assertModelMatchesAdapter(spec, registry, adapter, options) {
+  const mismatch = modelAdapterMismatch(
+    spec,
+    registry.modelTiers,
+    adapter,
+    options,
   );
+  if (!mismatch) return;
+  const err = new Error(mismatch);
   err.code = "model_adapter_mismatch";
   throw err;
 }
@@ -251,11 +259,25 @@ export function approveProposal(
       !registryVersionMismatch &&
       !isExpired(proposal, now)
     ) {
-      assertModelMatchesAdapter(
-        recordedSpec,
-        registry,
-        mapping?.adapter ?? recordedSpec.adapter,
-      );
+      // The recorded spec queues as-is, so its model is checked against the
+      // adapter it was planned for: the spec's own adapter — not the
+      // mapping's, which an overlay may have set differently at plan time
+      // (overlays live in the db, not in `registry`). The one exception is a
+      // process-wide `--adapter-override`, which substitutes execution only:
+      // the model was still resolved for the registered route. defHash
+      // matched above, so the current definition is the one that planned it:
+      // a definition `model:` is a known explicit pin; an overlay pin at plan
+      // time is unknowable.
+      const plannedFor =
+        adapterOverride != null && recordedSpec?.adapter === adapterOverride
+          ? mapping?.adapter
+          : (recordedSpec?.adapter ?? mapping?.adapter);
+      assertModelMatchesAdapter(recordedSpec, registry, plannedFor, {
+        explicitPin:
+          registry.agents.get(recordedSpec?.agent)?.model !== undefined
+            ? true
+            : undefined,
+      });
       return approveRun(db, proposal, envelope, {
         actor,
         now,
@@ -273,13 +295,14 @@ export function approveProposal(
         `proposal ${id} requires re-planning but event type ${envelope.type} is no longer registered`,
       );
     const storedSpec = recordedSpec ?? JSON.parse(proposal.spec_json);
+    const replanOptions = ttlReplanOptions(storedSpec, mapping.adapter);
     const built = {
       ...buildRunSpec(registry, envelope, mapping, {
         runId: proposal.run_id,
         policyVersion,
         adapterOverride,
         now,
-        ...ttlReplanOptions(storedSpec, mapping.adapter),
+        ...replanOptions,
       }),
       // configSnapshot can affect planning and is itself part of specs that
       // explicitly pin it. Keep the pin in the rebuilt spec as well as
@@ -302,7 +325,12 @@ export function approveProposal(
         }
       : built;
     const freshHash = hashJson(fresh);
-    assertModelMatchesAdapter(fresh, registry, mapping.adapter);
+    assertModelMatchesAdapter(fresh, registry, mapping.adapter, {
+      explicitPin:
+        plannedDef(getAgent(registry, mapping.agent), {
+          modelOverride: replanOptions.modelOverride,
+        }).model !== undefined,
+    });
     // Refresh-and-approve only when the caller named a real current version.
     // Replanning with `"unknown"` must not stamp that sentinel onto the
     // recorded spec and queue it.

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -711,3 +711,161 @@ describe("approveProposal after TTL expiry (§12)", () => {
     expect(getProposal(db, proposal.id).status).toBe("open");
   });
 });
+
+describe("approveProposal adapter/model consistency (gh-1704)", () => {
+  const DISPATCH = "factory.dispatch.requested";
+  /** The registry with the dispatch route flipped to another adapter. */
+  function routedTo(adapter) {
+    return {
+      ...registry,
+      eventTypes: {
+        ...registry.eventTypes,
+        [DISPATCH]: { ...registry.eventTypes[DISPATCH], adapter },
+      },
+    };
+  }
+  function storeSpec(db, proposal, runId, spec) {
+    const json = canonicalJson(spec);
+    const hash = hashJson(spec);
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(json, hash, proposal.id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(json, hash, runId);
+  }
+
+  test("within TTL, a consistent recorded pair is approved as-is even after the route flips adapter", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    const recorded = getProposal(db, proposal.id).spec;
+    expect(recorded).toMatchObject({
+      adapter: "cursor",
+      model: "cursor-grok-4.6-low-fast",
+    });
+
+    const result = approveProposal(db, routedTo("pi"), proposal.id, {
+      actor: "operator",
+      now: NOW + 1,
+      policyVersion: "git:test",
+    });
+
+    expect(result).toEqual({ approved: true, runId });
+    expect(runState(db, runId)).toBe("QUEUED");
+    expect(
+      JSON.parse(
+        db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId)
+          .spec_json,
+      ),
+    ).toMatchObject({ adapter: "cursor", model: "cursor-grok-4.6-low-fast" });
+  });
+
+  test("within TTL, the recorded model is checked against the recorded adapter, not the flipped route", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    // cursor spec carrying pi's light model: consistent with the *route*
+    // (now pi), inconsistent with the adapter the spec will execute on.
+    storeSpec(db, proposal, runId, {
+      ...getProposal(db, proposal.id).spec,
+      model: "openai-codex/gpt-5.6-luna",
+    });
+
+    expect(() =>
+      approveProposal(db, routedTo("pi"), proposal.id, {
+        actor: "operator",
+        now: NOW + 1,
+        policyVersion: "git:test",
+      }),
+    ).toThrow(expect.objectContaining({ code: "model_adapter_mismatch" }));
+    expect(runState(db, runId)).toBe("PROPOSED");
+    expect(getProposal(db, proposal.id).status).toBe("open");
+  });
+
+  test("a registry-version refresh re-resolves a carried model through the fresh adapter", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    storeSpec(db, proposal, runId, {
+      ...getProposal(db, proposal.id).spec,
+      promptVersion: "old",
+      policyVersion: "old",
+      adapter: "pi",
+      model: "openai-codex/gpt-5.6-luna",
+    });
+
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + 1,
+      policyVersion: "git:test",
+    });
+
+    expect(result).toMatchObject({ approved: false, replanned: true });
+    expect(result.proposal.spec).toMatchObject({
+      adapter: "cursor",
+      modelTier: "light",
+      model: "cursor-grok-4.6-low-fast",
+      promptVersion: "git:test",
+      policyVersion: "git:test",
+    });
+    expect(getProposal(db, proposal.id).status).toBe("superseded");
+    expect(runState(db, runId)).toBe("PROPOSED");
+  });
+
+  test("a registry-version refresh keeps a still-consistent model and queues the refreshed spec", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    storeSpec(db, proposal, runId, {
+      ...getProposal(db, proposal.id).spec,
+      promptVersion: "old",
+    });
+
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + 1,
+      policyVersion: "git:test",
+    });
+
+    expect(result).toEqual({ approved: true, runId });
+    expect(lifecycleOf(db, runId).at(-1).reason).toBe(
+      "approved_after_registry_replan",
+    );
+    expect(
+      JSON.parse(
+        db.query(`SELECT spec_json FROM runs WHERE run_id = ?`).get(runId)
+          .spec_json,
+      ),
+    ).toMatchObject({
+      adapter: "cursor",
+      model: "cursor-grok-4.6-low-fast",
+      promptVersion: "git:test",
+    });
+  });
+
+  test("an explicit definition model pin outside the tier map survives the re-plan instead of being refused", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    const pinned = {
+      ...registry,
+      agents: new Map(registry.agents),
+    };
+    pinned.agents.set("dispatch@1", {
+      ...registry.agents.get("dispatch@1"),
+      model: "claude-opus-4-1",
+    });
+    // The stored pi pin is dropped by the adapter change, so the fresh spec
+    // takes the definition's own pin — a value in no adapter's tier map.
+    storeSpec(db, proposal, runId, {
+      ...getProposal(db, proposal.id).spec,
+      adapter: "pi",
+      model: "openai-codex/gpt-5.6-luna",
+    });
+
+    const result = approveProposal(db, pinned, proposal.id, {
+      actor: "operator",
+      now: NOW + TTL_MS + 1,
+      policyVersion: "git:test",
+    });
+
+    expect(result).toMatchObject({ approved: false, replanned: true });
+    expect(result.proposal.spec).toMatchObject({
+      adapter: "cursor",
+      modelTier: "light",
+      model: "claude-opus-4-1",
+    });
+    expect(runState(db, runId)).toBe("PROPOSED");
+  });
+});

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -651,4 +651,63 @@ describe("approveProposal after TTL expiry (§12)", () => {
     expect(approved).toEqual({ approved: true, runId });
     expect(runState(db, runId)).toBe("QUEUED");
   });
+
+  test("re-resolves a carried model through the fresh adapter after TTL expiry", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    const staleSpec = {
+      ...getProposal(db, proposal.id).spec,
+      adapter: "pi",
+      model: "openai-codex/gpt-5.6-luna",
+    };
+    const staleJson = canonicalJson(staleSpec);
+    const staleHash = hashJson(staleSpec);
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(staleJson, staleHash, proposal.id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(staleJson, staleHash, runId);
+
+    const result = approveProposal(db, registry, proposal.id, {
+      actor: "operator",
+      now: NOW + TTL_MS + 1,
+      policyVersion: "git:test",
+    });
+
+    expect(result).toMatchObject({ approved: false, replanned: true });
+    expect(result.proposal.spec).toMatchObject({
+      adapter: "cursor",
+      modelTier: "light",
+      model: "cursor-grok-4.6-low-fast",
+    });
+  });
+
+  test("refuses an invalid stored adapter/model pair before queueing", () => {
+    const { db, proposal, runId } = dispatchPlanned();
+    const invalidSpec = {
+      ...getProposal(db, proposal.id).spec,
+      model: "openai-codex/gpt-5.6-terra",
+    };
+    const invalidJson = canonicalJson(invalidSpec);
+    const invalidHash = hashJson(invalidSpec);
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(invalidJson, invalidHash, proposal.id);
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(invalidJson, invalidHash, runId);
+
+    try {
+      approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        now: NOW + 1,
+        policyVersion: "git:test",
+      });
+      throw new Error("expected approval to refuse the invalid model");
+    } catch (err) {
+      expect(err.code).toBe("model_adapter_mismatch");
+    }
+    expect(runState(db, runId)).toBe("PROPOSED");
+    expect(getProposal(db, proposal.id).status).toBe("open");
+  });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1704

Re-plans now re-resolve model pins when the routed adapter changes and refuse invalid adapter/model pairs before queueing.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs event-runtime/lib/planner.test.mjs --timeout 20000` | pass | 116 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,151 tests, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend planning and approval logic only

run:run_79c32a76-b388-4152-8317-9854837ad293

## Post-review

Reviewer verdict FIX, addressed in 58a6b007ff412e1ea320ecbe320486f2dddcb4e6:

1. `approveProposal` in-TTL now validates the recorded model against `recordedSpec.adapter` (the spec queues as-is), not the mapping's current adapter; a process-wide `--adapter-override` still checks the registered route. Tests: consistent pair approved after a route flip; mismatched pair (checked against the recorded adapter) refused.
2. `modelAdapterMismatch` (planner, exported) is provenance-aware: explicit definition/API `model:` pins pass verbatim (`resolveModel` returns them as-is; there is no per-adapter known-model list), tier-resolved models must be in the adapter's map, unknown provenance refuses only another adapter's tier value, and non-model adapters (`fake`) never mismatch. The WM-135 `claude-opus-4-1` fixture is restored.
3. Added tests for the registry-version-refresh re-plan path (carried pin re-resolved through the fresh adapter; still-consistent spec queued) and for `buildEscalatedContinuationSpec` resolving the strong model for the failed spec's own adapter (AC3).

Verification: ticket command 128 pass; `bun run lint && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run check` — 2169 pass, 0 fail.
