### PR TITLE
fix(worktree): add elapsed startup timeout budgets

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -166,6 +166,20 @@ die() {
 info() { printf '\033[36m==>\033[0m %s\n' "$*"; }
 warn() { printf '\033[33mwarn:\033[0m %s\n' "$*" >&2; }
 
+# Bring-up waits are host-dependent: first boot migrations and validation can
+# take substantially longer than a warmed runtime. Keep the two budgets typed
+# and shared by every invocation mode before any worktree side effects begin.
+validate_worktree_timeout() { # <environment variable name> <default>
+  local name="$1" default="$2" value
+  value="${!name:-$default}"
+  [[ "$value" =~ ^[0-9]+$ && "$value" =~ [1-9] ]] \
+    || die "worktree_bad_timeout: $name must be a positive integer (got '$value')"
+  printf '%d\n' "$((10#$value))"
+}
+
+WORKTREE_HEALTH_TIMEOUT_S="$(validate_worktree_timeout FACTORY_WORKTREE_HEALTH_TIMEOUT_S 55)"
+WORKTREE_WEB_TIMEOUT_S="$(validate_worktree_timeout FACTORY_WORKTREE_WEB_TIMEOUT_S 5)"
+
 # Resolve a path without requiring its final component to exist. GNU `realpath
 # -m` offers this, but BSD/macOS realpath does not support `-m`. The parent
 # must exist here (as it does for the config paths below); `cd -P` both makes

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -187,6 +187,105 @@ function runWorktreeUp(fixture, ticket) {
   );
 }
 
