### PR TITLE
feat(merge-fix): human-readable PR comment formatting

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:9ebd623d5a871f2f5d34233dab2b0a16a688c368ce4c93d12d2c05b3aac107b6",
+    "agents/merge-fix.md": "sha256:cc13315ffd4fd3cddcec8285eeba8ac5d2bed76137d1daf4f79445c59605a5c6",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:cc13315ffd4fd3cddcec8285eeba8ac5d2bed76137d1daf4f79445c59605a5c6",
+    "agents/merge-fix.md": "sha256:abfdf9be239b636bcf825b62b422754ccf6c5b905222d08761dcc40655fe886e",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -96,13 +96,38 @@ isolated worktree for the ticket. This is not a general implementation run.
    update a falsifiable regression test where the finding is a code change (a
    pure rebase adds none), and run the ticket's exact Verification Command.
    Never weaken or skip it.
-4. Commit with the ticket ID and push the same head branch. For ordinary
-   findings, add a PR comment exactly
-   `factory-merge-fix round=<round> finding=<findingHash> old=<oldSha>
-new=<newSha>`. For `format_and_lint`, use the non-round marker exactly
-   `factory-merge-fix mechanical=format_and_lint finding=<findingHash>
-old=<oldSha> new=<newSha>`. Do not merge, approve, mark Done, or delete
-   anything.
+4. Commit with the ticket ID and push the same head branch. Post a
+   human-readable Markdown PR comment with the actual finding and a concise
+   summary of the correction. For ordinary findings, render this shape (the
+   short SHAs are the first seven characters of the full SHAs):
+
+   ```md
+   ### 🛠️ Factory Merge Auto-Fix (Round <round> of 2)
+
+   **Finding:** <finding description>
+   **Changes:** <summary of changes made>
+   **Commit:** `<oldSha first 7>` → `<newSha first 7>`
+
+   <!-- factory-merge-fix round=<round> finding=<findingHash> old=<oldSha> new=<newSha> -->
+   ```
+
+   The embedded HTML comment is the machine-readable tracking marker: preserve
+   its complete, exact field order and substitute the real full values. For
+   `format_and_lint`, retain its non-round marker inside an otherwise
+   human-readable comment (finding, changes, and short commit SHAs):
+
+   ```md
+   ### 🛠️ Factory Merge Auto-Fix (Formatting & Lint)
+
+   **Finding:** <finding description>
+   **Changes:** <summary of changes made>
+   **Commit:** `<oldSha first 7>` → `<newSha first 7>`
+
+   <!-- factory-merge-fix mechanical=format_and_lint finding=<findingHash> old=<oldSha> new=<newSha> -->
+   ```
+
+   Do not merge, approve, mark Done, or delete anything.
+
 5. Return UPDATED with the new 40-hex head SHA. Completion chains to a wholly
    new merge-scan run. You are forbidden to declare your own update mergeable.
 

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -102,7 +102,7 @@ isolated worktree for the ticket. This is not a general implementation run.
    short SHAs are the first seven characters of the full SHAs):
 
    ```md
-   ### 🛠️ Factory Merge Auto-Fix (Round <round> of 2)
+   ### 🛠️ Factory Merge Auto-Fix (Round <round> of <max_fix_rounds>)
 
    **Finding:** <finding description>
    **Changes:** <summary of changes made>
@@ -111,7 +111,9 @@ isolated worktree for the ticket. This is not a general implementation run.
    <!-- factory-merge-fix round=<round> finding=<findingHash> old=<oldSha> new=<newSha> -->
    ```
 
-   The embedded HTML comment is the machine-readable tracking marker: preserve
+   `<max_fix_rounds>` is the configured `merge.max_fix_rounds` cap (the same
+   value merge-review enforces; default 2), never a hardcoded number. The
+   embedded HTML comment is the machine-readable tracking marker: preserve
    its complete, exact field order and substitute the real full values. For
    `format_and_lint`, retain its non-round marker inside an otherwise
    human-readable comment (finding, changes, and short commit SHAs):

