### PR TITLE
fix(auto-approval): admit ci-doctor chain policy

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -51,6 +51,7 @@ chain_auto_approval:
     - factory.triage.requested
     - factory.triage-apply.requested
     - factory.dispatch.requested
+    - factory.ci-diagnose.requested
     - factory.merge.requested
     - factory.merge-review.requested
     - factory.merge-fix.requested

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -472,10 +472,14 @@ requires the emitted repository to match the predecessor input.
 
 `config/policy.yaml` is the only allowlist for unattended chain proposals. Its
 closed set covers `factory.work.requested`, `factory.triage.requested`,
-`factory.triage-apply.requested`, and `factory.dispatch.requested`; missing or
-malformed policy means watched. The event must have been admitted with source
-`chain`, and the normal proposal, lifecycle, journal, budget, and worker gates
-remain in force.
+`factory.triage-apply.requested`, `factory.dispatch.requested`, and the
+read-only `factory.ci-diagnose.requested`; missing or malformed policy means
+watched. The event must have been admitted with source `chain`, and the normal
+proposal, lifecycle, journal, budget, and worker gates remain in force.
+
+`factory.ci-diagnose.requested` runs `ci-doctor@2`, which is non-mutating and
+limited to `gh:read`; its downstream `ci-rerun` and `dispatch` edges retain
+their separate approval gates.
 
 Dispatch is re-read immediately before approval: it must still be Todo,
 unassigned, `ai:agent-ready`, inside its lease cap, and disjoint from active

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -387,14 +387,29 @@ log(
   `${ciCaptureProposal.runId} → COMPLETED (ci-log-capture@1, emitted ci-log artifact)`,
 );
 
