### PR TITLE
fix(planner): consult toolchain preflight on dispatch

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -68,8 +68,10 @@ import {
   RepoError,
   getRepo,
   loadRepos,
+  repoDispatchPreflightSync,
   reposConfigPath,
   reposRoot,
+  toolchainHash,
 } from "./repos.mjs";
 import { validate } from "./schema.mjs";
 import { inFlightRunsForAgent } from "./schedules.mjs";
@@ -90,6 +92,11 @@ import {
 /** In-flight issues list is stable across one scan; 60s is the ticket cap. */
 export const IN_FLIGHT_CACHE_TTL_MS = 60_000;
 export { DEFAULT_MAX_IN_FLIGHT };
+
+// Readiness belongs to this planner process and a repo's declared constraints,
+// not to an individual event. Cache failures too: dispatch bursts must run one
+// bounded probe set per repo/toolchain declaration.
+const dispatchToolchainPreflightCache = new Map();
 
 /**
  * §5.4 idempotency key: agent ref, output contract, then the event type's
@@ -899,6 +906,27 @@ export function policySnapshot(root = reposRoot()) {
 function snapshotRepos(snapshot) {
   if (snapshot?.reposError) throw snapshot.reposError;
   return snapshot?.repos ?? loadRepos();
+}
+
+function dispatchToolchainEligibility(
+  payload,
+  { configSnapshot = null, toolchain = {} } = {},
+) {
+  const repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
+  // Preserve the additive path exactly: no declared tools means no probe and
+  // no new dispatch behavior.
+  if (!repo.toolchain?.length) return null;
+  const cache = toolchain.cache ?? dispatchToolchainPreflightCache;
+  const key = `${repo.name}:${toolchainHash(repo.toolchain)}`;
+  if (cache.has(key)) return cache.get(key);
+  const result = repoDispatchPreflightSync(repo, {
+    node: toolchain.node,
+    now: toolchain.now,
+    which: toolchain.which,
+    spawn: toolchain.spawn,
+  });
+  cache.set(key, result);
+  return result;
 }
 
 function policyMaxInFlight(root = reposRoot(), snapshot = null) {
@@ -2136,7 +2164,15 @@ function ticketHumanNeededContext(payload, evidence) {
   return { repo, ticket, descriptionHash };
 }
 
-function humanNeeded(db, event, reason, at, ttlSeconds, ticketContext = null) {
+function humanNeeded(
+  db,
+  event,
+  reason,
+  at,
+  ttlSeconds,
+  ticketContext = null,
+  detail = null,
+) {
   const outcomeReason = reason;
   if (ticketContext) {
     const reasonPrefix = humanNeededReasonPrefix(reason);
@@ -2194,6 +2230,7 @@ function humanNeeded(db, event, reason, at, ttlSeconds, ticketContext = null) {
     // ticket body that produced this question without changing the schema.
     reason = `${reason}\n${hashMarker}`;
   }
+  if (detail) reason = `${reason}\n${detail}`;
   const proposal = insertProposal(db, {
     id: newProposalId(),
     event,
@@ -2243,6 +2280,7 @@ export function planEvent(
     adapterOverride,
     artifactStore = artifactsRoot(),
     dispatch = {},
+    toolchain = {},
     configSnapshot = null,
     log = console.log,
   } = {},
@@ -2253,6 +2291,7 @@ export function planEvent(
   // transaction only when the event is still admitted there — a raced plan
   // simply discards it via the idempotent early return.
   let worktreeEligibility = null;
+  let toolchainEligibility = null;
   {
     const row = db
       .query(
@@ -2275,27 +2314,35 @@ export function planEvent(
         typeof preEnvelope.payload?.ticket === "string" &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
-        try {
-          worktreeEligibility = worktreeDispatchAutoEligibility(
+        if (preEnvelope.type === "factory.dispatch.requested") {
+          toolchainEligibility = dispatchToolchainEligibility(
             preEnvelope.payload,
-            {
-              ...dispatch,
-              operatorAuthorized: preEnvelope.source === "operator",
-              configSnapshot,
-            },
+            { configSnapshot, toolchain },
           );
-        } catch (err) {
-          if (!isLinearRateLimited(err)) throw err;
-          worktreeEligibility = {
-            ok: false,
-            rateLimited: true,
-            resetAt: err.resetAt ?? null,
-            refusal: {
-              decision: "retry_later",
-              reason: "linear_rate_limited",
-              detail: err.message,
-            },
-          };
+        }
+        if (toolchainEligibility?.ready !== false) {
+          try {
+            worktreeEligibility = worktreeDispatchAutoEligibility(
+              preEnvelope.payload,
+              {
+                ...dispatch,
+                operatorAuthorized: preEnvelope.source === "operator",
+                configSnapshot,
+              },
+            );
+          } catch (err) {
+            if (!isLinearRateLimited(err)) throw err;
+            worktreeEligibility = {
+              ok: false,
+              rateLimited: true,
+              resetAt: err.resetAt ?? null,
+              refusal: {
+                decision: "retry_later",
+                reason: "linear_rate_limited",
+                detail: err.message,
+              },
+            };
+          }
         }
       }
     }
@@ -2381,6 +2428,24 @@ export function planEvent(
     const scopeRefusal = repoNotAllowed(def, envelope.payload);
     if (scopeRefusal)
       return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
+
+    if (
+      envelope.type === "factory.dispatch.requested" &&
+      toolchainEligibility?.ready === false
+    ) {
+      const executable =
+        toolchainEligibility.reasons?.find((reason) => reason?.executable)
+          ?.executable ?? "unknown";
+      return humanNeeded(
+        db,
+        event,
+        `toolchain_unsatisfied:${executable}`,
+        at,
+        ttlSeconds,
+        null,
+        JSON.stringify(toolchainEligibility.reasons ?? []),
+      );
+    }
 
     // A work scan reserves its repo as soon as its run is PROPOSED, before the
     // expensive model read can select a ticket. This is deliberately stronger

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -912,7 +912,15 @@ function dispatchToolchainEligibility(
   payload,
   { configSnapshot = null, toolchain = {} } = {},
 ) {
-  const repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
+  let repo;
+  try {
+    repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
+  } catch (err) {
+    // An unknown repo is not a toolchain fact: leave it to the worktree gate,
+    // which refuses it as `human_needed repo_unknown` with full evidence.
+    if (err instanceof RepoError) return null;
+    throw err;
+  }
   // Preserve the additive path exactly: no declared tools means no probe and
   // no new dispatch behavior.
   if (!repo.toolchain?.length) return null;

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2316,6 +2316,31 @@ describe("planEvent worktree gate (WM-108)", () => {
     });
   });
 
+  test("factory dispatch for a repo missing from config/repos.yaml → human_needed repo_unknown", () => {
+    withReposRoot(tierRepo, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "toolchain-repo-unknown",
+        correlationId: "toolchain-repo-unknown",
+        payload: { repo: "ghost", ticket: "WM-694" },
+      });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: tierDispatch(),
+        toolchain: {
+          cache: new Map(),
+          which: () => {
+            throw new Error("unknown repo must not probe");
+          },
+        },
+      });
+      expect(outcome.decision).toBe("human_needed");
+      expect(outcome.reason).toMatch(/^repo_unknown: /);
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+
   test("a repo missing from config/repos.yaml → human_needed repo_unknown", () => {
     withReposRoot(
       `repos:\n  - name: real\n    path: /tmp/nowhere\n    base: develop\n`,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2232,6 +2232,90 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
+  test("factory dispatch refuses a missing toolchain before ticket reads and memoizes the typed proposal", () => {
+    const toolchainRepo = tierRepo + `    toolchain:\n      uv: ">=0.5"\n`;
+    withReposRoot(toolchainRepo, () => {
+      const db = openDb(":memory:");
+      const calls = [];
+      const toolchain = {
+        cache: new Map(),
+        which: (executable) => {
+          calls.push(executable);
+          return null;
+        },
+      };
+      const plan = (eventId) => {
+        const ref = admit(db, {
+          type: "factory.dispatch.requested",
+          eventId,
+          correlationId: eventId,
+          payload: { repo: "tiered", ticket: "WM-694" },
+        });
+        return planEvent(db, registry, ref, { now: NOW, toolchain });
+      };
+
+      const first = plan("toolchain-missing-first");
+      const second = plan("toolchain-missing-second");
+      expect(first).toMatchObject({
+        decision: "human_needed",
+        reason: "toolchain_unsatisfied:uv",
+      });
+      expect(second).toMatchObject({
+        decision: "human_needed",
+        reason: "toolchain_unsatisfied:uv",
+      });
+      expect(calls).toEqual(["uv"]);
+      expect(first.proposal.reason).toContain("repo_toolchain_missing");
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
+    });
+  });
+
+  test("factory dispatch probes a satisfied declared toolchain and plans normally", () => {
+    const toolchainRepo = tierRepo + `    toolchain:\n      bun: ">=1.3 <2"\n`;
+    withReposRoot(toolchainRepo, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "toolchain-satisfied",
+        correlationId: "toolchain-satisfied",
+        payload: { repo: "tiered", ticket: "WM-694" },
+      });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: tierDispatch(),
+        toolchain: {
+          cache: new Map(),
+          which: () => "/opt/bin/bun",
+          spawn: () => ({ exitCode: 0, stdout: "1.3.14\n", stderr: "" }),
+        },
+      });
+      expect(outcome.decision).toBe("run");
+    });
+  });
+
+  test("factory dispatch skips probing when the repo declares no toolchain", () => {
+    withReposRoot(tierRepo, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "toolchain-undeclared",
+        correlationId: "toolchain-undeclared",
+        payload: { repo: "tiered", ticket: "WM-694" },
+      });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: tierDispatch(),
+        toolchain: {
+          cache: new Map(),
+          which: () => {
+            throw new Error("undeclared toolchain must not probe");
+          },
+        },
+      });
+      expect(outcome.decision).toBe("run");
+    });
+  });
+
   test("a repo missing from config/repos.yaml → human_needed repo_unknown", () => {
     withReposRoot(
       `repos:\n  - name: real\n    path: /tmp/nowhere\n    base: develop\n`,

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -503,6 +503,101 @@ function failedToolchainProbe({
 }
 
 /**
+ * Typed result for a tool `which` could not find on PATH. The reason's action
+ * differs from a failed probe: the operator installs, not investigates.
+ */
+function missingToolchainProbe({ node, repo, executable, constraint }) {
+  return {
+    tool: {
+      executable,
+      constraint,
+      resolved: null,
+      observed: null,
+      observedRaw: null,
+      satisfied: false,
+    },
+    reason: {
+      reason: REPO_TOOLCHAIN_MISSING,
+      node,
+      repo,
+      executable,
+      constraint,
+      observed: null,
+      action: `install ${executable} ${constraint} on ${node}, or drop it from repo ${repo}'s toolchain in config/repos.yaml`,
+    },
+  };
+}
+
+/**
+ * Turn one `--version` probe result into its typed tool record and, when the
+ * constraint is not satisfied, its mismatch reason. Shared by the async and
+ * sync preflights so both attest identically.
+ */
+function probedToolchainTool({
+  node,
+  repo,
+  executable,
+  constraint,
+  resolved,
+  probe,
+}) {
+  const { exitCode, stdout, stderr } = probe;
+  const output = stdout?.trim() ? stdout : (stderr ?? "");
+  const observedRaw =
+    output
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? null;
+  const observed = exitCode === 0 ? normalizeToolVersion(output) : null;
+  const satisfied = satisfiesConstraint(observed, constraint);
+  const tool = {
+    executable,
+    constraint,
+    resolved,
+    observed,
+    observedRaw,
+    satisfied,
+  };
+  if (satisfied) return { tool, reason: null };
+  return {
+    tool,
+    reason: {
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      node,
+      repo,
+      executable,
+      constraint,
+      // The observed version is the whole point of the payload: without it the
+      // operator still has to go to the node to find out what is installed.
+      observed,
+      observedRaw,
+      detail:
+        exitCode !== 0
+          ? "version_probe_failed"
+          : observed === null
+            ? "unparseable_version"
+            : "constraint_unsatisfied",
+      action: `make ${executable} ${constraint} the resolved version on ${node} (observed ${observed ?? observedRaw ?? "nothing"}), or relax repo ${repo}'s constraint in config/repos.yaml`,
+    },
+  };
+}
+
+/** Assemble the attestation both preflight variants return. */
+function toolchainAttestation({ repo, node, now, toolchain, tools, reasons }) {
+  return {
+    repo: repo?.name ?? null,
+    node,
+    implementationVersion: TOOLCHAIN_PREFLIGHT_VERSION,
+    toolchainHash: toolchainHash(toolchain),
+    declared: toolchain !== null,
+    verifiedAt: now().toISOString(),
+    ok: reasons.length === 0,
+    tools,
+    reasons,
+  };
+}
+
+/**
  * Verify one node's tooling against a repo's declared constraints and return
  * an attestation (docs/event-runtime-repos.md §6.2).
  *
@@ -527,43 +622,29 @@ export async function preflightToolchain(
   const toolchain = repo?.toolchain ?? null;
   const tools = [];
   const reasons = [];
+  const record = ({ tool, reason }) => {
+    tools.push(tool);
+    if (reason) reasons.push(reason);
+  };
 
   for (const { executable, constraint } of toolchain ?? []) {
+    const probeContext = { node, repo: repo.name, executable, constraint };
     let resolved;
     try {
       resolved = await which(executable);
     } catch (error) {
-      const failed = failedToolchainProbe({
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        resolved: null,
-        error,
-        detail: "which_failed",
-      });
-      tools.push(failed.tool);
-      reasons.push(failed.reason);
+      record(
+        failedToolchainProbe({
+          ...probeContext,
+          resolved: null,
+          error,
+          detail: "which_failed",
+        }),
+      );
       continue;
     }
     if (!resolved) {
-      tools.push({
-        executable,
-        constraint,
-        resolved: null,
-        observed: null,
-        observedRaw: null,
-        satisfied: false,
-      });
-      reasons.push({
-        reason: REPO_TOOLCHAIN_MISSING,
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        observed: null,
-        action: `install ${executable} ${constraint} on ${node}, or drop it from repo ${repo.name}'s toolchain in config/repos.yaml`,
-      });
+      record(missingToolchainProbe(probeContext));
       continue;
     }
 
@@ -571,68 +652,20 @@ export async function preflightToolchain(
     try {
       probe = await spawn([resolved, TOOLCHAIN_VERSION_ARG]);
     } catch (error) {
-      const failed = failedToolchainProbe({
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        resolved,
-        error,
-        detail: "version_probe_threw",
-      });
-      tools.push(failed.tool);
-      reasons.push(failed.reason);
+      record(
+        failedToolchainProbe({
+          ...probeContext,
+          resolved,
+          error,
+          detail: "version_probe_threw",
+        }),
+      );
       continue;
     }
-    const { exitCode, stdout, stderr } = probe;
-    const output = stdout?.trim() ? stdout : (stderr ?? "");
-    const observedRaw =
-      output
-        .split("\n")
-        .find((l) => l.trim())
-        ?.trim() ?? null;
-    const observed = exitCode === 0 ? normalizeToolVersion(output) : null;
-    const satisfied = satisfiesConstraint(observed, constraint);
-    tools.push({
-      executable,
-      constraint,
-      resolved,
-      observed,
-      observedRaw,
-      satisfied,
-    });
-    if (satisfied) continue;
-    reasons.push({
-      reason: REPO_TOOLCHAIN_MISMATCH,
-      node,
-      repo: repo.name,
-      executable,
-      constraint,
-      // The observed version is the whole point of the payload: without it the
-      // operator still has to go to the node to find out what is installed.
-      observed,
-      observedRaw,
-      detail:
-        exitCode !== 0
-          ? "version_probe_failed"
-          : observed === null
-            ? "unparseable_version"
-            : "constraint_unsatisfied",
-      action: `make ${executable} ${constraint} the resolved version on ${node} (observed ${observed ?? observedRaw ?? "nothing"}), or relax repo ${repo.name}'s constraint in config/repos.yaml`,
-    });
+    record(probedToolchainTool({ ...probeContext, resolved, probe }));
   }
 
-  return {
-    repo: repo?.name ?? null,
-    node,
-    implementationVersion: TOOLCHAIN_PREFLIGHT_VERSION,
-    toolchainHash: toolchainHash(toolchain),
-    declared: toolchain !== null,
-    verifiedAt: now().toISOString(),
-    ok: reasons.length === 0,
-    tools,
-    reasons,
-  };
+  return toolchainAttestation({ repo, node, now, toolchain, tools, reasons });
 }
 
 /**
@@ -652,43 +685,29 @@ export function preflightToolchainSync(
   const toolchain = repo?.toolchain ?? null;
   const tools = [];
   const reasons = [];
+  const record = ({ tool, reason }) => {
+    tools.push(tool);
+    if (reason) reasons.push(reason);
+  };
 
   for (const { executable, constraint } of toolchain ?? []) {
+    const probeContext = { node, repo: repo.name, executable, constraint };
     let resolved;
     try {
       resolved = which(executable);
     } catch (error) {
-      const failed = failedToolchainProbe({
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        resolved: null,
-        error,
-        detail: "which_failed",
-      });
-      tools.push(failed.tool);
-      reasons.push(failed.reason);
+      record(
+        failedToolchainProbe({
+          ...probeContext,
+          resolved: null,
+          error,
+          detail: "which_failed",
+        }),
+      );
       continue;
     }
     if (!resolved) {
-      tools.push({
-        executable,
-        constraint,
-        resolved: null,
-        observed: null,
-        observedRaw: null,
-        satisfied: false,
-      });
-      reasons.push({
-        reason: REPO_TOOLCHAIN_MISSING,
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        observed: null,
-        action: `install ${executable} ${constraint} on ${node}, or drop it from repo ${repo.name}'s toolchain in config/repos.yaml`,
-      });
+      record(missingToolchainProbe(probeContext));
       continue;
     }
 
@@ -696,66 +715,20 @@ export function preflightToolchainSync(
     try {
       probe = spawn([resolved, TOOLCHAIN_VERSION_ARG]);
     } catch (error) {
-      const failed = failedToolchainProbe({
-        node,
-        repo: repo.name,
-        executable,
-        constraint,
-        resolved,
-        error,
-        detail: "version_probe_threw",
-      });
-      tools.push(failed.tool);
-      reasons.push(failed.reason);
+      record(
+        failedToolchainProbe({
+          ...probeContext,
+          resolved,
+          error,
+          detail: "version_probe_threw",
+        }),
+      );
       continue;
     }
-    const { exitCode, stdout, stderr } = probe;
-    const output = stdout?.trim() ? stdout : (stderr ?? "");
-    const observedRaw =
-      output
-        .split("\n")
-        .find((line) => line.trim())
-        ?.trim() ?? null;
-    const observed = exitCode === 0 ? normalizeToolVersion(output) : null;
-    const satisfied = satisfiesConstraint(observed, constraint);
-    tools.push({
-      executable,
-      constraint,
-      resolved,
-      observed,
-      observedRaw,
-      satisfied,
-    });
-    if (satisfied) continue;
-    reasons.push({
-      reason: REPO_TOOLCHAIN_MISMATCH,
-      node,
-      repo: repo.name,
-      executable,
-      constraint,
-      observed,
-      observedRaw,
-      detail:
-        exitCode !== 0
-          ? "version_probe_failed"
-          : observed === null
-            ? "unparseable_version"
-            : "constraint_unsatisfied",
-      action: `make ${executable} ${constraint} the resolved version on ${node} (observed ${observed ?? observedRaw ?? "nothing"}), or relax repo ${repo.name}'s constraint in config/repos.yaml`,
-    });
+    record(probedToolchainTool({ ...probeContext, resolved, probe }));
   }
 
-  return {
-    repo: repo?.name ?? null,
-    node,
-    implementationVersion: TOOLCHAIN_PREFLIGHT_VERSION,
-    toolchainHash: toolchainHash(toolchain),
-    declared: toolchain !== null,
-    verifiedAt: now().toISOString(),
-    ok: reasons.length === 0,
-    tools,
-    reasons,
-  };
+  return toolchainAttestation({ repo, node, now, toolchain, tools, reasons });
 }
 
 /** Does this attestation still describe this repo on this node, recently enough? */

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -13,6 +13,7 @@
  * report-only one, and where its worktrees live (OPS-299).
  */
 import { createHash } from "node:crypto";
+import { spawnSync } from "node:child_process";
 import { existsSync, readFileSync, realpathSync } from "node:fs";
 import path from "node:path";
 import {
@@ -407,6 +408,11 @@ async function defaultWhich(executable) {
   return Bun.which(executable) ?? null;
 }
 
+/** Synchronous counterpart for the planner's deterministic admission path. */
+function defaultWhichSync(executable) {
+  return Bun.which(executable) ?? null;
+}
+
 /**
  * Default probe: run the resolved executable with exactly one argument,
  * `--version`, with no shell and no inherited stdin. This is the only
@@ -434,6 +440,25 @@ async function defaultSpawn(argv) {
       exitCodeResult.status === "fulfilled" ? exitCodeResult.value : null,
     stdout: stdoutResult.status === "fulfilled" ? stdoutResult.value : "",
     stderr: stderrResult.status === "fulfilled" ? stderrResult.value : "",
+  };
+}
+
+/**
+ * Synchronous version probe for planner admission. Keep its result shape
+ * identical to defaultSpawn so both preflight variants produce the same typed
+ * attestation. `spawnSync` enforces the same bounded probe timeout.
+ */
+function defaultSpawnSync(argv) {
+  const result = spawnSync(argv[0], argv.slice(1), {
+    stdio: ["ignore", "pipe", "pipe"],
+    encoding: "utf8",
+    timeout: TOOLCHAIN_PROBE_TIMEOUT_MS,
+  });
+  if (result.error) throw result.error;
+  return {
+    exitCode: result.status,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
   };
 }
 
@@ -610,6 +635,129 @@ export async function preflightToolchain(
   };
 }
 
+/**
+ * Synchronous form of preflightToolchain for the planner. Planning is
+ * deliberately synchronous; returning the same attestation shape keeps the
+ * admission decision typed without turning planEvent into an async API.
+ */
+export function preflightToolchainSync(
+  repo,
+  {
+    node = "local",
+    now = () => new Date(),
+    which = defaultWhichSync,
+    spawn = defaultSpawnSync,
+  } = {},
+) {
+  const toolchain = repo?.toolchain ?? null;
+  const tools = [];
+  const reasons = [];
+
+  for (const { executable, constraint } of toolchain ?? []) {
+    let resolved;
+    try {
+      resolved = which(executable);
+    } catch (error) {
+      const failed = failedToolchainProbe({
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        resolved: null,
+        error,
+        detail: "which_failed",
+      });
+      tools.push(failed.tool);
+      reasons.push(failed.reason);
+      continue;
+    }
+    if (!resolved) {
+      tools.push({
+        executable,
+        constraint,
+        resolved: null,
+        observed: null,
+        observedRaw: null,
+        satisfied: false,
+      });
+      reasons.push({
+        reason: REPO_TOOLCHAIN_MISSING,
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        observed: null,
+        action: `install ${executable} ${constraint} on ${node}, or drop it from repo ${repo.name}'s toolchain in config/repos.yaml`,
+      });
+      continue;
+    }
+
+    let probe;
+    try {
+      probe = spawn([resolved, TOOLCHAIN_VERSION_ARG]);
+    } catch (error) {
+      const failed = failedToolchainProbe({
+        node,
+        repo: repo.name,
+        executable,
+        constraint,
+        resolved,
+        error,
+        detail: "version_probe_threw",
+      });
+      tools.push(failed.tool);
+      reasons.push(failed.reason);
+      continue;
+    }
+    const { exitCode, stdout, stderr } = probe;
+    const output = stdout?.trim() ? stdout : (stderr ?? "");
+    const observedRaw =
+      output
+        .split("\n")
+        .find((line) => line.trim())
+        ?.trim() ?? null;
+    const observed = exitCode === 0 ? normalizeToolVersion(output) : null;
+    const satisfied = satisfiesConstraint(observed, constraint);
+    tools.push({
+      executable,
+      constraint,
+      resolved,
+      observed,
+      observedRaw,
+      satisfied,
+    });
+    if (satisfied) continue;
+    reasons.push({
+      reason: REPO_TOOLCHAIN_MISMATCH,
+      node,
+      repo: repo.name,
+      executable,
+      constraint,
+      observed,
+      observedRaw,
+      detail:
+        exitCode !== 0
+          ? "version_probe_failed"
+          : observed === null
+            ? "unparseable_version"
+            : "constraint_unsatisfied",
+      action: `make ${executable} ${constraint} the resolved version on ${node} (observed ${observed ?? observedRaw ?? "nothing"}), or relax repo ${repo.name}'s constraint in config/repos.yaml`,
+    });
+  }
+
+  return {
+    repo: repo?.name ?? null,
+    node,
+    implementationVersion: TOOLCHAIN_PREFLIGHT_VERSION,
+    toolchainHash: toolchainHash(toolchain),
+    declared: toolchain !== null,
+    verifiedAt: now().toISOString(),
+    ok: reasons.length === 0,
+    tools,
+    reasons,
+  };
+}
+
 /** Does this attestation still describe this repo on this node, recently enough? */
 export function toolchainAttestationCurrent(
   attestation,
@@ -755,6 +903,45 @@ export async function repoDispatchPreflight(
   const fresh = current
     ? attestation
     : await preflightToolchain(repo, { node, now, which, spawn });
+  return {
+    ...repoReadiness({ repo, attestation: fresh, node, now, maxAgeMs }),
+    attestation: fresh,
+  };
+}
+
+/**
+ * Synchronous dispatch readiness gate for planEvent. It deliberately mirrors
+ * repoDispatchPreflight's return contract so callers can use either boundary
+ * without changing their refusal handling.
+ */
+export function repoDispatchPreflightSync(
+  repo,
+  {
+    node = "local",
+    attestation = null,
+    now = () => new Date(),
+    maxAgeMs = TOOLCHAIN_ATTESTATION_MAX_AGE_MS,
+    which,
+    spawn,
+  } = {},
+) {
+  if (!repo?.toolchain?.length) {
+    return {
+      ready: true,
+      attested: false,
+      reasons: [],
+      refusal: null,
+      attestation: null,
+    };
+  }
+  const { current } = toolchainAttestationCurrent(attestation, repo, {
+    node,
+    now,
+    maxAgeMs,
+  });
+  const fresh = current
+    ? attestation
+    : preflightToolchainSync(repo, { node, now, which, spawn });
   return {
     ...repoReadiness({ repo, attestation: fresh, node, now, maxAgeMs }),
     attestation: fresh,

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -15,6 +15,7 @@ import {
   loadRepos,
   normalizeToolVersion,
   preflightToolchain,
+  preflightToolchainSync,
   proveMergeChecks,
   REPO_ATTESTATION_STALE,
   REPO_TOOLCHAIN_MISMATCH,
@@ -22,6 +23,7 @@ import {
   RepoError,
   findRepoForPath,
   repoDispatchPreflight,
+  repoDispatchPreflightSync,
   repoReadiness,
   reposView,
   resolvePromotionTarget,
@@ -1239,6 +1241,35 @@ describe("readiness: a repo is ready only on a current, passing attestation", ()
 });
 
 describe("repoDispatchPreflight is the gate dispatch consults before claiming", () => {
+  test("the synchronous planner variant returns the same typed failed result", () => {
+    const repo = repoWith(`    toolchain:\n      uv: ">=0.5"\n`);
+    const whichCalls = [];
+    const spawnCalls = [];
+    const gate = repoDispatchPreflightSync(repo, {
+      node: "planner",
+      now,
+      which: (executable) => {
+        whichCalls.push(executable);
+        return null;
+      },
+      spawn: (argv) => {
+        spawnCalls.push(argv);
+        return { exitCode: 0, stdout: "0.5.0", stderr: "" };
+      },
+    });
+    expect(gate.ready).toBe(false);
+    expect(gate.reasons[0]).toMatchObject({
+      reason: REPO_TOOLCHAIN_MISSING,
+      executable: "uv",
+      node: "planner",
+    });
+    expect(whichCalls).toEqual(["uv"]);
+    expect(spawnCalls).toEqual([]);
+    expect(preflightToolchainSync(repo, { now, which: () => null }).ok).toBe(
+      false,
+    );
+  });
+
   test("a repo whose preflight fails is refused, with the failing constraint named", async () => {
     const repo = repoWith(`    toolchain:\n      node: ">=22 <25"\n`);
     const node = fakeNode({ versions: { node: "v18.19.1" } });


### PR DESCRIPTION
Fixes watt-mind/factory#1759

Prevent dispatch attempts on workers missing a repo's declared toolchain.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs --timeout 20000` | pass | 107 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2201 tests, 0 failures; clean |
| UX critique | factory-ux-critic | not run | skipped — no user-facing surface |

UX critique: skipped

run:$FACTORY_RUN_ID

## Post-review

- `dispatchToolchainEligibility` now catches `RepoError` from `getRepo` and returns `null`, so a `factory.dispatch.requested` for a repo absent from `config/repos.yaml` still resolves to `human_needed repo_unknown` via the worktree gate instead of throwing out of `planEvent`.
- New planner test: `factory.dispatch.requested` with an unknown repo → `human_needed`, reason `repo_unknown: …`, 0 runs, and no toolchain probe (verified red without the fix).
- `preflightToolchain` / `preflightToolchainSync` now share `missingToolchainProbe`, `probedToolchainTool`, and `toolchainAttestation`; the only remaining per-variant code is the `await`. Behaviour and attestation shape unchanged (repos + planner suites green).