--- a/event-runtime/agents/merge-review.json
+++ b/event-runtime/agents/merge-review.json
@@ -25,7 +25,7 @@
     }
   ],
   "pins": {
-    "agents/merge-review.md": "sha256:4c6c9608c5dd046fb1e4f93c4d6d9104034d17efd16da38baf5b8e2e0d5a2516",
+    "agents/merge-review.md": "sha256:7a130afcbbb019e5dfe9a2cdd35dce6a52ccda86044983ba1876f274efdbcc6e",
     "schemas/merge-review.input.json": "sha256:d7051604031742a3b0e060f9fb1359aa5de3b3d42a80714f11492054e81a50f8",
     "schemas/merge-review.output.json": "sha256:efad4e30c1fed1978794630397819d71d78391381a6375edab704eaf5458b282"
   }

--- a/event-runtime/agents/merge-review.md
+++ b/event-runtime/agents/merge-review.md
@@ -132,15 +132,21 @@ and merge-fix already performs them:
   deviation on the ticket. Being outside scope alone is not a reason to stop.
 
 A FIX may auto-dispatch only when it is mechanical and its next round is at
-most `merge.max_fix_rounds` (2). Read PR comments for
-`factory-merge-fix round=<n> finding=<hash>` markers. Set the next round and
-SHA-256 hash of the exact finding. Exhausted rounds, security findings, and
-genuine product ambiguity are ESCALATE. `format_and_lint` is the deterministic
-exception: its separate
-`factory-merge-fix mechanical=format_and_lint finding=<hash>` marker does not
-consume or increment `max_fix_rounds`; after its fresh verification/CI, scan
-the PR from scratch. In the fast lane, formatting- or eslint-only red means
-auto-fix then re-evaluate every lane criterion, not disqualification.
+most `merge.max_fix_rounds` (2). Parse every complete PR comment body for
+`factory-merge-fix round=<n> finding=<hash>` markers. The marker may appear
+inside arbitrary multiline Markdown or an HTML comment; it need not occupy a
+whole comment body or line. Continue recognizing the legacy bare single-line
+form as well as the formatted embedded form, and count every extracted round
+marker for round counting and loop prevention. Set the next round and SHA-256
+hash of the exact finding. Exhausted rounds, security findings, and genuine
+product ambiguity are ESCALATE. `format_and_lint` is the deterministic
+exception: recognize its separate
+`factory-merge-fix mechanical=format_and_lint finding=<hash>` marker anywhere
+in a complete comment body, including an HTML comment, but do not count it as
+a round. It does not consume or increment `max_fix_rounds`; after its fresh
+verification/CI, scan the PR from scratch. In the fast lane, formatting- or
+eslint-only red means auto-fix then re-evaluate every lane criterion, not
+disqualification.
 
 Fail closed only on what truly cannot be evidenced — GitHub or Linear API
 errors, malformed config, an unresolvable base SHA — and record those as

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -396,8 +396,10 @@ describe("registry", () => {
     // Regenerated (#1700): merge-fix comments now pair human-readable Markdown
     // with embedded machine markers, and merge-review scans formatted multiline
     // and HTML comment bodies; both prompt definitions are registry inputs.
+    // Re-pinned (#1700 post-review): merge-fix templates the round cap as
+    // `<max_fix_rounds>` instead of hardcoding 2.
     const expected =
-      "sha256:a33e9b245e302890182c7a99f1dd13feb75ccc85d4b33f101518c2cc8510c88c";
+      "sha256:475609349143157c8b659367addb688b17847ea8218af380de5daba2c3b9059a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -393,8 +393,11 @@ describe("registry", () => {
     // Regenerated (#1337): the worker, not the dispatch model, verifies the
     // canonical authorisation description hash and path scope before execution;
     // dispatch.md trusts the worker-authenticated verified flag.
+    // Regenerated (#1700): merge-fix comments now pair human-readable Markdown
+    // with embedded machine markers, and merge-review scans formatted multiline
+    // and HTML comment bodies; both prompt definitions are registry inputs.
     const expected =
-      "sha256:a3685bcb3f85cb09522de22654860620138003cc5d9fbec8e5fe0dc3349d009c";
+      "sha256:a33e9b245e302890182c7a99f1dd13feb75ccc85d4b33f101518c2cc8510c88c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -691,6 +691,29 @@ describe("format and lint mechanical merge fixes (WM-769)", () => {
     );
   });
 
