### PR TITLE
fix(stack): validate live-stack timing knobs

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -187,11 +187,14 @@ WEB_SUPERVISOR_INTERVAL="${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
 # These values feed shell arithmetic and sleep below. Validate them before an
 # action can snapshot, spawn, or signal a daemon so malformed environment
 # overrides leave an existing stack untouched.
+# The two timeouts accept 0 (an immediate deadline: no wait, then the usual
+# teardown / fall-through); the supervisor interval must stay positive because
+# it is the sleep between ticks.
 validate_timing_knobs() {
-  [[ "$POOL_DRAIN_TIMEOUT" =~ ^[1-9][0-9]*$ ]] ||
-    die "FACTORY_POOL_DRAIN_TIMEOUT must be a positive integer"
-  [[ "$API_READY_TIMEOUT" =~ ^[1-9][0-9]*$ ]] ||
-    die "FACTORY_API_READY_TIMEOUT must be a positive integer"
+  [[ "$POOL_DRAIN_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    die "FACTORY_POOL_DRAIN_TIMEOUT must be a non-negative integer"
+  [[ "$API_READY_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    die "FACTORY_API_READY_TIMEOUT must be a non-negative integer"
   [[ "$WEB_SUPERVISOR_INTERVAL" =~ ^([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$ ]] ||
     die "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number"
 }
@@ -216,10 +219,13 @@ rotate_stack_logs() {
   rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
 }
 
-# Validate before actions touch disk or daemon lifecycle state. `up` creates
-# these itself once `--dry-run` has had its chance to exit.
-validate_timing_knobs
-if [[ "$ACTION" != "up" ]]; then mkdir -p "$RUN_DIR" "$HOME_DIR"; fi
+# Validate before actions touch disk or daemon lifecycle state. `up` validates
+# after its option parsing (so `--help` still prints on a malformed knob) and
+# creates these itself once `--dry-run` has had its chance to exit.
+if [[ "$ACTION" != "up" ]]; then
+  validate_timing_knobs
+  mkdir -p "$RUN_DIR" "$HOME_DIR"
+fi
 REPO="$(repo_root)"
 
 elapsed_seconds() {
@@ -378,6 +384,7 @@ case "$ACTION" in
       esac
       shift
     done
+    validate_timing_knobs
 
     # A supervised pool and --dev both want to own the worker slot, and they
     # want it for different reasons (scale vs. reload). Saying so beats silently

--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -24,6 +24,10 @@
 #   FACTORY_API_READY_TIMEOUT    # seconds `up` waits for the runtime /health
 #                                # endpoint before tearing its daemons down;
 #                                # default 60
+#   FACTORY_POOL_DRAIN_TIMEOUT   # seconds `down` lets a supervised worker pool
+#                                # drain before ordinary teardown; default 180
+#   FACTORY_WEB_SUPERVISOR_INTERVAL  # seconds between web supervisor ticks;
+#                                   # default 1 (positive decimals allowed)
 #
 # -E: `up` installs an ERR trap that tears down the daemons it started. Without
 # errexit-trace the trap is not inherited by functions or command substitutions,
@@ -177,6 +181,20 @@ LOG_KEEP="${FACTORY_LOG_KEEP:-3}"
 LOG_ROTATE_INTERVAL="${FACTORY_LOG_ROTATE_INTERVAL:-300}"
 LOG_ROTATE_MIN_BYTES=1048576
 API_READY_TIMEOUT="${FACTORY_API_READY_TIMEOUT:-60}"
+POOL_DRAIN_TIMEOUT="${FACTORY_POOL_DRAIN_TIMEOUT:-180}"
+WEB_SUPERVISOR_INTERVAL="${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
+
+# These values feed shell arithmetic and sleep below. Validate them before an
+# action can snapshot, spawn, or signal a daemon so malformed environment
+# overrides leave an existing stack untouched.
+validate_timing_knobs() {
+  [[ "$POOL_DRAIN_TIMEOUT" =~ ^[1-9][0-9]*$ ]] ||
+    die "FACTORY_POOL_DRAIN_TIMEOUT must be a positive integer"
+  [[ "$API_READY_TIMEOUT" =~ ^[1-9][0-9]*$ ]] ||
+    die "FACTORY_API_READY_TIMEOUT must be a positive integer"
+  [[ "$WEB_SUPERVISOR_INTERVAL" =~ ^([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$ ]] ||
+    die "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number"
+}
 
 # Reject knob values before anything touches a log. A threshold below 1 MiB
 # would rotate on nearly every tick (and lose the log's recent tail every time);
@@ -198,8 +216,9 @@ rotate_stack_logs() {
   rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
 }
 
-# `up` creates these itself once `--dry-run` has had its chance to exit: a dry
-# run must leave no trace on disk.
+# Validate before actions touch disk or daemon lifecycle state. `up` creates
+# these itself once `--dry-run` has had its chance to exit.
+validate_timing_knobs
 if [[ "$ACTION" != "up" ]]; then mkdir -p "$RUN_DIR" "$HOME_DIR"; fi
 REPO="$(repo_root)"
 
@@ -742,7 +761,7 @@ case "$ACTION" in
         rotate_stack_logs
         LOG_ROTATE_CHECKED=$(date +%s)
       fi
-      sleep "${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
+      sleep "$WEB_SUPERVISOR_INTERVAL"
     done
     printf '%s [web-supervisor] event runtime stopped; supervisor exiting\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
     ;;
@@ -795,7 +814,7 @@ case "$ACTION" in
     # patience; past it we fall through to the ordinary teardown, which is the
     # operator's "stop now" and says so.
     if [[ -f "$RUN_DIR/supervisor.pid" ]] && pid_alive "$RUN_DIR/worker.pid"; then
-      POOL_WAIT="${FACTORY_POOL_DRAIN_TIMEOUT:-180}"
+      POOL_WAIT="$POOL_DRAIN_TIMEOUT"
       info "draining worker pool (up to ${POOL_WAIT}s — runs in flight finish first)"
       term_daemon "$RUN_DIR/worker.pid" "worker pool supervisor"
       DEADLINE=$(( $(date +%s) + POOL_WAIT ))

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -372,6 +372,43 @@ test("failed runtime health cleans up only daemons spawned by this `up`", () => 
   }
 }, 20_000);
 
+test("malformed timing knobs fail before `up` snapshots or starts daemons", () => {
+  for (const [env, message] of [
+    [
+      { FACTORY_API_READY_TIMEOUT: "abc" },
+      "FACTORY_API_READY_TIMEOUT must be a positive integer",
+    ],
+    [
+      { FACTORY_WEB_SUPERVISOR_INTERVAL: "soon" },
+      "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number",
+    ],
+  ]) {
+    const f = makeFixture();
+    try {
+      const r = runStack(f, ["up"], env);
+      expect(r.status).toBe(1);
+      expect(r.stderr).toContain(message);
+      expect(r.spawns).toEqual([]);
+      expect(existsSync(f.runDir)).toBe(false);
+    } finally {
+      f.cleanup();
+    }
+  }
+});
+
+test("web supervisor interval accepts a positive decimal", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--dry-run"], {
+      FACTORY_WEB_SUPERVISOR_INTERVAL: "0.5",
+    });
+    expect(r.status).toBe(0);
+    expect(r.spawns).toEqual([]);
+  } finally {
+    f.cleanup();
+  }
+});
+
 test("runtime health allows a slow bind beyond the former 30-attempt budget", () => {
   const f = makeFixture();
   const calls = path.join(f.root, "curl-calls");
@@ -887,6 +924,33 @@ test("`down` gives the pool a bounded wait, then says so instead of hanging", ()
     f.cleanup();
   }
 }, 20_000);
+
+test("malformed pool drain timeout leaves the running stack untouched", () => {
+  const f = makeFixture();
+  try {
+    mkdirSync(f.runDir, { recursive: true });
+    for (const [name, body] of [
+      ["supervisor.pid", "4242\n"],
+      ["worker.pid", "4242\n"],
+      ["serve.pid", "4243\n"],
+    ])
+      writeFileSync(path.join(f.runDir, name), body, "utf8");
+
+    const r = runStack(f, ["down"], {
+      FAKE_ALIVE: "1",
+      FACTORY_POOL_DRAIN_TIMEOUT: "10s",
+    });
+    expect(r.status).toBe(1);
+    expect(r.stderr).toContain(
+      "FACTORY_POOL_DRAIN_TIMEOUT must be a positive integer",
+    );
+    expect(r.spawns).toEqual([]);
+    for (const name of ["supervisor.pid", "worker.pid", "serve.pid"])
+      expect(existsSync(path.join(f.runDir, name))).toBe(true);
+  } finally {
+    f.cleanup();
+  }
+});
 
 test("`down` without a supervisor pidfile is the pre-pool teardown, unchanged", () => {
   const f = makeFixture();

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -376,7 +376,15 @@ test("malformed timing knobs fail before `up` snapshots or starts daemons", () =
   for (const [env, message] of [
     [
       { FACTORY_API_READY_TIMEOUT: "abc" },
-      "FACTORY_API_READY_TIMEOUT must be a positive integer",
+      "FACTORY_API_READY_TIMEOUT must be a non-negative integer",
+    ],
+    [
+      { FACTORY_API_READY_TIMEOUT: "-1" },
+      "FACTORY_API_READY_TIMEOUT must be a non-negative integer",
+    ],
+    [
+      { FACTORY_WEB_SUPERVISOR_INTERVAL: "0" },
+      "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number",
     ],
     [
       { FACTORY_WEB_SUPERVISOR_INTERVAL: "soon" },
@@ -395,6 +403,40 @@ test("malformed timing knobs fail before `up` snapshots or starts daemons", () =
     }
   }
 });
+
+test("`up --help` prints usage even when a timing knob is malformed", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--help"], {
+      FACTORY_API_READY_TIMEOUT: "abc",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain("usage: factory up");
+    expect(r.stderr).not.toContain("FACTORY_API_READY_TIMEOUT");
+    expect(r.spawns).toEqual([]);
+    expect(existsSync(f.runDir)).toBe(false);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("FACTORY_API_READY_TIMEOUT=0 is an immediate deadline, not a rejection", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up"], {
+      FAKE_CURL_STATUS: "1",
+      FAKE_FAST_SLEEP: "1",
+      FACTORY_API_READY_TIMEOUT: "0",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).not.toContain("must be a");
+    expect(r.stderr).toContain("failed to start");
+    expect(r.stderr).toContain("within 0s");
+    expect(r.spawns).toContain("TERM event runtime");
+  } finally {
+    f.cleanup();
+  }
+}, 20_000);
 
 test("web supervisor interval accepts a positive decimal", () => {
   const f = makeFixture();
@@ -942,11 +984,32 @@ test("malformed pool drain timeout leaves the running stack untouched", () => {
     });
     expect(r.status).toBe(1);
     expect(r.stderr).toContain(
-      "FACTORY_POOL_DRAIN_TIMEOUT must be a positive integer",
+      "FACTORY_POOL_DRAIN_TIMEOUT must be a non-negative integer",
     );
     expect(r.spawns).toEqual([]);
     for (const name of ["supervisor.pid", "worker.pid", "serve.pid"])
       expect(existsSync(path.join(f.runDir, name))).toBe(true);
+  } finally {
+    f.cleanup();
+  }
+});
+
+test("FACTORY_POOL_DRAIN_TIMEOUT=0 skips the drain wait without rejecting the knob", () => {
+  const f = makeFixture({ policy: "workers:\n  min: 1\n  max: 3\n" });
+  try {
+    mkdirSync(f.runDir, { recursive: true });
+    writeFileSync(path.join(f.runDir, "supervisor.pid"), "4242\n", "utf8");
+    writeFileSync(path.join(f.runDir, "worker.pid"), "4242\n", "utf8");
+
+    const r = runStack(f, ["down"], {
+      FAKE_ALIVE: "1",
+      FAKE_IGNORES_TERM: "1",
+      FACTORY_POOL_DRAIN_TIMEOUT: "0",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).not.toContain("must be a");
+    expect(r.stdout).toContain("draining worker pool (up to 0s");
+    expect(r.stderr).toContain("worker pool still draining after 0s");
   } finally {
     f.cleanup();
   }


### PR DESCRIPTION
Fixes #1790

Review the early timing validation that rejects malformed overrides before changing the live stack.

## Validation

| Check                | Command                                                                                                          | Result  | Notes                                    |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs && bun run lint && bun run format:check`                                        | pass    | 44 tests, 0 failures; lint warnings only |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2203 pass, 10 skip; emit clean           |
| UX critique          | factory-ux-critic                                                                                                | not run | no user-facing surface                   |

UX critique: skipped — no user-facing surface

run:run_1bdeabac-4f26-4436-a425-5c35ad9fd4e0

## Post-review

- `factory up --help` now prints usage before timing-knob validation (validation still runs before any mkdir/spawn/signal; other actions validate before mkdir as before).
- `FACTORY_API_READY_TIMEOUT` / `FACTORY_POOL_DRAIN_TIMEOUT` accept `0` again (immediate deadline); `FACTORY_WEB_SUPERVISOR_INTERVAL` stays strictly positive. Test rows added for `--help` under a bad knob, `0` for both timeouts, `-1`, and interval `0`.
