### PR TITLE
fix(worker): canonicalize harness pin paths

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -409,7 +409,15 @@ export function materializeRunHarness({
   // `safeJoin` returns a realpath-canonical destination. Keep the root used
   // for receipt-relative paths in that same namespace so a symlinked workspace
   // parent does not turn an in-workspace harness file into an apparent escape.
-  const canonicalWorkspaceDir = realpathSync(path.resolve(workspaceDir));
+  let canonicalWorkspaceDir;
+  try {
+    canonicalWorkspaceDir = realpathSync(path.resolve(workspaceDir));
+  } catch (err) {
+    throw new HarnessMaterializeError(
+      "harness_unmaterializable",
+      `workspace root ${JSON.stringify(String(workspaceDir))} cannot be resolved: ${err?.message ?? String(err)}`,
+    );
+  }
   const layout = adapter?.HARNESS_LAYOUT;
   const roots = harnessCatalogRoots(registry, factoryRoot);
   const written = [];

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -18,6 +18,7 @@ import {
   mkdirSync,
   readdirSync,
   readFileSync,
+  realpathSync,
   statSync,
   unlinkSync,
   writeFileSync,
@@ -405,6 +406,10 @@ export function materializeRunHarness({
   );
   if (declaredCount === 0) return [];
 
+  // `safeJoin` returns a realpath-canonical destination. Keep the root used
+  // for receipt-relative paths in that same namespace so a symlinked workspace
+  // parent does not turn an in-workspace harness file into an apparent escape.
+  const canonicalWorkspaceDir = realpathSync(path.resolve(workspaceDir));
   const layout = adapter?.HARNESS_LAYOUT;
   const roots = harnessCatalogRoots(registry, factoryRoot);
   const written = [];
@@ -444,7 +449,10 @@ export function materializeRunHarness({
       const src = path.join(factoryRoot, ...srcParts);
       let dest;
       try {
-        dest = safeJoin(workspaceDir, harnessRelDest(kindLayout, name));
+        dest = safeJoin(
+          canonicalWorkspaceDir,
+          harnessRelDest(kindLayout, name),
+        );
       } catch (err) {
         throw new HarnessMaterializeError(
           "harness_unmaterializable",
@@ -477,8 +485,8 @@ export function materializeRunHarness({
       written.push({
         kind,
         name,
-        dest: path.relative(workspaceDir, dest),
-        pins: harnessFilePins(dest, workspaceDir),
+        dest: path.relative(canonicalWorkspaceDir, dest),
+        pins: harnessFilePins(dest, canonicalWorkspaceDir),
       });
     }
   }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -380,9 +380,14 @@ describe("worker", () => {
     expect(fetches).toBe(0);
   });
 
-  test("materialized harness entries record hashes for every copied file", () => {
+  test("materialized harness entries remain workspace-relative through a symlinked parent", () => {
     const factoryRoot = tmpDir("evrt-harness-source-");
-    const workspaceDir = tmpDir("evrt-harness-workspace-");
+    const realWorkspaceParent = tmpDir("evrt-harness-workspace-real-");
+    const workspaceAliasBase = tmpDir("evrt-harness-workspace-alias-");
+    const workspaceAliasParent = path.join(workspaceAliasBase, "parent");
+    symlinkSync(realWorkspaceParent, workspaceAliasParent, "dir");
+    const workspaceDir = path.join(workspaceAliasParent, "workspace");
+    mkdirSync(workspaceDir);
     const catalog = path.join(factoryRoot, "catalog");
     const source = path.join(factoryRoot, "dist", "fake", "skills", "demo");
     mkdirSync(path.join(catalog, "skills", "demo"), { recursive: true });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -99,6 +99,7 @@ import {
   expireRunDeadline,
   extendRunDeadline,
   forceFailRun,
+  HarnessMaterializeError,
   humanDecisionAuthorisationGate,
   LEASE_GRACE_SECONDS,
   policyMaxRunMinutes,
@@ -378,6 +379,71 @@ describe("worker", () => {
       }),
     ).toEqual({ ok: true, input });
     expect(fetches).toBe(0);
+  });
+
+  const demoSkillFixture = () => {
+    const factoryRoot = tmpDir("evrt-harness-source-");
+    const catalog = path.join(factoryRoot, "catalog");
+    const source = path.join(factoryRoot, "dist", "fake", "skills", "demo");
+    mkdirSync(path.join(catalog, "skills", "demo"), { recursive: true });
+    mkdirSync(source, { recursive: true });
+    writeFileSync(
+      path.join(catalog, "skills", "demo", "SKILL.md"),
+      "catalog\n",
+    );
+    writeFileSync(path.join(source, "SKILL.md"), "first\n");
+    writeFileSync(path.join(source, "notes.md"), "second\n");
+    return {
+      spec: { harness: { skills: ["demo"] } },
+      adapterKey: "fake",
+      adapter: {
+        HARNESS_LAYOUT: {
+          skills: {
+            source: (name) => ["dist", "fake", "skills", name],
+            dest: (name) => [".fake", "skills", name],
+            type: "dir",
+          },
+        },
+      },
+      registry: { harnessRoots: [{ skills: path.join(catalog, "skills") }] },
+      factoryRoot,
+    };
+  };
+
+  test("materialized harness entries record hashes for every copied file", () => {
+    const workspaceDir = tmpDir("evrt-harness-workspace-");
+    const written = materializeRunHarness({
+      ...demoSkillFixture(),
+      workspaceDir,
+    });
+
+    expect(written).toEqual([
+      {
+        kind: "skills",
+        name: "demo",
+        dest: ".fake/skills/demo",
+        pins: {
+          ".fake/skills/demo/SKILL.md": hashBytes("first\n"),
+          ".fake/skills/demo/notes.md": hashBytes("second\n"),
+        },
+      },
+    ]);
+  });
+
+  test("materialize refuses a missing workspace root as harness_unmaterializable", () => {
+    const workspaceDir = path.join(
+      tmpDir("evrt-harness-workspace-missing-"),
+      "does-not-exist",
+    );
+    let caught;
+    try {
+      materializeRunHarness({ ...demoSkillFixture(), workspaceDir });
+    } catch (err) {
+      caught = err;
+    }
+    expect(caught).toBeInstanceOf(HarnessMaterializeError);
+    expect(caught.code).toBe("harness_unmaterializable");
+    expect(caught.message).toContain("workspace root");
   });
 
   test("materialized harness entries remain workspace-relative through a symlinked parent", () => {


### PR DESCRIPTION
Fixes #1575

Canonicalize the harness workspace root so receipt pins stay workspace-relative on symlinked macOS TMPDIR paths.

## Validation

| Check                | Command                                                    | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 135 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2169 pass, 0 failures; lint warnings only |
| UX critique          | factory-ux-critic                                          | not run | no user-facing surface        |

UX critique: skipped

run:run_66ea8985-8b44-4c4b-bb71-1b5e58c277ae

## Post-review

- Reviewer fold: `realpathSync(path.resolve(workspaceDir))` in `materializeRunHarness` is now wrapped; an unresolvable workspace root rethrows `HarnessMaterializeError("harness_unmaterializable")` (REFUSED) instead of a raw ENOENT.
- Tests: added "materialize refuses a missing workspace root as harness_unmaterializable"; restored the non-symlinked "records hashes for every copied file" case beside the symlinked-parent case (shared fixture helper).
- Merged `origin/develop`. Verified: ticket command (`bun test event-runtime/lib/worker.test.mjs --timeout 20000` → 137 pass), `bun run lint`, `bun test event-runtime/lib --timeout 20000` (2185 pass), `bun build/emit.mjs --check` (floor warning = known #1743), `bun run format:check`, `bun run check` — all green.