### PR TITLE
fix(repos): harden toolchain probe failures

### DIFF
--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -419,12 +419,62 @@ async function defaultSpawn(argv) {
     stderr: "pipe",
     timeout: TOOLCHAIN_PROBE_TIMEOUT_MS,
   });
-  const [stdout, stderr] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-  ]);
-  const exitCode = await proc.exited;
-  return { exitCode, stdout, stderr };
+  // A timeout can abort one of the pipe reads before its sibling has drained.
+  // Preserve whatever was read and turn the probe into a normal failed result
+  // so the caller can attest the tool instead of losing the whole preflight.
+  const [stdoutResult, stderrResult, exitCodeResult] = await Promise.allSettled(
+    [
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ],
+  );
+  return {
+    exitCode:
+      exitCodeResult.status === "fulfilled" ? exitCodeResult.value : null,
+    stdout: stdoutResult.status === "fulfilled" ? stdoutResult.value : "",
+    stderr: stderrResult.status === "fulfilled" ? stderrResult.value : "",
+  };
+}
+
+function probeErrorMessage(error) {
+  const message = error?.message;
+  return typeof message === "string" && message.trim()
+    ? message
+    : String(error);
+}
+
+function failedToolchainProbe({
+  node,
+  repo,
+  executable,
+  constraint,
+  resolved,
+  error,
+  detail,
+}) {
+  const observedRaw = probeErrorMessage(error);
+  return {
+    tool: {
+      executable,
+      constraint,
+      resolved,
+      observed: null,
+      observedRaw,
+      satisfied: false,
+    },
+    reason: {
+      reason: REPO_TOOLCHAIN_MISSING,
+      node,
+      repo,
+      executable,
+      constraint,
+      observed: null,
+      observedRaw,
+      detail,
+      action: `check that ${executable} is present and executable on ${node}, then re-run toolchain preflight for repo ${repo}`,
+    },
+  };
 }
 
 /**
@@ -454,7 +504,23 @@ export async function preflightToolchain(
   const reasons = [];
 
   for (const { executable, constraint } of toolchain ?? []) {
-    const resolved = await which(executable);
+    let resolved;
+    try {
+      resolved = await which(executable);
+    } catch (error) {
+      const failed = failedToolchainProbe({
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        resolved: null,
+        error,
+        detail: "which_failed",
+      });
+      tools.push(failed.tool);
+      reasons.push(failed.reason);
+      continue;
+    }
     if (!resolved) {
       tools.push({
         executable,
@@ -476,10 +542,24 @@ export async function preflightToolchain(
       continue;
     }
 
-    const { exitCode, stdout, stderr } = await spawn([
-      resolved,
-      TOOLCHAIN_VERSION_ARG,
-    ]);
+    let probe;
+    try {
+      probe = await spawn([resolved, TOOLCHAIN_VERSION_ARG]);
+    } catch (error) {
+      const failed = failedToolchainProbe({
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        resolved,
+        error,
+        detail: "version_probe_threw",
+      });
+      tools.push(failed.tool);
+      reasons.push(failed.reason);
+      continue;
+    }
+    const { exitCode, stdout, stderr } = probe;
     const output = stdout?.trim() ? stdout : (stderr ?? "");
     const observedRaw =
       output

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -968,6 +968,64 @@ describe("preflightToolchain verifies without mutating the host", () => {
     expect(reasons[1].observedRaw).toBe("no version here");
   });
 
+  test("throwing which and spawn probes become failed attestations and later tools still run", async () => {
+    const repo = repoWith(
+      `    toolchain:\n      which-broken: ">=1"\n      spawn-broken: ">=1"\n      bun: ">=1.3 <2"\n`,
+    );
+    const spawnCalls = [];
+    const attestation = await preflightToolchain(repo, {
+      now,
+      which: async (executable) => {
+        if (executable === "which-broken") throw new Error("which denied");
+        return `/opt/bin/${executable}`;
+      },
+      spawn: async (argv) => {
+        spawnCalls.push(argv);
+        if (argv[0] === "/opt/bin/spawn-broken") {
+          throw new Error("spawn denied");
+        }
+        return { exitCode: 0, stdout: "1.3.14\n", stderr: "" };
+      },
+    });
+
+    expect(attestation.ok).toBe(false);
+    expect(attestation.tools).toMatchObject([
+      {
+        executable: "which-broken",
+        resolved: null,
+        observed: null,
+        observedRaw: "which denied",
+        satisfied: false,
+      },
+      {
+        executable: "spawn-broken",
+        resolved: "/opt/bin/spawn-broken",
+        observed: null,
+        observedRaw: "spawn denied",
+        satisfied: false,
+      },
+      { executable: "bun", observed: "1.3.14", satisfied: true },
+    ]);
+    expect(attestation.reasons.map((reason) => reason.executable)).toEqual([
+      "which-broken",
+      "spawn-broken",
+    ]);
+    expect(attestation.reasons).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ reason: REPO_TOOLCHAIN_MISSING }),
+      ]),
+    );
+    expect(
+      attestation.reasons.every((reason) =>
+        reason.action.includes(reason.executable),
+      ),
+    ).toBe(true);
+    expect(spawnCalls).toEqual([
+      ["/opt/bin/spawn-broken", "--version"],
+      ["/opt/bin/bun", "--version"],
+    ]);
+  });
+
   test("preflight is non-mutating: the only command spawned is `<exe> --version`", async () => {
     const repo = repoWith(
       `    toolchain:\n      bun: ">=1.3 <2"\n      node: ">=22 <25"\n      git: ">=2.40"\n`,

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -189,6 +189,29 @@ describe("repo toolchain diagnostics (#1097)", () => {
     expect(uv.fix).toContain("install uv >=0.5");
   });
 
+  test("a throwing version probe yields a red row and later tools are still diagnosed", async () => {
+    const rows = await repoToolchainDiagnostics({
+      repos: [{ name: "demo", toolchain: { broken: ">=1", bun: ">=1.3 <2" } }],
+      which: async (executable) => `/opt/${executable}`,
+      spawn: async ([resolved]) => {
+        if (resolved === "/opt/broken") throw new Error("permission denied");
+        return { exitCode: 0, stdout: "1.3.14\n", stderr: "" };
+      },
+    });
+
+    expect(rows).toEqual([
+      expect.objectContaining({
+        ok: false,
+        label: "toolchain broken",
+        detail: ">=1  observed permission denied",
+      }),
+      expect.objectContaining({
+        ok: true,
+        label: "toolchain bun",
+      }),
+    ]);
+  });
+
   test("not-declared: no new rows and no probe is spawned", async () => {
     let probes = 0;
     const counted = {


### PR DESCRIPTION
Fixes watt-mind/factory#1732

Toolchain preflight now records thrown probe errors and continues attesting later tools.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs orchestrator/doctor.test.mjs --timeout 30000` | pass | 95 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (614 existing warnings) |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped

run:run_e59e7906-0717-4b29-bb5d-bf1a410c2449