### PR TITLE
docs(kernel-and-packs): reattach update-pins paragraph

### DIFF
--- a/docs/kernel-and-packs.md
+++ b/docs/kernel-and-packs.md
@@ -138,11 +138,11 @@ re-pins built-in agent definitions also hashes every file under the built-in
 (`hashHarnessRoots`, `updateHarnessPins`, `verifyHarnessPins`); `loadRegistry`
 validates a supplied `harnessRoots` array against this file at load time,
 failing closed exactly like the per-agent pin check, on either an unpinned
-file or content that has drifted from its pin:
+file or content that has drifted from its pin.
 
 Adding or removing any file under `shared/` requires re-running
 `bun event-runtime/cli.mjs update-pins`. The repository verification gate
-enforces that the committed harness pins remain current.
+enforces that the committed harness pins remain current:
 
 ```sh
 bun event-runtime/cli.mjs update-pins --check


### PR DESCRIPTION
Fixes watt-mind/factory#1729

Restores the update-pins gate command’s explanatory context in the kernel-and-packs guide.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `grep -n -A2 'drifted from its pin' docs/kernel-and-packs.md && grep -n -B3 'update-pins --check' docs/kernel-and-packs.md` | pass | prose and fence adjacency confirmed |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,176 pass, 0 failures |
| UX critique | factory-ux-critic | skipped | docs-only change; no user-facing surface |

UX critique: skipped

run:run_38dda4e4-e2cf-4d5a-90cd-4765074a226e