### PR TITLE
feat(doctor): validate chain auto-approval policy

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -34,6 +34,10 @@ import {
   preflightToolchain,
 } from "../event-runtime/lib/repos.mjs";
 import {
+  CHAIN_AUTO_APPROVAL_EVENT_TYPES,
+  loadChainAutoApprovalPolicy,
+} from "../event-runtime/lib/auto-approval.mjs";
+import {
   browserLaunchCheck,
   piChromeDevtoolsCheck,
 } from "./doctor-browser.mjs";
@@ -272,6 +276,103 @@ export async function repoToolchainDiagnostics({
   return diagnostics;
 }
 
+const CHAIN_POLICY_FIX =
+  "compare config/policy.yaml chain_auto_approval.allowed_event_types with CHAIN_AUTO_APPROVAL_EVENT_TYPES";
+
+function chainPolicySource(root) {
+  const local = path.join(root, "config", "policy.yaml");
+  if (existsSync(local)) return local;
+  const example = path.join(root, "config", "policy.example.yaml");
+  return existsSync(example) ? example : local;
+}
+
+function invalidAllowedEventTypesDetail(root) {
+  try {
+    const allowed = Bun.YAML.parse(
+      readFileSync(chainPolicySource(root), "utf8"),
+    )?.chain_auto_approval?.allowed_event_types;
+    if (!Array.isArray(allowed)) {
+      return "chain_auto_approval.allowed_event_types must be an array of strings";
+    }
+    if (!allowed.every((eventType) => typeof eventType === "string")) {
+      return "chain_auto_approval.allowed_event_types contains non-string entries";
+    }
+  } catch {
+    return "config/policy.yaml is not valid YAML";
+  }
+  return "chain_auto_approval.allowed_event_types is invalid";
+}
+
+function forbiddenAllowedEventTypes(root) {
+  try {
+    const allowed = Bun.YAML.parse(
+      readFileSync(chainPolicySource(root), "utf8"),
+    )?.chain_auto_approval?.allowed_event_types;
+    return Array.isArray(allowed)
+      ? allowed.filter(
+          (eventType) =>
+            typeof eventType === "string" &&
+            !CHAIN_AUTO_APPROVAL_EVENT_TYPES.has(eventType),
+        )
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/** Diagnose the instance policy through the runtime's authoritative loader. */
+export function chainAutoApprovalPolicyDiagnostic({
+  root = factoryRoot(),
+} = {}) {
+  const policy = loadChainAutoApprovalPolicy({ root });
+  const label = "chain auto-approval policy";
+  if (policy.reason === null) {
+    const allowed = [...policy.allowed].sort();
+    return {
+      ok: true,
+      label,
+      detail:
+        `ok (${allowed.length} allowed event type${allowed.length === 1 ? "" : "s"}: ${allowed.join(", ")}; ` +
+        `merge max_fix_rounds=${policy.maxFixRounds}, batch_size=${policy.mergeBatchSize}; ` +
+        `escalation auto_merge_base=${[...policy.autoMergeBase].join(",") || "none"}, ` +
+        `auto_merge_owners=${[...policy.autoMergeOwners].join(",") || "none"})`,
+      fix: null,
+    };
+  }
+  if (policy.reason === "policy_missing") {
+    return {
+      ok: "warn",
+      label,
+      detail: "policy_missing — every chain proposal is watched",
+      fix: "add config/policy.yaml chain_auto_approval.allowed_event_types to opt into safe chain approvals",
+    };
+  }
+  if (policy.reason === "policy_invalid") {
+    return {
+      ok: false,
+      label,
+      detail: `policy_invalid — ${invalidAllowedEventTypesDetail(root)}`,
+      fix: CHAIN_POLICY_FIX,
+    };
+  }
+  if (policy.reason === "policy_contains_forbidden_event") {
+    const offending = forbiddenAllowedEventTypes(root);
+    return {
+      ok: false,
+      label,
+      detail: `policy_contains_forbidden_event — offending entries: ${offending.join(", ") || "unreadable"}`,
+      fix: CHAIN_POLICY_FIX,
+    };
+  }
+  return {
+    ok: false,
+    label,
+    detail:
+      "merge_policy_invalid — merge.max_fix_rounds and escalation.auto_merge_base/auto_merge_owners must be valid when merge events are allowed",
+    fix: "repair merge.max_fix_rounds and escalation.auto_merge_base/auto_merge_owners in config/policy.yaml",
+  };
+}
+
 const ROOT = factoryRoot();
 installLinearBudgetCapture();
 const argv = process.argv.slice(2);
@@ -381,6 +482,11 @@ if (import.meta.main) {
       pcd.detail,
       pcd.status === "pass" ? null : pcd.fix,
     );
+  }
+
+  {
+    const diagnostic = chainAutoApprovalPolicyDiagnostic({ root: ROOT });
+    check(diagnostic.ok, diagnostic.label, diagnostic.detail, diagnostic.fix);
   }
 
   // Disk: worktrees are the bulk of what this machine holds, and a bootstrap that

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -32,6 +32,7 @@ import { harnessGitignoreIsCurrent } from "../lib/factory-gitignore.mjs";
 import {
   normalizeToolchain,
   preflightToolchain,
+  reposRoot,
 } from "../event-runtime/lib/repos.mjs";
 import {
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
@@ -320,10 +321,13 @@ function forbiddenAllowedEventTypes(root) {
   }
 }
 
-/** Diagnose the instance policy through the runtime's authoritative loader. */
-export function chainAutoApprovalPolicyDiagnostic({
-  root = factoryRoot(),
-} = {}) {
+/**
+ * Diagnose the instance policy through the runtime's authoritative loader.
+ * Defaults to `reposRoot()` (FACTORY_REPOS_ROOT || FACTORY_ROOT) — the same
+ * resolution `loadChainAutoApprovalPolicy()` uses in serve — so the doctor
+ * validates the config/policy.yaml the runtime actually reads.
+ */
+export function chainAutoApprovalPolicyDiagnostic({ root = reposRoot() } = {}) {
   const policy = loadChainAutoApprovalPolicy({ root });
   const label = "chain auto-approval policy";
   if (policy.reason === null) {
@@ -485,7 +489,7 @@ if (import.meta.main) {
   }
 
   {
-    const diagnostic = chainAutoApprovalPolicyDiagnostic({ root: ROOT });
+    const diagnostic = chainAutoApprovalPolicyDiagnostic();
     check(diagnostic.ok, diagnostic.label, diagnostic.detail, diagnostic.fix);
   }
 

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -321,8 +321,44 @@ escalation:
       fix: "compare config/policy.yaml chain_auto_approval.allowed_event_types with CHAIN_AUTO_APPROVAL_EVENT_TYPES",
     });
 
-    for (const root of [valid, missing, invalid, forbidden]) {
+    const mergeInvalid = scratch();
+    writePolicy(
+      mergeInvalid,
+      "chain_auto_approval:\n  allowed_event_types: [factory.merge.requested]\nmerge:\n  max_fix_rounds: -1\nescalation:\n  auto_merge_base: [develop]\n  auto_merge_owners: [watt-mind]\n",
+    );
+    expect(chainAutoApprovalPolicyDiagnostic({ root: mergeInvalid })).toEqual({
+      ok: false,
+      label: "chain auto-approval policy",
+      detail:
+        "merge_policy_invalid — merge.max_fix_rounds and escalation.auto_merge_base/auto_merge_owners must be valid when merge events are allowed",
+      fix: "repair merge.max_fix_rounds and escalation.auto_merge_base/auto_merge_owners in config/policy.yaml",
+    });
+
+    for (const root of [valid, missing, invalid, forbidden, mergeInvalid]) {
       rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  test("defaults to the runtime's reposRoot() so FACTORY_REPOS_ROOT wins over the checkout", () => {
+    const reposRootDir = scratch();
+    writePolicy(
+      reposRootDir,
+      "chain_auto_approval:\n  allowed_event_types: [factory.triage.requested]\n",
+    );
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = reposRootDir;
+    try {
+      expect(chainAutoApprovalPolicyDiagnostic()).toEqual({
+        ok: true,
+        label: "chain auto-approval policy",
+        detail:
+          "ok (1 allowed event type: factory.triage.requested; merge max_fix_rounds=0, batch_size=4; escalation auto_merge_base=none, auto_merge_owners=none)",
+        fix: null,
+      });
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+      rmSync(reposRootDir, { recursive: true, force: true });
     }
   });
 });

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -13,6 +13,7 @@
 import { test, expect, describe } from "bun:test";
 import {
   mkdtempSync,
+  mkdirSync,
   writeFileSync,
   chmodSync,
   existsSync,
@@ -29,6 +30,7 @@ import {
 } from "./doctor-browser.mjs";
 import {
   compareCliVersions,
+  chainAutoApprovalPolicyDiagnostic,
   MIN_BUN_VERSION,
   MIN_GIT_VERSION,
   ossOnboardingDiagnostics,
@@ -256,6 +258,72 @@ describe("repo toolchain diagnostics (#1097)", () => {
     // Doctor keeps going: the next repo is still probed.
     expect(rows[1]).toMatchObject({ ok: true, label: "toolchain bun" });
     expect(probes).toBe(1);
+  });
+});
+
+describe("chain auto-approval policy diagnostic (#1779)", () => {
+  const writePolicy = (root, policy) => {
+    mkdirSync(path.join(root, "config"));
+    writeFileSync(path.join(root, "config", "policy.yaml"), policy);
+  };
+
+  test("reports the four loader outcomes from a temporary instance root", () => {
+    const valid = scratch();
+    writePolicy(
+      valid,
+      `chain_auto_approval:
+  allowed_event_types:
+    - factory.merge.requested
+merge:
+  max_fix_rounds: 2
+  batch_size: 3
+escalation:
+  auto_merge_base: [develop]
+  auto_merge_owners: [watt-mind]
+`,
+    );
+    expect(chainAutoApprovalPolicyDiagnostic({ root: valid })).toEqual({
+      ok: true,
+      label: "chain auto-approval policy",
+      detail:
+        "ok (1 allowed event type: factory.merge.requested; merge max_fix_rounds=2, batch_size=3; escalation auto_merge_base=develop, auto_merge_owners=watt-mind)",
+      fix: null,
+    });
+
+    const missing = scratch();
+    expect(chainAutoApprovalPolicyDiagnostic({ root: missing })).toEqual({
+      ok: "warn",
+      label: "chain auto-approval policy",
+      detail: "policy_missing — every chain proposal is watched",
+      fix: "add config/policy.yaml chain_auto_approval.allowed_event_types to opt into safe chain approvals",
+    });
+
+    const invalid = scratch();
+    writePolicy(invalid, "chain_auto_approval:\n  allowed_event_types: nope\n");
+    expect(chainAutoApprovalPolicyDiagnostic({ root: invalid })).toEqual({
+      ok: false,
+      label: "chain auto-approval policy",
+      detail:
+        "policy_invalid — chain_auto_approval.allowed_event_types must be an array of strings",
+      fix: "compare config/policy.yaml chain_auto_approval.allowed_event_types with CHAIN_AUTO_APPROVAL_EVENT_TYPES",
+    });
+
+    const forbidden = scratch();
+    writePolicy(
+      forbidden,
+      "chain_auto_approval:\n  allowed_event_types: [factory.work.requested, factory.ship-apply.requested]\nescalation:\n  auto_merge_base: []\n  auto_merge_owners: []\n",
+    );
+    expect(chainAutoApprovalPolicyDiagnostic({ root: forbidden })).toEqual({
+      ok: false,
+      label: "chain auto-approval policy",
+      detail:
+        "policy_contains_forbidden_event — offending entries: factory.ship-apply.requested",
+      fix: "compare config/policy.yaml chain_auto_approval.allowed_event_types with CHAIN_AUTO_APPROVAL_EVENT_TYPES",
+    });
+
+    for (const root of [valid, missing, invalid, forbidden]) {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });
 


### PR DESCRIPTION
Fixes #1779

Run `factory doctor` to identify malformed chain auto-approval policy before proposals silently degrade to watched.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test orchestrator/doctor.test.mjs --timeout 60000` | pass | 33 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2203 passed, 10 skipped; lint warnings only |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_9c2f7f47-5579-4bee-9697-d6240307857d

## Post-review

- Reviewer nit: `chainAutoApprovalPolicyDiagnostic` now defaults to `reposRoot()` (FACTORY_REPOS_ROOT || FACTORY_ROOT), the same resolution `loadChainAutoApprovalPolicy()` uses in serve, so the doctor validates the policy.yaml the runtime reads. Added test rows for FACTORY_REPOS_ROOT pointing to a different dir and for the loader's fifth reason `merge_policy_invalid`.
