### PR TITLE
fix(worktree): disable dispatch demo seeding

### DIFF
--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -28,7 +28,7 @@ TICKET=""
 TYPE="feat"
 SLUG=""
 HERE=0
-SEED=1
+SEED="${FACTORY_WORKTREE_SEED:-1}"
 RESEED=0
 LIVE=0
 CHECKOUT_ONLY=0
@@ -40,6 +40,9 @@ PRESERVATION_REPORT="${FACTORY_WORKTREE_PRESERVATION_REPORT:-}"
 EXPECTED_LEASE_FILE="${FACTORY_WORKTREE_EXPECTED_LEASE_FILE:-}"
 EXPECTED_LEASE_PID="${FACTORY_WORKTREE_EXPECTED_LEASE_PID:-}"
 POS=0
+
+[[ "$SEED" == "0" || "$SEED" == "1" ]] \
+  || die "FACTORY_WORKTREE_SEED must be 0 or 1 (got '$SEED')"
 
 while [[ $# -gt 0 ]]; do
   case "$1" in
@@ -514,9 +517,10 @@ if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
       seed_ok=1
       break
     fi
-    if [[ "$seed_out" =~ "SQLITE_BUSY" || "$seed_out" =~ "database is locked" || "$seed_out" =~ "locked" || "$seed_out" =~ "internal_error" || "$seed_out" =~ "500" || "$seed_out" =~ "409" ]]; then
+    seed_exit=$?
+    if [[ "$seed_exit" -eq 78 || "$seed_out" =~ "SQLITE_BUSY" || "$seed_out" =~ "database is locked" || "$seed_out" =~ "locked" || "$seed_out" =~ "internal_error" || "$seed_out" =~ "500" || "$seed_out" =~ "409" ]]; then
       backoff_delay=$(( 1 << (seed_attempt - 1) ))
-      warn "demo seed hit transient lock/error (attempt $seed_attempt/$max_seed_attempts) — retrying in ${backoff_delay}s"
+      warn "demo seed hit retryable error (attempt $seed_attempt/$max_seed_attempts, exit $seed_exit) — retrying in ${backoff_delay}s"
       sleep "$backoff_delay"
       seed_attempt=$(( seed_attempt + 1 ))
     else

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -24,6 +24,40 @@
 # reinstalls only what bun decides is stale, and re-seeds only on --reseed.
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 
+# seed_demo_data <worktree> <api-port> <prefix>
+# Runs event-runtime/demo/seed.mjs with a bounded retry. The status is
+# captured directly from the command substitution (`|| seed_exit=$?`, which also
+# survives `set -e`) — an `if cmd; then` wrapper would leave `$?` reporting the
+# compound's (always-zero) status and make the retry arm unreachable (#1758). Exit 78 is the seed's typed adapter-probe
+# timeout; transient store contention is matched on output. Anything else dies.
+seed_demo_data() { # <worktree> <api-port> <prefix>
+  local wt="$1" api_port="$2" prefix="$3"
+  local seed_attempt=1 max_seed_attempts=5 seed_ok=0 seed_out="" seed_exit=0
+  local backoff_delay
+  while [[ $seed_attempt -le $max_seed_attempts ]]; do
+    seed_exit=0
+    seed_out=$(cd "$wt" && bun event-runtime/demo/seed.mjs --port "$api_port" --prefix "$prefix" 2>&1) || seed_exit=$?
+    if [[ $seed_exit -eq 0 ]]; then
+      printf '%s\n' "$seed_out"
+      seed_ok=1
+      break
+    fi
+    if [[ "$seed_exit" -eq 78 || "$seed_out" =~ "SQLITE_BUSY" || "$seed_out" =~ "database is locked" || "$seed_out" =~ "locked" || "$seed_out" =~ "internal_error" || "$seed_out" =~ "500" || "$seed_out" =~ "409" ]]; then
+      backoff_delay=$(( 1 << (seed_attempt - 1) ))
+      warn "demo seed hit retryable error (attempt $seed_attempt/$max_seed_attempts, exit $seed_exit) — retrying in ${backoff_delay}s"
+      sleep "$backoff_delay"
+      seed_attempt=$(( seed_attempt + 1 ))
+    else
+      printf '%s\n' "$seed_out" >&2
+      die "seed failed (exit $seed_exit) — see output above"
+    fi
+  done
+  if [[ "$seed_ok" -ne 1 ]]; then
+    printf '%s\n' "$seed_out" >&2
+    die "seed failed after $max_seed_attempts attempts — see output above"
+  fi
+}
+
 TICKET=""
 TYPE="feat"
 SLUG=""
@@ -507,31 +541,7 @@ if [[ "$SEED" -eq 1 && ( "$FRESH" -eq 1 || "$RESEED" -eq 1 ) ]]; then
   PREFIX="demo"
   [[ "$RESEED" -eq 1 && "$FRESH" -eq 0 ]] && PREFIX="demo-$(date +%s)"
   info "seeding demo data (prefix $PREFIX)"
-  seed_attempt=1
-  max_seed_attempts=5
-  seed_ok=0
-  seed_out=""
-  while [[ $seed_attempt -le $max_seed_attempts ]]; do
-    if seed_out=$(cd "$WT" && bun event-runtime/demo/seed.mjs --port "$API_PORT" --prefix "$PREFIX" 2>&1); then
-      printf '%s\n' "$seed_out"
-      seed_ok=1
-      break
-    fi
-    seed_exit=$?
-    if [[ "$seed_exit" -eq 78 || "$seed_out" =~ "SQLITE_BUSY" || "$seed_out" =~ "database is locked" || "$seed_out" =~ "locked" || "$seed_out" =~ "internal_error" || "$seed_out" =~ "500" || "$seed_out" =~ "409" ]]; then
-      backoff_delay=$(( 1 << (seed_attempt - 1) ))
-      warn "demo seed hit retryable error (attempt $seed_attempt/$max_seed_attempts, exit $seed_exit) — retrying in ${backoff_delay}s"
-      sleep "$backoff_delay"
-      seed_attempt=$(( seed_attempt + 1 ))
-    else
-      printf '%s\n' "$seed_out" >&2
-      die "seed failed — see output above"
-    fi
-  done
-  if [[ "$seed_ok" -ne 1 ]]; then
-    printf '%s\n' "$seed_out" >&2
-    die "seed failed after $max_seed_attempts attempts — see output above"
-  fi
+  seed_demo_data "$WT" "$API_PORT" "$PREFIX"
 elif [[ "$SEED" -eq 1 ]]; then
   info "existing database found — not reseeding (use --reseed for a fresh set)"
 else

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -57,6 +57,8 @@ const flag = (name) => {
 const port = Number(flag("--port") ?? process.env.FACTORY_EVENT_PORT ?? 7381);
 const prefix = flag("--prefix") ?? "demo";
 const pollMs = Number(flag("--poll-ms") ?? 300);
+const adapterProbeTimeoutMs = 30_000;
+const ADAPTER_PROBE_TIMEOUT_EXIT_CODE = 78;
 if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
   console.error("seed: --poll-ms must be an integer between 25 and 5000");
   process.exit(2);
@@ -159,25 +161,32 @@ async function until(what, fn, { timeoutMs = 30_000, everyMs = pollMs } = {}) {
   throw new Error(`timed out waiting for ${what}`);
 }
 
-async function proposalFor(eventId, { agent, status = "open" } = {}) {
-  return until(`proposal for ${agent ?? eventId}`, async () => {
-    const { proposals } = await client.proposals(
-      status === "open" ? undefined : "all",
-    );
-    return proposals.find((p) => {
-      if (status !== "all" && p.status !== status) return false;
-      const eventMatches =
-        p.spec?.idempotencyKey?.includes(eventId) ||
-        p.reason?.includes(eventId) ||
-        p.eventId === eventId ||
-        (p.spec?.input && JSON.stringify(p.spec.input).includes(eventId));
-      if (agent) {
-        const agentMatches = p.spec?.agent === agent || p.agent === agent;
-        return agentMatches && eventMatches;
-      }
-      return eventMatches;
-    });
-  });
+async function proposalFor(
+  eventId,
+  { agent, status = "open", timeoutMs } = {},
+) {
+  return until(
+    `proposal for ${agent ?? eventId}`,
+    async () => {
+      const { proposals } = await client.proposals(
+        status === "open" ? undefined : "all",
+      );
+      return proposals.find((p) => {
+        if (status !== "all" && p.status !== status) return false;
+        const eventMatches =
+          p.spec?.idempotencyKey?.includes(eventId) ||
+          p.reason?.includes(eventId) ||
+          p.eventId === eventId ||
+          (p.spec?.input && JSON.stringify(p.spec.input).includes(eventId));
+        if (agent) {
+          const agentMatches = p.spec?.agent === agent || p.agent === agent;
+          return agentMatches && eventMatches;
+        }
+        return eventMatches;
+      });
+    },
+    { timeoutMs },
+  );
 }
 
 async function openProposalFor(eventId, options = {}) {
@@ -248,7 +257,20 @@ try {
 // planning time, so probe with a throwaway event and inspect its proposal.
 const probeId = `${prefix}-adapter-probe`;
 await replay(envelope("adapter-probe", ["ok"]));
-const probe = await openProposalFor(probeId);
+let probe;
+try {
+  probe = await openProposalFor(probeId, {
+    timeoutMs: adapterProbeTimeoutMs,
+  });
+} catch (err) {
+  if (err?.message === `timed out waiting for proposal for ${probeId}`) {
+    console.error(
+      `seed_probe_timeout: no proposal for ${probeId} within ${adapterProbeTimeoutMs}ms`,
+    );
+    process.exit(ADAPTER_PROBE_TIMEOUT_EXIT_CODE);
+  }
+  throw err;
+}
 if (probe.spec?.adapter !== "fake") {
   await client.reject(
     probe.id,

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -158,7 +158,10 @@ async function until(what, fn, { timeoutMs = 30_000, everyMs = pollMs } = {}) {
     if (value) return value;
     await sleep(everyMs);
   }
-  throw new Error(`timed out waiting for ${what}`);
+  throw Object.assign(new Error(`timed out waiting for ${what}`), {
+    code: "SEED_TIMEOUT",
+    what,
+  });
 }
 
 async function proposalFor(
@@ -263,7 +266,7 @@ try {
     timeoutMs: adapterProbeTimeoutMs,
   });
 } catch (err) {
-  if (err?.message === `timed out waiting for proposal for ${probeId}`) {
+  if (err?.code === "SEED_TIMEOUT") {
     console.error(
       `seed_probe_timeout: no proposal for ${probeId} within ${adapterProbeTimeoutMs}ms`,
     );

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -638,6 +638,10 @@ function materializeWorktree({
     env: {
       ...process.env,
       FACTORY_WORKTREE_REPORT: reportPath,
+      // Dispatched agents need an isolated checkout and daemons, not the
+      // interactive demo fixture. Keep the script's default seeded for direct
+      // developer use; dispatch opts out explicitly.
+      FACTORY_WORKTREE_SEED: "0",
       FACTORY_WORKTREE_PRESERVE_ABANDONED: "1",
       FACTORY_WORKTREE_PRESERVATION_REPORT: preservationPath,
       // Revalidated by factory's worktree-up while it holds the per-ticket

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -10,6 +10,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import { spawnSync } from "node:child_process";
 import { Database } from "bun:sqlite";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import { MEMO_SCHEMA_VERSION, memoDigest, withProvenance } from "./memos.mjs";
@@ -958,5 +959,56 @@ describe("memos.json materialization (WM-810)", () => {
       artifactStore: tmpDir("evrt-memo-store-absent-"),
     });
     expect(existsSync(path.join(created.dir, "memos.json"))).toBe(false);
+  });
+});
+
+describe("bin/worktree-up.sh seed_demo_data (#1758)", () => {
+  const BIN = path.resolve(import.meta.dir, "..", "..", "bin");
+
+  // Drive the real `seed_demo_data` function (extracted from worktree-up.sh so
+  // the rest of the script — git, ports, daemons — stays out of the way) against
+  // a fake `event-runtime/demo/seed.mjs` under a temp worktree.
+  function runSeed(fakeSeedSource) {
+    const wt = tmpDir("evrt-seed-wt-");
+    mkdirSync(path.join(wt, "event-runtime", "demo"), { recursive: true });
+    writeFileSync(
+      path.join(wt, "event-runtime", "demo", "seed.mjs"),
+      fakeSeedSource,
+    );
+    const script = [
+      `source '${path.join(BIN, "worktree-common.sh")}'`,
+      `eval "$(sed -n '/^seed_demo_data() {/,/^}/p' '${path.join(BIN, "worktree-up.sh")}')"`,
+      `seed_demo_data '${wt}' 7999 demo`,
+    ].join("\n");
+    const r = spawnSync("bash", ["-c", script], { encoding: "utf8" });
+    return { ...r, wt };
+  }
+
+  test("retries exit 78 (adapter-probe timeout) and succeeds on the next attempt", () => {
+    const r = runSeed(
+      `import { existsSync, writeFileSync } from "node:fs";\n` +
+        `const marker = new URL("./attempted", import.meta.url).pathname;\n` +
+        `if (!existsSync(marker)) {\n` +
+        `  writeFileSync(marker, "1");\n` +
+        `  console.error("seed_probe_timeout: no proposal for demo-adapter-probe within 1ms");\n` +
+        `  process.exit(78);\n` +
+        `}\n` +
+        `console.log("seeded ok " + process.argv.slice(2).join(" "));\n`,
+    );
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("retryable error (attempt 1/5, exit 78)");
+    expect(r.stdout).toContain("seeded ok --port 7999 --prefix demo");
+    expect(
+      existsSync(path.join(r.wt, "event-runtime", "demo", "attempted")),
+    ).toBe(true);
+  });
+
+  test("dies on a non-retryable exit code without retrying", () => {
+    const r = runSeed(
+      `console.error("seed: refusing — runtime is not fake");\nprocess.exit(1);\n`,
+    );
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("seed failed (exit 1)");
+    expect(r.stderr).not.toContain("retryable error");
   });
 });

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -327,7 +327,7 @@ describe("worktree workspaces (WM-108)", () => {
     mkdirSync(path.join(repoDir, "bin"), { recursive: true });
     writeFileSync(
       path.join(repoDir, "bin", "worktree-up.sh"),
-      `#!/bin/bash\nset -e\nWT="${wtRoot}/$1"\necho "up $1 cwd=$PWD" >> "${callsLog}"\nif [[ -e "$WT/ports" || -e "$WT/run/serve.pid" || -e "$WT/run/worker.pid" || -e "$WT/run/web.pid" ]]; then\n  echo "stale daemon state for $1" >&2\n  exit 9\nfi\nmkdir -p "$WT/run"\nprintf '7740 7741\\n' > "$WT/ports"\ntouch "$WT/run/serve.pid" "$WT/run/worker.pid" "$WT/run/web.pid"\n`,
+      `#!/bin/bash\nset -e\nWT="${wtRoot}/$1"\necho "up $1 cwd=$PWD seed=\${FACTORY_WORKTREE_SEED:-unset}" >> "${callsLog}"\n[[ "\${FACTORY_WORKTREE_SEED:-}" == "0" ]] || { echo "dispatch must disable demo seeding" >&2; exit 10; }\nif [[ -e "$WT/ports" || -e "$WT/run/serve.pid" || -e "$WT/run/worker.pid" || -e "$WT/run/web.pid" ]]; then\n  echo "stale daemon state for $1" >&2\n  exit 9\nfi\nmkdir -p "$WT/run"\nprintf '7740 7741\\n' > "$WT/ports"\ntouch "$WT/run/serve.pid" "$WT/run/worker.pid" "$WT/run/web.pid"\n`,
     );
     writeFileSync(
       path.join(repoDir, "bin", "worktree-down.sh"),
@@ -420,7 +420,7 @@ describe("worktree workspaces (WM-108)", () => {
 
   test("up is delegated to the repo's script; the tree is reachable at ./repo; verify rides along", () => {
     const { dir, worktree } = make("wtrepo", "WM-1", "run_wt1");
-    expect(calls()).toContainEqual(`up WM-1 cwd=${repoDir}`);
+    expect(calls()).toContainEqual(`up WM-1 cwd=${repoDir} seed=0`);
     expect(worktree).toEqual({
       repo: "wtrepo",
       ticket: "WM-1",
@@ -439,6 +439,9 @@ describe("worktree workspaces (WM-108)", () => {
     expect(
       JSON.parse(readFileSync(path.join(dir, ".worktree.json"), "utf8")).ticket,
     ).toBe("WM-1");
+    expect(existsSync(path.join(wtRoot, "WM-1", ".factory", "demo.db"))).toBe(
+      false,
+    );
     expect(destroyWorkspace(dir)).toBe(true);
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1758

Dispatch worktrees skip demo seeding and retry typed adapter-probe timeouts.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/workspace.test.mjs --timeout 20000` | pass | 35 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2189 pass, 10 skipped; lint warnings only |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped
run:run_7131deed-3b80-49a7-a101-4e2ad10f0d86

## Post-review

Reviewer FIX addressed on `fe229022dadf95c9ee57a69682f6f8b705e345d0`:
- `bin/worktree-up.sh`: the retry loop read `$?` after an `if` compound (always 0), so the exit-78 arm was dead and a probe timeout still died. The seed run now captures its status directly (`|| seed_exit=$?`, survives `set -e`) inside a new `seed_demo_data` function; 78 → bounded retry, other → die.
- `event-runtime/lib/workspace.test.mjs`: bash fixture test drives the real `seed_demo_data` with a fake `seed.mjs` that exits 78 once then 0 (retry path), plus a non-retryable exit-1 case.
- `event-runtime/demo/seed.mjs`: probe timeout detected via `err.code === "SEED_TIMEOUT"` instead of a message-string match.

Verification: `bun test event-runtime/lib/workspace.test.mjs --timeout 20000` 37 pass; `bun run lint` ok (warnings only); `bun test event-runtime/lib` 2194 pass / 10 skip / 0 fail; `bun build/emit.mjs --check` exit 0 (still prints the AGENTS.md floor-delivery warning for the operator's live checkout, not this branch); `bun run format:check` clean; `bun run check` ok.
