### PR TITLE
fix(cli): diagnose rejected inbox failures

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -239,14 +239,27 @@ case "$cmd" in
               source: process.env.FACTORY_INBOX_SOURCE,
             }),
           });
-          const responseBody = await response.clone().json().catch(() => null);
+          const responseText = await response.clone().text().catch(() => "");
+          let responseBody = null;
+          try {
+            responseBody = JSON.parse(responseText);
+          } catch {}
           if (response.status === 401 || (response.status === 503 && responseBody?.error === "control_api_token_unset")) {
             console.error(token
               ? "notify: control API rejected FACTORY_CONTROL_API_TOKEN"
               : "notify: control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env");
             process.exit(10);
           }
-          if (!response.ok) process.exit(10);
+          if (!response.ok) {
+            const rawDetail = typeof responseBody?.error === "string" ? responseBody.error : responseText;
+            const detail = (token ? rawDetail.split(token).join("[redacted]") : rawDetail)
+              .trim()
+              .replace(/\s+/g, " ")
+              .slice(-200)
+              || "(empty response)";
+            console.error(`notify: control API POST /inbox failed: HTTP ${response.status} ${detail}`);
+            process.exit(10);
+          }
           const body = responseBody;
           // Durable record succeeded; the serve-side notify.py projection did
           // not. Exit 12 so the shell falls through to the CLI transport

--- a/bin/factory.test.mjs
+++ b/bin/factory.test.mjs
@@ -177,7 +177,7 @@ function runNotify({ args, stdin = "", exitCode = "0", env = {} }) {
   };
 }
 
-async function withInboxStub(response, fn) {
+async function withInboxStub(response, fn, status = 201) {
   const dir = mkdtempSync(path.join(tmpdir(), "factory-inbox-server-"));
   const requestFile = path.join(dir, "request.json");
   const headersFile = path.join(dir, "headers.json");
@@ -195,7 +195,7 @@ class Handler(BaseHTTPRequestHandler):
         with open(${JSON.stringify(headersFile)}, "w") as f:
             f.write(json.dumps({k.lower(): v for k, v in self.headers.items()}))
         body = json.dumps(json.loads(${JSON.stringify(JSON.stringify(response))})).encode()
-        self.send_response(201)
+        self.send_response(${status})
         self.send_header("content-type", "application/json")
         self.send_header("content-length", str(len(body)))
         self.end_headers()
@@ -321,6 +321,27 @@ test("factory notify sends no authorization header when FACTORY_CONTROL_API_TOKE
         result.cleanup();
       }
     },
+  );
+});
+
+test("factory notify diagnoses a rejected inbox response before exiting terminally", async () => {
+  await withInboxStub(
+    { error: "inbox validation failed" },
+    async ({ port }) => {
+      const result = runNotify({
+        args: ["BLOCKED", "WM-1:", "choose policy"],
+        env: { FACTORY_EVENT_PORT: String(port) },
+      });
+      try {
+        expect(result.status).toBe(10);
+        expect(result.stderr).toContain(
+          "notify: control API POST /inbox failed: HTTP 500 inbox validation failed",
+        );
+      } finally {
+        result.cleanup();
+      }
+    },
+    500,
   );
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1731

Logs token-safe HTTP failure context for rejected notify inbox requests.

## Validation

| Check                | Command                                                                                                     | Result  | Notes                     |
| -------------------- | ----------------------------------------------------------------------------------------------------------- | ------- | ------------------------- |
| Verification Command | `bun test bin/factory.test.mjs --timeout 30000`                                                          | pass    | 19 tests, 0 failures      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,176 pass; lint warnings |
| UX critique          | factory-ux-critic                                                                                           | not run | no user-facing surface    |

UX critique: skipped
run:run_24097cf4-95e0-4eb6-9410-dbc59503d904