### PR TITLE
fix(api): bound ticket index queries by activity window

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -932,25 +932,80 @@ export function ticketIndexView(db, options = {}) {
     }
   }
 
+  // Keep every JSON-bearing table bounded by the requested activity window.
+  // Lifecycle activity can revive an older run, so first select those run IDs
+  // by their indexed `at` value, then include their runs with the recent ones.
+  // Results and lifecycle reasons are fetched only for that selected run set.
   const eventRows = db
-    .query(`SELECT * FROM events ORDER BY admitted_at, rowid`)
-    .all();
+    .query(
+      `SELECT * FROM events WHERE admitted_at >= ? ORDER BY admitted_at, rowid`,
+    )
+    .all(sinceIso);
   const proposalRows = db
-    .query(`SELECT * FROM proposals ORDER BY created_at, rowid`)
-    .all();
+    .query(
+      `SELECT * FROM proposals WHERE created_at >= ? ORDER BY created_at, rowid`,
+    )
+    .all(sinceIso);
   const runRows = db
-    .query(`SELECT * FROM runs ORDER BY created_at, rowid`)
-    .all();
-  const resultRows = db.query(`SELECT * FROM results ORDER BY rowid`).all();
-  const lifecycleRows = db
-    .query(`SELECT * FROM lifecycle_events ORDER BY rowid`)
-    .all();
+    .query(
+      `SELECT * FROM runs WHERE created_at >= ? ORDER BY created_at, rowid`,
+    )
+    .all(sinceIso);
+  const lifecycleRunIds = db
+    .query(
+      `SELECT DISTINCT run_id FROM lifecycle_events WHERE at >= ? ORDER BY run_id`,
+    )
+    .all(sinceIso)
+    .map((row) => row.run_id);
+  const chunked = (values, size = 400) => {
+    const chunks = [];
+    for (let i = 0; i < values.length; i += size)
+      chunks.push(values.slice(i, i + size));
+    return chunks;
+  };
+  const placeholders = (values) => values.map(() => "?").join(", ");
+  const runIds = new Set(runRows.map((row) => row.run_id));
+  for (const chunk of chunked(
+    lifecycleRunIds.filter((id) => !runIds.has(id)),
+  )) {
+    for (const row of db
+      .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(chunk)})`)
+      .all(...chunk)) {
+      runRows.push(row);
+      runIds.add(row.run_id);
+    }
+  }
+
+  const resultRows = [];
+  const lifecycleRows = [];
+  for (const chunk of chunked([...runIds])) {
+    resultRows.push(
+      ...db
+        .query(
+          `SELECT * FROM results WHERE run_id IN (${placeholders(chunk)}) ORDER BY rowid`,
+        )
+        .all(...chunk),
+    );
+    lifecycleRows.push(
+      ...db
+        .query(
+          `SELECT * FROM lifecycle_events
+           WHERE at >= ? AND run_id IN (${placeholders(chunk)}) ORDER BY rowid`,
+        )
+        .all(sinceIso, ...chunk),
+    );
+  }
 
   const resultByRun = new Map();
   for (const row of resultRows) {
     const result = parseObject(row.result_json);
     if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
     resultByRun.get(row.run_id).push(result);
+  }
+  const lifecycleByRun = new Map();
+  for (const row of lifecycleRows) {
+    if (!lifecycleByRun.has(row.run_id)) lifecycleByRun.set(row.run_id, []);
+    lifecycleByRun.get(row.run_id).push(row);
   }
 
   // Collect candidate ticket IDs across all entities
@@ -1213,6 +1268,9 @@ export function ticketIndexView(db, options = {}) {
           at: r.updated_at || r.created_at,
           kind: spec.agent?.startsWith("merge-") ? "merge" : "run",
         });
+      }
+      for (const lifecycle of lifecycleByRun.get(r.run_id) ?? []) {
+        activities.push({ at: lifecycle.at, kind: "run" });
       }
     }
 

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -932,10 +932,16 @@ export function ticketIndexView(db, options = {}) {
     }
   }
 
-  // Keep every JSON-bearing table bounded by the requested activity window.
-  // Lifecycle activity can revive an older run, so first select those run IDs
-  // by their indexed `at` value, then include their runs with the recent ones.
-  // Results and lifecycle reasons are fetched only for that selected run set.
+  // The activity window only decides WHICH tickets are candidates: a ticket is
+  // listed when any event, proposal, run, or lifecycle row touching it landed in
+  // the window. Every JSON-bearing read here is bounded by that window through
+  // the indexed `admitted_at` / `created_at` / `at` columns.
+  //
+  // Once the candidate set is known, each ticket is re-enriched with bounded,
+  // indexed lookups (runs by `subject`, proposals by `run_id` and event key,
+  // events/runs/results by primary key) so that title, repo, PR, merge state,
+  // attempts, and the last decision stay complete even when the ticket's
+  // history predates the window.
   const eventRows = db
     .query(
       `SELECT * FROM events WHERE admitted_at >= ? ORDER BY admitted_at, rowid`,
@@ -964,28 +970,48 @@ export function ticketIndexView(db, options = {}) {
     return chunks;
   };
   const placeholders = (values) => values.map(() => "?").join(", ");
+  const eventKey = (row) => `${row.source}\0${row.event_id}`;
   const runIds = new Set(runRows.map((row) => row.run_id));
-  for (const chunk of chunked(
-    lifecycleRunIds.filter((id) => !runIds.has(id)),
-  )) {
-    for (const row of db
-      .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(chunk)})`)
-      .all(...chunk)) {
-      runRows.push(row);
+  const eventKeys = new Set(eventRows.map(eventKey));
+  const proposalIds = new Set(proposalRows.map((row) => row.id));
+  const addRuns = (rows) => {
+    for (const row of rows) {
+      if (runIds.has(row.run_id)) continue;
       runIds.add(row.run_id);
+      runRows.push(row);
     }
-  }
+  };
+  const addEvents = (rows) => {
+    for (const row of rows) {
+      const key = eventKey(row);
+      if (eventKeys.has(key)) continue;
+      eventKeys.add(key);
+      eventRows.push(row);
+    }
+  };
+  const addProposals = (rows) => {
+    for (const row of rows) {
+      if (proposalIds.has(row.id)) continue;
+      proposalIds.add(row.id);
+      proposalRows.push(row);
+    }
+  };
+  const fetchRunsById = (ids) => {
+    for (const chunk of chunked(ids.filter((id) => !runIds.has(id)))) {
+      addRuns(
+        db
+          .query(`SELECT * FROM runs WHERE run_id IN (${placeholders(chunk)})`)
+          .all(...chunk),
+      );
+    }
+  };
+  fetchRunsById(lifecycleRunIds);
 