+function delayedHealthFixture() {
+  const fixture = worktreeUpFixture();
+  const fakeBun = path.join(fixture.mockBin, "bun");
+  mkdirSync(path.join(fixture.root, "event-runtime", "web"), {
+    recursive: true,
+  });
+  mkdirSync(path.join(fixture.root, "event-runtime", "web", "src"), {
+    recursive: true,
+  });
+  mkdirSync(path.join(fixture.root, "event-runtime", "web", "public"), {
+    recursive: true,
+  });
+  writeFileSync(
+    path.join(fixture.root, "event-runtime", "web", "package.json"),
+    '{"scripts":{"build:fast":"true"}}\n',
+  );
+  writeFileSync(
+    path.join(fixture.root, "event-runtime", "web", "src", "main.js"),
+    "export {};\n",
+  );
+  writeFileSync(
+    path.join(fixture.root, "event-runtime", "web", "public", ".keep"),
+    "\n",
+  );
+  for (const file of [
+    "bun.lock",
+    "vite.config.ts",
+    "tsconfig.json",
+    "index.html",
+  ]) {
+    writeFileSync(path.join(fixture.root, "event-runtime", "web", file), "\n");
+  }
+  writeFileSync(
+    fakeBun,
+    `#!/usr/bin/env bash
+set -euo pipefail
+case "${"${1:-}"} ${"${2:-}"}" in
+  "--eval "|"-e ") exec "$REAL_BUN" "$@" ;;
+  "install "*) exit 0 ;;
+  "run build:fast") exit 1 ;;
+  "event-runtime/cli.mjs serve")
+    exec "$REAL_BUN" --eval '
+      const delay = Number(Bun.env.FAKE_HEALTH_DELAY_MS ?? 2000);
+      setTimeout(() => Bun.serve({
+        hostname: "127.0.0.1",
+        port: Number(Bun.env.FACTORY_EVENT_PORT),
+        fetch() { return Response.json({ env: { home: Bun.env.FACTORY_EVENT_HOME, adapter: "fake" } }); },
+      }), delay);
+      setInterval(() => {}, 1 << 30);
+    '
+    ;;
+  "event-runtime/cli.mjs work") exec "$REAL_BUN" --eval 'setInterval(() => {}, 1 << 30)' ;;
+  *) exec "$REAL_BUN" "$@" ;;
+esac
+`,
+  );
+  chmodSync(fakeBun, 0o755);
+  git(fixture.root, "add", "event-runtime", "bin");
+  git(fixture.root, "commit", "-qm", "delayed health fixture");
+  git(fixture.root, "push", "-q", "origin", "develop");
+  return fixture;
+}
+
+function runDelayedHealthWorktreeUp(fixture, timeout, resume = false) {
+  return command(
+    [
+      "bash",
+      "bin/worktree-up.sh",
+      "WM-1763",
+      "--no-seed",
+      ...(resume ? ["--resume"] : []),
+    ],
+    fixture.root,
+    {
+      FACTORY_WT_ROOT: fixture.worktrees,
+      FACTORY_LOCK_DIR: path.join(fixture.root, ".locks", "bun-install"),
+      FACTORY_PORT_RESERVATION_ROOT: path.join(fixture.root, ".locks", "ports"),
+      FACTORY_WORKTREE_HEALTH_TIMEOUT_S: String(timeout),
+      FAKE_HEALTH_DELAY_MS: "2000",
+      REAL_BUN: process.execPath,
+      PATH: `${fixture.mockBin}:${TEST_PATH}`,
+    },
+  );
+}
+
+function stopFixtureDaemons(fixture) {
+  const worktree = path.join(fixture.worktrees, "WM-1763");
+  for (const daemon of ["serve", "worker", "web"]) {
+    try {
+      const pid = Number(
+        readFileSync(path.join(worktree, ".factory", "run", `${daemon}.pid`)),
+      );
+      if (Number.isInteger(pid)) process.kill(-pid, "SIGTERM");
+    } catch {
+      // A failed bring-up cleans up daemons itself; absent pidfiles are normal.
+    }
+  }
+}
+
 async function shAsync(body, extraEnv = {}) {
   const proc = Bun.spawn(["bash", "-c", `source "${COMMON}"\n${body}`], {
     stdout: "pipe",
@@ -1078,6 +1177,38 @@ test("worktree-up fails closed when a matching remote branch diverged after a st
     rmSync(fixture.worktrees, { recursive: true, force: true });
     rmSync(fixture.mockBin, { recursive: true, force: true });
     rmSync(remoteClone, { recursive: true, force: true });
+  }
+});
+
+test("worktree timeout settings reject non-positive integer values", () => {
+  for (const [name, value] of [
+    ["FACTORY_WORKTREE_HEALTH_TIMEOUT_S", "0"],
+    ["FACTORY_WORKTREE_HEALTH_TIMEOUT_S", "nope"],
+    ["FACTORY_WORKTREE_WEB_TIMEOUT_S", "-1"],
+  ]) {
+    const r = sh("true", { [name]: value });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain("worktree_bad_timeout:");
+    expect(r.stderr).toContain(name);
+  }
+});
+
+test("worktree-up uses the elapsed health budget for delayed serve startup", () => {
+  const fixture = delayedHealthFixture();
+  try {
+    const shortBudget = runDelayedHealthWorktreeUp(fixture, 1);
+    expect(shortBudget.status).not.toBe(0);
+    expect(shortBudget.stderr).toContain("control API not healthy after");
+    expect(shortBudget.stderr).toContain("budget 1s");
+    expect(shortBudget.stderr).toMatch(/last curl exit \d+/);
+
+    const defaultBudget = runDelayedHealthWorktreeUp(fixture, 55, true);
+    expect(defaultBudget.status).toBe(0);
+  } finally {
+    stopFixtureDaemons(fixture);
+    rmSync(fixture.root, { recursive: true, force: true });
+    rmSync(fixture.worktrees, { recursive: true, force: true });
+    rmSync(fixture.mockBin, { recursive: true, force: true });
   }
 });
 

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -434,23 +434,29 @@ dump_daemon_log() { # <logfile> <label>
 # count as ready. If our recorded pid died at bind, say so from serve.log
 # instead of adopting the process that won the port.
 HEALTH_JSON=""
-for _ in {1..50}; do
-  HEALTH_JSON=$(curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" 2>/dev/null) && break
-  HEALTH_JSON=""
+HEALTH_WAIT_STARTED=$SECONDS
+HEALTH_LAST_CURL_EXIT=0
+while :; do
+  if HEALTH_JSON=$(curl -sf -m 1 "http://127.0.0.1:$API_PORT/health" 2>/dev/null); then
+    break
+  else
+    HEALTH_LAST_CURL_EXIT=$?
+    HEALTH_JSON=""
+  fi
   if ! pid_alive "$RUN_DIR/serve.pid"; then
     dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
     die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
+  fi
+  HEALTH_WAIT_ELAPSED=$((SECONDS - HEALTH_WAIT_STARTED))
+  if (( HEALTH_WAIT_ELAPSED >= WORKTREE_HEALTH_TIMEOUT_S )); then
+    dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
+    die "control API not healthy after ${HEALTH_WAIT_ELAPSED}s (budget ${WORKTREE_HEALTH_TIMEOUT_S}s, last curl exit ${HEALTH_LAST_CURL_EXIT}) — see $RUN_DIR/serve.log"
   fi
   sleep 0.1
 done
 if ! pid_alive "$RUN_DIR/serve.pid"; then
   dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
   die "event runtime died during startup on $API_PORT — see $RUN_DIR/serve.log"
-fi
-if [[ -z "$HEALTH_JSON" ]]; then
-  dump_daemon_log "$RUN_DIR/serve.log" "event runtime"
-  HEALTH_JSON=$(curl -sf -m 2 "http://127.0.0.1:$API_PORT/health") \
-    || die "control API never came up on $API_PORT — see $RUN_DIR/serve.log"
 fi
 assert_event_home "$HEALTH_JSON" "$HOME_DIR" "$API_PORT"
 assert_event_adapter "$HEALTH_JSON" "$LIVE" "$API_PORT"
@@ -484,19 +490,21 @@ if [[ "$WEB_AVAILABLE" -eq 1 ]]; then
   # adjacent port after allocation. Require the recorded web daemon itself to own
   # the persisted port before reporting the environment ready.
   WEB_PID_PORT=""
-  for _ in {1..50}; do
+  WEB_WAIT_STARTED=$SECONDS
+  while :; do
     if ! pid_alive "$RUN_DIR/web.pid"; then
       dump_daemon_log "$RUN_DIR/web.log" "web server"
       die "web server died during startup on $WEB_PORT — see $RUN_DIR/web.log"
     fi
     WEB_PID_PORT=$(listen_tcp_port "$RUN_DIR/web.pid" || true)
     [[ "$WEB_PID_PORT" == "$WEB_PORT" ]] && break
+    WEB_WAIT_ELAPSED=$((SECONDS - WEB_WAIT_STARTED))
+    if (( WEB_WAIT_ELAPSED >= WORKTREE_WEB_TIMEOUT_S )); then
+      dump_daemon_log "$RUN_DIR/web.log" "web server"
+      die "web server pid $(cat "$RUN_DIR/web.pid") did not bind reserved port $WEB_PORT after ${WEB_WAIT_ELAPSED}s (budget ${WORKTREE_WEB_TIMEOUT_S}s, last observed port ${WEB_PID_PORT:-none})"
+    fi
     sleep 0.1
   done
-  if [[ "$WEB_PID_PORT" != "$WEB_PORT" ]]; then
-    dump_daemon_log "$RUN_DIR/web.log" "web server"
-    die "web server pid $(cat "$RUN_DIR/web.pid") did not bind reserved port $WEB_PORT"
-  fi
 fi
 
 # ------------------------------------------------------------------- seed ---


### PR DESCRIPTION
Fixes watt-mind/factory#1763

Configure elapsed health and web startup budgets so slow worktree services report actionable timeout diagnostics.

## Validation

| Check                | Command                                                                                             | Result  | Notes                              |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test bin/worktree-common.test.mjs --timeout 60000`                                            | pass    | 49 pass, 0 fail                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2189 pass, 10 skipped; lint clean |
| UX critique          | factory-ux-critic                                                                                   | not run | no user-facing surface             |

UX critique: skipped

run:run_e3ba1032-6b25-42b9-bd99-734ef6154f5e