### PR TITLE
test(worker): isolate supervisor lock home

### DIFF
--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -963,16 +963,20 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   test("same-identity dispatch claims share the supervisor lock when event home is isolated", async () => {
     const previousEventHome = process.env.FACTORY_EVENT_HOME;
     const previousLocksDir = process.env.FACTORY_LOCKS_DIR;
+    const previousHome = process.env.HOME;
     const repoName = "wt-worker";
-    const supervisorLock = dispatchLockPath(
-      repoName,
-      path.join(homedir(), ".factory", "locks"),
-    );
-    process.env.FACTORY_EVENT_HOME = tmpDir("evrt-isolated-event-home-");
-    delete process.env.FACTORY_LOCKS_DIR;
+    const scratchHome = tmpDir("evrt-isolated-lock-home-");
+    let supervisorLock;
     let claimCalls = 0;
 
     try {
+      process.env.HOME = scratchHome;
+      process.env.FACTORY_EVENT_HOME = tmpDir("evrt-isolated-event-home-");
+      delete process.env.FACTORY_LOCKS_DIR;
+      supervisorLock = dispatchLockPath(
+        repoName,
+        path.join(homedir(), ".factory", "locks"),
+      );
       expect(acquireClaimLock(supervisorLock)).toBe(true);
       const db = openDb(":memory:");
       queueRun(
@@ -1009,6 +1013,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       else process.env.FACTORY_EVENT_HOME = previousEventHome;
       if (previousLocksDir === undefined) delete process.env.FACTORY_LOCKS_DIR;
       else process.env.FACTORY_LOCKS_DIR = previousLocksDir;
+      if (previousHome === undefined) delete process.env.HOME;
+      else process.env.HOME = previousHome;
     }
   });
 

--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -1007,7 +1007,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
       expect(summary.reasonCode).toBe("claim_lock_contention");
       expect(claimCalls).toBe(0);
     } finally {
-      releaseClaimLock(supervisorLock);
+      if (supervisorLock) releaseClaimLock(supervisorLock);
       if (previousEventHome === undefined)
         delete process.env.FACTORY_EVENT_HOME;
       else process.env.FACTORY_EVENT_HOME = previousEventHome;


### PR DESCRIPTION
Fixes watt-mind/factory#1567

Confines the supervisor-lock test to scratch HOME so sibling supervisors cannot interfere through ~/.factory/locks/wt-worker.dispatch.lock.

## Validation

| Check                | Command                                                                                       | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/worker-dispatch-hardening.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000` | pass    | 173 tests, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | unit, emit, format, and lint clean         |
| UX critique          | factory-ux-critic                                                                             | not run | no user-facing surface (test-only change)  |

UX critique: skipped
run:run_54afd294-ed0b-42ae-b640-a2ac867c2b3f

## Post-review

- Guarded the supervisor-lock release in the isolated-lock-home test `finally` with `if (supervisorLock)` so an early throw before `acquireClaimLock` is not masked by a release error (reviewer fold). Merged `origin/develop`. Verified: targeted tests x3, lint, `bun test event-runtime/lib`, emit --check, format:check, check.
