### PR TITLE
feat(cli): filter and paginate runs

### DIFF
--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -4,7 +4,12 @@ import { events } from "./cli/events.mjs";
 import { inbox as legacyInbox } from "./cli/inbox.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
 import { ps } from "./cli/ps.mjs";
-import { runs, runsCommand } from "./cli/runs.mjs";
+import {
+  RUN_LIST_MAX_PAGES,
+  dispatchOnlyPredicate,
+  runs,
+  runsCommand,
+} from "./cli/runs.mjs";
 import { CLI, freePort, runCli, throwawayRunDir } from "./cli/test-helpers.mjs";
 import { apiClient } from "./lib/client.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
@@ -247,7 +252,9 @@ describe("cli routing", () => {
     } finally {
       console.log = log;
     }
-    expect(calls).toEqual([{ state: "RUNNING", agent: "dispatch@1" }]);
+    expect(calls).toEqual([
+      { state: "RUNNING", agent: "dispatch@1", limit: 200 },
+    ]);
     expect(lines).toEqual(["no runs with state RUNNING"]);
   });
 
@@ -311,8 +318,8 @@ describe("cli routing", () => {
       console.log = log;
     }
     expect(calls).toEqual([
-      { state: "RUNNING" },
-      { state: "RUNNING", before: "cursor-1" },
+      { state: "RUNNING", limit: 200 },
+      { state: "RUNNING", limit: 200, before: "cursor-1" },
     ]);
     expect(lines).toEqual(["2"]);
   });