-// Hop 2: ci-doctor@2 (artifacts workspace type with $.artifactHash.ci-log)
-const ciDoctorProposal = await openProposalFor(ciEventId, {
+// Hop 2: ci-doctor@2 (artifacts workspace type with $.artifactHash.ci-log).
+// The chain policy may approve the diagnosis unattended (GH-1727): the
+// proposal is then already decided by the time we see it, so only click
+// through when it is still waiting for a human.
+const ciDoctorProposal = await proposalFor(ciEventId, {
   agent: "ci-doctor@2",
+  status: "all",
 });
-await client.approve(ciDoctorProposal.id);
+let ciDoctorAuto = ciDoctorProposal.status !== "open";
+if (!ciDoctorAuto) {
+  try {
+    await client.approve(ciDoctorProposal.id);
+  } catch (err) {
+    // The chain pass may win the race between our read and our click.
+    const { proposals } = await client.proposals("all");
+    const decided = proposals.find((p) => p.id === ciDoctorProposal.id);
+    if (decided?.status !== "approved") throw err;
+    ciDoctorAuto = true;
+  }
+}
 await runTerminal(ciDoctorProposal.runId, "COMPLETED");
 log(
-  `${ciDoctorProposal.runId} → COMPLETED (ci-doctor@2, verdict FLAKE, artifacts workspace)`,
+  `${ciDoctorProposal.runId} → COMPLETED (ci-doctor@2, verdict FLAKE, artifacts workspace${ciDoctorAuto ? ", auto-approved" : ""})`,
 );
 
 // Hop 3: ci-rerun@1 (command adapter follow-up with causationId)

--- a/event-runtime/lib/artifact-inputs.test.mjs
+++ b/event-runtime/lib/artifact-inputs.test.mjs
@@ -255,23 +255,34 @@ describe("POC chain: capture a CI log, diagnose from the stored bytes (OPS-372)"
     // The chain passes the HASH, not the bytes.
     expect(resolveChains(db, registry).emitted).toBe(1);
     planAdmittedEvents(db, registry, opts);
-    const diagnose = openProposals(db, {}).find(
-      (p) => p.spec?.agent === "ci-doctor@2",
-    );
+    // Whether the diagnosis waits for a human or was approved unattended is
+    // the chain policy's call (GH-1727), not this test's: it is about the
+    // artifact plumbing, so accept the proposal in either state.
+    const diagnose = db
+      .query(`SELECT * FROM proposals ORDER BY created_at, rowid`)
+      .all()
+      .map((row) => ({ ...row, spec: JSON.parse(row.spec_json) }))
+      .find((p) => p.spec?.agent === "ci-doctor@2");
     expect(diagnose.spec.input.logArtifact).toBe(logEntry.sha256);
 
     // Node 2: the doctor reads ./failed.log, proving materialization happened.
-    const diagnoseRun = approveProposal(db, registry, diagnose.id, {
-      actor: "operator",
-      policyVersion: "git:test",
-    });
+    if (diagnose.status === "open") {
+      expect(
+        approveProposal(db, registry, diagnose.id, {
+          actor: "operator",
+          policyVersion: "git:test",
+        }).approved,
+      ).toBe(true);
+    } else {
+      expect(diagnose.status).toBe("approved");
+    }
     expect((await runOnce(db, registry, adapters, opts)).terminalState).toBe(
       "COMPLETED",
     );
     const diagnosis = JSON.parse(
       db
         .query(`SELECT result_json FROM results WHERE run_id = ?`)
-        .get(diagnoseRun.runId).result_json,
+        .get(diagnose.run_id).result_json,
     );
     expect(diagnosis.artifact.evidenceLines).toEqual(["socket hang up"]);
     expect(diagnosis.evidence.logBytes).toBeGreaterThan(0);

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -33,6 +33,9 @@ export const CHAIN_AUTO_APPROVAL_EVENT_TYPES = new Set([
   "factory.triage.requested",
   "factory.triage-apply.requested",
   "factory.dispatch.requested",
+  // ci-doctor@2 is non-mutating and gh:read-only; ci-rerun and dispatch
+  // downstream edges retain their own approval gates.
+  "factory.ci-diagnose.requested",
   "factory.merge.requested",
   "factory.merge-review.requested",
   "factory.merge-fix.requested",

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test";
+import { copyFileSync, mkdirSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { withTmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-auto-approval-test-mjs";
 
 import {
   autoApproveChains,
+  buildChainApprovalPolicy,
   chainRuntimeGuard,
   CHAIN_AUTO_APPROVAL_ACTOR,
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
@@ -10,6 +14,7 @@ import {
   loadChainAutoApprovalPolicy,
 } from "./auto-approval.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import { createHookRegistry, hookDecisionsFor } from "./hooks.mjs";
 import { admitEvent } from "./intake.mjs";
@@ -489,12 +494,59 @@ describe("declared chain command edge characterization (WM-469)", () => {
 });
 
 describe("chain auto approval (WM-357)", () => {
-  test("git-owned policy is an explicit closed allowlist", async () => {
-    const loaded = loadChainAutoApprovalPolicy();
-    expect([...loaded.allowed].sort()).toEqual(
-      [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
-    );
-    expect(loaded.reason).toBeNull();
+  test("git-owned policy is an explicit closed allowlist", () => {
+    withTmpDir("factory-auto-approval-", (root) => {
+      mkdirSync(path.join(root, "config"));
+      copyFileSync(
+        path.join(FACTORY_ROOT, "config", "policy.example.yaml"),
+        path.join(root, "config", "policy.yaml"),
+      );
+      const loaded = loadChainAutoApprovalPolicy({ root });
+      expect([...loaded.allowed].sort()).toEqual(
+        [...CHAIN_AUTO_APPROVAL_EVENT_TYPES].sort(),
+      );
+      expect(loaded.reason).toBeNull();
+    });
+  });
+
+  test("ci-doctor diagnoses can be explicitly auto-approved by chain policy", () => {
+    withTmpDir("factory-auto-approval-", (root) => {
+      mkdirSync(path.join(root, "config"));
+      writeFileSync(
+        path.join(root, "config", "policy.yaml"),
+        "chain_auto_approval:\n  allowed_event_types:\n    - factory.ci-diagnose.requested\n",
+      );
+
+      const allowed = loadChainAutoApprovalPolicy({ root });
+      expect(allowed.reason).toBeNull();
+      expect(
+        buildChainApprovalPolicy("factory.ci-diagnose.requested", {
+          source: "chain",
+          policy: allowed,
+        }),
+      ).toEqual({
+        source: "chain",
+        mode: "auto",
+        eventType: "factory.ci-diagnose.requested",
+      });
+
+      writeFileSync(
+        path.join(root, "config", "policy.yaml"),
+        "chain_auto_approval:\n  allowed_event_types: []\n",
+      );
+      const watched = loadChainAutoApprovalPolicy({ root });
+      expect(
+        buildChainApprovalPolicy("factory.ci-diagnose.requested", {
+          source: "chain",
+          policy: watched,
+        }),
+      ).toEqual({
+        source: "chain",
+        mode: "watched",
+        eventType: "factory.ci-diagnose.requested",
+        reason: "event_type_not_allowlisted",
+      });
+    });
   });
 
   test("merge-scan REVIEW proposals auto-approve factory.merge-review.requested (WM-907)", async () => {

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -1,9 +1,11 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-chain-test-mjs";
-import { describe, expect, test } from "bun:test";
-import { cpSync, writeFileSync } from "node:fs";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cpSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { memoryForge } from "../../lib/forge/memory.mjs";
 import * as fake from "./adapters/fake.mjs";
+import { CHAIN_AUTO_APPROVAL_ACTOR } from "./auto-approval.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
 import {
   admitChainEvent,
   buildChainInput,
@@ -44,7 +46,49 @@ function failedRunEnvelope(overrides = {}) {
   };
 }
 
-function harness() {
+/**
+ * The chain auto-approval allowlist is read from `<reposRoot>/config/policy.yaml`
+ * at plan time (falling back to `config/policy.example.yaml` when the instance
+ * file is absent). Tests must not depend on whichever policy the checkout
+ * happens to carry, so each harness pins FACTORY_REPOS_ROOT to a temp root
+ * whose policy is the shipped example with an explicit allowlist (GH-1727).
+ */
+const CI_DIAGNOSE = "factory.ci-diagnose.requested";
+const envRestores = [];
+
+function chainPolicyRoot(allowed) {
+  const root = tmpDir("evrt-chain-policy-");
+  mkdirSync(path.join(root, "config"));
+  const policy = Bun.YAML.parse(
+    readFileSync(
+      path.join(FACTORY_ROOT, "config", "policy.example.yaml"),
+      "utf8",
+    ),
+  );
+  policy.chain_auto_approval = { allowed_event_types: allowed };
+  // The day-budget guard scans the operator's real ~/.factory/logs; no
+  // budget means no scan, keeping the harness hermetic.
+  delete policy.budget;
+  // YAML is a JSON superset, so the parsed object round-trips as-is.
+  writeFileSync(
+    path.join(root, "config", "policy.yaml"),
+    JSON.stringify(policy, null, 2),
+  );
+  const previous = process.env.FACTORY_REPOS_ROOT;
+  process.env.FACTORY_REPOS_ROOT = root;
+  envRestores.push(() => {
+    if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+    else process.env.FACTORY_REPOS_ROOT = previous;
+  });
+  return root;
+}
+
+afterEach(() => {
+  while (envRestores.length) envRestores.pop()();
+});
+
+function harness({ allowed = [CI_DIAGNOSE] } = {}) {
+  chainPolicyRoot(allowed);
   const dir = tmpDir("evrt-chain-");
   const db = openDb(path.join(dir, "runtime.db"));
   const workspaces = tmpDir("evrt-chain-ws-");
@@ -146,29 +190,92 @@ describe("buildChainInput", () => {
   });
 });
 
+/** Every proposal (any status) whose spec targets `agent`, oldest first. */
+function proposalsForAgent(db, agent) {
+  return db
+    .query(`SELECT * FROM proposals ORDER BY created_at, rowid`)
+    .all()
+    .map((row) => ({
+      ...row,
+      spec: row.spec_json && JSON.parse(row.spec_json),
+    }))
+    .filter((p) => p.spec?.agent === agent);
+}
+
 /**
  * github.workflow-run.failed now lands on ci-log-capture@1, which stores the
  * log as an artifact and chains to ci-doctor@2 (OPS-372). Run that first hop
  * so these tests stay about the *verdict* edges they were written for.
+ *
+ * With `factory.ci-diagnose.requested` allowlisted (the harness default) the
+ * planner's chain pass approves the diagnosis unattended: no operator click,
+ * the run is already QUEUED when planning returns (GH-1727).
  */
 async function throughCapture(h, eventId) {
   const capture = await h.runToCompletion(eventId);
   expect(resolveChains(h.db, registry).emitted).toBe(1);
   planAdmittedEvents(h.db, registry, { policyVersion: PV });
-  const diagnose = openProposals(h.db, {}).find(
-    (p) => p.spec?.agent === "ci-doctor@2",
-  );
-  expect(diagnose).toBeTruthy();
-  const approved = approveProposal(h.db, registry, diagnose.id, {
-    actor: "operator",
-    policyVersion: PV,
-  });
+  expect(
+    openProposals(h.db, {}).find((p) => p.spec?.agent === "ci-doctor@2"),
+  ).toBeUndefined();
+  const [diagnose, ...extra] = proposalsForAgent(h.db, "ci-doctor@2");
+  expect(extra).toEqual([]);
+  expect(diagnose.status).toBe("approved");
+  expect(diagnose.decided_by).toBe(CHAIN_AUTO_APPROVAL_ACTOR);
+  const run = h.db
+    .query(`SELECT state FROM runs WHERE run_id = ?`)
+    .get(diagnose.run_id);
+  expect(["APPROVED", "QUEUED"]).toContain(run.state);
   const summary = await runOnce(h.db, registry, h.adapters, h.workerOpts);
   expect(summary.terminalState).toBe("COMPLETED");
-  return { capture, diagnoseRunId: approved.runId, diagnoseProposal: diagnose };
+  return {
+    capture,
+    diagnoseRunId: diagnose.run_id,
+    diagnoseProposal: diagnose,
+  };
 }
 
 describe("discovered chain: ci-doctor → follow-up (OPS-223)", () => {
+  test("ci-doctor stays a watched proposal when the allowlist omits factory.ci-diagnose.requested", async () => {
+    const h = harness({ allowed: ["factory.work.requested"] });
+    const { db, adapters, workerOpts, runToCompletion } = h;
+    expect(
+      admitEvent(db, registry, failedRunEnvelope({ eventId: "gh-watched-1" }))
+        .admitted,
+    ).toBe(true);
+    await runToCompletion("gh-watched-1");
+    expect(resolveChains(db, registry).emitted).toBe(1);
+    planAdmittedEvents(db, registry, { policyVersion: PV });
+
+    const diagnose = openProposals(db, {}).find(
+      (p) => p.spec?.agent === "ci-doctor@2",
+    );
+    expect(diagnose).toBeTruthy();
+    expect(diagnose.status).toBe("open");
+    expect(diagnose.reason).toBe(
+      "auto_approval_ineligible:run_approval_policy_watched",
+    );
+    expect(diagnose.spec.approvalPolicy).toEqual({
+      source: "chain",
+      mode: "watched",
+      eventType: CI_DIAGNOSE,
+      reason: "event_type_not_allowlisted",
+    });
+    expect(
+      db.query(`SELECT state FROM runs WHERE run_id = ?`).get(diagnose.run_id)
+        .state,
+    ).toBe("PROPOSED");
+
+    // The human click still works exactly as before.
+    const approved = approveProposal(db, registry, diagnose.id, {
+      actor: "operator",
+      policyVersion: PV,
+    });
+    expect(approved.approved).toBe(true);
+    const summary = await runOnce(db, registry, adapters, workerOpts);
+    expect(summary.terminalState).toBe("COMPLETED");
+  });
+
   test("FLAKE verdict chains to a watched ci-rerun proposal with inherited correlation", async () => {
     const h = harness();
     const { db, runToCompletion } = h;


### PR DESCRIPTION
Fixes watt-mind/factory#1727

Allow operators to opt the read-only ci-doctor request into chain auto approval without disabling the chain policy.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/auto-approval.test.mjs --timeout 20000` | pass | 43 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; existing lint warnings |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_db1d47f6-46dc-4f5b-aa9e-6fdd31cb0af4

## Post-review
- CI was deterministically red because a checkout without `config/policy.yaml` falls back to `config/policy.example.yaml`, which this PR widened: the ci-doctor@2 proposal is now auto-approved by the planner's chain pass, so `openProposals(...).find(agent === "ci-doctor@2")` was `undefined` in the OPS-223 (chain.test.mjs), OPS-372 (artifact-inputs.test.mjs) and OPS-464 seed tests (`demo/seed.mjs` waited for an open proposal until SIGTERM).
- `event-runtime/lib/chain.test.mjs`: harness pins `FACTORY_REPOS_ROOT` to a temp policy root (shipped example + explicit allowlist, budget stanza dropped for hermeticity). The OPS-223 tests now assert the diagnosis is approved by `chain-auto-approval` with the run in APPROVED/QUEUED before the chain continues; a new case with an allowlist omitting `factory.ci-diagnose.requested` asserts the proposal stays open with `run_approval_policy_watched` and the human click still works.
- `event-runtime/lib/artifact-inputs.test.mjs` (OPS-372) accepts the ci-doctor proposal in either state; `event-runtime/demo/seed.mjs` (OPS-464 suite) approves only when still open and tolerates losing the race to the chain pass. Both files are outside the ticket's Owned Paths but fail from this diff alone.
- Verified: `bun test event-runtime/lib/chain.test.mjs event-runtime/lib/auto-approval.test.mjs`, ticket Verification Command, `bun test event-runtime/demo/seed.test.mjs` (5 pass), `bun run lint`, `bun test event-runtime/lib` (2194 pass), `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
