### PR TITLE
feat(cli): status --json exposing admitted-not-planned and queued in-flight counts

### DIFF
--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -148,8 +148,24 @@ export function getPoolLines(pool, s) {
   return { line, anomalies };
 }
 
-export async function status(client) {
+export async function status(client, args = []) {
   const s = await client.status();
+  const pool = getPoolLines(readPool(), s);
+  const anomalyLines = [...getAnomalyLines(s), ...pool.anomalies];
+  if (args.includes("--json")) {
+    console.log(
+      JSON.stringify({
+        ...s,
+        inFlight: {
+          admittedNotPlanned: s.events?.admitted ?? 0,
+          queued: s.runs?.byState?.QUEUED ?? 0,
+          running: s.runs?.byState?.RUNNING ?? 0,
+        },
+        anomalies: anomalyLines,
+      }),
+    );
+    return anomalyLines;
+  }
   if (s.env) {
     console.log(
       `${pad("env", 11)}${s.env.name}${s.env.adapter ? `   (adapter override: ${s.env.adapter})` : ""}   ${s.env.home}`,
@@ -180,9 +196,7 @@ export async function status(client) {
       console.log(spendLine(`  ${row.agent}`, row));
     }
   }
-  const pool = getPoolLines(readPool(), s);
   if (pool.line) console.log(pool.line);
-  const anomalyLines = [...getAnomalyLines(s), ...pool.anomalies];
   if (anomalyLines.length === 0) console.log(`${pad("anomalies", 11)}none`);
   else
     for (const line of anomalyLines)
@@ -190,6 +204,6 @@ export async function status(client) {
   return anomalyLines;
 }
 
-export default function statusCommand() {
-  return withClient(status);
+export default function statusCommand(args) {
+  return withClient((client) => status(client, args));
 }

--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -1,5 +1,6 @@
 import { readPool } from "./supervise.mjs";
 import { pad, withClient } from "./shared.mjs";
+import { apiClient } from "../lib/client.mjs";
 
 function countLine(label, counts, order = Object.keys(counts)) {
   const parts = order.map((k) => `${k} ${counts[k] ?? 0}`);
@@ -204,6 +205,20 @@ export async function status(client, args = []) {
   return anomalyLines;
 }
 
-export default function statusCommand(args) {
-  return withClient((client) => status(client, args));
+export default async function statusCommand(args = []) {
+  if (!args.includes("--json")) {
+    return withClient((client) => status(client, args));
+  }
+
+  const client = apiClient();
+  try {
+    return await status(client, args);
+  } catch (err) {
+    const error =
+      err.status === undefined
+        ? `control API not reachable on ${client.host}:${client.port} — start it with: bun event-runtime/cli.mjs serve`
+        : err.message;
+    console.error(JSON.stringify({ error }));
+    process.exit(1);
+  }
 }

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -79,9 +79,9 @@ describe("status and doctor commands", () => {
     });
     expect(json.status).not.toBe(0);
     expect(json.stdout).toBe("");
-    expect(json.stderr).toContain(
-      `control API not reachable on 127.0.0.1:${DEAD_PORT} — start it with: bun event-runtime/cli.mjs serve`,
-    );
+    expect(JSON.parse(json.stderr)).toEqual({
+      error: `control API not reachable on 127.0.0.1:${DEAD_PORT} — start it with: bun event-runtime/cli.mjs serve`,
+    });
   });
 
   test("ps against a dead port says serve is not running, non-zero exit", () => {

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -17,10 +17,69 @@ import {
 registerCliTmpCleanup();
 
 describe("status and doctor commands", () => {
+  test(
+    "status --json reports in-flight counts from a live seeded serve",
+    async () => {
+      const home = tmpDir("evrt-status-json-");
+      const controlApiToken = "status-json-control-token";
+      const box = await spawnLiveServe({
+        home,
+        extraEnv: { FACTORY_CONTROL_API_TOKEN: controlApiToken },
+      });
+      let result;
+      try {
+        const at = new Date().toISOString();
+        const db = openDb(path.join(home, "runtime.db"));
+        db.query(
+          `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at)
+           VALUES ('test', 'admitted-event', 'test.event', ?, ?, '{}', 'hash', 'admitted', ?)`,
+        ).run(at, at, at);
+        db.query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+           VALUES ('queued-run', 'queued-key', '{}', 'hash', 'QUEUED', ?, ?)`,
+        ).run(at, at);
+        db.close();
+        result = spawnSync("bun", [CLI, "status", "--json"], {
+          encoding: "utf8",
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: home,
+            FACTORY_EVENT_PORT: box.port,
+            FACTORY_RUN_DIR: throwawayRunDir(),
+            FACTORY_CONTROL_API_TOKEN: controlApiToken,
+          },
+        });
+      } finally {
+        box.child.kill("SIGTERM");
+        await new Promise((resolve) => box.child.once("exit", resolve));
+      }
+
+      expect(result.status).toBe(0);
+      const payload = JSON.parse(result.stdout);
+      expect(payload.events.admitted).toBeNumber();
+      expect(payload.inFlight).toMatchObject({
+        admittedNotPlanned: payload.events.admitted,
+        queued: 1,
+        running: 0,
+      });
+      expect(Array.isArray(payload.anomalies)).toBe(true);
+    },
+    loadAdjustedTimeout(30_000),
+  );
+
   test("status against a dead port says serve is not running, non-zero exit", () => {
     const r = runCli(["status"], { FACTORY_EVENT_PORT: DEAD_PORT });
     expect(r.status).not.toBe(0);
     expect(r.all).toContain(
+      `control API not reachable on 127.0.0.1:${DEAD_PORT} — start it with: bun event-runtime/cli.mjs serve`,
+    );
+
+    const json = runCli(["status", "--json"], {
+      FACTORY_EVENT_PORT: DEAD_PORT,
+    });
+    expect(json.status).not.toBe(0);
+    expect(json.stdout).toBe("");
+    expect(json.stderr).toContain(
       `control API not reachable on 127.0.0.1:${DEAD_PORT} — start it with: bun event-runtime/cli.mjs serve`,
     );
   });


### PR DESCRIPTION
Fixes watt-mind/factory#1757

Expose machine-readable admitted, queued, and running status counts for safe redeploy automation.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli/status.test.mjs --timeout 20000` | pass | 10 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; lint 0 errors |
| UX critique          | factory-ux-critic                | not run | backend CLI-only change |

UX critique: skipped

run:run_9fc0c788-7b4d-4c3a-8124-b7494c735ee2