@@ -340,8 +347,123 @@ describe("cli routing", () => {
     } finally {
       console.log = log;
     }
-    expect(calls).toEqual([{ state: "RUNNING" }]);
+    expect(calls).toEqual([{ state: "RUNNING", limit: 200 }]);
     expect(lines).toEqual(["0"]);
+  });
+
+  test("dispatch-only keeps dispatch agents by id, prefix, or contract and drops unregistered ones", () => {
+    const keep = dispatchOnlyPredicate([
+      { id: "dispatch", ref: "dispatch@1" },
+      { id: "dispatch-hotfix", ref: "dispatch-hotfix@2" },
+      {
+        id: "lander",
+        ref: "lander@1",
+        outputContract: "factory.dispatch-result/v1",
+      },
+      { id: "merge-fix", ref: "merge-fix@1" },
+      { id: "merge-review", ref: "merge-review@1" },
+      { id: "work-scan", ref: "work-scan@1" },
+    ]);
+    const kept = [
+      "dispatch@1",
+      "dispatch-hotfix@2",
+      "lander@1",
+      "worker@1",
+      "dispatch@7",
+    ];
+    const dropped = [
+      "merge-fix@1",
+      "merge-review@1",
+      "work-scan@1",
+      "ci-doctor@1",
+      "retired-agent@1",
+    ];
+    expect(kept.map((agent) => keep({ agent }))).toEqual(kept.map(() => true));
+    expect(dropped.map((agent) => keep({ agent }))).toEqual(
+      dropped.map(() => false),
+    );
+  });
+
+  function captureConsole() {
+    const out = [];
+    const err = [];
+    const log = console.log;
+    const error = console.error;
+    console.log = (...values) => out.push(values.join(" "));
+    console.error = (...values) => err.push(values.join(" "));
+    return {
+      out,
+      err,
+      restore: () => ((console.log = log), (console.error = error)),
+    };
+  }
+
+  test("runs clamps the page size to 200 and stops fetching once --limit is reached", async () => {
+    const calls = [];
+    const client = {
+      runs: async (options) => {
+        calls.push(options);
+        return {
+          runs: [{ runId: `run-${calls.length}` }],
+          nextBefore: `cursor-${calls.length}`,
+        };
+      },
+    };
+    const c = captureConsole();
+    try {
+      await runs(client, "running", { limit: 2 });
+    } finally {
+      c.restore();
+    }
+    expect(calls.map((o) => o.limit)).toEqual([2, 2]);
+    expect(c.out.filter((l) => l.startsWith("run-"))).toHaveLength(2);
+    expect(c.err).toEqual(["... 0+ more rows (truncated)"]);
+
+    calls.length = 0;
+    const big = captureConsole();
+    try {
+      await runs(client, "running", { limit: 5000, count: true });
+    } finally {
+      big.restore();
+    }
+    expect(calls[0].limit).toBe(200);
+    expect(calls).toHaveLength(RUN_LIST_MAX_PAGES);
+  });
+
+  test("runs caps the page walk and breaks on a repeated cursor", async () => {
+    let calls = 0;
+    const endless = {
+      runs: async () => {
+        calls += 1;
+        return { runs: [{ runId: `run-${calls}` }], nextBefore: `c-${calls}` };
+      },
+    };
+    const capped = captureConsole();
+    try {
+      await runs(endless, "running", { count: true });
+    } finally {
+      capped.restore();
+    }
+    expect(calls).toBe(RUN_LIST_MAX_PAGES);
+    expect(capped.out).toEqual([String(RUN_LIST_MAX_PAGES)]);
+    expect(capped.err[0]).toContain("page cap");
+
+    calls = 0;
+    const looping = {
+      runs: async () => {
+        calls += 1;
+        return { runs: [{ runId: `run-${calls}` }], nextBefore: "same" };
+      },
+    };
+    const loop = captureConsole();
+    try {
+      await runs(looping, "running", {});
+    } finally {
+      loop.restore();
+    }
+    expect(calls).toBe(2);
+    expect(loop.err[0]).toContain("repeated");
+    expect(loop.err.at(-1)).toBe("... 0+ more rows (truncated)");
   });
 
   test("client.runs accepts options while retaining the state-string form", async () => {

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -4,8 +4,9 @@ import { events } from "./cli/events.mjs";
 import { inbox as legacyInbox } from "./cli/inbox.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
 import { ps } from "./cli/ps.mjs";
-import { runs } from "./cli/runs.mjs";
+import { runs, runsCommand } from "./cli/runs.mjs";
 import { CLI, freePort, runCli, throwawayRunDir } from "./cli/test-helpers.mjs";
+import { apiClient } from "./lib/client.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
 const EXPECTED_COMMANDS = [
@@ -228,6 +229,146 @@ describe("cli routing", () => {
       ["events", "QUEUED"],
     ]);
     expect(lines.join("\n")).toContain("RUNNING");
+  });
+
+  test("runs forwards its agent filter", async () => {
+    const calls = [];
+    const client = {
+      runs: async (options) => {
+        calls.push(options);
+        return { runs: [], nextBefore: null };
+      },
+    };
+    const lines = [];
+    const log = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await runs(client, "running", { agent: "dispatch@1" });
+    } finally {
+      console.log = log;
+    }
+    expect(calls).toEqual([{ state: "RUNNING", agent: "dispatch@1" }]);
+    expect(lines).toEqual(["no runs with state RUNNING"]);
+  });
+
+  test("runs excludes agents client-side", async () => {
+    const client = {
+      runs: async () => ({
+        runs: [
+          {
+            runId: "dispatch-run",
+            state: "RUNNING",
+            agent: "dispatch@1",
+            adapter: "cursor",
+            attempts: 1,
+            maxAttempts: 1,
+            updated_at: "now",
+          },
+          {
+            runId: "review-run",
+            state: "RUNNING",
+            agent: "merge-review@1",
+            adapter: "agy",
+            attempts: 1,
+            maxAttempts: 1,
+            updated_at: "now",
+          },
+        ],
+        nextBefore: null,
+      }),
+    };
+    const lines = [];
+    const log = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await runs(client, "running", { excludeAgents: ["merge-review@1"] });
+    } finally {
+      console.log = log;
+    }
+    expect(lines.join("\n")).toContain("dispatch-run");
+    expect(lines.join("\n")).not.toContain("review-run");
+  });
+
+  test("runs follows cursors and count writes only the integer", async () => {
+    const calls = [];
+    const client = {
+      runs: async (options) => {
+        calls.push(options);
+        return options.before
+          ? { runs: [{ runId: "run-2" }], nextBefore: null }
+          : {
+              runs: [{ runId: "run-1" }],
+              nextBefore: "cursor-1",
+            };
+      },
+    };
+    const lines = [];
+    const log = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await runs(client, "running", { count: true });
+    } finally {
+      console.log = log;
+    }
+    expect(calls).toEqual([
+      { state: "RUNNING" },
+      { state: "RUNNING", before: "cursor-1" },
+    ]);
+    expect(lines).toEqual(["2"]);
+  });
+
+  test("runs command dispatch-only excludes every non-dispatch registry agent", async () => {
+    const calls = [];
+    const client = {
+      agents: async () => ({
+        agents: [
+          { id: "dispatch", ref: "dispatch@1" },
+          { id: "merge-review", ref: "merge-review@1" },
+          { id: "ci-doctor", ref: "ci-doctor@1" },
+        ],
+      }),
+      runs: async (options) => {
+        calls.push(options);
+        return { runs: [], nextBefore: null };
+      },
+    };
+    const lines = [];
+    const log = console.log;
+    console.log = (...values) => lines.push(values.join(" "));
+    try {
+      await runsCommand(["RUNNING", "--dispatch-only", "--count"], client);
+    } finally {
+      console.log = log;
+    }
+    expect(calls).toEqual([{ state: "RUNNING" }]);
+    expect(lines).toEqual(["0"]);
+  });
+
+  test("client.runs accepts options while retaining the state-string form", async () => {
+    const paths = [];
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        paths.push(new URL(request.url).pathname + new URL(request.url).search);
+        return Response.json({ runs: [], nextBefore: null });
+      },
+    });
+    try {
+      const client = apiClient({ port: server.port });
+      await client.runs("RUNNING");
+      await client.runs({
+        state: "RUNNING",
+        agent: "dispatch@1",
+        limit: 20,
+        before: "cursor-1",
+      });
+    } finally {
+      server.stop(true);
+    }
+    expect(paths).toEqual([
+      "/runs?state=RUNNING",
+      "/runs?state=RUNNING&agent=dispatch%401&limit=20&before=cursor-1",
+    ]);
   });
 
   test("registered command set is unchanged", () => {

--- a/event-runtime/cli/runs.mjs
+++ b/event-runtime/cli/runs.mjs
@@ -1,22 +1,126 @@
 import { pad, withClient } from "./shared.mjs";
 
-export async function runs(client, stateFilter) {
+const DISPATCH_AGENT_IDS = new Set(["dispatch", "worker"]);
+
+function parsePositiveInteger(value, flag) {
+  const number = Number(value);
+  if (!Number.isInteger(number) || number < 1) {
+    throw new Error(`${flag} requires a positive integer`);
+  }
+  return number;
+}
+
+export function parseRunsArgs(args) {
+  const options = { excludeAgents: [] };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (!arg.startsWith("--")) {
+      if (options.state !== undefined)
+        throw new Error(`unexpected runs argument: ${arg}`);
+      options.state = arg;
+      continue;
+    }
+    if (arg === "--dispatch-only") {
+      options.dispatchOnly = true;
+      continue;
+    }
+    if (arg === "--count") {
+      options.count = true;
+      continue;
+    }
+    const value = args[index + 1];
+    if (value === undefined || value.startsWith("--")) {
+      throw new Error(`${arg} requires a value`);
+    }
+    index += 1;
+    if (arg === "--agent") options.agent = value;
+    else if (arg === "--exclude-agent") options.excludeAgents.push(value);
+    else if (arg === "--limit")
+      options.limit = parsePositiveInteger(value, arg);
+    else throw new Error(`unknown runs option: ${arg}`);
+  }
+  return options;
+}
+
+function isDispatchWorkerAgent(def) {
+  return DISPATCH_AGENT_IDS.has(def?.id);
+}
+
+export async function runs(client, stateFilter, options = {}) {
   const state = stateFilter?.toUpperCase();
-  const { runs: rows } = await client.runs(state);
-  if (rows.length === 0) {
+  const query = {
+    ...(state ? { state } : {}),
+    ...(options.agent ? { agent: options.agent } : {}),
+    ...(options.limit ? { limit: options.limit } : {}),
+  };
+  const usesOptions = Boolean(
+    options.agent ||
+    options.limit ||
+    options.count ||
+    (options.excludeAgents?.length ?? 0) > 0,
+  );
+  const rows = [];
+  let before = null;
+  do {
+    // Preserve the original string call for state-only programmatic callers.
+    const request =
+      before === null &&
+      !usesOptions &&
+      Object.keys(query).length === 1 &&
+      query.state
+        ? query.state
+        : { ...query, ...(before ? { before } : {}) };
+    const page = await client.runs(request);
+    rows.push(...(page.runs ?? []));
+    const hasNextPage = page.hasNextPage ?? Boolean(page.nextBefore);
+    if (!hasNextPage) break;
+    if (typeof page.nextBefore !== "string" || page.nextBefore === "") {
+      throw new Error(
+        "runs response has another page but no nextBefore cursor",
+      );
+    }
+    before = page.nextBefore;
+  } while (before);
+
+  const excluded = new Set(options.excludeAgents ?? []);
+  const filtered = rows.filter((row) => !excluded.has(row.agent));
+  const visible = options.limit ? filtered.slice(0, options.limit) : filtered;
+  const truncated = filtered.length - visible.length;
+  if (options.count) {
+    console.log(visible.length);
+    return;
+  }
+  if (visible.length === 0) {
     console.log(state ? `no runs with state ${state}` : "no runs");
     return;
   }
   console.log(
     `${pad("RUN ID", 42)}${pad("STATE", 12)}${pad("AGENT", 26)}${pad("ADAPTER", 12)}${pad("ATTEMPTS", 10)}${pad("ORIGIN EVENT", 24)}UPDATED`,
   );
-  for (const r of rows) {
+  for (const r of visible) {
     console.log(
       `${pad(r.runId, 42)}${pad(r.state, 12)}${pad(r.agent, 26)}${pad(r.adapter, 12)}${pad(`${r.attempts}/${r.maxAttempts}`, 10)}${pad(r.eventId ?? "-", 24)}${r.updated_at}`,
     );
   }
+  if (truncated > 0) console.error(`... ${truncated} more rows (truncated)`);
 }
 
-export default function runsCommand(args) {
-  return withClient((client) => runs(client, args[0]));
+export async function runsCommand(args, injectedClient = null) {
+  const options = parseRunsArgs(args);
+  const execute = async (client) => {
+    if (options.dispatchOnly) {
+      const { agents = [] } = await client.agents();
+      options.excludeAgents.push(
+        ...agents
+          .filter((agent) => !isDispatchWorkerAgent(agent))
+          .map((agent) => agent.ref),
+      );
+    }
+    await runs(client, options.state, options);
+  };
+  return injectedClient ? execute(injectedClient) : withClient(execute);
+}
+
+export default function runsCommandDefault(args) {
+  return runsCommand(args);
 }

--- a/event-runtime/cli/runs.mjs
+++ b/event-runtime/cli/runs.mjs
@@ -1,6 +1,35 @@
 import { pad, withClient } from "./shared.mjs";
 
-const DISPATCH_AGENT_IDS = new Set(["dispatch", "worker"]);
+/**
+ * `--dispatch-only` allowlist. A run counts as dispatch work when its agent
+ * definition matches any of these, in order:
+ *
+ * 1. its `id` is in DISPATCH_AGENT_IDS (`dispatch`; `worker` is the legacy
+ *    name some fixtures and older registries still use);
+ * 2. its `id` starts with `dispatch-` (repo-local dispatch variants);
+ * 3. its `outputContract` is a dispatch result contract — the registry field
+ *    that actually marks "this agent lands a ticket", so a renamed dispatch
+ *    agent still counts without touching this file.
+ *
+ * Everything else the registry knows (merge-review, merge-fix, ci-doctor,
+ * ci-notify, merge-notify, triage-scan, merge-scan, work-scan, reaper, the
+ * smoke probes, ...) is excluded, and so is any row whose agent is not in the
+ * registry at all: a drain (`until [ "$(factory runs RUNNING --dispatch-only
+ * --count)" = 0 ]`) must not be kept busy by an agent that was since removed.
+ */
+export const DISPATCH_AGENT_IDS = new Set(["dispatch", "worker"]);
+export const DISPATCH_OUTPUT_CONTRACTS = new Set([
+  "factory.dispatch-result/v1",
+]);
+
+/**
+ * Hard limits for the cursor walk. The control API clamps a page to
+ * RUN_LIST_MAX_LIMIT (200, `lib/api-runs.mjs`) and rejects anything larger,
+ * so the CLI never asks for more; MAX_PAGES bounds a runaway walk (a server
+ * that keeps handing out cursors) at 50 x 200 = 10,000 rows.
+ */
+export const RUN_LIST_PAGE_SIZE = 200;
+export const RUN_LIST_MAX_PAGES = 50;
 
 function parsePositiveInteger(value, flag) {
   const number = Number(value);
@@ -42,49 +71,100 @@ export function parseRunsArgs(args) {
   return options;
 }
 
-function isDispatchWorkerAgent(def) {
-  return DISPATCH_AGENT_IDS.has(def?.id);
+export function isDispatchWorkerAgent(def) {
+  const id = typeof def?.id === "string" ? def.id : "";
+  return (
+    DISPATCH_AGENT_IDS.has(id) ||
+    id.startsWith("dispatch-") ||
+    DISPATCH_OUTPUT_CONTRACTS.has(def?.outputContract)
+  );
+}
+
+/** Agent id of a run row's `agent` ref (`dispatch@1` -> `dispatch`). */
+function agentIdOf(ref) {
+  return typeof ref === "string" ? ref.split("@")[0] : "";
+}
+
+/**
+ * Build the row predicate for `--dispatch-only` from the registry: keep rows
+ * whose agent ref (or bare id) belongs to a dispatch definition, or whose id
+ * is a known dispatch id even when the registry no longer lists it.
+ */
+export function dispatchOnlyPredicate(agents) {
+  const refs = new Set();
+  for (const def of agents ?? []) {
+    if (!isDispatchWorkerAgent(def)) continue;
+    if (typeof def.ref === "string") refs.add(def.ref);
+    if (typeof def.id === "string") refs.add(def.id);
+  }
+  return (row) =>
+    refs.has(row.agent) || isDispatchWorkerAgent({ id: agentIdOf(row.agent) });
 }
 
 export async function runs(client, stateFilter, options = {}) {
   const state = stateFilter?.toUpperCase();
+  const limit = options.limit ?? null;
+  const pageSize = Math.min(limit ?? RUN_LIST_PAGE_SIZE, RUN_LIST_PAGE_SIZE);
   const query = {
     ...(state ? { state } : {}),
     ...(options.agent ? { agent: options.agent } : {}),
-    ...(options.limit ? { limit: options.limit } : {}),
   };
   const usesOptions = Boolean(
     options.agent ||
     options.limit ||
     options.count ||
+    options.keep ||
     (options.excludeAgents?.length ?? 0) > 0,
   );
-  const rows = [];
+  const excluded = new Set(options.excludeAgents ?? []);
+  const keep = (row) =>
+    !excluded.has(row.agent) && (options.keep ? options.keep(row) : true);
+
+  const filtered = [];
+  const seenCursors = new Set();
   let before = null;
-  do {
+  let pages = 0;
+  // True when the server still had rows we did not fetch (cap or --limit).
+  let unfetched = false;
+  while (true) {
     // Preserve the original string call for state-only programmatic callers.
     const request =
-      before === null &&
-      !usesOptions &&
-      Object.keys(query).length === 1 &&
-      query.state
-        ? query.state
-        : { ...query, ...(before ? { before } : {}) };
+      before === null && !usesOptions && !options.agent && state
+        ? state
+        : { ...query, limit: pageSize, ...(before ? { before } : {}) };
     const page = await client.runs(request);
-    rows.push(...(page.runs ?? []));
+    pages += 1;
+    filtered.push(...(page.runs ?? []).filter(keep));
     const hasNextPage = page.hasNextPage ?? Boolean(page.nextBefore);
     if (!hasNextPage) break;
+    if (limit !== null && filtered.length >= limit) {
+      unfetched = true;
+      break;
+    }
+    if (pages >= RUN_LIST_MAX_PAGES) {
+      console.error(
+        `... stopped after ${pages} pages (${RUN_LIST_MAX_PAGES} page cap); pass --limit or a narrower filter`,
+      );
+      unfetched = true;
+      break;
+    }
     if (typeof page.nextBefore !== "string" || page.nextBefore === "") {
       throw new Error(
         "runs response has another page but no nextBefore cursor",
       );
     }
+    if (seenCursors.has(page.nextBefore)) {
+      console.error(
+        `... stopped: runs cursor ${page.nextBefore} repeated (server paging loop)`,
+      );
+      unfetched = true;
+      break;
+    }
+    seenCursors.add(page.nextBefore);
     before = page.nextBefore;
-  } while (before);
+  }
 
-  const excluded = new Set(options.excludeAgents ?? []);
-  const filtered = rows.filter((row) => !excluded.has(row.agent));
-  const visible = options.limit ? filtered.slice(0, options.limit) : filtered;
+  const visible = limit !== null ? filtered.slice(0, limit) : filtered;
   const truncated = filtered.length - visible.length;
   if (options.count) {
     console.log(visible.length);
@@ -102,7 +182,11 @@ export async function runs(client, stateFilter, options = {}) {
       `${pad(r.runId, 42)}${pad(r.state, 12)}${pad(r.agent, 26)}${pad(r.adapter, 12)}${pad(`${r.attempts}/${r.maxAttempts}`, 10)}${pad(r.eventId ?? "-", 24)}${r.updated_at}`,
     );
   }
-  if (truncated > 0) console.error(`... ${truncated} more rows (truncated)`);
+  if (truncated > 0 || unfetched) {
+    console.error(
+      `... ${truncated}${unfetched ? "+" : ""} more rows (truncated)`,
+    );
+  }
 }
 
 export async function runsCommand(args, injectedClient = null) {
@@ -110,11 +194,7 @@ export async function runsCommand(args, injectedClient = null) {
   const execute = async (client) => {
     if (options.dispatchOnly) {
       const { agents = [] } = await client.agents();
-      options.excludeAgents.push(
-        ...agents
-          .filter((agent) => !isDispatchWorkerAgent(agent))
-          .map((agent) => agent.ref),
-      );
+      options.keep = dispatchOnlyPredicate(agents);
     }
     await runs(client, options.state, options);
   };

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -40,7 +40,8 @@ usage: bun event-runtime/cli.mjs <command>
   doctor                         system health check: anomaly report (exits non-zero on anomalies)
   events [status]                admitted events, optionally filtered by status
   ps [state]                     running event processes/runs (default: RUNNING or LEASED)
-  runs [state]                   runs (optionally filtered by state)
+  runs [state] [--agent ID] [--exclude-agent ID] [--dispatch-only]
+       [--count] [--limit N]     runs; filters, count-only output, and pagination
   proposals                      open proposals with TTL age
   inbox                          open items waiting on the human
   agents                         registered agent definitions and event routing

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -41,7 +41,14 @@ usage: bun event-runtime/cli.mjs <command>
   events [status]                admitted events, optionally filtered by status
   ps [state]                     running event processes/runs (default: RUNNING or LEASED)
   runs [state] [--agent ID] [--exclude-agent ID] [--dispatch-only]
-       [--count] [--limit N]     runs; filters, count-only output, and pagination
+       [--count] [--limit N]     runs; --agent is forwarded to the API, --exclude-agent
+                                 (repeatable) filters client-side, --dispatch-only keeps
+                                 only dispatch agents (id dispatch/worker/dispatch-*, or
+                                 output contract factory.dispatch-result/v1) and drops
+                                 merge-*/ci-*/*-scan and unregistered agents, --count
+                                 prints the integer only; pages of 200 are followed until
+                                 exhausted, --limit N, or 50 pages, then
+                                 "... N more rows (truncated)" goes to stderr
   proposals                      open proposals with TTL age
   inbox                          open items waiting on the human
   agents                         registered agent definitions and event routing

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -132,8 +132,24 @@ export function apiClient({
       call("POST", `/proposals/${encodeURIComponent(id)}/reject`, {
         body: JSON.stringify({ reason }),
       }),
-    runs: (state) =>
-      call("GET", `/runs${state ? `?state=${encodeURIComponent(state)}` : ""}`),
+    /**
+     * List runs. Accept the original state string for existing callers, or an
+     * options object so list clients can carry the API's cursor and filters.
+     */
+    runs: (stateOrOptions) => {
+      const options =
+        typeof stateOrOptions === "string"
+          ? { state: stateOrOptions }
+          : (stateOrOptions ?? {});
+      const query = new URLSearchParams();
+      for (const key of ["state", "agent", "limit", "before"]) {
+        if (options[key] !== undefined && options[key] !== null) {
+          query.set(key, String(options[key]));
+        }
+      }
+      const suffix = query.size > 0 ? `?${query}` : "";
+      return call("GET", `/runs${suffix}`);
+    },
     run: (id) => call("GET", `/runs/${encodeURIComponent(id)}`),
     /**
      * Raw artifact bytes by content address (GET /artifacts/:sha). The route


### PR DESCRIPTION
Fixes #1760

Filter dispatch runs and count them accurately past API page limits.

## Validation

| Check                | Command                                                                          | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000`                            | pass    | 18 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,192 pass, 10 skipped        |
| UX critique          | factory-ux-critic                                                                | not run | internal CLI surface          |

UX critique: skipped — internal CLI surface

run:run_f61b9244-bf51-499f-b689-48a909d9b5da

## Post-review

Reviewer verdict FIX, addressed in the follow-up commit:

- Cursor walk is bounded: at most 50 pages (10,000 rows) and a repeated `nextBefore` cursor breaks the loop; both print a stderr note and the `... N+ more rows (truncated)` marker.
- `--limit N` stops fetching once N matching rows are collected instead of draining every page first.
- Per-page size is clamped to the API maximum (200) so `--limit 5000` no longer gets a 400 from `GET /runs`.
- `--dispatch-only` is now an allowlist: agents whose id is `dispatch`/`worker`/`dispatch-*` or whose output contract is `factory.dispatch-result/v1` are kept; every other registry agent and any unregistered agent is dropped. Documented in `usage.mjs` and in the `runs.mjs` header.
- Tests: page cap, repeated cursor, `--limit` early stop + 200 clamp, allowlist predicate (`event-runtime/cli.test.mjs`).
