### PR TITLE
feat(status): add GitHub intake health projection

### DIFF
--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -200,6 +200,14 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
       ).run(`prop-piling-reaper-${i}`, `clock:reaper:${i}`, atIso);
     }
 
+    // A GitHub delivery admitted 90 seconds ago supplies the intake freshness
+    // projection without changing the numeric event-status counts.
+    const githubAdmittedAt = new Date(nowMs - 90_000).toISOString();
+    db.query(
+      `INSERT INTO events (source, event_id, type, subject, status, payload_hash, occurred_at, received_at, admitted_at, envelope_json)
+       VALUES ("github", "delivery-status-1", "github.pull_request", "watt-mind/factory", "admitted", "dummy-hash", ?, ?, ?, "{}")`,
+    ).run(githubAdmittedAt, githubAdmittedAt, githubAdmittedAt);
+
     const s = await makeServer({
       db,
       secret: "sec",
@@ -218,6 +226,19 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
         extractDirectProperties(statusViewBlock).sort();
       expect(Object.keys(status).sort()).toEqual(expectedStatusKeys);
       expect(status.inbox).toEqual({ open: 0, acked: 0, byKind: {} });
+      expect(status.githubIntake).toEqual({
+        configured: true,
+        lastAdmittedAt: githubAdmittedAt,
+        ageMs: 90_000,
+        rejected: 0,
+        stale: false,
+        staleAfterMs: 12 * 60 * 60 * 1000,
+      });
+      expect(Object.keys(status.githubIntake).sort()).toEqual(
+        extractDirectProperties(
+          extractInterfaceBlock(typesSrc, "GithubIntakeStatus"),
+        ).sort(),
+      );
 
       // StatusView.env matches EnvIdentity
       const envIdentityBlock = extractInterfaceBlock(typesSrc, "EnvIdentity");
@@ -317,6 +338,20 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
           lastError: "failed to plan",
         },
       ]);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("GET /status reports GitHub intake as unconfigured without a webhook secret", async () => {
+    const s = await makeServer({ githubSecret: null });
+    try {
+      const status = await (await fetch(s.url("/status"))).json();
+      expect(status.githubIntake).toMatchObject({
+        configured: false,
+        ageMs: null,
+        stale: false,
+      });
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -37,6 +37,7 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 import { createHookRegistry } from "./hooks.mjs";
+import { GITHUB_INTAKE_STALE_AFTER_MS } from "./intake.mjs";
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -230,9 +231,9 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
         configured: true,
         lastAdmittedAt: githubAdmittedAt,
         ageMs: 90_000,
-        rejected: 0,
+        rejected: expect.any(Number),
         stale: false,
-        staleAfterMs: 12 * 60 * 60 * 1000,
+        staleAfterMs: GITHUB_INTAKE_STALE_AFTER_MS,
       });
       expect(Object.keys(status.githubIntake).sort()).toEqual(
         extractDirectProperties(

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -282,6 +282,7 @@ export function statusView(
 
   return {
     events: eventCounts(db),
+    githubIntake,
     proposals: { open: open.length, expired: expiredOpen.length },
     inbox: inboxCounts(db),
     runs,

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -831,6 +831,8 @@ export interface UnmatchedPlacementRun {
 export interface StatusView {
   env: EnvIdentity;
   events: Record<string, number>;
+  /** GitHub webhook intake health; absent on pre-#1632 control APIs. */
+  githubIntake?: GithubIntakeStatus;
   proposals: { open: number; expired: number };
   runs: { byState: Partial<Record<RunState, number>> };
   /** Fleet counts; `live` and `busy` exclude stale workers, as the API does. */
@@ -875,6 +877,16 @@ export interface StatusView {
     ambiguousOpenProposals: { runId: string; count: number }[];
     proposalsPilingUp?: ProposalPilingUp[];
   };
+}
+
+/** Durable GitHub admission freshness plus process-local rejected deliveries. */
+export interface GithubIntakeStatus {
+  configured: boolean;
+  lastAdmittedAt: string | null;
+  ageMs: number | null;
+  rejected: number;
+  stale: boolean;
+  staleAfterMs: number;
 }
 
 export interface ApproveOutcome {


### PR DESCRIPTION
Fixes watt-mind/factory#1632

Expose typed GitHub webhook intake freshness and configuration health on GET /status.

## Validation

| Check                | Command                                                                                           | Result  | Notes                  |
| -------------------- | ------------------------------------------------------------------------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-status-view.test.mjs --timeout 20000` | pass    | 47 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2177 pass, 0 failures  |
| UX critique          | `factory-ux-critic`                                                                               | not run | no user-facing surface |

UX critique: skipped

run:$FACTORY_RUN_ID

## Post-review

- Merged `origin/develop` into the branch.
- `api-status-view.test.mjs`: `rejected: expect.any(Number)` (counter is process-global) and `staleAfterMs` now imports `GITHUB_INTAKE_STALE_AFTER_MS` from `intake.mjs` instead of re-hardcoding 12 h.
- Verified: ticket Verification Command (47 pass), `bun run lint`, `bun test event-runtime/lib` (2193 pass), `bun build/emit.mjs --check` (known floor warning, #1743), `bun run format:check`, `bun run check`.
