### PR TITLE
fix(serve): bound and memoise chain auto-approval; expire stale scheduler proposals

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -230,6 +230,7 @@ export async function tick({
 } = {}) {
   const tickStart = Date.now();
   const stepMs = {};
+  let expiredScheduledProposals = 0;
   const runStep = async (name, fn) => {
     const start = Date.now();
     try {
@@ -271,6 +272,7 @@ export async function tick({
     });
     for (const a of auto.approved)
       logLine(`schedule approved ${a.loop} → run ${a.runId} (actor: schedule)`);
+    expiredScheduledProposals = auto.expired.length;
     for (const err of auto.errors) logLine(`schedule approval error: ${err}`);
   });
 
@@ -289,6 +291,11 @@ export async function tick({
       );
     for (const e of auto.errors)
       logLine(`chain approval error: ${e.proposalId}:${e.reason}`);
+    if (auto.skipped > 0 || expiredScheduledProposals > 0) {
+      logLine(
+        `proposal staleness: skipped ${auto.skipped} pending chain row(s); expired ${expiredScheduledProposals} unreplannable scheduler row(s)`,
+      );
+    }
   });
 
   await runStep("announce", () => {

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -293,7 +293,7 @@ export async function tick({
       logLine(`chain approval error: ${e.proposalId}:${e.reason}`);
     if (auto.skipped > 0 || expiredScheduledProposals > 0) {
       logLine(
-        `proposal staleness: skipped ${auto.skipped} pending chain row(s); expired ${expiredScheduledProposals} unreplannable scheduler row(s)`,
+        `proposal staleness: skipped ${auto.skipped} pending chain row(s) (${auto.memoised ?? 0} memoised registry-stale); expired ${expiredScheduledProposals} unreplannable scheduler row(s)`,
       );
     }
   });

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -628,7 +628,7 @@ export default async function start() {
 
     expect(logs).toEqual(
       expect.arrayContaining([
-        "proposal staleness: skipped 0 pending chain row(s); expired 1 unreplannable scheduler row(s)",
+        "proposal staleness: skipped 0 pending chain row(s) (0 memoised registry-stale); expired 1 unreplannable scheduler row(s)",
       ]),
     );
     db.close();

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -585,6 +585,55 @@ export default async function start() {
     expect(chainsRan).toBe(true);
   });
 
+  test("tick logs one stale-proposal summary when it expires a retired scheduler row (#1706)", async () => {
+    const { tick } = await import("../cli.mjs");
+    const { emitDueTicks } = await import("../lib/schedules.mjs");
+    const { planAdmittedEvents } = await import("../lib/planner.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T13:00:00.000Z");
+    const current = loadRegistry();
+    const registry = {
+      ...current,
+      schedules: {
+        reaper: {
+          every: "60m",
+          eventType: "clock.tick.reaper",
+          catchUp: "none",
+          singleton: true,
+          approval: "auto",
+          enabled: true,
+        },
+      },
+    };
+    emitDueTicks(db, registry, { now });
+    planAdmittedEvents(db, registry, { now, policyVersion: "git:old" });
+    const stale = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
+    stale.agents.delete("reaper@1");
+    delete stale.eventTypes["clock.tick.reaper"];
+    const logs = [];
+
+    await tick({
+      db,
+      registry: stale,
+      now,
+      policyVersion: "git:test",
+      skipPlan: true,
+      log: (line) => logs.push(line),
+    });
+
+    expect(logs).toEqual(
+      expect.arrayContaining([
+        "proposal staleness: skipped 0 pending chain row(s); expired 1 unreplannable scheduler row(s)",
+      ]),
+    );
+    db.close();
+  });
+
   test("tick sweeps retained memo rows alongside artifact GC and logs the count", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -58,6 +58,10 @@ export const CHAIN_AUTO_APPROVAL_ACTOR = "chain-auto-approval";
 export const HANDOFF_AUTO_APPROVAL_REASON =
   "auto_approved:handoff-dispatch-policy@1";
 export const HANDOFF_AUTO_APPROVAL_ACTOR = "handoff-auto-approval";
+// A serve tick runs every second. Keep the chain pass deliberately small so a
+// backlog (especially one pinned to a retired registry) cannot monopolize the
+// control plane before fresh proposals get a turn.
+export const DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK = 8;
 const NEVER_AUTO_APPROVE = new Set(["factory.ship-apply.requested"]);
 
 function policyPath(root = reposRoot()) {
@@ -942,7 +946,7 @@ const PASSES = new WeakMap();
  * the rest of the pass; `serve` awaits it. The Promise never rejects — every
  * fault is a typed reason on the proposal or an `errors` entry.
  *
- * @returns {Promise<{ approved: Array<{ proposalId: string, runId: string }>, open: Array<{ proposalId: string, reason: string }>, errors: Array<{ proposalId: string|null, reason: string, message: string }> }>}
+ * @returns {Promise<{ approved: Array<{ proposalId: string, runId: string }>, open: Array<{ proposalId: string, reason: string }>, errors: Array<{ proposalId: string|null, reason: string, message: string }>, skipped: number }>}
  */
 export function autoApproveChains(db, registry, options = {}) {
   const state = PASSES.get(db) ?? { tail: null };
@@ -987,6 +991,7 @@ async function runPass(
     runtimeGuardOptions = {},
     hooks = defaultHookRegistry(),
     hookTimeoutMs,
+    maxRows = DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK,
   } = {},
   marker = { settled: false },
 ) {
@@ -995,11 +1000,26 @@ async function runPass(
     const approved = [];
     const open = [];
     const errors = [];
+    const limit =
+      Number.isInteger(maxRows) && maxRows > 0
+        ? maxRows
+        : DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK;
+    let skipped = 0;
     // One in-flight read per repo for the whole pass, shared across every
     // proposal's eligibility recheck (#1064).
     const passDispatch = withPassInFlightCache(dispatch);
     let rows;
     try {
+      const pending = db
+        .query(
+          `SELECT COUNT(*) AS n
+           FROM proposals p
+           JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+          WHERE p.status = 'open' AND p.decision = 'run'
+            AND e.source IN ('chain', 'handoff')`,
+        )
+        .get().n;
+      skipped = Math.max(0, pending - limit);
       rows = db
         .query(
           `SELECT p.id, p.run_id, p.event_source, p.event_id, p.spec_json AS proposal_spec_json, p.spec_hash AS proposal_spec_hash,
@@ -1010,16 +1030,17 @@ async function runPass(
          JOIN runs r ON r.run_id = p.run_id
         WHERE p.status = 'open' AND p.decision = 'run'
           AND e.source IN ('chain', 'handoff')
-        ORDER BY p.created_at, p.rowid`,
+        ORDER BY p.created_at, p.rowid
+        LIMIT ?`,
         )
-        .all();
+        .all(limit);
     } catch (err) {
       errors.push({
         proposalId: null,
         reason: "pass_failed",
         message: String(err?.message ?? err),
       });
-      return { approved, open, errors };
+      return { approved, open, errors, skipped };
     }
 
     for (const row of rows) {
@@ -1092,7 +1113,7 @@ async function runPass(
         });
       }
     }
-    return { approved, open, errors };
+    return { approved, open, errors, skipped };
   } finally {
     marker.settled = true;
   }

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -62,6 +62,11 @@ export const HANDOFF_AUTO_APPROVAL_ACTOR = "handoff-auto-approval";
 // backlog (especially one pinned to a retired registry) cannot monopolize the
 // control plane before fresh proposals get a turn.
 export const DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK = 8;
+// A pending row pinned to an older registry version than the one serve runs
+// with re-plans on approval (#1679). When that re-plan leaves it open, nothing
+// about it changes until the registry moves again, so its verdict is held per
+// (run_id, registryVersion) and only revisited this often (#1706).
+export const DEFAULT_STALE_CHAIN_REVISIT_MS = 60_000;
 const NEVER_AUTO_APPROVE = new Set(["factory.ship-apply.requested"]);
 
 function policyPath(root = reposRoot()) {
@@ -934,6 +939,38 @@ function noteOpenReason(db, id, reason) {
 
 /** One pass at a time per database: a floating pass and an awaited one must not interleave. */
 const PASSES = new WeakMap();
+/** Per database: `${run_id}\0${registryVersion}` → held verdict for a registry-stale row (#1706). */
+const STALE_VERDICTS = new WeakMap();
+
+function staleVerdictsFor(db) {
+  let memo = STALE_VERDICTS.get(db);
+  if (!memo) {
+    memo = new Map();
+    STALE_VERDICTS.set(db, memo);
+  }
+  return memo;
+}
+
+/** The registry version a recorded proposal spec pins, or null when unpinned. */
+function pinnedRegistryVersion(specJson) {
+  let spec;
+  try {
+    spec = JSON.parse(specJson);
+  } catch {
+    return null;
+  }
+  for (const value of [spec?.policyVersion, spec?.promptVersion]) {
+    if (typeof value === "string" && value !== "" && value !== "unknown")
+      return value;
+  }
+  return null;
+}
+
+/** True when the row's recorded spec pins a registry version other than serve's. */
+function pinnedToOlderRegistry(row, registryVersion) {
+  const pinned = pinnedRegistryVersion(row.proposal_spec_json);
+  return pinned !== null && pinned !== registryVersion;
+}
 
 /**
  * Recheck and approve the currently open, eligible chain proposals once.
@@ -946,7 +983,13 @@ const PASSES = new WeakMap();
  * the rest of the pass; `serve` awaits it. The Promise never rejects — every
  * fault is a typed reason on the proposal or an `errors` entry.
  *
- * @returns {Promise<{ approved: Array<{ proposalId: string, runId: string }>, open: Array<{ proposalId: string, reason: string }>, errors: Array<{ proposalId: string|null, reason: string, message: string }>, skipped: number }>}
+ * Per tick the pass evaluates at most `maxRows` rows; the rest are counted in
+ * `skipped`. A registry-stale row whose evaluation left it open is memoised per
+ * (run_id, registryVersion) and skipped — without touching the control plane —
+ * until `staleRevisitMs` elapses, the registry version changes, or the row is
+ * re-planned into a fresh proposal (#1706). `memoised` counts those skips.
+ *
+ * @returns {Promise<{ approved: Array<{ proposalId: string, runId: string }>, open: Array<{ proposalId: string, reason: string }>, errors: Array<{ proposalId: string|null, reason: string, message: string }>, skipped: number, memoised: number }>}
  */
 export function autoApproveChains(db, registry, options = {}) {
   const state = PASSES.get(db) ?? { tail: null };
@@ -992,6 +1035,7 @@ async function runPass(
     hooks = defaultHookRegistry(),
     hookTimeoutMs,
     maxRows = DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK,
+    staleRevisitMs = DEFAULT_STALE_CHAIN_REVISIT_MS,
   } = {},
   marker = { settled: false },
 ) {
@@ -1004,22 +1048,19 @@ async function runPass(
       Number.isInteger(maxRows) && maxRows > 0
         ? maxRows
         : DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK;
+    const revisitMs =
+      Number.isFinite(staleRevisitMs) && staleRevisitMs >= 0
+        ? staleRevisitMs
+        : DEFAULT_STALE_CHAIN_REVISIT_MS;
+    const memo = staleVerdictsFor(db);
     let skipped = 0;
+    let memoised = 0;
+    let evaluated = 0;
     // One in-flight read per repo for the whole pass, shared across every
     // proposal's eligibility recheck (#1064).
     const passDispatch = withPassInFlightCache(dispatch);
     let rows;
     try {
-      const pending = db
-        .query(
-          `SELECT COUNT(*) AS n
-           FROM proposals p
-           JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
-          WHERE p.status = 'open' AND p.decision = 'run'
-            AND e.source IN ('chain', 'handoff')`,
-        )
-        .get().n;
-      skipped = Math.max(0, pending - limit);
       rows = db
         .query(
           `SELECT p.id, p.run_id, p.event_source, p.event_id, p.spec_json AS proposal_spec_json, p.spec_hash AS proposal_spec_hash,
@@ -1030,20 +1071,51 @@ async function runPass(
          JOIN runs r ON r.run_id = p.run_id
         WHERE p.status = 'open' AND p.decision = 'run'
           AND e.source IN ('chain', 'handoff')
-        ORDER BY p.created_at, p.rowid
-        LIMIT ?`,
+        ORDER BY p.created_at, p.rowid`,
         )
-        .all(limit);
+        .all();
     } catch (err) {
       errors.push({
         proposalId: null,
         reason: "pass_failed",
         message: String(err?.message ?? err),
       });
-      return { approved, open, errors, skipped };
+      return { approved, open, errors, skipped, memoised };
+    }
+
+    // Verdicts for rows that are no longer pending (decided, superseded,
+    // re-planned under a new proposal id) or that were held under another
+    // registry version are dead; drop them so the memo tracks the backlog.
+    const live = new Map(
+      rows.map((row) => [`${row.run_id}\0${resolvedPolicyVersion}`, row.id]),
+    );
+    for (const [key, held] of memo) {
+      if (live.get(key) !== held.proposalId) memo.delete(key);
     }
 
     for (const row of rows) {
+      const memoKey = `${row.run_id}\0${resolvedPolicyVersion}`;
+      const stale = pinnedToOlderRegistry(row, resolvedPolicyVersion);
+      const held = stale ? memo.get(memoKey) : undefined;
+      if (held && held.proposalId === row.id && held.until > now) {
+        skipped += 1;
+        memoised += 1;
+        continue;
+      }
+      if (evaluated >= limit) {
+        skipped += 1;
+        continue;
+      }
+      evaluated += 1;
+      const hold = (reason) => {
+        if (stale)
+          memo.set(memoKey, {
+            proposalId: row.id,
+            reason,
+            until: now + revisitMs,
+          });
+        else memo.delete(memoKey);
+      };
       try {
         const age = now - Date.parse(row.created_at);
         let reason;
@@ -1065,6 +1137,7 @@ async function runPass(
         if (reason) {
           noteOpenReason(db, row.id, reason);
           open.push({ proposalId: row.id, reason });
+          hold(reason);
           continue;
         }
         let guardReason;
@@ -1076,6 +1149,8 @@ async function runPass(
         if (guardReason) {
           noteOpenReason(db, row.id, guardReason);
           open.push({ proposalId: row.id, reason: guardReason });
+          // The guard is a live-capacity answer, not a property of the row.
+          memo.delete(memoKey);
           continue;
         }
         try {
@@ -1096,6 +1171,8 @@ async function runPass(
             noteOpenReason(db, row.id, "replanned");
             open.push({ proposalId: row.id, reason: "replanned" });
           }
+          // Approved, or re-planned into a fresh proposal id: nothing to hold.
+          memo.delete(memoKey);
         } catch (err) {
           const message = String(err?.message ?? err);
           noteOpenReason(db, row.id, "approval_error");
@@ -1104,6 +1181,7 @@ async function runPass(
             reason: "approval_error",
             message,
           });
+          hold("approval_error");
         }
       } catch (err) {
         errors.push({
@@ -1111,9 +1189,10 @@ async function runPass(
           reason: "pass_row_failed",
           message: String(err?.message ?? err),
         });
+        hold("pass_row_failed");
       }
     }
-    return { approved, open, errors, skipped };
+    return { approved, open, errors, skipped, memoised };
   } finally {
     marker.settled = true;
   }

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1964,11 +1964,9 @@ describe("chain auto approval (WM-357)", () => {
     };
     const json = canonicalJson(spec);
     const hash = hashJson(spec);
-    db.query(`UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`).run(
-      json,
-      hash,
-      seeded.runId,
-    );
+    db.query(
+      `UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`,
+    ).run(json, hash, seeded.runId);
     db.query(
       `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
     ).run(json, hash, seeded.id);

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -5,6 +5,7 @@ import {
   chainRuntimeGuard,
   CHAIN_AUTO_APPROVAL_ACTOR,
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
+  DEFAULT_STALE_CHAIN_REVISIT_MS,
   CHAIN_AUTO_APPROVAL_REASON,
   loadChainAutoApprovalPolicy,
 } from "./auto-approval.mjs";
@@ -1950,6 +1951,30 @@ describe("chain auto approval (WM-357)", () => {
     expect(inFlightReads).toBe(1);
   });
 
+  /** Re-pin a seeded proposal/run pair to an older registry version (#1706). */
+  const pinRegistryVersion = (db, seeded, version) => {
+    const spec = {
+      ...JSON.parse(
+        db
+          .query(`SELECT spec_json FROM runs WHERE run_id = ?`)
+          .get(seeded.runId).spec_json,
+      ),
+      promptVersion: version,
+      policyVersion: version,
+    };
+    const json = canonicalJson(spec);
+    const hash = hashJson(spec);
+    db.query(`UPDATE runs SET spec_json = ?, spec_hash = ? WHERE run_id = ?`).run(
+      json,
+      hash,
+      seeded.runId,
+    );
+    db.query(
+      `UPDATE proposals SET spec_json = ?, spec_hash = ? WHERE id = ?`,
+    ).run(json, hash, seeded.id);
+    return seeded;
+  };
+
   test("a large pending chain backlog is bounded per pass (#1706)", async () => {
     const db = openDb(":memory:");
     const backlog = Array.from({ length: 50 }, (_, i) =>
@@ -1972,6 +1997,7 @@ describe("chain auto approval (WM-357)", () => {
     });
 
     expect(result.skipped).toBe(42);
+    expect(result.memoised).toBe(0);
     expect(Date.now() - startedAt).toBeLessThan(2_000);
     expect(eligibilityChecks).toBe(8);
     expect(result.open).toHaveLength(8);
@@ -1979,5 +2005,98 @@ describe("chain auto approval (WM-357)", () => {
       db.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get()
         .n,
     ).toBe(backlog.length);
+  });
+
+  test("registry-stale rows are evaluated once per (run, registryVersion) and then memoised (#1706)", async () => {
+    const db = openDb(":memory:");
+    const backlog = Array.from({ length: 60 }, (_, i) =>
+      pinRegistryVersion(
+        db,
+        dispatchSeed(db, `stale-${i}`, { ticket: `WM-${17100 + i}` }),
+        "git:old",
+      ),
+    );
+    const checksByRun = new Map();
+    const options = {
+      maxRows: 100,
+      policyVersion: "git:new",
+      dispatchEligibility: ({ ticket }) => {
+        checksByRun.set(ticket, (checksByRun.get(ticket) ?? 0) + 1);
+        return {
+          ok: false,
+          reason: "registry_stale",
+          evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+        };
+      },
+      runtimeGuard: () => null,
+    };
+
+    const startedAt = Date.now();
+    const first = await auto(db, options);
+    expect(first.open).toHaveLength(backlog.length);
+    expect(first.memoised).toBe(0);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+
+    // Every subsequent tick under the same registry version skips the whole
+    // backlog without another control-plane read.
+    for (let tick = 1; tick <= 5; tick += 1) {
+      const next = await auto(db, { ...options, now: now + tick * 1000 });
+      expect(next.open).toHaveLength(0);
+      expect(next.skipped).toBe(backlog.length);
+      expect(next.memoised).toBe(backlog.length);
+    }
+    expect(checksByRun.size).toBe(backlog.length);
+    for (const count of checksByRun.values()) expect(count).toBe(1);
+
+    // The hold expires, and a registry bump re-evaluates immediately.
+    const revisited = await auto(db, {
+      ...options,
+      now: now + DEFAULT_STALE_CHAIN_REVISIT_MS,
+    });
+    expect(revisited.memoised).toBe(0);
+    expect(revisited.open).toHaveLength(backlog.length);
+    const bumped = await auto(db, { ...options, policyVersion: "git:newer" });
+    expect(bumped.memoised).toBe(0);
+    expect(bumped.open).toHaveLength(backlog.length);
+    expect(
+      db.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get()
+        .n,
+    ).toBe(backlog.length);
+  });
+
+  test("memoised stale rows do not consume the per-tick budget of fresh rows (#1706)", async () => {
+    const db = openDb(":memory:");
+    for (let i = 0; i < 20; i += 1)
+      pinRegistryVersion(
+        db,
+        dispatchSeed(db, `stale-${i}`, { ticket: `WM-${17200 + i}` }),
+        "git:old",
+      );
+    const fresh = dispatchSeed(db, "fresh", { ticket: "WM-17299" });
+    const ineligible = {
+      ok: false,
+      reason: "registry_stale",
+      evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+    };
+    const options = {
+      maxRows: 8,
+      policyVersion: "git:new",
+      dispatchEligibility: ({ ticket }) =>
+        ticket === "WM-17299" ? dispatchOk() : ineligible,
+      runtimeGuard: () => null,
+    };
+
+    // Three ticks walk the stale backlog (8 + 8 + 4) before the newest row.
+    const first = await auto(db, options);
+    expect(first.approved).toEqual([]);
+    expect(first.memoised).toBe(0);
+    const second = await auto(db, { ...options, now: now + 1000 });
+    expect(second.memoised).toBe(8);
+    const third = await auto(db, { ...options, now: now + 2000 });
+    expect(third.memoised).toBe(16);
+    expect(third.approved).toEqual([
+      { proposalId: fresh.id, runId: fresh.runId },
+    ]);
+    expect(runState(db, fresh.runId)).toBe("QUEUED");
   });
 });

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1949,4 +1949,35 @@ describe("chain auto approval (WM-357)", () => {
     );
     expect(inFlightReads).toBe(1);
   });
+
+  test("a large pending chain backlog is bounded per pass (#1706)", async () => {
+    const db = openDb(":memory:");
+    const backlog = Array.from({ length: 50 }, (_, i) =>
+      dispatchSeed(db, `bounded-${i}`, { ticket: `WM-${17060 + i}` }),
+    );
+    let eligibilityChecks = 0;
+    const startedAt = Date.now();
+
+    const result = await auto(db, {
+      maxRows: 8,
+      dispatchEligibility: () => {
+        eligibilityChecks += 1;
+        return {
+          ok: false,
+          reason: "registry_stale",
+          evidence: { ticket: { labels: [] }, escalatePathIntersections: [] },
+        };
+      },
+      runtimeGuard: () => null,
+    });
+
+    expect(result.skipped).toBe(42);
+    expect(Date.now() - startedAt).toBeLessThan(2_000);
+    expect(eligibilityChecks).toBe(8);
+    expect(result.open).toHaveLength(8);
+    expect(
+      db.query(`SELECT COUNT(*) AS n FROM runs WHERE state = 'PROPOSED'`).get()
+        .n,
+    ).toBe(backlog.length);
+  });
 });

--- a/event-runtime/lib/schedules.mjs
+++ b/event-runtime/lib/schedules.mjs
@@ -12,6 +12,8 @@
  */
 import { canonicalJson } from "./canonical.mjs";
 import { admitEvent } from "./intake.mjs";
+import { rejectProposal } from "./proposals.mjs";
+import { getAgent, getEventType } from "./registry.mjs";
 
 export const SCHEDULE_SOURCE = "schedule";
 /** Fields emitDueTicks always stamps itself, overriding a static payload. */
@@ -324,6 +326,18 @@ function matchesConfiguredTick(envelope, row, loop, schedule) {
   return true;
 }
 
+/** A missing event mapping or target definition has no valid re-plan path. */
+function cannotReplanScheduledDefinition(registry, eventType) {
+  const mapping = getEventType(registry, eventType);
+  if (!mapping) return true;
+  try {
+    getAgent(registry, mapping.agent);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 /**
  * Approve open proposals belonging to loops that declare `approval: auto`
  * (§6). Separate from planning on purpose: auto-approval is the step that
@@ -341,22 +355,39 @@ export function autoApproveScheduled(
   { now = Date.now(), policyVersion } = {},
 ) {
   const approved = [];
+  const expired = [];
   const errors = [];
   const autoLoops = new Map(
     Object.entries(registry.schedules ?? {}).filter(
       ([, s]) => s.enabled && (s.approval ?? "watched") === "auto",
     ),
   );
-  if (autoLoops.size === 0) return { approved, errors };
-
   const rows = db
     .query(
-      `SELECT p.id, e.event_id, e.type, e.envelope_json FROM proposals p
+      `SELECT p.id, p.run_id, e.event_id, e.type, e.envelope_json FROM proposals p
        JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        WHERE p.status = 'open' AND p.decision = 'run' AND e.source = ?`,
     )
     .all(SCHEDULE_SOURCE);
   for (const row of rows) {
+    // A scheduler can outlive its mapped event or target definition across a
+    // registry deploy. Approving this row would only re-plan and throw, so
+    // resolve it once rather than reconsidering it on every serve tick.
+    if (cannotReplanScheduledDefinition(registry, row.type)) {
+      try {
+        rejectProposal(db, row.id, {
+          actor: SCHEDULE_SOURCE,
+          reason: "registry_stale",
+          now,
+          policyVersion,
+        });
+        expired.push({ proposalId: row.id, runId: row.run_id });
+      } catch (err) {
+        errors.push(`registry_stale ${row.id}: ${err.message}`);
+      }
+      continue;
+    }
+
     let envelope;
     try {
       envelope = JSON.parse(row.envelope_json);
@@ -383,7 +414,7 @@ export function autoApproveScheduled(
       errors.push(`${loop}: ${err.message}`);
     }
   }
-  return { approved, errors };
+  return { approved, expired, errors };
 }
 
 export const DEFAULT_PROPOSALS_PILING_THRESHOLD = 3;

--- a/event-runtime/lib/schedules.test.mjs
+++ b/event-runtime/lib/schedules.test.mjs
@@ -545,6 +545,34 @@ describe("planning a tick (§5, §6)", () => {
     expect(openProposals(d, {})[0].id).toBe("prop_registry_replacement");
   });
 
+  test("an unreplannable stale scheduler proposal is cancelled once (#1706)", () => {
+    const d = db();
+    const registry = withLoop({ approval: "auto" });
+    const now = at("2026-08-13T21:00:00Z");
+    emitDueTicks(d, registry, { now });
+    planAdmittedEvents(d, registry, { policyVersion: PV, now });
+    const stale = {
+      ...registry,
+      agents: new Map(registry.agents),
+      eventTypes: { ...registry.eventTypes },
+    };
+    stale.agents.delete("reaper@1");
+    delete stale.eventTypes["clock.tick.reaper"];
+
+    const outcome = autoApproveScheduled(d, stale, approveProposal, {
+      now,
+      policyVersion: PV,
+    });
+
+    expect(outcome.expired).toHaveLength(1);
+    expect(outcome.errors).toEqual([]);
+    expect(d.query(`SELECT state FROM runs`).get().state).toBe("CANCELLED");
+    expect(d.query(`SELECT status, reason FROM proposals`).get()).toEqual({
+      status: "rejected",
+      reason: "registry_stale",
+    });
+  });
+
   test("reserved schedule provenance is refused at the external boundary but the tick loop still admits (#960)", () => {
     const d = db();
     const registry = withLoop({ approval: "auto" });


### PR DESCRIPTION
Fixes #1706 (folds #1722).

## Problem
The serve tick's `auto-approve-chains` step re-evaluated every PROPOSED chain row on every 1 s tick. With a backlog pinned to retired registry versions (17+ stale scheduler proposals after a release), each tick re-ran the #1679 registry re-plan and the per-row control-plane eligibility reads, growing to 47–73 s per tick and starving `/health` and the control API.

## Changes (all inside Owned Paths)
- `event-runtime/lib/auto-approval.mjs`
  - Per-tick bound: `maxRows` (default `DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK = 8`) rows evaluated per pass; the rest are counted in `skipped`.
  - Memoised verdict per `(run_id, registryVersion)`: a row whose recorded spec pins an older registry version and whose evaluation leaves it open is held for `staleRevisitMs` (default `DEFAULT_STALE_CHAIN_REVISIT_MS = 60 s`) and skipped without any control-plane read. The hold is dropped when the registry version changes, the row is approved/re-planned into a new proposal id, or a runtime-guard (live capacity) answer was the only blocker. Memoised rows do not consume the per-tick budget, so fresh proposals are not starved by the stale backlog.
  - `autoApproveChains` now returns `{ approved, open, errors, skipped, memoised }`.
- `event-runtime/lib/schedules.mjs`: `autoApproveScheduled` cancels (`rejectProposal`, reason `registry_stale`, actor `schedule`) open scheduler proposals whose event type or target agent is no longer registered — these can never be re-planned — and returns them in `expired`.
- `event-runtime/cli/serve.mjs`: one summary line per tick when anything was skipped/expired: `proposal staleness: skipped N pending chain row(s) (M memoised registry-stale); expired K unreplannable scheduler row(s)`.
- Tests: 50-row bounded backlog (≤8 evaluations, <2 s); 60 registry-stale rows evaluated exactly once per row across 6 ticks, revisited after the hold expires and immediately on a registry bump; fresh row approved behind a 20-row stale backlog; unreplannable scheduler proposal cancelled once; serve tick logs the summary line.

## Verification
- `bun test event-runtime/lib/auto-approval.test.mjs event-runtime/lib/chain.test.mjs --timeout 20000` — 72 pass
- `bun run lint` (0 errors), `bun test event-runtime/lib --timeout 20000` (2180 pass), `bun test event-runtime/cli/serve.test.mjs` (18 pass), `bun build/emit.mjs --check` (AGENTS.md floor warning is #1743), `bun run format:check`, `bun run check` — all green
- `git diff --stat origin/develop...HEAD` touches only the six owned files.

## Handoff
- Defaults are conservative: 8 rows/tick and a 60 s revisit for stale rows. Both are options on `autoApproveChains` (`maxRows`, `staleRevisitMs`) should serve need tuning.
- The memo is in-process (`WeakMap` per db handle); a serve restart re-evaluates once. That is intentional — the verdict is cheap to recompute once and never has to persist.
- Stale scheduler rows whose definition still exists are left to the #1679 re-plan path (they are approved-after-replan or superseded), only definitions that no longer exist are cancelled.
- The wip branch `wip/watt-mind/factory#1706-20260830T134301Z` held an older base plus a narrower stale check (agent AND event type both missing); the broader either-missing check on this branch was kept since either condition makes `approveProposal` throw. Nothing else from it was needed.
