### PR TITLE
fix(proposals): expire orphaned non-run rows

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -27,7 +27,10 @@ import { notifyPending, sweepNotifyLog } from "../lib/notify.mjs";
 import { reconcileInbox } from "../lib/inbox.mjs";
 import { loadModelTierMap, loadRegistry } from "../lib/registry.mjs";
 import { applyModelTierCellOverrides } from "../lib/runtime-overrides.mjs";
-import { approveProposal } from "../lib/proposals.mjs";
+import {
+  approveProposal,
+  sweepOrphanedNonRunProposals,
+} from "../lib/proposals.mjs";
 import { startApi } from "../lib/api.mjs";
 import { codeStamp, REGISTRY_STAMP_PATHS } from "../lib/worker.mjs";
 import { reapExpiredLeases } from "../lib/reaper.mjs";
@@ -158,6 +161,7 @@ export const TICK_SUBSYSTEMS = [
   "auto-approve-chains",
   "announce",
   "inbox",
+  "proposals",
   "notify",
   "reap",
   "worker",
@@ -307,6 +311,14 @@ export async function tick({
   // resolve automatically once the proposal/event no longer needs a human.
   await runStep("inbox", () => {
     reconcileInbox(db, { now });
+  });
+
+  await runStep("proposals", () => {
+    const expired = sweepOrphanedNonRunProposals(db, { now });
+    if (expired > 0)
+      logLine(
+        `proposals: expired ${expired} orphaned human_needed/noop row(s)`,
+      );
   });
 
   // Push channel for states awaiting a human (WM-65): human_needed parks and

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -634,6 +634,60 @@ export default async function start() {
     db.close();
   });
 
+  test("tick expires orphaned non-run proposals and logs only when it does", async () => {
+    const { tick } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T13:00:00.000Z");
+    const at = new Date(now).toISOString();
+    const insertEvent = db.query(
+      `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at, status)
+       VALUES ('test', ?, 'test.event', ?, ?, '{}', 'hash', ?, ?)`,
+    );
+    insertEvent.run("moved-on", at, at, at, "admitted");
+    insertEvent.run("still-parked", at, at, at, "human_needed");
+    const insertProposal = db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, 'human_needed', 'open', ?, 1800)`,
+    );
+    insertProposal.run("orphaned", "moved-on", at);
+    insertProposal.run("parked", "still-parked", at);
+    const logs = [];
+
+    await tick({
+      db,
+      registry: loadRegistry(),
+      now,
+      policyVersion: "git:test",
+      skipPlan: true,
+      log: (line) => logs.push(line),
+    });
+
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = 'orphaned'").get(),
+    ).toEqual({ status: "expired" });
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = 'parked'").get(),
+    ).toEqual({ status: "open" });
+    expect(logs).toContain(
+      "proposals: expired 1 orphaned human_needed/noop row(s)",
+    );
+
+    logs.length = 0;
+    await tick({
+      db,
+      registry: loadRegistry(),
+      now: now + 1_000,
+      policyVersion: "git:test",
+      skipPlan: true,
+      log: (line) => logs.push(line),
+    });
+    expect(logs).not.toContain(
+      "proposals: expired 0 orphaned human_needed/noop row(s)",
+    );
+    db.close();
+  });
+
   test("tick sweeps retained memo rows alongside artifact GC and logs the count", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -59,7 +59,35 @@ export function openProposals(db, { now = Date.now() } = {}) {
       `SELECT * FROM proposals WHERE status = 'open' ORDER BY created_at, rowid`,
     )
     .all()
-    .map((row) => ({ ...withSpec(row), expired: isExpired(row, now) }));
+    .map((row) => ({
+      ...withSpec(row),
+      // TTL re-planning is only meaningful for runnable proposals. A parked
+      // refusal remains actionable until its event moves on.
+      expired: row.decision === "run" && isExpired(row, now),
+    }));
+}
+
+/**
+ * Retire parked refusals after their event has moved on. Unlike runnable
+ * proposals, human-needed and noop rows do not expire by TTL: they remain
+ * open while the event is still parked so the inbox can surface the decision.
+ */
+export function sweepOrphanedNonRunProposals(db, { now = Date.now() } = {}) {
+  const result = db
+    .query(
+      `UPDATE proposals AS p
+       SET status = 'expired', decided_by = 'serve', reason = 'event_moved_on', decided_at = ?
+       WHERE p.status = 'open'
+         AND p.decision IN ('human_needed', 'noop')
+         AND NOT EXISTS (
+           SELECT 1 FROM events AS e
+           WHERE e.source = p.event_source
+             AND e.event_id = p.event_id
+             AND e.status IN ('human_needed', 'noop')
+         )`,
+    )
+    .run(new Date(now).toISOString());
+  return result.changes;
 }
 
 /**

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -15,6 +15,7 @@ import {
   getProposal,
   openProposals,
   rejectProposal,
+  sweepOrphanedNonRunProposals,
 } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
 import { claimNext } from "./worker.mjs";
@@ -166,6 +167,59 @@ describe("openProposals / getProposal", () => {
 
     expect(getProposal(db, proposal.id).spec.runId).toBe(runId);
     expect(getProposal(db, "prop_nope")).toBeNull();
+  });
+
+  test("does not expire a parked non-run proposal by TTL", () => {
+    const db = openDb(":memory:");
+    const admitted = admitEvent(
+      db,
+      registry,
+      envelope({ eventId: "parked-past-ttl", type: "totally.unknown.type" }),
+      { now: NOW },
+    );
+    const outcome = planEvent(
+      db,
+      registry,
+      { source: admitted.event.source, eventId: admitted.event.event_id },
+      { now: NOW },
+    );
+
+    expect(outcome.decision).toBe("human_needed");
+    expect(openProposals(db, { now: NOW + TTL_MS + 1 })[0].expired).toBe(false);
+  });
+});
+
+describe("sweepOrphanedNonRunProposals", () => {
+  test("expires an orphaned row and leaves a still-parked row open", () => {
+    const db = openDb(":memory:");
+    const plan = (eventId) => {
+      const admitted = admitEvent(
+        db,
+        registry,
+        envelope({ eventId, type: "totally.unknown.type" }),
+        { now: NOW },
+      );
+      return planEvent(
+        db,
+        registry,
+        { source: admitted.event.source, eventId: admitted.event.event_id },
+        { now: NOW },
+      );
+    };
+    const orphaned = plan("orphaned-park");
+    const parked = plan("still-parked");
+    db.query(
+      "UPDATE events SET status = 'admitted' WHERE source = ? AND event_id = ?",
+    ).run(orphaned.proposal.event_source, orphaned.proposal.event_id);
+
+    expect(sweepOrphanedNonRunProposals(db, { now: NOW + 1_000 })).toBe(1);
+    expect(getProposal(db, orphaned.proposal.id)).toMatchObject({
+      status: "expired",
+      decided_by: "serve",
+      reason: "event_moved_on",
+      decided_at: new Date(NOW + 1_000).toISOString(),
+    });
+    expect(getProposal(db, parked.proposal.id).status).toBe("open");
   });
 });
 

--- a/event-runtime/lib/status-view.test.mjs
+++ b/event-runtime/lib/status-view.test.mjs
@@ -21,6 +21,22 @@ describe("statusView outbox counts", () => {
     });
   });
 
+  test("counts only expired run proposals as anomalies", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T08:00:00.000Z");
+    const createdAt = new Date(now - 61_000).toISOString();
+    const insert = db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, ?, 'open', ?, 60)`,
+    );
+    insert.run("run-expired", "run-event", "run", createdAt);
+    insert.run("parked-past-ttl", "parked-event", "human_needed", createdAt);
+
+    const view = statusView(db, { schedules: [] }, now);
+    expect(view.proposals).toEqual({ open: 2, expired: 1 });
+    expect(view.anomalies.expiredOpenProposals).toEqual(["run-expired"]);
+  });
+
   test("reports an unconfigured GitHub intake separately from a stale configured intake", () => {
     const db = openDb(":memory:");
     const now = Date.parse("2026-08-30T08:00:00.000Z");


### PR DESCRIPTION
Fixes watt-mind/factory#1762

Review the orphaned non-run proposal sweep and TTL-only run expiry behavior.

## Validation

| Check                | Command                                                                                                                            | Result  | Notes                    |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs event-runtime/lib/status-view.test.mjs event-runtime/cli/serve.test.mjs --timeout 30000` | pass    | 50 tests, 0 failures    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`              | pass    | 2193 pass, 0 failures   |
| UX critique          | factory-ux-critic                                                                                                                  | not run | no user-facing surface  |

UX critique: skipped

run:$FACTORY_RUN_ID
