### PR TITLE
fix(memos): confine supersession targets (#1785)

### DIFF
--- a/docs/event-runtime-memos.md
+++ b/docs/event-runtime-memos.md
@@ -527,8 +527,9 @@ Store size and memo counts join `status`.
 ### 6.2 Fold size
 
 Per-subject growth is bounded three ways: `supersedes` (a producer replacing
-its own earlier note on the same subject+kind — `run-postmortem` always
-supersedes the previous postmortem for the same ticket), kind-default expiry
+its own earlier note on the same subject+kind — the ledger enforces this
+subject+kind confinement — `run-postmortem` always supersedes the previous
+postmortem for the same ticket), kind-default expiry
 (`postmortem` 30 days, `decision` 90 days, `flake` 14 days; a binding, when
 present, always wins), and the consumer's `max`. `listMemos` orders newest
 first, so a runaway producer degrades to "the last N notes", never to an

--- a/event-runtime/lib/memos.mjs
+++ b/event-runtime/lib/memos.mjs
@@ -473,13 +473,35 @@ function insertMemoRow(db, { sha256, document }, { now }) {
     descriptionHash,
     headSha,
   );
+  let superseded = false;
+  let supersedesIgnored;
   if (supersedes) {
-    db.query(
-      `UPDATE memos SET superseded_by = ?
-       WHERE sha256 = ? AND superseded_by IS NULL`,
-    ).run(sha256, supersedes);
+    const update = db
+      .query(
+        `UPDATE memos SET superseded_by = ?
+       WHERE sha256 = ?
+         AND subject_type = ?
+         AND subject_id = ?
+         AND kind = ?
+         AND superseded_by IS NULL`,
+      )
+      .run(sha256, supersedes, subject.type, subject.id, document.kind);
+    superseded = update.changes > 0;
+    if (!superseded) {
+      supersedesIgnored = supersedes;
+      console.warn(
+        `memos: ignored supersedes ${supersedes}; predecessor is unknown, already superseded, or does not match ${subject.type}:${subject.id} ${document.kind}`,
+      );
+    }
   }
-  return { sha256, inserted: true, subject, kind: document.kind };
+  return {
+    sha256,
+    inserted: true,
+    subject,
+    kind: document.kind,
+    superseded,
+    ...(supersedesIgnored ? { supersedesIgnored } : {}),
+  };
 }
 
 /**

--- a/event-runtime/lib/memos.test.mjs
+++ b/event-runtime/lib/memos.test.mjs
@@ -274,7 +274,11 @@ describe("registerMemos / listMemos", () => {
       }),
       { runId: "run_b", now: now + 1000 },
     );
-    registerMemos(db, "run_b", second.result, { now: now + 1000 });
+    const registered = registerMemos(db, "run_b", second.result, {
+      now: now + 1000,
+    });
+    expect(registered[0]).toMatchObject({ superseded: true });
+    expect(registered[0].supersedesIgnored).toBeUndefined();
     const live = listMemos(
       db,
       { type: "ticket", id: "WM-809" },
@@ -290,6 +294,81 @@ describe("registerMemos / listMemos", () => {
     expect(all.find((row) => row.sha256 === first.sha256).supersededBy).toBe(
       second.sha256,
     );
+    db.close();
+  });
+
+  test("ignores supersedes targets with a different subject or kind", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const decision = accepted(
+      postmortemDoc({
+        subject: { type: "ticket", id: "WM-1" },
+        kind: "decision",
+        precedentOnly: true,
+      }),
+      { now },
+    );
+    registerMemos(db, "run_decision", decision.result, { now });
+
+    const crossSubject = accepted(
+      repoNoteDoc({ supersedes: decision.sha256 }),
+      { runId: "run_note", now: now + 1000 },
+    );
+    const crossSubjectResult = registerMemos(
+      db,
+      "run_note",
+      crossSubject.result,
+      {
+        now: now + 1000,
+      },
+    );
+    expect(crossSubjectResult[0]).toMatchObject({
+      superseded: false,
+      supersedesIgnored: decision.sha256,
+    });
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-1" }, { now: now + 1000 }),
+    ).toHaveLength(1);
+
+    const crossKind = accepted(
+      postmortemDoc({
+        subject: { type: "ticket", id: "WM-1" },
+        supersedes: decision.sha256,
+      }),
+      { runId: "run_postmortem", now: now + 2000 },
+    );
+    const crossKindResult = registerMemos(
+      db,
+      "run_postmortem",
+      crossKind.result,
+      {
+        now: now + 2000,
+      },
+    );
+    expect(crossKindResult[0]).toMatchObject({
+      superseded: false,
+      supersedesIgnored: decision.sha256,
+    });
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-1" }, { now: now + 2000 }),
+    ).toHaveLength(2);
+    db.close();
+  });
+
+  test("reports an unknown supersedes target without rejecting the memo", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const unknown = "a".repeat(64);
+    const memo = accepted(postmortemDoc({ supersedes: unknown }), { now });
+    const registered = registerMemos(db, "run_unknown", memo.result, { now });
+    expect(registered[0]).toMatchObject({
+      inserted: true,
+      superseded: false,
+      supersedesIgnored: unknown,
+    });
+    expect(
+      listMemos(db, { type: "ticket", id: "WM-809" }, { now }),
+    ).toHaveLength(1);
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1785

Confine memo supersession to matching subject and kind while reporting ignored targets.

## Validation

| Check                | Command                                                                                                          | Result  | Notes                                   |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- | --------------------------------------- |
| Verification Command | `bun test event-runtime/lib/memos.test.mjs event-runtime/lib/api-memos.test.mjs && bun run lint && bun run format:check` | pass    | 44 tests, 0 failures                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2215 tests; emit, format, lint clean   |
| UX critique          | factory-ux-critic                                                                                                | not run | skipped — no user-facing surface        |

UX critique: skipped

run:run_e1462b98-7933-4874-864e-f812b327d64b
