### PR TITLE
fix(adapters): forward control API token to command-adapter children

### DIFF
--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -20,6 +20,11 @@ export const RUNTIME_IDENTITY_ENV = [
   "FACTORY_EVENT_PORT",
   "FACTORY_EVENT_SECRET",
   "FACTORY_EVENT_ENV",
+  // The control bearer travels with runtime identity: a child that reconnects
+  // to this worker's control API needs it, while BASE_INHERITED_ENV must not
+  // expose it to adapters that do not inherit that identity. PUSH_CREDENTIAL_ENV
+  // remains reserved for explicitly mutating definitions and push transport.
+  "FACTORY_CONTROL_API_TOKEN",
 ];
 
 // These are assigned from a dispatch RunSpec by the worker, rather than

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -112,6 +112,24 @@ describe("shared child environment", () => {
     }
   });
 
+  test("inherits the control bearer only with runtime identity", () => {
+    process.env.FACTORY_CONTROL_API_TOKEN = "worker-control-bearer";
+
+    expect(
+      safeChildEnvironment({}, false, { inheritRuntimeIdentity: true })
+        .FACTORY_CONTROL_API_TOKEN,
+    ).toBe("worker-control-bearer");
+    expect(
+      safeChildEnvironment({}, false).FACTORY_CONTROL_API_TOKEN,
+    ).toBeUndefined();
+
+    for (const environment of [claudeEnvironment, agyEnvironment]) {
+      expect(
+        environment({}, { mutating: false }).FACTORY_CONTROL_API_TOKEN,
+      ).toBeUndefined();
+    }
+  });
+
   test("applies shared options after the caller environment", () => {
     process.env.FACTORY_EVENT_PORT = "17381";
     const output = safeChildEnvironment(

--- a/event-runtime/lib/adapters/command.test.mjs
+++ b/event-runtime/lib/adapters/command.test.mjs
@@ -1,6 +1,6 @@
 import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-command-test-mjs";
-import { afterAll, describe, expect, test } from "bun:test";
-import { existsSync, readFileSync } from "node:fs";
+import { afterAll, afterEach, describe, expect, test } from "bun:test";
+import { chmodSync, existsSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { FACTORY_ROOT } from "../config.mjs";
 import { openDb } from "../db.mjs";
@@ -186,6 +186,16 @@ describe("safeChildEnvironment", () => {
 });
 
 describe("execute", () => {
+  const originalControlApiToken = process.env.FACTORY_CONTROL_API_TOKEN;
+
+  afterEach(() => {
+    if (originalControlApiToken === undefined) {
+      delete process.env.FACTORY_CONTROL_API_TOKEN;
+    } else {
+      process.env.FACTORY_CONTROL_API_TOKEN = originalControlApiToken;
+    }
+  });
+
   test("exit 0 writes a factory.agent-result/v1 with the resolved command", async () => {
     const workspaceDir = ws();
     const outcome = await execute({
@@ -332,6 +342,32 @@ describe("execute", () => {
         else process.env[key] = value;
       }
     }
+  });
+
+  test("forwards the worker control bearer to a command child", async () => {
+    const workspaceDir = ws();
+    const binDir = tmpDir("evrt-command-factory-bin-");
+    const factory = path.join(binDir, "factory");
+    writeFileSync(
+      factory,
+      '#!/bin/sh\nprintf "%s\\n" "$FACTORY_CONTROL_API_TOKEN"\n',
+    );
+    chmodSync(factory, 0o755);
+    process.env.FACTORY_CONTROL_API_TOKEN = "worker-control-bearer";
+
+    const outcome = await execute({
+      spec: spec({}),
+      def: { ...def(["factory"]), mutating: false },
+      workspaceDir,
+      timeoutMs: 5000,
+      env: { PATH: `${binDir}${path.delimiter}${process.env.PATH}` },
+    });
+
+    expect(outcome).toEqual({ exitCode: 0, timedOut: false });
+    const result = JSON.parse(
+      readFileSync(path.join(workspaceDir, "result.json"), "utf8"),
+    );
+    expect(result.artifact.outputTail.trim()).toBe("worker-control-bearer");
   });
 
   test("writesResult leaves a command-authored result.json in place (WM-907)", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1726

Restores ci-notify control-API authentication by forwarding the token only to runtime-identity command children.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/child-env.test.mjs event-runtime/lib/adapters/command.test.mjs --timeout 20000` | pass | 30 pass, 2 skipped |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2178 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_f16460d6-702c-4a9d-ab62-bcbcf270b49a