### PR TITLE
feat(control-plane): add description replacement verb (#1666)

### DIFF
--- a/event-runtime/lib/control-plane.test.mjs
+++ b/event-runtime/lib/control-plane.test.mjs
@@ -653,6 +653,28 @@ for (const [name, make] of IMPLEMENTATIONS) {
       expect(t.description.match(/## Verification/g)).toHaveLength(1);
     });
 
+    test("replaceDetail replaces the description exactly", async () => {
+      const { cp } = make();
+      const replacement = "# Replacement\n\nThis is the complete body.";
+      await expect(
+        cp.replaceDetail("WM-1", replacement),
+      ).resolves.toBeUndefined();
+      expect((await cp.getTicket("WM-1")).description).toBe(replacement);
+    });
+
+    test("replaceDetail rejects invalid bodies", async () => {
+      const { cp } = make();
+      await expect(cp.replaceDetail("WM-1", "")).rejects.toThrow(
+        ControlPlaneError,
+      );
+      await expect(cp.replaceDetail("WM-1", null)).rejects.toThrow(
+        ControlPlaneError,
+      );
+      await expect(cp.replaceDetail("WM-999", "replacement")).rejects.toThrow(
+        ControlPlaneError,
+      );
+    });
+
     test("raw is the escape hatch; unknown queries throw", async () => {
       const { cp } = make();
       expect(await cp.raw(RAW_PING)).toEqual({ ping: true });

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -2079,6 +2079,16 @@ export function githubControlPlane(options = {}) {
       return { appended: true };
     },
 
+    async replaceDetail(identifier, body) {
+      const { repo, number } = locate(identifier);
+      await fetchIssue(repo, number);
+      if (typeof body !== "string" || body.length === 0)
+        throw new ControlPlaneError(
+          "replacement body must be a non-empty string",
+        );
+      await call("PATCH", `repos/${repo}/issues/${number}`, { body: { body } });
+    },
+
     async raw(query, variables = {}) {
       if (typeof query === "string" && query.trim().startsWith("/")) {
         return call("GET", query.trim().replace(/^\//, ""), {

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -2080,6 +2080,8 @@ export function githubControlPlane(options = {}) {
     },
 
     async replaceDetail(identifier, body) {
+      // Writes under the calling token: an App-bot edit trips the planner's
+      // ticket_untrusted_author gate (re-pin needed) — call with the operator PAT.
       const { repo, number } = locate(identifier);
       await fetchIssue(repo, number);
       if (typeof body !== "string" || body.length === 0)

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1692,6 +1692,19 @@ describe("control-plane contract: github", () => {
     expect(t.description.match(/## Verification/g)).toHaveLength(1);
   });
 
+  test("replaceDetail PATCHes the complete replacement body", async () => {
+    const { api, cp } = makePlane();
+    const body = "# Replacement\n\nPrevious text is gone.";
+    await expect(cp.replaceDetail(`${REPO}#1`, body)).resolves.toBeUndefined();
+    expect((await cp.getTicket(`${REPO}#1`)).description).toBe(body);
+    expect(api.calls).toContainEqual({
+      method: "PATCH",
+      pathName: `repos/${REPO}/issues/1`,
+      body: { body },
+      query: undefined,
+    });
+  });
+
   test("raw is the escape hatch for GitHub GraphQL and rooted REST paths", async () => {
     const { cp } = makePlane();
     expect(await cp.raw(RAW_PING)).toEqual({ ping: true });

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -498,6 +498,15 @@ export function linearControlPlane({
       return { appended: true };
     },
 
+    async replaceDetail(identifier, body) {
+      const issue = await issueByKey(identifier);
+      if (typeof body !== "string" || body.length === 0)
+        throw new ControlPlaneError(
+          "replacement body must be a non-empty string",
+        );
+      await issueUpdate(issue.id, { description: body });
+    },
+
     async raw(query, variables = {}) {
       return call(query, variables);
     },

--- a/lib/control-plane/memory.mjs
+++ b/lib/control-plane/memory.mjs
@@ -353,6 +353,16 @@ export function memoryControlPlane(seed = {}) {
       return { appended: true };
     },
 
+    async replaceDetail(identifier, body) {
+      calls.push({ op: "replaceDetail", identifier, body });
+      const ticket = requireTicket(identifier);
+      if (typeof body !== "string" || body.length === 0)
+        throw new ControlPlaneError(
+          "replacement body must be a non-empty string",
+        );
+      ticket.description = body;
+    },
+
     async raw(query, variables = {}) {
       calls.push({ op: "raw", query, variables });
       const hit = state.raw[query];

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -136,6 +136,9 @@
  *   rather than returning false.
  * @property {(opts: FileTicketOpts) => Promise<{ identifier: string, url: string }>} file
  * @property {(identifier: string, markdown: string) => Promise<{ appended: boolean }>} appendDetail
+ * @property {(identifier: string, body: string) => Promise<void>} replaceDetail
+ *   Replace the ticket description in full. `body` must be a non-empty string;
+ *   invalid bodies and unknown tickets throw {@link ControlPlaneError}.
  * @property {(query: string, variables?: object) => Promise<object>} raw
  *   Escape hatch: tracker-native query. Linear accepts GraphQL; GitHub accepts
  *   GraphQL or a leading-slash REST path (with variables as query parameters).

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -139,6 +139,11 @@
  * @property {(identifier: string, body: string) => Promise<void>} replaceDetail
  *   Replace the ticket description in full. `body` must be a non-empty string;
  *   invalid bodies and unknown tickets throw {@link ControlPlaneError}.
+ *   The body is written under the calling token's identity. On GitHub, a
+ *   body edited by the GitHub App bot makes the planner refuse the ticket
+ *   with `ticket_untrusted_author` and the ready-pin must be re-stamped
+ *   (labels remove/add), so callers must run this verb with the operator
+ *   PAT, never the App token.
  * @property {(query: string, variables?: object) => Promise<object>} raw
  *   Escape hatch: tracker-native query. Linear accepts GraphQL; GitHub accepts
  *   GraphQL or a leading-slash REST path (with variables as query parameters).


### PR DESCRIPTION
Fixes #1666

Use replaceDetail to overwrite tracker descriptions through the adapter-neutral control plane.

## Validation

| Check                | Command                                                                            | Result  | Notes                              |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test lib/control-plane/github.test.mjs event-runtime/lib/control-plane.test.mjs --timeout 20000` | pass    | 191 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 614 existing lint warnings  |
| UX critique          | factory-ux-critic                                                                  | not run | no user-facing control-plane surface |

UX critique: skipped

run:run_23632a38-5d91-4e9c-a7e3-472e91581326

## Post-review

- Folded reviewer note: `replaceDetail` JSDoc (`lib/control-plane/types.mjs`) and a comment in `lib/control-plane/github.mjs` now document that the body is written under the calling token — an App-bot edit trips the planner `ticket_untrusted_author` gate and requires a ready-pin re-stamp (labels remove/add), so callers must use the operator PAT.
- Verified: ticket Verification Command (191 pass), `bun test event-runtime/lib` (2173 pass, no MODEL_ADAPTERS regression), lint (0 errors), format:check clean.
