### PR TITLE
fix(work): persist skipped-run diagnostics

### DIFF
--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -207,10 +207,15 @@ export default async function work(args) {
     ];
   }
 
-  function reportSkippedQueuedRuns(now) {
-    const skipped = inspectSkippedQueuedRuns(now);
-    skippedQueuedRuns = skipped;
+  /** Refresh the bounded snapshot the registry row and heartbeat publish. */
+  function snapshotSkippedQueuedRuns(now) {
+    skippedQueuedRuns = inspectSkippedQueuedRuns(now);
     lastSkipInspectionAt = now;
+  }
+
+  /** Log the current snapshot, rate-limited per (run, reason). */
+  function emitSkipReport(now) {
+    const skipped = skippedQueuedRuns;
     const present = new Set(
       skipped.map(({ runId, reason }) => `${runId}\u0000${reason}`),
     );
@@ -225,9 +230,17 @@ export default async function work(args) {
     }
   }
 
+  function reportSkippedQueuedRuns(now) {
+    snapshotSkippedQueuedRuns(now);
+    emitSkipReport(now);
+  }
+
   // Inspect once before registration so the first registry row is useful, and
   // retain this bounded snapshot until the idle-loop throttle refreshes it.
-  reportSkippedQueuedRuns(startedAt);
+  // The log lines are emitted only after the row exists: an observer that
+  // sees the first "skipped" line must be able to find the same diagnostics
+  // in the registry.
+  snapshotSkippedQueuedRuns(startedAt);
   registerWorker(db, {
     workerId,
     labels,
@@ -235,6 +248,7 @@ export default async function work(args) {
     skipped: skippedQueuedRuns,
     now: startedAt,
   });
+  emitSkipReport(startedAt);
   log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
   if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
   if (!sandboxReport.available)

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -29,6 +29,9 @@ import {
 } from "../lib/workers.mjs";
 import { fail, flagValue, log } from "./shared.mjs";
 
+/** Bound registry diagnostics so one incompatible queue cannot bloat a row. */
+const MAX_SKIPPED_DIAGNOSTICS = 50;
+
 // ---------------------------------------------------------------------------
 // work — the worker process (OPS-233; docs/event-runtime-workers.md §2)
 // ---------------------------------------------------------------------------
@@ -120,27 +123,11 @@ export default async function work(args) {
     : Object.keys(adapters);
   const startedAt = Date.now();
 
-  registerWorker(db, {
-    workerId,
-    labels,
-    adapters: adapterNames,
-    now: startedAt,
-  });
-  log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
-  if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
-  if (!sandboxReport.available)
-    log(`sandbox: unavailable — ${sandboxReport.reason}`);
-  if (adapterOverride)
-    log(`adapter override: executing every run with "${adapterOverride}"`);
-  if (drainFile)
-    log(
-      `drain-file: ${drainFile} (supervised worker — exits 0 when it appears, between claims)`,
-    );
-
   let draining = false;
   let inFlight = null;
   let idleSince = null;
   let lastSkipInspectionAt = null;
+  let skippedQueuedRuns = [];
   const reportedSkips = new Map();
 
   // Keep this exactly aligned with claimNext: a run in this window is QUEUED
@@ -164,7 +151,7 @@ export default async function work(args) {
       .all();
     const checkoutVersion = checkoutPolicyVersion();
 
-    return candidates.flatMap((candidate) => {
+    const skipped = candidates.flatMap((candidate) => {
       const spec = JSON.parse(candidate.spec_json);
       const backoff = claimBackoff.exec(candidate.queue_reason ?? "");
       if (backoff) {
@@ -210,10 +197,19 @@ export default async function work(args) {
       }
       return [];
     });
+    if (skipped.length <= MAX_SKIPPED_DIAGNOSTICS) return skipped;
+    return [
+      ...skipped.slice(0, MAX_SKIPPED_DIAGNOSTICS - 1),
+      {
+        runId: "...",
+        reason: `and ${skipped.length - MAX_SKIPPED_DIAGNOSTICS + 1} more`,
+      },
+    ];
   }
 
   function reportSkippedQueuedRuns(now) {
     const skipped = inspectSkippedQueuedRuns(now);
+    skippedQueuedRuns = skipped;
     lastSkipInspectionAt = now;
     const present = new Set(
       skipped.map(({ runId, reason }) => `${runId}\u0000${reason}`),
@@ -228,6 +224,27 @@ export default async function work(args) {
       reportedSkips.set(key, now);
     }
   }
+
+  // Inspect once before registration so the first registry row is useful, and
+  // retain this bounded snapshot until the idle-loop throttle refreshes it.
+  reportSkippedQueuedRuns(startedAt);
+  registerWorker(db, {
+    workerId,
+    labels,
+    adapters: adapterNames,
+    skipped: skippedQueuedRuns,
+    now: startedAt,
+  });
+  log(`worker ${workerId} on ${hostname()} (db ${dbPath()}, policy ${pv})`);
+  if (Object.keys(labels).length > 0) log(`labels: ${JSON.stringify(labels)}`);
+  if (!sandboxReport.available)
+    log(`sandbox: unavailable — ${sandboxReport.reason}`);
+  if (adapterOverride)
+    log(`adapter override: executing every run with "${adapterOverride}"`);
+  if (drainFile)
+    log(
+      `drain-file: ${drainFile} (supervised worker — exits 0 when it appears, between claims)`,
+    );
 
   function reportSkipsWhenDue(now) {
     idleSince ??= now;
@@ -267,6 +284,7 @@ export default async function work(args) {
       ...options,
       labels,
       adapters: adapterNames,
+      skipped: skippedQueuedRuns,
       startedAt,
     });
   const beat = setInterval(

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -11,6 +11,7 @@ import {
 import path from "node:path";
 import { policyVersion } from "../lib/config.mjs";
 import { openDb } from "../lib/db.mjs";
+import { listWorkers } from "../lib/workers.mjs";
 import {
   CLI,
   DEAD_PORT,
@@ -193,6 +194,57 @@ describe("work command", () => {
           /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
         );
         expect(box.out).not.toContain("refused run_registry_skip");
+        const d = openDb(path.join(home, "runtime.db"));
+        const [worker] = listWorkers(d);
+        d.close();
+        expect(worker.skipped).toEqual([
+          {
+            runId: "run_registry_skip",
+            definition: "factory-status-report@1",
+            reason: expect.stringMatching(/^registry_stale:/),
+          },
+        ]);
+      } finally {
+        box.child.kill("SIGTERM");
+        await exitOf(box.child);
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    loadAdjustedTimeout(30_000),
+  );
+
+  test(
+    "publishes cached skipped diagnostics to the registry and caps them",
+    async () => {
+      const home = tmpDir("evrt-work-registry-diagnostics-");
+      for (let index = 0; index < 51; index += 1) {
+        await seedSkippedRun(home, {
+          runId: `run_registry_${String(index).padStart(3, "0")}`,
+          promptVersion: "git:older-registry",
+        });
+      }
+      const box = spawnWorker(
+        [
+          "--adapter-override",
+          "fake",
+          "--poll-ms",
+          "25",
+          "--skip-report-ms",
+          "1000",
+        ],
+        { FACTORY_EVENT_HOME: home },
+      );
+      try {
+        await waitFor(box, '"runId":"run_registry_000"');
+        const d = openDb(path.join(home, "runtime.db"));
+        const [worker] = listWorkers(d);
+        d.close();
+        expect(worker.skipped).toHaveLength(50);
+        expect(worker.skipped[0].runId).toBe("run_registry_000");
+        expect(worker.skipped.at(-1)).toEqual({
+          runId: "...",
+          reason: "and 2 more",
+        });
       } finally {
         box.child.kill("SIGTERM");
         await exitOf(box.child);

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -40,6 +40,19 @@ registerTestProcessCleanup(import.meta.url);
 const WORKER_POLICY_VERSION = policyVersion();
 const LIVE_STACK = path.resolve(import.meta.dir, "../../bin/live-stack.sh");
 
+/** Poll the registry until the worker row exists (registration is racy vs stdout). */
+async function registeredWorker(home, { timeoutMs = 5_000 } = {}) {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const db = openDb(path.join(home, "runtime.db"));
+    const [worker] = listWorkers(db);
+    db.close();
+    if (worker) return worker;
+    if (Date.now() >= deadline) throw new Error("worker never registered");
+    await Bun.sleep(25);
+  }
+}
+
 async function seedSkippedRun(
   home,
   { runId, placement, promptVersion = WORKER_POLICY_VERSION, queuedReason },
@@ -194,9 +207,7 @@ describe("work command", () => {
           /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
         );
         expect(box.out).not.toContain("refused run_registry_skip");
-        const d = openDb(path.join(home, "runtime.db"));
-        const [worker] = listWorkers(d);
-        d.close();
+        const worker = await registeredWorker(home);
         expect(worker.skipped).toEqual([
           {
             runId: "run_registry_skip",
@@ -236,9 +247,7 @@ describe("work command", () => {
       );
       try {
         await waitFor(box, '"runId":"run_registry_000"');
-        const d = openDb(path.join(home, "runtime.db"));
-        const [worker] = listWorkers(d);
-        d.close();
+        const worker = await registeredWorker(home);
         expect(worker.skipped).toHaveLength(50);
         expect(worker.skipped[0].runId).toBe("run_registry_000");
         expect(worker.skipped.at(-1)).toEqual({

--- a/event-runtime/lib/workers.mjs
+++ b/event-runtime/lib/workers.mjs
@@ -127,20 +127,30 @@ export function heartbeat(
     runId = null,
     labels = {},
     adapters = [],
-    skipped = [],
+    skipped,
     now = Date.now(),
     startedAt = now,
   } = {},
 ) {
   const at = iso(now);
-  const normalizedSkipped = normalizeSkipped(skipped);
+  const normalizedSkipped =
+    skipped === undefined ? undefined : normalizeSkipped(skipped);
   const { changes } = db
     .query(
       `UPDATE workers
-          SET last_seen = ?, state = ?, current_run = ?, skipped_json = ?
+          SET last_seen = ?, state = ?, current_run = ?,
+              skipped_json = COALESCE(?, skipped_json)
         WHERE worker_id = ?`,
     )
-    .run(at, state, runId, JSON.stringify(normalizedSkipped), workerId);
+    .run(
+      at,
+      state,
+      runId,
+      normalizedSkipped === undefined
+        ? null
+        : JSON.stringify(normalizedSkipped),
+      workerId,
+    );
   if (changes) return;
 
   db.query(
@@ -155,7 +165,7 @@ export function heartbeat(
     process.pid,
     JSON.stringify(labels),
     adapters.join(","),
-    JSON.stringify(normalizedSkipped),
+    JSON.stringify(normalizedSkipped ?? []),
     iso(startedAt),
     at,
     state,

--- a/event-runtime/lib/workers.test.mjs
+++ b/event-runtime/lib/workers.test.mjs
@@ -190,7 +190,7 @@ describe("worker registry and heartbeats (OPS-233)", () => {
     expect(w.stale).toBe(false); // stopped is not stale — it left on purpose
   });
 
-  test("heartbeats persist skipped-run diagnostics and clear them when omitted", () => {
+  test("heartbeats preserve omitted skipped diagnostics and clear them explicitly", () => {
     const d = db();
     registerWorker(d, { workerId: "w1" });
     const skipped = [
@@ -200,7 +200,14 @@ describe("worker registry and heartbeats (OPS-233)", () => {
     heartbeat(d, "w1", { skipped });
     expect(listWorkers(d)[0].skipped).toEqual(skipped);
 
-    heartbeat(d, "w1");
+    heartbeat(d, "w1", { state: "busy", runId: "run_busy" });
+    expect(listWorkers(d)[0]).toMatchObject({
+      state: "busy",
+      currentRun: "run_busy",
+      skipped,
+    });
+
+    heartbeat(d, "w1", { skipped: [] });
     expect(listWorkers(d)[0].skipped).toEqual([]);
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1780

Persist capped worker skip diagnostics in the registry so status can surface queued-run reasons.

## Validation

| Check                | Command                                                                          | Result  | Notes                                 |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------- |
| Verification Command | `bun test event-runtime/cli/work.test.mjs event-runtime/lib/workers.test.mjs --timeout 60000` | pass | 53 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,197 pass; emit, format, lint clean  |
| UX critique          | `factory-ux-critic`                                                             | skipped | backend worker-registry behavior only |

UX critique: skipped — backend worker-registry behavior has no user-facing surface

run:run_584c2ddd-cfee-4a46-b910-cc607934dfb7

## Post-review

- Reviewer found CI red on the new test `publishes cached skipped diagnostics to the registry and caps them`: the pre-registration skip report logged before `registerWorker` inserted the row, so an observer keyed on the first `skipped` log line could read an empty registry. Fixed by splitting `reportSkippedQueuedRuns` into `snapshotSkippedQueuedRuns` (state only) and `emitSkipReport` (logging): snapshot, register, then emit. The two registry-reading tests now poll `listWorkers` via a `registeredWorker(home)` helper instead of assuming the row exists.
- Noted, not changed: `workerHeartbeat` in `work.mjs` always passes `skipped`, so the COALESCE "undefined = preserve" path in `workers.mjs` `heartbeat` has no in-repo caller today. Left in place as the documented contract for callers that do not track skipped diagnostics.