-  const resultRows = [];
+  // Lifecycle rows are read only inside the window: they can surface a ticket
+  // (via reasons) and they carry recent activity, but older transitions never
+  // outrank in-window activity and add nothing to the enrichment below.
   const lifecycleRows = [];
   for (const chunk of chunked([...runIds])) {
-    resultRows.push(
-      ...db
-        .query(
-          `SELECT * FROM results WHERE run_id IN (${placeholders(chunk)}) ORDER BY rowid`,
-        )
-        .all(...chunk),
-    );
     lifecycleRows.push(
       ...db
         .query(
@@ -995,20 +1021,32 @@ export function ticketIndexView(db, options = {}) {
         .all(sinceIso, ...chunk),
     );
   }
-
-  const resultByRun = new Map();
-  for (const row of resultRows) {
-    const result = parseObject(row.result_json);
-    if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
-    resultByRun.get(row.run_id).push(result);
-  }
   const lifecycleByRun = new Map();
   for (const row of lifecycleRows) {
     if (!lifecycleByRun.has(row.run_id)) lifecycleByRun.set(row.run_id, []);
     lifecycleByRun.get(row.run_id).push(row);
   }
 
-  // Collect candidate ticket IDs across all entities
+  const resultByRun = new Map();
+  const fetchResults = () => {
+    const missing = [...runIds].filter((id) => !resultByRun.has(id));
+    for (const chunk of chunked(missing)) {
+      for (const row of db
+        .query(
+          `SELECT * FROM results WHERE run_id IN (${placeholders(chunk)}) ORDER BY rowid`,
+        )
+        .all(...chunk)) {
+        if (!resultByRun.has(row.run_id)) resultByRun.set(row.run_id, []);
+        resultByRun.get(row.run_id).push(parseObject(row.result_json));
+      }
+      for (const id of chunk) {
+        if (!resultByRun.has(id)) resultByRun.set(id, []);
+      }
+    }
+  };
+  fetchResults();
+
+  // Collect candidate ticket IDs across all in-window entities
   const allTicketIds = new Set();
   for (const row of eventRows) {
     if (normalizeTicketId(row.subject)) {
@@ -1032,6 +1070,77 @@ export function ticketIndexView(db, options = {}) {
   for (const row of lifecycleRows) {
     collectTicketIds(row.reason, allTicketIds);
   }
+
+  // Enrichment: pull the full history of every candidate ticket through
+  // indexed lookups, independent of the window. Subjects are matched by their
+  // normalized id plus every raw spelling seen in-window (GitHub refs keep
+  // their original case in `runs.subject` / `events.subject`).
+  const subjectKeys = new Set(allTicketIds);
+  for (const row of [...runRows, ...eventRows]) {
+    if (
+      typeof row.subject === "string" &&
+      allTicketIds.has(normalizeTicketId(row.subject))
+    ) {
+      subjectKeys.add(row.subject);
+    }
+  }
+  for (const chunk of chunked([...subjectKeys])) {
+    addRuns(
+      db
+        .query(`SELECT * FROM runs WHERE subject IN (${placeholders(chunk)})`)
+        .all(...chunk),
+    );
+    addEvents(
+      db
+        .query(`SELECT * FROM events WHERE subject IN (${placeholders(chunk)})`)
+        .all(...chunk),
+    );
+  }
+  // Close the event ↔ proposal ↔ run graph: proposals by run_id and by event
+  // key, then the runs/events those proposals reference, until stable.
+  const proposalsByEvent = db.query(
+    `SELECT * FROM proposals WHERE event_source = ? AND event_id = ?`,
+  );
+  const eventsByKey = db.query(
+    `SELECT * FROM events WHERE source = ? AND event_id = ?`,
+  );
+  const seenRunLookups = new Set();
+  const seenEventLookups = new Set();
+  const seenEventFetches = new Set();
+  for (let pass = 0; pass < 8; pass += 1) {
+    const before = proposalIds.size + runIds.size + eventKeys.size;
+    const newRunIds = [...runIds].filter((id) => !seenRunLookups.has(id));
+    for (const chunk of chunked(newRunIds)) {
+      addProposals(
+        db
+          .query(
+            `SELECT * FROM proposals WHERE run_id IN (${placeholders(chunk)})`,
+          )
+          .all(...chunk),
+      );
+      for (const id of chunk) seenRunLookups.add(id);
+    }
+    for (const row of eventRows) {
+      const key = eventKey(row);
+      if (seenEventLookups.has(key)) continue;
+      seenEventLookups.add(key);
+      addProposals(proposalsByEvent.all(row.source, row.event_id));
+    }
+    fetchRunsById(
+      proposalRows.map((row) => row.run_id).filter((id) => id != null),
+    );
+    for (const row of proposalRows) {
+      const key = `${row.event_source}\0${row.event_id}`;
+      if (eventKeys.has(key) || seenEventFetches.has(key)) continue;
+      seenEventFetches.add(key);
+      addEvents(eventsByKey.all(row.event_source, row.event_id));
+    }
+    if (proposalIds.size + runIds.size + eventKeys.size === before) break;
+  }
+  fetchResults();
+  eventRows.sort((a, b) => a.admitted_at.localeCompare(b.admitted_at));
+  proposalRows.sort((a, b) => a.created_at.localeCompare(b.created_at));
+  runRows.sort((a, b) => a.created_at.localeCompare(b.created_at));
 
   const summaries = [];
 
@@ -1252,25 +1361,33 @@ export function ticketIndexView(db, options = {}) {
     for (const r of matchedRunRows) {
       const results = resultByRun.get(r.run_id) ?? [];
       const spec = parseObject(r.spec_json);
+      // A run's activity kind is its strongest outcome (merge > pr > run);
+      // lifecycle transitions inherit it so a later state change never
+      // downgrades a merge/pr activity to a plain "run".
+      let runKind = spec.agent?.startsWith("merge-") ? "merge" : "run";
       for (const res of results) {
         const isMerge =
           res?.artifact?.outcome === "MERGED" ||
           spec.agent?.startsWith("merge-");
         const isPr =
           res?.artifact?.outcome === "PR_OPEN" || Boolean(res?.artifact?.prUrl);
+        const kind = isMerge ? "merge" : isPr ? "pr" : "run";
+        if (kind === "merge" || (kind === "pr" && runKind === "run")) {
+          runKind = kind;
+        }
         activities.push({
           at: res.accepted_at || r.updated_at || r.created_at,
-          kind: isMerge ? "merge" : isPr ? "pr" : "run",
+          kind,
         });
       }
       if (results.length === 0) {
         activities.push({
           at: r.updated_at || r.created_at,
-          kind: spec.agent?.startsWith("merge-") ? "merge" : "run",
+          kind: runKind,
         });
       }
       for (const lifecycle of lifecycleByRun.get(r.run_id) ?? []) {
-        activities.push({ at: lifecycle.at, kind: "run" });
+        activities.push({ at: lifecycle.at, kind: runKind });
       }
     }
 

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1287,6 +1287,82 @@ describe("recent-ticket index (WM-821)", () => {
       s.close();
     }
   });
+
+  test("bounds ticket index reads by since and retains recent lifecycle activity", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const insertRun = s.db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES (?, ?, ?, 'sha256:test', 'COMPLETED', 1, ?, ?)`,
+      );
+      const insertLifecycle = s.db.query(
+        `INSERT INTO lifecycle_events (run_id, to_state, actor, at, record_hash)
+         VALUES (?, 'COMPLETED', 'test', ?, ?)`,
+      );
+      const insertEvent = s.db.query(
+        `INSERT INTO events
+         (source, event_id, type, subject, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+         VALUES ('test', ?, 'ticket.updated', ?, ?, ?, '{}', 'sha256:test', ?)`,
+      );
+      const at = (daysAgo) =>
+        new Date(nowMs - daysAgo * 86_400_000).toISOString();
+
+      insertRun.run(
+        "run-recent-lifecycle",
+        "recent-lifecycle",
+        spec({ repo: "factory", ticket: "WM-1765" }),
+        at(3),
+        at(3),
+      );
+      insertLifecycle.run(
+        "run-recent-lifecycle",
+        at(1),
+        "sha256:recent-lifecycle",
+      );
+      insertEvent.run(
+        "recent-event",
+        "WM-1766",
+        at(1 / 24),
+        at(1 / 24),
+        at(1 / 24),
+      );
+      insertEvent.run("stale-event", "WM-1767", at(30), at(30), at(30));
+
+      const queries = [];
+      const observedDb = {
+        filename: s.db.filename,
+        query(sql) {
+          queries.push(sql);
+          return s.db.query(sql);
+        },
+      };
+      const tickets = ticketIndexView(observedDb, {
+        nowMs,
+        since: "2d",
+        noCache: true,
+      });
+
+      expect(tickets.map((ticket) => ticket.id)).toEqual([
+        "WM-1766",
+        "WM-1765",
+      ]);
+      expect(
+        queries.some((sql) => /events WHERE admitted_at >= \?/.test(sql)),
+      ).toBe(true);
+      expect(
+        queries.some((sql) => /lifecycle_events\s+WHERE at >= \?/.test(sql)),
+      ).toBe(true);
+      expect(
+        queries.some((sql) => /WHERE at >= \? AND run_id IN \(\?\)/.test(sql)),
+      ).toBe(true);
+      expect(queries.join("\n")).not.toContain(
+        "SELECT * FROM results ORDER BY",
+      );
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("watched flow and operator verbs (§12, §13, §15)", () => {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1363,6 +1363,157 @@ describe("recent-ticket index (WM-821)", () => {
       s.close();
     }
   });
+
+  test("re-enriches a ticket with history older than the window (gh-1764)", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const at = (daysAgo) =>
+        new Date(nowMs - daysAgo * 86_400_000).toISOString();
+      // Old history: proposal -> merge run (subject-indexed) -> MERGED result,
+      // all 30 days ago, far outside the 2d window.
+      s.db
+        .query(
+          `INSERT INTO events
+           (source, event_id, type, subject, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+           VALUES ('test', 'old-dispatch', 'ticket.ready', 'WM-1764', ?, ?, ?, 'sha256:test', ?)`,
+        )
+        .run(
+          at(30),
+          at(30),
+          JSON.stringify({
+            payload: { ticket: "WM-1764", ticketTitle: "Old but merged" },
+          }),
+          at(30),
+        );
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, run_id, decision, spec_json, spec_hash, status, created_at, ttl_seconds, decided_at, decided_by)
+           VALUES ('prop-1764', 'test', 'old-dispatch', 'run-1764-merge', 'dispatch', ?, 'sha256:test', 'approved', ?, 3600, ?, 'operator')`,
+        )
+        .run(spec({ repo: "factory", ticket: "WM-1764" }), at(30), at(30));
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+           VALUES ('run-1764-merge', 'key-1764-merge', ?, 'sha256:test', 'COMPLETED', 2, ?, ?, 'WM-1764')`,
+        )
+        .run(
+          spec({ repo: "factory", ticket: "WM-1764" }, "merge-apply@1"),
+          at(29),
+          at(29),
+        );
+      s.db
+        .query(
+          `INSERT INTO results
+           (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+           VALUES ('run-1764-merge', 1, ?, 'sha256:res', '{}', '{}', ?)`,
+        )
+        .run(
+          JSON.stringify({
+            terminalState: "completed",
+            artifact: {
+              outcome: "MERGED",
+              prUrl: "https://github.com/watt-mind/factory/pull/1771",
+            },
+          }),
+          at(29),
+        );
+      // Fresh activity: a bare event inside the window with no metadata.
+      s.db
+        .query(
+          `INSERT INTO events
+           (source, event_id, type, subject, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+           VALUES ('test', 'fresh-comment', 'ticket.commented', 'WM-1764', ?, ?, '{}', 'sha256:test', ?)`,
+        )
+        .run(at(0.5), at(0.5), at(0.5));
+
+      const [ticket] = ticketIndexView(s.db, {
+        nowMs,
+        since: "2d",
+        noCache: true,
+      });
+      expect(ticket.id).toBe("WM-1764");
+      expect(ticket.merged).toBe(true);
+      expect(ticket.state).toBe("Done");
+      expect(ticket.pr).toEqual({
+        number: 1771,
+        url: "https://github.com/watt-mind/factory/pull/1771",
+      });
+      expect(ticket.title).toBe("Old but merged");
+      expect(ticket.repo).toBe("factory");
+      expect(ticket.attempts).toBe(2);
+      expect(ticket.lastDecision).toBe("dispatch");
+      expect(ticket.lastActivityKind).toBe("event");
+      expect(ticket.lastActivityAt).toBe(at(0.5));
+    } finally {
+      s.close();
+    }
+  });
+
+  test("lifecycle transitions keep a run's merge/pr activity kind (gh-1764)", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const at = (hoursAgo) =>
+        new Date(nowMs - hoursAgo * 3_600_000).toISOString();
+      const insertRun = s.db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+         VALUES (?, ?, ?, 'sha256:test', 'COMPLETED', 1, ?, ?, ?)`,
+      );
+      const insertResult = s.db.query(
+        `INSERT INTO results
+         (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+         VALUES (?, 1, ?, 'sha256:res', '{}', '{}', ?)`,
+      );
+      const insertLifecycle = s.db.query(
+        `INSERT INTO lifecycle_events (run_id, to_state, actor, at, record_hash)
+         VALUES (?, 'COMPLETED', 'test', ?, 'sha256:lc')`,
+      );
+
+      insertRun.run(
+        "run-1768-merge",
+        "key-1768-merge",
+        spec({ repo: "factory", ticket: "WM-1768" }, "merge-apply@1"),
+        at(6),
+        at(2),
+        "WM-1768",
+      );
+      insertResult.run(
+        "run-1768-merge",
+        JSON.stringify({ artifact: { outcome: "MERGED", pr: 1768 } }),
+        at(3),
+      );
+      insertLifecycle.run("run-1768-merge", at(2));
+
+      insertRun.run(
+        "run-1769-pr",
+        "key-1769-pr",
+        spec({ repo: "factory", ticket: "WM-1769" }),
+        at(6),
+        at(2),
+        "WM-1769",
+      );
+      insertResult.run(
+        "run-1769-pr",
+        JSON.stringify({ artifact: { outcome: "PR_OPEN", pr: 1769 } }),
+        at(3),
+      );
+      insertLifecycle.run("run-1769-pr", at(2));
+
+      const tickets = ticketIndexView(s.db, {
+        nowMs,
+        since: "1d",
+        noCache: true,
+      });
+      const byId = Object.fromEntries(tickets.map((t) => [t.id, t]));
+      expect(byId["WM-1768"].lastActivityAt).toBe(at(2));
+      expect(byId["WM-1768"].lastActivityKind).toBe("merge");
+      expect(byId["WM-1769"].lastActivityAt).toBe(at(2));
+      expect(byId["WM-1769"].lastActivityKind).toBe("pr");
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("watched flow and operator verbs (§12, §13, §15)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1764

Bounds ticket-index reads to recent activity while retaining recent lifecycle transitions for older runs.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs --timeout 60000` | pass | 40 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,190 pass, 0 failures |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped\nrun:run_c87c009b-9acd-4283-a78f-e6a04622d4af

## Post-review

Reviewer verdict FIX, addressed in 3f90bf57:

1. **Window vs enrichment split.** The `since` window now only discovers the candidate ticket set (rows with in-window activity via the indexed `admitted_at`/`created_at`/`at` columns). Every candidate is then re-enriched with bounded indexed lookups: `runs` by `subject` (idx_runs_subject), `proposals` by `run_id` (idx_proposals_run_id) and by event key (idx_proposals_event), and events/runs/results by primary key, iterated until the event-proposal-run closure is stable. Tickets whose history predates the window keep `title/repo/pr/merged/state/attempts/lastDecision`. Test: old merged run (30d) + fresh bare event (12h) at `since=2d` still reports `merged=true`, `state=Done`, `pr`, title, attempts and lastDecision.
2. **Lifecycle activity kind.** Lifecycle transitions now inherit the run's strongest activity kind (merge > pr > run) instead of pushing `kind: "run"`, so a later state change never downgrades `lastActivityKind`. Test: merge/pr runs with a later in-window lifecycle row keep `merge`/`pr`.

Verified: `bun test event-runtime/lib/api-runs.test.mjs --timeout 60000` (42 pass), `bun run lint`, `bun test event-runtime/lib`, `bun build/emit.mjs --check`, `bun run format:check`, `bun run check`.
