### PR TITLE
fix(planner): deduplicate unchanged human-needed proposals

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2106,7 +2106,73 @@ function coalesceWebhookMergeRequest(
   };
 }
 
-function humanNeeded(db, event, reason, at, ttlSeconds) {
+function humanNeededReasonPrefix(reason) {
+  return String(reason).split(":", 1)[0];
+}
+
+function ticketHumanNeededContext(payload, evidence) {
+  const repo = payload?.repo;
+  const ticket = payload?.ticket;
+  const descriptionHash = evidence?.ticket?.descriptionHash;
+  // A missing ticket has no body to compare. Its synthetic empty-description
+  // hash must not make unrelated failed lookups suppress each other.
+  if (
+    evidence?.checks?.ticket_found !== true ||
+    typeof repo !== "string" ||
+    typeof ticket !== "string" ||
+    typeof descriptionHash !== "string"
+  ) {
+    return null;
+  }
+  return { repo, ticket, descriptionHash };
+}
+
+function humanNeeded(db, event, reason, at, ttlSeconds, ticketContext = null) {
+  const outcomeReason = reason;
+  if (ticketContext) {
+    const reasonPrefix = humanNeededReasonPrefix(reason);
+    const matching = db
+      .query(
+        `SELECT p.*
+         FROM proposals p
+         JOIN events e
+           ON e.source = p.event_source AND e.event_id = p.event_id
+         WHERE p.decision = 'human_needed'
+           AND p.status = 'open'
+           AND json_extract(e.envelope_json, '$.payload.repo') = ?
+           AND json_extract(e.envelope_json, '$.payload.ticket') = ?
+           AND substr(p.reason, 1, ?) = ?
+         ORDER BY p.created_at, p.rowid`,
+      )
+      .all(
+        ticketContext.repo,
+        ticketContext.ticket,
+        reasonPrefix.length,
+        reasonPrefix,
+      );
+    const hashMarker = `[dispatch_ticket_body_hash:${ticketContext.descriptionHash}]`;
+    const current = matching.find((proposal) =>
+      String(proposal.reason ?? "").includes(hashMarker),
+    );
+    const stale = matching.filter((proposal) => proposal.id !== current?.id);
+    for (const proposal of stale) {
+      db.query(
+        `UPDATE proposals
+         SET status = 'superseded', decided_at = ?, decided_by = ?,
+             reason = 'superseded_by_ticket_body_change'
+         WHERE id = ?`,
+      ).run(at, "planner", proposal.id);
+    }
+    if (current) {
+      const noopReason = `human_needed_already_open:${current.id}`;
+      setEventStatus(db, event, "noop", noopReason);
+      return { decision: "noop", reason: noopReason };
+    }
+    // Proposals do not have an evidence column. Retain the body hash in the
+    // operator-facing reason detail so a later scan can compare the exact
+    // ticket body that produced this question without changing the schema.
+    reason = `${reason}\n${hashMarker}`;
+  }
   const proposal = insertProposal(db, {
     id: newProposalId(),
     event,
@@ -2117,7 +2183,7 @@ function humanNeeded(db, event, reason, at, ttlSeconds) {
     ttlSeconds,
   });
   setEventStatus(db, event, "human_needed");
-  return { decision: "human_needed", proposal, reason };
+  return { decision: "human_needed", proposal, reason: outcomeReason };
 }
 
 /** Idempotent path: the event was already planned — report what was decided. */
@@ -2462,7 +2528,17 @@ export function planEvent(
       worktreeEligibility?.ok === false ? worktreeEligibility.refusal : null;
     if (worktreeGateFor(def) === "dispatch" && worktreeRefusal) {
       if (worktreeRefusal.decision === "human_needed") {
-        return humanNeeded(db, event, worktreeRefusal.reason, at, ttlSeconds);
+        return humanNeeded(
+          db,
+          event,
+          worktreeRefusal.reason,
+          at,
+          ttlSeconds,
+          ticketHumanNeededContext(
+            envelope.payload,
+            worktreeEligibility.evidence,
+          ),
+        );
       }
       const proposal = insertProposal(db, {
         id: newProposalId(),

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2106,6 +2106,15 @@ function coalesceWebhookMergeRequest(
   };
 }
 
+const HUMAN_NEEDED_BODY_HASH_MARKER = /\[dispatch_ticket_body_hash:([^\]]+)\]/;
+
+function proposalExpiredAt(proposal, at) {
+  return (
+    Date.parse(at) - Date.parse(proposal.created_at) >
+    Number(proposal.ttl_seconds) * 1000
+  );
+}
+
 function humanNeededReasonPrefix(reason) {
   return String(reason).split(":", 1)[0];
 }
@@ -2151,17 +2160,29 @@ function humanNeeded(db, event, reason, at, ttlSeconds, ticketContext = null) {
         reasonPrefix,
       );
     const hashMarker = `[dispatch_ticket_body_hash:${ticketContext.descriptionHash}]`;
-    const current = matching.find((proposal) =>
-      String(proposal.reason ?? "").includes(hashMarker),
+    // Expiry is derived from created_at + ttl_seconds (nothing writes
+    // status='expired'), so an aged-out open row is not current: the unchanged
+    // ticket must be re-proposed once its earlier question has expired.
+    const current = matching.find(
+      (proposal) =>
+        !proposalExpiredAt(proposal, at) &&
+        String(proposal.reason ?? "").includes(hashMarker),
     );
     const stale = matching.filter((proposal) => proposal.id !== current?.id);
     for (const proposal of stale) {
+      const previousMarker = String(proposal.reason ?? "").match(
+        HUMAN_NEEDED_BODY_HASH_MARKER,
+      );
+      const supersedeReason =
+        previousMarker && previousMarker[1] !== ticketContext.descriptionHash
+          ? "superseded_by_ticket_body_change"
+          : "superseded_by_replan";
       db.query(
         `UPDATE proposals
          SET status = 'superseded', decided_at = ?, decided_by = ?,
-             reason = 'superseded_by_ticket_body_change'
+             reason = ?
          WHERE id = ?`,
-      ).run(at, "planner", proposal.id);
+      ).run(at, "planner", supersedeReason, proposal.id);
     }
     if (current) {
       const noopReason = `human_needed_already_open:${current.id}`;

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1165,6 +1165,110 @@ describe("planEvent worktree gate (WM-108)", () => {
     fetchInFlight: () => [],
   });
 
+  test("ticket-scoped human-needed refusals deduplicate unchanged bodies and supersede changed ones", () => {
+    const closureRepo =
+      `repos:\n  - name: closure\n    path: /tmp/nowhere\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n` +
+      `    owned_paths_policy:\n      direct:\n        - source: generated/input.mjs\n          requires:\n            - generated/pin.json\n`;
+    withReposRoot(closureRepo, () => {
+      const db = openDb(":memory:");
+      const ticket = {
+        ...tierTicket(),
+        description: "## Owned Paths\n- generated/input.mjs\n",
+      };
+      const dispatch = {
+        ...tierDispatch(),
+        fetchTicket: () => ticket,
+      };
+      const plan = (eventId) => {
+        const ref = admit(db, {
+          type: "test.worktree.requested",
+          eventId,
+          correlationId: eventId,
+          payload: { repo: "closure", ticket: "WM-694" },
+        });
+        return planEvent(db, syntheticRegistry(), ref, {
+          now: NOW,
+          dispatch,
+        });
+      };
+
+      const first = plan("closure-first");
+      expect(first).toMatchObject({
+        decision: "human_needed",
+        reason: "owned_paths_not_closed",
+      });
+      expect(first.proposal.reason).toContain("[dispatch_ticket_body_hash:");
+
+      const unchanged = plan("closure-unchanged");
+      expect(unchanged).toEqual({
+        decision: "noop",
+        reason: `human_needed_already_open:${first.proposal.id}`,
+      });
+      expect(db.query(`SELECT COUNT(*) AS n FROM proposals`).get().n).toBe(1);
+
+      ticket.description =
+        "## Owned Paths\n- generated/input.mjs\n\nChanged ticket body.\n";
+      const changed = plan("closure-changed");
+      expect(changed).toMatchObject({
+        decision: "human_needed",
+        reason: "owned_paths_not_closed",
+      });
+      expect(changed.proposal.id).not.toBe(first.proposal.id);
+      expect(
+        db
+          .query(`SELECT status FROM proposals WHERE id = ?`)
+          .get(first.proposal.id).status,
+      ).toBe("superseded");
+    });
+  });
+
+  test("the human-needed guard covers other ticket refusals and reopens after resolution", () => {
+    const unconfiguredRepo =
+      `repos:\n  - name: unconfigured\n    path: /tmp/nowhere\n    base: develop\n` +
+      `    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`;
+    withReposRoot(unconfiguredRepo, () => {
+      const db = openDb(":memory:");
+      const dispatch = tierDispatch();
+      const plan = (eventId) => {
+        const ref = admit(db, {
+          type: "test.worktree.requested",
+          eventId,
+          correlationId: eventId,
+          payload: { repo: "unconfigured", ticket: "WM-694" },
+        });
+        return planEvent(db, syntheticRegistry(), ref, {
+          now: NOW,
+          dispatch,
+        });
+      };
+
+      const first = plan("unconfigured-first");
+      expect(first).toMatchObject({
+        decision: "human_needed",
+        reason:
+          "repo_unconfigured: team/project missing for the in-flight query",
+      });
+      expect(plan("unconfigured-unchanged")).toEqual({
+        decision: "noop",
+        reason: `human_needed_already_open:${first.proposal.id}`,
+      });
+
+      let active = first.proposal;
+      for (const status of ["approved", "rejected", "expired"]) {
+        db.query(`UPDATE proposals SET status = ? WHERE id = ?`).run(
+          status,
+          active.id,
+        );
+        const fresh = plan(`unconfigured-${status}`);
+        expect(fresh.decision).toBe("human_needed");
+        active = fresh.proposal;
+      }
+    });
+  });
+
   test("dispatch model tier precedence is payload > ticket label > definition and records its source (WM-694)", () => {
     withReposRoot(tierRepo, () => {
       const cases = [

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -1218,9 +1218,12 @@ describe("planEvent worktree gate (WM-108)", () => {
       expect(changed.proposal.id).not.toBe(first.proposal.id);
       expect(
         db
-          .query(`SELECT status FROM proposals WHERE id = ?`)
-          .get(first.proposal.id).status,
-      ).toBe("superseded");
+          .query(`SELECT status, reason FROM proposals WHERE id = ?`)
+          .get(first.proposal.id),
+      ).toEqual({
+        status: "superseded",
+        reason: "superseded_by_ticket_body_change",
+      });
     });
   });
 
@@ -1232,7 +1235,7 @@ describe("planEvent worktree gate (WM-108)", () => {
     withReposRoot(unconfiguredRepo, () => {
       const db = openDb(":memory:");
       const dispatch = tierDispatch();
-      const plan = (eventId) => {
+      const plan = (eventId, now = NOW) => {
         const ref = admit(db, {
           type: "test.worktree.requested",
           eventId,
@@ -1240,7 +1243,7 @@ describe("planEvent worktree gate (WM-108)", () => {
           payload: { repo: "unconfigured", ticket: "WM-694" },
         });
         return planEvent(db, syntheticRegistry(), ref, {
-          now: NOW,
+          now,
           dispatch,
         });
       };
@@ -1257,7 +1260,7 @@ describe("planEvent worktree gate (WM-108)", () => {
       });
 
       let active = first.proposal;
-      for (const status of ["approved", "rejected", "expired"]) {
+      for (const status of ["approved", "rejected"]) {
         db.query(`UPDATE proposals SET status = ? WHERE id = ?`).run(
           status,
           active.id,
@@ -1266,6 +1269,23 @@ describe("planEvent worktree gate (WM-108)", () => {
         expect(fresh.decision).toBe("human_needed");
         active = fresh.proposal;
       }
+
+      // Nothing writes status='expired': expiry is derived from
+      // created_at + ttl_seconds. An open row that aged out must not
+      // suppress the unchanged ticket's next question.
+      const ttlMs = Number(active.ttl_seconds) * 1000;
+      expect(plan("unconfigured-within-ttl", NOW + ttlMs)).toEqual({
+        decision: "noop",
+        reason: `human_needed_already_open:${active.id}`,
+      });
+      const afterExpiry = plan("unconfigured-expired", NOW + ttlMs + 1000);
+      expect(afterExpiry.decision).toBe("human_needed");
+      expect(afterExpiry.proposal.id).not.toBe(active.id);
+      expect(
+        db
+          .query(`SELECT status, reason FROM proposals WHERE id = ?`)
+          .get(active.id),
+      ).toEqual({ status: "superseded", reason: "superseded_by_replan" });
     });
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1730

Suppress duplicate unchanged-ticket human-needed proposals while retaining fresh prompts for changed bodies.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs --timeout 60000` | pass | 104 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2178 pass, 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_a0dfcaca-7a0d-412b-aff9-3be9ff173e00


## Post-review

- The `humanNeeded` dedupe guard now treats an open proposal as current only while it is within its TTL (`created_at + ttl_seconds`, computed at plan time `at`), matching how `proposals.mjs`, `janitor.mjs` and `metrics.mjs` derive expiry. Production never writes `status='expired'`, so previously an unchanged ticket was never re-proposed after its question aged out (AC3). Aged-out rows are superseded like stale ones.
- Supersede reason is `superseded_by_ticket_body_change` only when the prior row carried a body-hash marker that differs from the current hash; otherwise `superseded_by_replan`.
- Test no longer fakes expiry via `UPDATE proposals SET status='expired'`; it plans at `NOW + ttl_seconds` (still noop) and `NOW + ttl_seconds + 1s` (fresh proposal, old row `superseded_by_replan`), and asserts the body-change supersede reason.
- The `[dispatch_ticket_body_hash:…]` marker stays in `proposals.reason`: `spec_json`/`spec_hash` are not a cheap alternative because a non-null `spec_json` on a proposal routes it through the approve/run-spec paths in `proposals.mjs` (`recordedSpec` / `storedSpec`) and auto-approval hash checks. Human-facing views (inbox/web) are outside this PR's owned paths, so the marker is not stripped there; a follow-up can strip it in the renderers if it proves noisy.