+  test("formatted fix comments retain machine markers across multiline HTML bodies", () => {
+    expect(fixPrompt).toContain(
+      "### 🛠️ Factory Merge Auto-Fix (Round <round> of 2)",
+    );
+    expect(fixPrompt).toContain("**Finding:** <finding description>");
+    expect(fixPrompt).toContain("**Changes:** <summary of changes made>");
+    expect(fixPrompt).toContain(
+      "**Commit:** `<oldSha first 7>` → `<newSha first 7>`",
+    );
+    expect(fixPrompt).toContain(
+      "<!-- factory-merge-fix round=<round> finding=<findingHash> old=<oldSha> new=<newSha> -->",
+    );
+    expect(fixPrompt).toContain(
+      "<!-- factory-merge-fix mechanical=format_and_lint finding=<findingHash> old=<oldSha> new=<newSha> -->",
+    );
+    expect(scanPrompt).toMatch(/every complete PR comment body/);
+    expect(scanPrompt).toMatch(
+      /arbitrary multiline Markdown or an HTML comment/,
+    );
+    expect(scanPrompt).toMatch(/legacy bare single-line\s+form/);
+    expect(scanPrompt).toMatch(/do not count it as\s+a round/);
+  });
+
   test("the reviewer emits the distinct mechanical tag for prettier/eslint-only findings", () => {
     expect(reviewerSource).toMatch(
       /verdict `FIX`, canonical\s+finding `format_and_lint`, and tag the finding `mechanical`/,

--- a/event-runtime/merge.test.mjs
+++ b/event-runtime/merge.test.mjs
@@ -693,7 +693,7 @@ describe("format and lint mechanical merge fixes (WM-769)", () => {
 
   test("formatted fix comments retain machine markers across multiline HTML bodies", () => {
     expect(fixPrompt).toContain(
-      "### 🛠️ Factory Merge Auto-Fix (Round <round> of 2)",
+      "### 🛠️ Factory Merge Auto-Fix (Round <round> of <max_fix_rounds>)",
     );
     expect(fixPrompt).toContain("**Finding:** <finding description>");
     expect(fixPrompt).toContain("**Changes:** <summary of changes made>");


### PR DESCRIPTION
Fixes watt-mind/factory#1700

Review the readable auto-fix comment template and backward-compatible marker parsing guidance.

## Validation

| Check                | Command                                                                                                  | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/merge.test.mjs`                                                                 | pass    | 46 pass, 0 fail               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | all gates passed; warnings only |
| UX critique          | factory-ux-critic                                                                                        | not run | no user-facing surface        |

UX critique: skipped

run:$FACTORY_RUN_ID

## Post-review

- Reviewer FIX-lite: `merge-fix.md` hardcoded `(Round <round> of 2)`; now renders `of <max_fix_rounds>` from `merge.max_fix_rounds` (matches merge-review). Re-pinned `merge-fix.json` sha and the registry digest baseline; `merge.test.mjs` expectation updated.
- Verified: `bun test event-runtime/merge.test.mjs` (46 pass), `bun run lint`, `bun test event-runtime/lib` (2154 pass), `bun build/emit.mjs --check` (94 generated files match), `bun run format:check`, `bun run check`.
- Post-review commit: 6fd6f9b2d5add7ef38e1c9820b78217811473784
