### PR TITLE
feat(dispatch): gate claims on repo toolchain preflight

### DIFF
--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -29,9 +29,14 @@ import {
   createWriteStream,
 } from "node:fs";
 import { spawn, spawnSync } from "node:child_process";
-import { homedir, tmpdir } from "node:os";
+import { homedir, hostname, tmpdir } from "node:os";
 import path from "node:path";
 import { loadConfigYaml, ROOT } from "../lib/schedule.mjs";
+import {
+  getRepo,
+  loadRepos,
+  repoDispatchPreflight,
+} from "../event-runtime/lib/repos.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { ticketFileName, ticketSlug } from "../lib/ticket-slug.mjs";
 import {
@@ -51,6 +56,27 @@ import {
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 
 export const DISPATCH_FAILURE_THRESHOLD = 3;
+
+/**
+ * Resolve the raw scheduler entry through the normalized registry, then check
+ * the host toolchain before a dispatcher can read or claim the queue.
+ *
+ * Keeping this seam small makes the pre-claim ordering testable without
+ * starting workers or touching a control plane.
+ */
+export async function preflightDispatchRepo(
+  configuredRepo,
+  {
+    loadReposFn = loadRepos,
+    preflight = repoDispatchPreflight,
+    node = hostname(),
+    ...preflightOptions
+  } = {},
+) {
+  const repo = getRepo(loadReposFn(), configuredRepo.name);
+  const gate = await preflight(repo, { node, ...preflightOptions });
+  return { repo, gate };
+}
 
 /**
  * A failed spawn emits `error` asynchronously and is commonly followed by
@@ -292,16 +318,35 @@ export async function main(argv = process.argv.slice(2)) {
   const expand = (p) => String(p ?? "").replace(/^~/, homedir());
   const cfg = loadConfigYaml("repos");
   const policy = loadConfigYaml("policy");
-  const repo = (cfg.repos ?? []).find((r) => r.name === val("--repo"));
-  if (!repo) {
+  const configuredRepo = (cfg.repos ?? []).find(
+    (r) => r.name === val("--repo"),
+  );
+  if (!configuredRepo) {
     console.error(
       `--repo required; known: ${(cfg.repos ?? []).map((r) => r.name).join(", ")}`,
     );
     process.exit(2);
   }
-  if (repo.report_only) {
+  if (configuredRepo.report_only) {
     console.error(
-      `${repo.name} is report_only — no worktree tooling, dispatch is unsafe here`,
+      `${configuredRepo.name} is report_only — no worktree tooling, dispatch is unsafe here`,
+    );
+    process.exit(2);
+  }
+
+  // This must run before the first queue read, not merely before the inner
+  // claim loop: a failed host constraint must consume neither a tracker query
+  // nor a dispatch slot. `preflightDispatchRepo` also converts map-form YAML
+  // toolchain declarations into the canonical array expected by the gate.
+  const { repo, gate: toolchainGate } =
+    await preflightDispatchRepo(configuredRepo);
+  if (!toolchainGate.ready) {
+    const reasonCodes = toolchainGate.reasons
+      .map((reason) => reason.reason)
+      .filter(Boolean)
+      .join(", ");
+    console.error(
+      `${toolchainGate.refusal}${reasonCodes ? ` [${reasonCodes}]` : ""}`,
     );
     process.exit(2);
   }

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -338,8 +338,28 @@ export async function main(argv = process.argv.slice(2)) {
   // claim loop: a failed host constraint must consume neither a tracker query
   // nor a dispatch slot. `preflightDispatchRepo` also converts map-form YAML
   // toolchain declarations into the canonical array expected by the gate.
-  const { repo, gate: toolchainGate } =
-    await preflightDispatchRepo(configuredRepo);
+  //
+  // Only the gate is taken from the preflight. The normalized registry entry
+  // it resolves is camelCase (`worktreeUp`, `worktreeRoot`, ...); everything
+  // below reads the raw scheduler entry's snake_case fields (`worktree_up`,
+  // `max_in_flight`, ...), so rebinding `repo` here would silently break
+  // worktree creation for every dispatch.
+  const repo = configuredRepo;
+  let toolchainGate;
+  try {
+    ({ gate: toolchainGate } = await preflightDispatchRepo(configuredRepo));
+  } catch (err) {
+    // A registry that cannot resolve the repo (repos-root mismatch, malformed
+    // toolchain, ...) is a refusal, not a crash: say why and exit 2 like every
+    // other pre-claim gate, before any tracker query or claim.
+    if (err?.name === "RepoError") {
+      console.error(
+        `${configuredRepo.name}: dispatch refused — ${err.message}`,
+      );
+      process.exit(2);
+    }
+    throw err;
+  }
   if (!toolchainGate.ready) {
     const reasonCodes = toolchainGate.reasons
       .map((reason) => reason.reason)

--- a/orchestrator/tick.test.mjs
+++ b/orchestrator/tick.test.mjs
@@ -1,10 +1,21 @@
 import { describe, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
 import { EventEmitter } from "node:events";
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { acquireClaimLock, observeChildTermination } from "./tick.mjs";
+import { loadRepos } from "../event-runtime/lib/repos.mjs";
+import {
+  acquireClaimLock,
+  observeChildTermination,
+  preflightDispatchRepo,
+} from "./tick.mjs";
 
 const NOW = 1_750_000_000_000;
 
@@ -16,6 +27,20 @@ function withLock(content, run) {
     return run(lock);
   } finally {
     rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+async function withDispatchRepo(toolchain, run) {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-tick-toolchain-"));
+  mkdirSync(path.join(root, "config"));
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `repos:\n  - name: dispatch-fixture\n    path: /tmp/dispatch-fixture\n${toolchain}`,
+  );
+  try {
+    return await run({ name: "dispatch-fixture" }, () => loadRepos({ root }));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
   }
 }
 
@@ -153,5 +178,71 @@ describe("tick resolves its control plane from the repo (#880)", () => {
     ]) {
       expect(SRC).not.toContain(shape);
     }
+  });
+});
+
+describe("tick toolchain preflight (#1096)", () => {
+  test("normalizes a map-form constraint and refuses before dispatch when it fails", async () => {
+    await withDispatchRepo(
+      '    toolchain:\n      node: ">=22 <25"\n',
+      async (configuredRepo, loadReposFn) => {
+        const { repo, gate } = await preflightDispatchRepo(configuredRepo, {
+          loadReposFn,
+          node: "mac-mini",
+          which: async () => "/usr/bin/node",
+          spawn: async () => ({
+            exitCode: 0,
+            stdout: "v18.19.1\n",
+            stderr: "",
+          }),
+        });
+
+        expect(repo.toolchain).toEqual([
+          { executable: "node", constraint: ">=22 <25" },
+        ]);
+        expect(gate.ready).toBe(false);
+        expect(gate.refusal).toContain("node >=22 <25 (observed 18.19.1)");
+        expect(gate.reasons.map((reason) => reason.reason)).toEqual([
+          "repo_toolchain_mismatch",
+        ]);
+      },
+    );
+  });
+
+  test("admits a repo whose normalized constraint passes", async () => {
+    await withDispatchRepo(
+      '    toolchain:\n      bun: ">=1.3 <2"\n',
+      async (configuredRepo, loadReposFn) => {
+        const { gate } = await preflightDispatchRepo(configuredRepo, {
+          loadReposFn,
+          node: "runner",
+          which: async () => "/opt/bun",
+          spawn: async () => ({
+            exitCode: 0,
+            stdout: "1.3.14\n",
+            stderr: "",
+          }),
+        });
+
+        expect(gate.ready).toBe(true);
+        expect(gate.reasons).toEqual([]);
+      },
+    );
+  });
+
+  test("does not probe a repo with no declared toolchain", async () => {
+    await withDispatchRepo("", async (configuredRepo, loadReposFn) => {
+      const { gate } = await preflightDispatchRepo(configuredRepo, {
+        loadReposFn,
+        which: async () => {
+          throw new Error("a no-toolchain repo must not resolve executables");
+        },
+        spawn: async () => {
+          throw new Error("a no-toolchain repo must not spawn probes");
+        },
+      });
+
+      expect(gate).toMatchObject({ ready: true, attested: false, reasons: [] });
+    });
   });
 });

--- a/orchestrator/tick.test.mjs
+++ b/orchestrator/tick.test.mjs
@@ -11,6 +11,7 @@ import {
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
+import { loadConfigYaml } from "../lib/schedule.mjs";
 import {
   acquireClaimLock,
   observeChildTermination,
@@ -18,6 +19,8 @@ import {
 } from "./tick.mjs";
 
 const NOW = 1_750_000_000_000;
+const SRC = readFileSync(new URL("./tick.mjs", import.meta.url), "utf8");
+const TICK = new URL("./tick.mjs", import.meta.url).pathname;
 
 function withLock(content, run) {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-tick-lock-"));
@@ -144,8 +147,6 @@ describe("acquireClaimLock", () => {
 //   Entity not found: Issue — Could not find referenced Issue.
 // It failed safe, but no ticket on a non-default plane could ever dispatch.
 describe("tick resolves its control plane from the repo (#880)", () => {
-  const SRC = readFileSync(new URL("./tick.mjs", import.meta.url), "utf8");
-
   test("there is no bare loadControlPlane() call", () => {
     // A bare call silently resolves to the workspace default. Two handles in
     // one file is the defect; one handle, built from the repo, is the fix.
@@ -244,5 +245,114 @@ describe("tick toolchain preflight (#1096)", () => {
 
       expect(gate).toMatchObject({ ready: true, attested: false, reasons: [] });
     });
+  });
+});
+
+// ------------------------------------------- preflight runs before any claim ---
+// The dispatcher is driven as a real child here: the seam test above proves
+// the gate's verdict, this proves `main()` honours it before touching a
+// control plane. Neither child has a tracker token or a runtime home, so any
+// path past the preflight surfaces as "Dispatch error" / exit 1 rather than
+// the typed refusal / exit 2 asserted below.
+describe("tick preflight refuses before any claim (#1096)", () => {
+  // The scheduler entry (`--repo`) comes from the checkout's own repos.yaml;
+  // the registry the preflight resolves through comes from FACTORY_REPOS_ROOT.
+  // Pointing the latter at a fixture keeps the child hermetic.
+  const dispatchable = (loadConfigYaml("repos", { warn: () => {} }).repos ?? [])
+    .filter((r) => r?.name && !r.report_only)
+    .map((r) => r.name);
+
+  function runTick(registryYaml, repoName) {
+    const root = mkdtempSync(path.join(tmpdir(), "factory-tick-preflight-"));
+    const home = mkdtempSync(path.join(tmpdir(), "factory-tick-home-"));
+    mkdirSync(path.join(root, "config"));
+    writeFileSync(path.join(root, "config", "repos.yaml"), registryYaml);
+    const env = { ...process.env };
+    for (const k of [
+      "FACTORY_ROOT",
+      "FACTORY_CONTROL_API_TOKEN",
+      "FACTORY_WEB_URL",
+      "LINEAR_API_KEY",
+      "GH_TOKEN",
+      "GITHUB_TOKEN",
+    ]) {
+      delete env[k];
+    }
+    env.FACTORY_REPOS_ROOT = root;
+    env.FACTORY_EVENT_HOME = home;
+    return new Promise((resolve) => {
+      const child = spawn(
+        process.execPath,
+        [TICK, "--repo", repoName, "--apply", "--max", "1"],
+        { env, stdio: ["ignore", "pipe", "pipe"] },
+      );
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d));
+      child.stderr.on("data", (d) => (stderr += d));
+      child.on("close", (code) => {
+        rmSync(root, { recursive: true, force: true });
+        rmSync(home, { recursive: true, force: true });
+        resolve({ code, stdout, stderr });
+      });
+    });
+  }
+
+  test.skipIf(dispatchable.length === 0)(
+    "a failing toolchain constraint exits 2 with the typed refusal",
+    async () => {
+      const name = dispatchable[0];
+      const { code, stdout, stderr } = await runTick(
+        `repos:\n  - name: ${name}\n    path: /tmp/${name}-preflight-fixture\n    toolchain:\n      factory-1096-missing-tool: ">=1"\n`,
+        name,
+      );
+      expect(code).toBe(2);
+      expect(stderr).toContain("repo_toolchain_missing");
+      expect(stderr).not.toContain("Dispatch error");
+      // Nothing was read from a queue or claimed: the dispatcher never got to
+      // print its banner or a single ticket line.
+      expect(stdout).toBe("");
+    },
+    20_000,
+  );
+
+  test.skipIf(dispatchable.length === 0)(
+    "a registry that cannot resolve the repo refuses with the RepoError, not a stack",
+    async () => {
+      const name = dispatchable[0];
+      const { code, stdout, stderr } = await runTick(
+        "repos:\n  - name: somebody-else\n    path: /tmp/somebody-else\n",
+        name,
+      );
+      expect(code).toBe(2);
+      expect(stderr).toContain("dispatch refused");
+      expect(stderr).toContain(`repo "${name}" is not in config/repos.yaml`);
+      expect(stderr).not.toContain("Dispatch error");
+      expect(stderr).not.toMatch(/^\s+at /m);
+      expect(stdout).toBe("");
+    },
+    20_000,
+  );
+
+  test("main() keeps `repo` bound to the raw scheduler entry after the preflight", () => {
+    // The preflight's normalized registry entry is camelCase; the dispatcher
+    // body reads snake_case. Rebinding `repo` to the preflight result broke
+    // worktree creation for every dispatch, so only the gate may be taken.
+    const mainSrc = SRC.slice(SRC.indexOf("export async function main("));
+    expect(mainSrc).toContain("const repo = configuredRepo;");
+    expect(mainSrc).not.toMatch(
+      /const \{\s*repo\b[^}]*\}\s*=\s*await preflightDispatchRepo/,
+    );
+    for (const field of [
+      "repo.worktree_up",
+      "repo.worktree_root",
+      "repo.worktree_warm",
+      "repo.max_in_flight",
+    ]) {
+      expect(mainSrc).toContain(field);
+    }
+    expect(mainSrc).not.toMatch(
+      /\brepo\.(worktreeUp|worktreeRoot|worktreeWarm|maxInFlight)\b/,
+    );
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1096

Dispatch now normalizes configured toolchains and refuses before queue reads or claims when host readiness fails.

## Validation

| Check                | Command                                                                          | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test --timeout 20000 --max-concurrency=4 orchestrator/tick.test.mjs event-runtime/lib/repos.test.mjs` | pass    | 79 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; existing lint warnings only     |
| UX critique          | factory-ux-critic                                                                | not run | skipped — dispatcher-only, no user-facing surface |

UX critique: skipped — dispatcher-only, no user-facing surface

run:run_a13bf886-330c-4044-afff-ba724d3008e2

## Post-review

Reviewer verdict FIX — addressed in the follow-up commit:

1. `orchestrator/tick.mjs` no longer rebinds `repo` to the camelCase normalized registry entry returned by `preflightDispatchRepo`; `repo` stays the raw scheduler entry, so `repo.worktree_up` / `worktree_root` / `worktree_warm` / `max_in_flight` keep resolving and worktree creation works again. Only the gate is taken from the preflight.
2. `RepoError` thrown by `getRepo`/`loadRepos` during the preflight (repos-root mismatch, malformed toolchain) is now a typed refusal with `exit(2)` before any tracker query or claim, instead of an unhandled stack.
3. `orchestrator/tick.test.mjs` gains a spawn-a-child block: a failing toolchain constraint and an unresolvable registry both exit 2 with the typed message and produce no stdout (no queue read, no claim); a source-level test pins `const repo = configuredRepo;` and the snake_case field reads.

Verified: ticket Verification Command (82 pass / 0 fail), `bun run lint` (0 errors), `bun test event-runtime/lib --timeout 20000` (2164 pass / 0 fail), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
