### PR TITLE
fix(api): keep parked proposals open past TTL

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -13,7 +13,12 @@ import {
   TERMINAL_STATES,
 } from "./lifecycle.mjs";
 import { archiveDeadLetteredEvent, requeueEvent } from "./planner.mjs";
-import { approveProposal, rejectProposal } from "./proposals.mjs";
+import {
+  approveProposal,
+  isProposalExpired,
+  proposalExpiresAt,
+  rejectProposal,
+} from "./proposals.mjs";
 import { traceOf } from "./trace.mjs";
 import {
   attemptDeadline,
@@ -126,14 +131,11 @@ function proposalHistory(
   const proposals = pageRows.flatMap((row) => {
     let decisionAt = row.decided_at ?? null;
     let effectiveStatus = row.status;
-    const expiresAt =
-      Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
     const expired =
       row.status === "open" &&
-      Number.isFinite(expiresAt) &&
-      expiresAt < (filters.nowMs ?? Date.now());
+      isProposalExpired(row, filters.nowMs ?? Date.now());
     if (filteredDecision && expired) {
-      decisionAt = new Date(expiresAt).toISOString();
+      decisionAt = new Date(proposalExpiresAt(row)).toISOString();
       effectiveStatus = "expired";
     }
     if (filteredDecision) {
@@ -599,14 +601,9 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
         b.created_at.localeCompare(a.created_at) || b.list_rowid - a.list_rowid,
     )
     .map((row) => {
-      const expiresAt =
-        Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
       return proposalView({
         ...row,
-        expired:
-          row.status === "open" &&
-          Number.isFinite(expiresAt) &&
-          expiresAt < nowMs,
+        expired: row.status === "open" && isProposalExpired(row, nowMs),
         spec: row.spec_json ? JSON.parse(row.spec_json) : null,
       });
     });
@@ -2112,17 +2109,12 @@ export async function handleRunApiRoute({
     const id = decodeURIComponent(proposalDetail[1]);
     const row = db.query(`SELECT * FROM proposals WHERE id = ?`).get(id);
     if (!row) return send(404, { error: `unknown proposal ${id}` });
-    const expiresAt =
-      Date.parse(row.created_at) + Number(row.ttl_seconds) * 1000;
     return send(200, {
       proposal: proposalView(
         {
           ...row,
           spec: row.spec_json ? JSON.parse(row.spec_json) : null,
-          expired:
-            row.status === "open" &&
-            Number.isFinite(expiresAt) &&
-            expiresAt < nowMs,
+          expired: row.status === "open" && isProposalExpired(row, nowMs),
         },
         registry,
       ),

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -944,6 +944,22 @@ describe("ticket journey join (WM-595)", () => {
           "2026-01-01T10:00:00.000Z",
           3600,
         );
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, decision, spec_json, spec_hash, status, created_at, ttl_seconds)
+           VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "prop-run-expired",
+          "linear",
+          "ticket-expiry",
+          "run",
+          JSON.stringify({ input: { repo: "factory", ticket: "WM-1328" } }),
+          "sha256:prop-run-expired",
+          "open",
+          "2026-01-01T10:00:00.000Z",
+          60,
+        );
       const nowMs = Date.parse("2026-01-01T10:30:00.000Z");
       const journey = ticketJourneyView(s.db, "WM-1328", { nowMs });
       const byId = Object.fromEntries(
@@ -953,11 +969,15 @@ describe("ticket journey join (WM-595)", () => {
       expect(byId["prop-expired"].status).toBe("open");
       expect(byId["prop-no-spec"].expired).toBe(false);
       expect(byId["prop-no-spec"].spec).toBeNull();
-      expect(
+      expect(byId["prop-run-expired"].expired).toBe(true);
+      expect(byId["prop-run-expired"].status).toBe("open");
+      const beforeTtl = Object.fromEntries(
         ticketJourneyView(s.db, "WM-1328", {
           nowMs: Date.parse("2026-01-01T10:00:30.000Z"),
-        }).proposals.find((proposal) => proposal.id === "prop-expired").expired,
-      ).toBe(false);
+        }).proposals.map((proposal) => [proposal.id, proposal.expired]),
+      );
+      expect(beforeTtl["prop-expired"]).toBe(false);
+      expect(beforeTtl["prop-run-expired"]).toBe(false);
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -904,7 +904,7 @@ describe("ticket journey join (WM-595)", () => {
     }
   });
 
-  test("journey proposals keep TTL expiry and null spec", async () => {
+  test("journey keeps parked human-needed proposals open past their TTL", async () => {
     const s = await makeServer();
     try {
       await s.client.replay(
@@ -949,7 +949,7 @@ describe("ticket journey join (WM-595)", () => {
       const byId = Object.fromEntries(
         journey.proposals.map((proposal) => [proposal.id, proposal]),
       );
-      expect(byId["prop-expired"].expired).toBe(true);
+      expect(byId["prop-expired"].expired).toBe(false);
       expect(byId["prop-expired"].status).toBe("open");
       expect(byId["prop-no-spec"].expired).toBe(false);
       expect(byId["prop-no-spec"].spec).toBeNull();
@@ -958,6 +958,63 @@ describe("ticket journey join (WM-595)", () => {
           nowMs: Date.parse("2026-01-01T10:00:30.000Z"),
         }).proposals.find((proposal) => proposal.id === "prop-expired").expired,
       ).toBe(false);
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("parked proposal expiry API projections (factory#1775)", () => {
+  const now = Date.parse("2026-08-19T12:00:00.000Z");
+
+  function insertParkedProposal(db, id) {
+    db.query(
+      `INSERT INTO proposals
+         (id, event_source, event_id, decision, status, created_at, ttl_seconds, spec_json)
+       VALUES (?, 'test', ?, 'human_needed', 'open', ?, 60, '{}')`,
+    ).run(id, `event-${id}`, new Date(now - 120_000).toISOString());
+  }
+
+  test("decision history excludes a parked proposal from virtual expiry", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      insertParkedProposal(s.db, "parked-decision");
+      const from = "2026-08-19T10:00:00.000Z";
+      const to = "2026-08-19T13:00:00.000Z";
+      const expired = await fetch(
+        s.url(
+          `/proposals?status=all&population=decision&from=${from}&to=${to}&decisionStatus=expired`,
+        ),
+      );
+      expect(expired.status).toBe(200);
+      expect((await expired.json()).proposals).toEqual([]);
+
+      const open = await fetch(s.url("/proposals?status=open"));
+      expect((await open.json()).proposals).toContainEqual(
+        expect.objectContaining({
+          id: "parked-decision",
+          status: "open",
+          expired: false,
+          decided_at: null,
+        }),
+      );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("proposal detail keeps a parked proposal open past its TTL", async () => {
+    const s = await makeServer({ now: () => now });
+    try {
+      insertParkedProposal(s.db, "parked-detail");
+      const response = await fetch(s.url("/proposals/parked-detail"));
+      expect(response.status).toBe(200);
+      expect((await response.json()).proposal).toMatchObject({
+        id: "parked-detail",
+        status: "open",
+        expired: false,
+        decided_at: null,
+      });
     } finally {
       s.close();
     }

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -346,6 +346,7 @@ function inboxExpiredPredicate(item = "i") {
     SELECT 1 FROM proposals p
      WHERE p.id = ${item}.proposal_id
        AND p.status = 'open'
+       AND p.decision = 'run'
        AND p.ttl_seconds > 0
        AND unixepoch(p.created_at) + p.ttl_seconds <= unixepoch()
   ))`;

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1013,6 +1013,10 @@ describe("human inbox ledger (WM-285)", () => {
       `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
        VALUES ('live-proposal', 'test', 'live-evt', 'run', 'open', ?, 60)`,
     ).run(liveAt);
+    db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES ('parked-proposal', 'test', 'parked-evt', 'human_needed', 'open', ?, 60)`,
+    ).run(expiredAt);
     createInboxItem(db, { kind: "BLOCKED", title: "active" }, { id: "active" });
     createInboxItem(
       db,
@@ -1037,6 +1041,15 @@ describe("human inbox ledger (WM-285)", () => {
       },
       { id: "live-proposal-item" },
     );
+    createInboxItem(
+      db,
+      {
+        kind: "decision_needed",
+        title: "parked by proposal",
+        refs: { proposalId: "parked-proposal" },
+      },
+      { id: "parked-proposal-item" },
+    );
 
     const items = listInboxItems(db, { status: "all" });
     expect(
@@ -1050,6 +1063,14 @@ describe("human inbox ledger (WM-285)", () => {
     expect(
       items.find((item) => item.id === "live-proposal-item"),
     ).toMatchObject({
+      expired: false,
+    });
+    expect(
+      items.find((item) => item.id === "parked-proposal-item"),
+    ).toMatchObject({
+      expired: false,
+    });
+    expect(getInboxItem(db, "parked-proposal-item")).toMatchObject({
       expired: false,
     });
     expect(inboxCounts(db)).toMatchObject({

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -31,8 +31,19 @@ import { computeDefHash } from "./receipts.mjs";
  */
 const HUMAN_ACTOR = "operator";
 
-function isExpired(proposal, now) {
-  return now - Date.parse(proposal.created_at) > proposal.ttl_seconds * 1000;
+/**
+ * TTL expiry applies only to runnable proposals. Parked human-needed and noop
+ * proposals remain actionable until their event moves on.
+ */
+export function proposalExpiresAt(proposal) {
+  return Date.parse(proposal.created_at) + Number(proposal.ttl_seconds) * 1000;
+}
+
+export function isProposalExpired(proposal, now = Date.now()) {
+  const expiresAt = proposalExpiresAt(proposal);
+  return (
+    proposal.decision === "run" && Number.isFinite(expiresAt) && expiresAt < now
+  );
 }
 
 /** A pin that can be compared. `"unknown"` is the no-registry sentinel, not a version. */
@@ -61,9 +72,7 @@ export function openProposals(db, { now = Date.now() } = {}) {
     .all()
     .map((row) => ({
       ...withSpec(row),
-      // TTL re-planning is only meaningful for runnable proposals. A parked
-      // refusal remains actionable until its event moves on.
-      expired: row.decision === "run" && isExpired(row, now),
+      expired: isProposalExpired(row, now),
     }));
 }
 
@@ -285,7 +294,7 @@ export function approveProposal(
     if (
       !registryReloadMismatch &&
       !registryVersionMismatch &&
-      !isExpired(proposal, now)
+      !isProposalExpired(proposal, now)
     ) {
       // The recorded spec queues as-is, so its model is checked against the
       // adapter it was planned for: the spec's own adapter — not the


### PR DESCRIPTION
Fixes watt-mind/factory#1775

Keeps parked human decisions actionable after TTL across API and inbox projections.

## Validation

| Check                | Command                                                                                                          | Result  | Notes                              |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/inbox.test.mjs --timeout 20000` | pass    | 114 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2215 tests; 613 warnings, 0 errors |
| UX critique          | factory-ux-critic                                                                                               | skipped | no user-facing surface             |

UX critique: skipped

run:run_4bb93104-d191-4c35-a82f-88cb3dea30f8

## Post-review

Reviewer nit: the journey test lost its positive TTL case when the human_needed fixture flipped to `expired: false`. Added a `decision=run` fixture (`prop-run-expired`) past its TTL asserting `expired: true` (and `false` before the TTL) in `event-runtime/lib/api-runs.test.mjs`.
