### PR TITLE
fix(floor): guard factory floor delivery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,10 +128,10 @@ test -n "$run_id" || { echo "no CI workflow run found for this commit" >&2; exit
 gh run watch "$run_id" --exit-status --interval 60
 ```
 
-`gh run list` and `gh run watch` use GitHub's REST API. Do not default to
-`gh pr checks <PR> --watch --interval 60`: it polls GraphQL every 10 seconds
-by default and can exhaust the shared GraphQL budget. If it is unavoidable,
-`--interval 60` or greater is mandatory. A green `gh run watch` covers one
+`gh run list` and `gh run watch` use GitHub's REST API. Do not default to the
+GraphQL-backed `gh pr checks` waiter: it polls every 10 seconds by default and
+can exhaust the shared GraphQL budget. If that fallback is unavoidable, use an
+interval of at least 60 seconds. A green `gh run watch` covers one
 workflow; before a merge that must be fully green, assert every check-run on
 the commit is completed and successful via REST
 (`gh api repos/<owner>/<repo>/commits/<sha>/check-runs`).
@@ -146,7 +146,7 @@ for i in $(seq 60); do curl -sf localhost:4222 >/dev/null && break; sleep 2; don
 
 **Never end your turn while background jobs are running.** Subagents must not park mid-flow or yield prematurely while waiting for slow commands, test suites, or background sub-processes. When an agent yields without active foreground execution, the orchestrator cannot distinguish between an agent legitimately waiting on slow work, an agent stalled needing a nudge, or an agent finished but under-reporting. Block on readiness (e.g. `gh run watch <run-id> --exit-status --interval 60`, `wait <pid>`, or bounded polling) until the work is complete before completing your turn.
 
-**GitHub Actions secondary rate limits.** Avoid rapid, unthrottled polling of GitHub's Actions and jobs APIs (e.g. tight loops calling `gh run view` or `gh api`). Aggressive polling triggers GitHub's secondary rate limits and blocks the harness. Prefer the REST-backed `gh run watch <run-id> --exit-status --interval 60`; `gh pr checks <PR> --watch --interval 60` or greater is the minimum only when that GraphQL-backed fallback is unavoidable.
+**GitHub Actions secondary rate limits.** Avoid rapid, unthrottled polling of GitHub's Actions and jobs APIs (e.g. tight loops calling `gh run view` or `gh api`). Aggressive polling triggers GitHub's secondary rate limits and blocks the harness. Prefer the REST-backed `gh run watch <run-id> --exit-status --interval 60`; the GraphQL-backed PR-check fallback must use an interval of at least 60 seconds when unavoidable.
 
 **Session scratchpad isolation.** Never use generic shared filenames (such as `pr-body.md` or `scratch/critique.json`) across concurrent tasks. Reviewer, implementer, and critic agents operating in shared session scratchpads must namespace all temporary files by ticket ID or session identifier (e.g. `pr-body-<TICKET-ID>.md`, `<TICKET-ID>-critique.json`) to prevent cross-agent collisions and silent overwrites.
 

--- a/build/emit.mjs
+++ b/build/emit.mjs
@@ -529,6 +529,19 @@ function floorStatus({ preferRunning = false } = {}) {
   });
 }
 
+/**
+ * The current checkout is CI's one hermetic floor-delivery target. Unlike the
+ * configured-repository report below, it never follows config/repos.yaml to a
+ * sibling or the operator's live checkout.
+ */
+function runningFloorStatus() {
+  const agents = path.join(ROOT, "AGENTS.md");
+  if (!existsSync(agents)) return { agents, state: "missing" };
+  const body = read(agents);
+  if (!body.includes(FLOOR_BEGIN)) return { agents, state: "missing" };
+  return { agents, state: floorIsCurrent(body, floor) ? "ok" : "stale" };
+}
+
 if (process.argv.includes("--sync-floor")) {
   console.log("\nsyncing the floor into each configured repo's AGENTS.md:");
   // Writes target the running checkout for this repository, never the
@@ -592,6 +605,24 @@ if (CHECK) {
   }
   console.log(`ok — ${expected.length} generated files match shared/`);
 
+  // CI must reject a factory commit whose own committed floor splice is stale.
+  // This is intentionally independent of config/repos.yaml: that file names
+  // operator-local sibling checkouts, which are useful to report but cannot
+  // make a hermetic factory CI run pass or fail.
+  const runningFloor = runningFloorStatus();
+  let checkExitCode = 0;
+  if (runningFloor.state !== "ok") {
+    console.error(
+      `Current checkout floor is ${runningFloor.state}: ${rel(runningFloor.agents)}`,
+    );
+    console.error(
+      "Run `bun build/emit.mjs --sync-floor` and commit AGENTS.md.",
+    );
+    checkExitCode = 1;
+  } else {
+    console.log("ok — current checkout AGENTS.md carries the current floor");
+  }
+
   // A reproducible dist/ proves the floor was WRITTEN, not that it was
   // DELIVERED. Checking only the former passed green on 2026-08-04 while all
   // four repos carried no floor at all — the check was measuring the half that
@@ -618,7 +649,7 @@ if (CHECK) {
       `floor delivery: ${repos.length} repo(s) carrying the current floor`,
     );
   }
-  process.exit(0);
+  process.exit(checkExitCode);
 }
 
 console.log(

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -325,6 +325,37 @@ test("floor check uses the running checkout when its configured path is missing"
   }
 });
 
+test("floor check fails when the running checkout's floor is stale", () => {
+  const fixture = makeEmitFixture();
+  const staleAgents =
+    "<!-- FACTORY:FLOOR:BEGIN -->\nstale floor\n<!-- FACTORY:FLOOR:END -->\n";
+
+  try {
+    writeFileSync(path.join(fixture, "AGENTS.md"), staleAgents);
+    writeFileSync(path.join(fixture, "config", "repos.yaml"), "repos: []\n");
+
+    const result = Bun.spawnSync({
+      cmd: ["bun", "build/emit.mjs", "--check"],
+      cwd: fixture,
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+
+    expect(result.exitCode).toBe(1);
+    expect(result.stderr.toString()).toContain(
+      "Current checkout floor is stale: AGENTS.md",
+    );
+    expect(result.stderr.toString()).toContain(
+      "bun build/emit.mjs --sync-floor",
+    );
+    expect(result.stdout.toString()).toContain(
+      "floor delivery: no configured repo checked out here — not verified",
+    );
+  } finally {
+    rmSync(fixture, { recursive: true, force: true });
+  }
+});
+
 test("sync-floor writes the running checkout, never the configured one", () => {
   const fixture = makeEmitFixture();
   const configured = mkdtempSync(path.join(tmpdir(), "emit-floor-live-"));

--- a/docs/kernel-and-packs.md
+++ b/docs/kernel-and-packs.md
@@ -153,3 +153,11 @@ call (`event-runtime/cli/serve.mjs`, `event-runtime/cli/work.mjs`), recording
 the per-run materialized-harness content hash on `RunSpec`/execution
 receipts, and surfacing harness pins on the Web UI's Run detail view are
 tracked as follow-up work, outside this ticket's owned paths.
+
+## Floor delivery
+
+`shared/floor.md` is spliced into each repository's committed `AGENTS.md`.
+After every edit to that source, run `bun build/emit.mjs --sync-floor` and
+commit the regenerated `AGENTS.md` for the repository being changed. The
+factory verification gate rejects a stale floor splice in its own checkout;
+reports about configured sibling checkouts remain informational.


### PR DESCRIPTION
Fixes watt-mind/factory#1743

CI now rejects a stale factory AGENTS.md floor splice while sibling checkout reports remain informational.

## Validation

| Check                | Command                                                                                  | Result  | Notes                                      |
| -------------------- | ---------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun build/emit.mjs --check && bun test build/emit.test.mjs --timeout 20000`             | pass    | 31 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2178 passed, 10 skipped, 0 failures        |
| UX critique          | `factory-ux-critic`                                                                     | not run | backend/docs tooling; no user-facing surface |

UX critique: skipped

run:run_d4457509-0079-4ee6-b595-2b35c7d21b57