### PR TITLE
test(api): pin makeServer clients to test token

### DIFF
--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -6,6 +6,7 @@ import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { artifactReferenceIndex } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import {
+  CONTROL_TOKEN,
   GH_SECRET,
   PV,
   SECRET,
@@ -397,7 +398,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
 
   test("declared artifacts and the transcript survive the workspace and stream from the API", async () => {
     const { db, server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     const home = tmpDir("evrt-home-");
     try {
       await client.replay(
@@ -448,7 +449,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
     });
     await new Promise((resolve) => server.on("listening", resolve));
     const port = server.address().port;
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(
         envelope({ eventId: "art-2", payload: { repos: ["with-artifact"] } }),

--- a/event-runtime/lib/api-observed-model.test.mjs
+++ b/event-runtime/lib/api-observed-model.test.mjs
@@ -5,6 +5,7 @@ import {
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { clearObservedModelCache, handleRunApiRoute } from "./api-runs.mjs";
 import {
+  CONTROL_TOKEN,
   GH_SECRET,
   PV,
   SECRET,
@@ -167,7 +168,7 @@ describe("model surfacing on run views (WM-221)", () => {
     const { db, server, port, close } = await makeServer({
       env: { name: "test", home },
     });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(envelope({ eventId: "model-1" }));
       planAdmittedEvents(db, registry, {

--- a/event-runtime/lib/api-panels.test.mjs
+++ b/event-runtime/lib/api-panels.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import { PANEL_ENDPOINTS, panelsView } from "./api-panels.mjs";
 import {
+  CONTROL_TOKEN,
   apiClient,
   loadRegistry,
   makeServer as makeApiServer,
@@ -18,7 +19,10 @@ describe("GET /panels (WM-840)", () => {
   test("lists the accepted panels with their origin and file, plus the endpoint allow-list", async () => {
     const { server } = await makeServer();
     try {
-      const client = apiClient({ port: server.address().port });
+      const client = apiClient({
+        port: server.address().port,
+        token: CONTROL_TOKEN,
+      });
       const body = await client.panels();
       expect(body.endpoints).toEqual([...PANEL_ENDPOINTS]);
       expect(body.panels).toHaveLength(1);
@@ -68,7 +72,7 @@ describe("GET /panels (WM-840)", () => {
     const { server } = await makeServer({ registry });
     try {
       const port = server.address().port;
-      const client = apiClient({ port });
+      const client = apiClient({ port, token: CONTROL_TOKEN });
       const body = await client.panels();
       expect(body.panels.map((p) => [p.name, p.origin])).toEqual([
         ["inbox-open", "builtin"],

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -24,6 +24,7 @@ import {
   ticketSupplyView,
 } from "./api-runs.mjs";
 import {
+  CONTROL_TOKEN,
   GH_SECRET,
   PV,
   SECRET,
@@ -1628,7 +1629,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
 describe("webui surface: proposal linkage, history, journal, outbox, requeue (OPS-212)", () => {
   test("proposals carry their originating event; history filter works; runs list is enriched", async () => {
     const { db, server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(envelope({ eventId: "link-1" }));
       planAdmittedEvents(db, registry, {
@@ -1676,7 +1677,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
 
   test("journal feed pages by seq and outbox exposes delivery state", async () => {
     const { db, server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(envelope({ eventId: "feed-1" }));
       planAdmittedEvents(db, registry, {
@@ -1804,7 +1805,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
 
   test("requeue recovers a dead-lettered event and refuses everything else", async () => {
     const { db, server, port, onEvents } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(envelope({ eventId: "dead-1" }));
       db.query(
@@ -1829,7 +1830,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
   test("archives dead-lettered events and releases stalled worker leases from status anomalies (WM-326)", async () => {
     const nowMs = 300_000;
     const { db, server, port } = await makeServer({ now: () => nowMs });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(envelope({ eventId: "dead-archive" }));
       db.query(
@@ -1924,7 +1925,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
 
   test("requeueing a human_needed event supersedes its open proposal", async () => {
     const { db, server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(
         envelope({ eventId: "hn-1", type: "unregistered.event.type" }),
@@ -1946,7 +1947,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
 describe("run trace surfacing (OPS-295)", () => {
   test("GET /runs/:id/trace pages incrementally; 404 unknown; empty for an untraced run (OPS-295)", async () => {
     const { db, server, port } = await makeServer();
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       await client.replay(
         envelope({ eventId: "trace-1", payload: { repos: ["ok"] } }),

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -4,6 +4,7 @@ import {
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import {
+  CONTROL_TOKEN,
   GH_SECRET,
   PV,
   SECRET,
@@ -382,7 +383,7 @@ describe("artifact-view sidecar on GET /agents (WM-454)", () => {
         state: () => ({ loadedAt, stamp: "files:test", lastReloadError: null }),
       },
     });
-    const client = apiClient({ port });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
     try {
       const before = await client.agents();
       const agents = new Map(registry.agents);


### PR DESCRIPTION
Fixes watt-mind/factory#1737

Pins makeServer API clients to the test token so polluted control-token environments no longer cause 401 test failures.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Contaminated-env regression | `FACTORY_CONTROL_API_TOKEN=not-the-test-token bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-artifacts.test.mjs event-runtime/lib/api-observed-model.test.mjs event-runtime/lib/api-panels.test.mjs --timeout 20000` | pass | 75 tests, 0 failures |
| Verification Command | `bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-artifacts.test.mjs event-runtime/lib/api-observed-model.test.mjs event-runtime/lib/api-panels.test.mjs --timeout 20000` | pass | 75 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2169 pass, 0 failures; generated and format checks clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface; test-only change |

UX critique: skipped

run:$FACTORY_RUN_ID
