### PR TITLE
feat(cli): proposals --json / --approvable with a stable schema

### DIFF
--- a/event-runtime/cli/proposals.mjs
+++ b/event-runtime/cli/proposals.mjs
@@ -1,22 +1,48 @@
 import { pad, withClient } from "./shared.mjs";
 
-export async function proposals(client) {
+function proposalRow(proposal) {
+  const expired = proposal.expired === true;
+  return {
+    id: proposal.id,
+    runId: proposal.runId,
+    eventId: proposal.eventId,
+    decision: proposal.decision,
+    agent: proposal.agent,
+    ttlSeconds: proposal.ttl_seconds,
+    createdAt: proposal.created_at,
+    expired,
+    approvable: proposal.decision === "run" && !expired,
+    reason: proposal.reason ?? null,
+  };
+}
+
+export async function proposals(client, args = []) {
   const { proposals: open } = await client.proposals();
-  if (open.length === 0) {
+  const json = args.includes("--json");
+  const rows = open.map(proposalRow);
+  const displayed = args.includes("--approvable")
+    ? rows.filter((row) => row.approvable)
+    : rows;
+
+  if (json) {
+    console.log(JSON.stringify(displayed));
+    return displayed;
+  }
+  if (displayed.length === 0) {
     console.log("no open proposals");
     return;
   }
   console.log(
     `${pad("ID", 42)}${pad("DECISION", 14)}${pad("AGENT", 26)}${pad("TTL", 8)}${pad("EXPIRED", 9)}REASON`,
   );
-  for (const p of open) {
+  for (const p of displayed) {
     console.log(
-      `${pad(p.id, 42)}${pad(p.decision, 14)}${pad(p.agent, 26)}${pad(`${p.ttl_seconds}s`, 8)}${pad(p.expired ? "yes" : "no", 9)}${p.reason ?? "-"}`,
+      `${pad(p.id, 42)}${pad(p.decision, 14)}${pad(p.agent, 26)}${pad(`${p.ttlSeconds}s`, 8)}${pad(p.expired ? "yes" : "no", 9)}${p.reason ?? "-"}`,
     );
   }
   console.log(`\napprove with: bun event-runtime/cli.mjs approve <id>`);
 }
 
 export default function proposalsCommand(args) {
-  return withClient((client) => proposals(client));
+  return withClient((client) => proposals(client, args));
 }

--- a/event-runtime/cli/proposals.test.mjs
+++ b/event-runtime/cli/proposals.test.mjs
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+import { proposals } from "./proposals.mjs";
+
+const rows = [
+  {
+    id: "proposal-run",
+    runId: "run-1",
+    eventId: "event-1",
+    decision: "run",
+    agent: "worker@1",
+    ttl_seconds: 900,
+    created_at: "2026-08-30T12:00:00.000Z",
+    expired: false,
+    reason: null,
+  },
+  {
+    id: "proposal-human-needed",
+    runId: "run-2",
+    eventId: "event-2",
+    decision: "human_needed",
+    agent: "worker@1",
+    ttl_seconds: 900,
+    created_at: "2026-08-30T12:01:00.000Z",
+    expired: false,
+    reason: "policy requires a human",
+  },
+  {
+    id: "proposal-expired",
+    runId: "run-3",
+    eventId: "event-3",
+    decision: "run",
+    agent: "worker@1",
+    ttl_seconds: 900,
+    created_at: "2026-08-30T12:02:00.000Z",
+    expired: true,
+    reason: "expired",
+  },
+];
+
+async function captureOutput(run) {
+  const lines = [];
+  const originalLog = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  try {
+    await run();
+  } finally {
+    console.log = originalLog;
+  }
+  return lines;
+}
+
+function client(proposals = rows) {
+  return { proposals: async () => ({ proposals }) };
+}
+
+describe("proposals command", () => {
+  test("prints the stable JSON schema with derived approvability", async () => {
+    const lines = await captureOutput(() => proposals(client(), ["--json"]));
+
+    expect(lines).toHaveLength(1);
+    const output = JSON.parse(lines[0]);
+    expect(output).toHaveLength(3);
+    expect(Object.keys(output[0])).toEqual([
+      "id",
+      "runId",
+      "eventId",
+      "decision",
+      "agent",
+      "ttlSeconds",
+      "createdAt",
+      "expired",
+      "approvable",
+      "reason",
+    ]);
+    expect(output).toEqual([
+      {
+        id: "proposal-run",
+        runId: "run-1",
+        eventId: "event-1",
+        decision: "run",
+        agent: "worker@1",
+        ttlSeconds: 900,
+        createdAt: "2026-08-30T12:00:00.000Z",
+        expired: false,
+        approvable: true,
+        reason: null,
+      },
+      expect.objectContaining({
+        id: "proposal-human-needed",
+        decision: "human_needed",
+        expired: false,
+        approvable: false,
+      }),
+      expect.objectContaining({
+        id: "proposal-expired",
+        decision: "run",
+        expired: true,
+        approvable: false,
+      }),
+    ]);
+  });
+
+  test("filters approvable rows in JSON and text output", async () => {
+    const jsonLines = await captureOutput(() =>
+      proposals(client(), ["--approvable", "--json"]),
+    );
+    expect(JSON.parse(jsonLines[0]).map((row) => row.id)).toEqual([
+      "proposal-run",
+    ]);
+
+    const textLines = await captureOutput(() =>
+      proposals(client(), ["--approvable"]),
+    );
+    expect(textLines.join("\n")).toContain("proposal-run");
+    expect(textLines.join("\n")).not.toContain("proposal-human-needed");
+    expect(textLines.join("\n")).not.toContain("proposal-expired");
+  });
+
+  test("prints an empty JSON array for no open proposals", async () => {
+    const lines = await captureOutput(() => proposals(client([]), ["--json"]));
+    expect(lines).toEqual(["[]"]);
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1755

Use --json for stable automation or --approvable to list only actionable proposals.

## Validation

| Check                | Command                                                                            | Result  | Notes                               |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | ----------------------------------- |
| Verification Command | `bun test event-runtime/cli/proposals.test.mjs --timeout 20000`                   | pass    | 3 tests, 0 failures                 |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | unit, emit, format, lint exit 0     |
| UX critique          | factory-ux-critic                                                                  | skipped | no user-facing surface              |

UX critique: skipped — no user-facing surface

run:run_d32f5adc-064e-4fee-9260-a0c0657a0968
