### PR TITLE
feat(repos): add in-repo repository configuration

### DIFF
--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -1,10 +1,10 @@
 /**
- * Repo facts, read from the factory's local config/repos.yaml (OPS-228).
+ * Repo facts, read from the factory's local config/repos.yaml (OPS-228) and
+ * overlaid with portable policy from each checkout's factory.repo/v1 file.
  *
- * Deliberately a reader, not an owner: repos.yaml is already the single
- * source of routing truth for the dispatcher (base branch, worktree scripts,
- * verify command). A second registry inside the event runtime would drift,
- * and a drifting port or base branch is how two agents collide.
+ * Deliberately a reader, not an owner: host config remains the source of
+ * checkout identity, routing, and concurrency, while repository-intrinsic
+ * build and policy settings evolve with that repository in git.
  *
  * Tier 1 uses `name`, `path`, `github`, and `base`. The `worktree_*` and
  * `verify` fields are read but unused until tier 2 (docs/event-runtime-workers.md).
@@ -21,6 +21,7 @@ import {
   FACTORY_ROOT,
   resolveConfigPath,
 } from "./config.mjs";
+import { validate } from "./schema.mjs";
 // types.mjs only, never index.mjs: index.mjs reads this registry to resolve a
 // repo's control plane (WM-1007), so importing it back here would cycle.
 // types.mjs imports nothing.
@@ -45,6 +46,136 @@ export function reposRoot() {
 
 export function reposConfigPath(root = reposRoot()) {
   return resolveConfigPath("repos", { root });
+}
+
+const IN_REPO_CONFIG_PATHS = [".factory.yaml", ".factory/config.yaml"];
+const IN_REPO_CONFIG_SCHEMA_PATH = new URL(
+  "../schemas/repo-config.schema.json",
+  import.meta.url,
+);
+let inRepoConfigSchema;
+
+function repoConfigSchema() {
+  if (inRepoConfigSchema) return inRepoConfigSchema;
+  try {
+    inRepoConfigSchema = JSON.parse(
+      readFileSync(IN_REPO_CONFIG_SCHEMA_PATH, "utf8"),
+    );
+  } catch (error) {
+    throw new RepoError(
+      `cannot load built-in factory.repo/v1 schema: ${error.message}`,
+    );
+  }
+  return inRepoConfigSchema;
+}
+
+function validateInRepoConfigSemantics(config, file) {
+  normalizeToolchain(config.toolchain, "in-repo config", file);
+  normalizeOwnedPathsPolicy(config.owned_paths_policy, "in-repo config", file);
+  normalizeSecurity(config.security, "in-repo config", file);
+
+  if (config.merge_ci !== undefined && config.merge_ci !== null) {
+    const { workflow, required_checks: requiredChecks } = config.merge_ci;
+    if (new Set(requiredChecks).size !== requiredChecks.length) {
+      throw new RepoError(
+        `${file}: in-repo config merge_ci.required_checks must be unique`,
+      );
+    }
+    if (!workflow.trim() || requiredChecks.some((check) => !check.trim())) {
+      throw new RepoError(
+        `${file}: in-repo config merge_ci values must be non-empty`,
+      );
+    }
+  }
+}
+
+/**
+ * Read portable repository policy from the checkout itself.
+ *
+ * A repository may use either the root-level shorthand or the namespaced
+ * location, never both. Missing files are the legacy/host-only case and return
+ * null; malformed or ambiguous declarations fail closed before host overlay.
+ */
+export function loadInRepoConfig(repoRoot = process.cwd()) {
+  const files = IN_REPO_CONFIG_PATHS.map((relative) =>
+    path.join(repoRoot, relative),
+  ).filter((file) => existsSync(file));
+  if (files.length === 0) return null;
+  if (files.length > 1) {
+    throw new RepoError(
+      `${repoRoot}: both .factory.yaml and .factory/config.yaml exist; keep exactly one in-repo config`,
+    );
+  }
+
+  const file = files[0];
+  let parsed;
+  try {
+    parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  } catch (error) {
+    throw new RepoError(`${file}: invalid YAML: ${error.message}`);
+  }
+  const result = validate(repoConfigSchema(), parsed);
+  if (!result.valid) {
+    throw new RepoError(
+      `${file}: invalid factory.repo/v1 config: ${result.errors.join("; ")}`,
+    );
+  }
+  validateInRepoConfigSemantics(parsed, file);
+  return parsed;
+}
+
+const hasOwn = (value, key) =>
+  value !== null &&
+  typeof value === "object" &&
+  Object.prototype.hasOwnProperty.call(value, key);
+
+/**
+ * Overlay repository-owned policy onto one host registry entry.
+ *
+ * Host identity and infrastructure stay intact. In-repo values own the
+ * portable fields, escalate paths are a stable union, and the two explicitly
+ * host-owned scheduling/routing controls always win.
+ */
+export function mergeRepoConfig(hostConfig, inRepoConfig) {
+  if (inRepoConfig === null || inRepoConfig === undefined) {
+    return { ...hostConfig };
+  }
+
+  const { schemaVersion: _schemaVersion, worktree, ...portable } = inRepoConfig;
+  const merged = { ...hostConfig, ...portable };
+
+  if (hasOwn(inRepoConfig, "escalate_paths")) {
+    const hostPaths = hostConfig.escalate_paths;
+    const repoPaths = inRepoConfig.escalate_paths;
+    if (Array.isArray(hostPaths) && Array.isArray(repoPaths)) {
+      merged.escalate_paths = [...new Set([...hostPaths, ...repoPaths])];
+    } else if (
+      (hostPaths === undefined || hostPaths === null) &&
+      Array.isArray(repoPaths)
+    ) {
+      merged.escalate_paths = [...repoPaths];
+    } else {
+      // Preserve malformed host policy as malformed. loadRepos projects it to
+      // null so the planner's escalate-path gate refuses to evaluate it.
+      merged.escalate_paths = hostPaths;
+    }
+  }
+
+  if (worktree && typeof worktree === "object") {
+    for (const [nested, flat] of [
+      ["up", "worktree_up"],
+      ["down", "worktree_down"],
+      ["warm", "worktree_warm"],
+    ]) {
+      if (hasOwn(worktree, nested)) merged[flat] = worktree[nested];
+    }
+  }
+
+  for (const hostOnly of ["max_in_flight", "control_plane"]) {
+    if (hasOwn(hostConfig, hostOnly)) merged[hostOnly] = hostConfig[hostOnly];
+    else delete merged[hostOnly];
+  }
+  return merged;
 }
 
 /** Expand a leading ~ the way the config files write paths. */
@@ -946,10 +1077,15 @@ export function loadRepos({ root = reposRoot() } = {}) {
     throw new RepoError(`${file}: invalid YAML: ${err.message}`);
   }
   const repos = new Map();
-  for (const entry of parsed?.repos ?? []) {
-    if (!entry?.name) throw new RepoError(`${file}: a repo entry has no name`);
-    if (!entry.path)
-      throw new RepoError(`${file}: repo ${entry.name} has no path`);
+  for (const hostEntry of parsed?.repos ?? []) {
+    if (!hostEntry?.name)
+      throw new RepoError(`${file}: a repo entry has no name`);
+    if (!hostEntry.path)
+      throw new RepoError(`${file}: repo ${hostEntry.name} has no path`);
+    const entry = mergeRepoConfig(
+      hostEntry,
+      loadInRepoConfig(expandHome(hostEntry.path)),
+    );
     let maxInFlight = null;
     if (entry.max_in_flight !== undefined && entry.max_in_flight !== null) {
       if (

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -3,8 +3,9 @@
  * overlaid with portable policy from each checkout's factory.repo/v1 file.
  *
  * Deliberately a reader, not an owner: host config remains the source of
- * checkout identity, routing, and concurrency, while repository-intrinsic
- * build and policy settings evolve with that repository in git.
+ * checkout identity, routing, concurrency, and every input to a host-executed
+ * command (`verify`, the `security` scanner flags), while repository-intrinsic
+ * policy settings evolve with that repository in git.
  *
  * Tier 1 uses `name`, `path`, `github`, and `base`. The `worktree_*` and
  * `verify` fields are read but unused until tier 2 (docs/event-runtime-workers.md).
@@ -49,6 +50,19 @@ export function reposConfigPath(root = reposRoot()) {
 }
 
 const IN_REPO_CONFIG_PATHS = [".factory.yaml", ".factory/config.yaml"];
+/**
+ * Keys the host registry owns outright. An in-repo file may never set them:
+ * `verify` and `security` are inputs to commands the host executes against a
+ * PR's own checkout, so a PR that could author them could weaken its own
+ * verification or secret scan; `max_in_flight` and `control_plane` are host
+ * scheduling and routing controls (#1638 review).
+ */
+export const IN_REPO_HOST_OWNED_KEYS = Object.freeze([
+  "verify",
+  "security",
+  "max_in_flight",
+  "control_plane",
+]);
 const IN_REPO_CONFIG_SCHEMA_PATH = new URL(
   "../schemas/repo-config.schema.json",
   import.meta.url,
@@ -69,19 +83,14 @@ function repoConfigSchema() {
   return inRepoConfigSchema;
 }
 
+const hasOwn = (value, key) =>
+  value !== null &&
+  typeof value === "object" &&
+  Object.prototype.hasOwnProperty.call(value, key);
+
 function validateInRepoConfigSemantics(config, file) {
   normalizeToolchain(config.toolchain, "in-repo config", file);
   normalizeOwnedPathsPolicy(config.owned_paths_policy, "in-repo config", file);
-  normalizeSecurity(config.security, "in-repo config", file);
-
-  if (
-    typeof config.security?.python_version === "number" &&
-    !Number.isFinite(config.security.python_version)
-  ) {
-    throw new RepoError(
-      `${file}: in-repo config security.python_version must be finite`,
-    );
-  }
 
   if (config.merge_ci !== undefined && config.merge_ci !== null) {
     const { workflow, required_checks: requiredChecks } = config.merge_ci;
@@ -123,6 +132,18 @@ export function loadInRepoConfig(repoRoot = process.cwd()) {
   } catch (error) {
     throw new RepoError(`${file}: invalid YAML: ${error.message}`);
   }
+  const hostOwned = IN_REPO_HOST_OWNED_KEYS.filter((key) =>
+    hasOwn(parsed, key),
+  );
+  if (hostOwned.length > 0) {
+    throw new RepoError(
+      `${file}: in-repo config may not set host-owned ${hostOwned
+        .map((key) => `"${key}"`)
+        .join(
+          ", ",
+        )}; the host repos.yaml owns ${IN_REPO_HOST_OWNED_KEYS.join(", ")}`,
+    );
+  }
   const result = validate(repoConfigSchema(), parsed);
   if (!result.valid) {
     throw new RepoError(
@@ -133,17 +154,13 @@ export function loadInRepoConfig(repoRoot = process.cwd()) {
   return parsed;
 }
 
-const hasOwn = (value, key) =>
-  value !== null &&
-  typeof value === "object" &&
-  Object.prototype.hasOwnProperty.call(value, key);
-
 /**
  * Overlay repository-owned policy onto one host registry entry.
  *
  * Host identity and infrastructure stay intact. In-repo values own the
- * portable fields, escalate paths are a stable union, and the two explicitly
- * host-owned scheduling/routing controls always win.
+ * portable fields, escalate paths are a stable union, and every
+ * IN_REPO_HOST_OWNED_KEYS entry always comes from the host — even for direct
+ * callers that bypass loadInRepoConfig's rejection.
  */
 export function mergeRepoConfig(hostConfig, inRepoConfig) {
   if (inRepoConfig === null || inRepoConfig === undefined) {
@@ -187,7 +204,7 @@ export function mergeRepoConfig(hostConfig, inRepoConfig) {
     }
   }
 
-  for (const hostOnly of ["max_in_flight", "control_plane"]) {
+  for (const hostOnly of IN_REPO_HOST_OWNED_KEYS) {
     if (hasOwn(hostConfig, hostOnly)) merged[hostOnly] = hostConfig[hostOnly];
     else delete merged[hostOnly];
   }
@@ -1098,10 +1115,20 @@ export function loadRepos({ root = reposRoot() } = {}) {
       throw new RepoError(`${file}: a repo entry has no name`);
     if (!hostEntry.path)
       throw new RepoError(`${file}: repo ${hostEntry.name} has no path`);
-    const entry = mergeRepoConfig(
-      hostEntry,
-      loadInRepoConfig(expandHome(hostEntry.path)),
-    );
+    // One checkout's malformed .factory.yaml must not take the whole registry
+    // down (and every other repo's dispatch with it): skip that repo's overlay,
+    // warn, and let the host entry stand on its own. Mirrors the escalate_paths
+    // stance below — the strict check belongs to the repo it describes.
+    let inRepoConfig = null;
+    try {
+      inRepoConfig = loadInRepoConfig(expandHome(hostEntry.path));
+    } catch (err) {
+      if (!(err instanceof RepoError)) throw err;
+      console.warn(
+        `warning: repo ${hostEntry.name}: in-repo config ignored, host config applies: ${err.message}`,
+      );
+    }
+    const entry = mergeRepoConfig(hostEntry, inRepoConfig);
     let maxInFlight = null;
     if (entry.max_in_flight !== undefined && entry.max_in_flight !== null) {
       if (

--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -74,6 +74,15 @@ function validateInRepoConfigSemantics(config, file) {
   normalizeOwnedPathsPolicy(config.owned_paths_policy, "in-repo config", file);
   normalizeSecurity(config.security, "in-repo config", file);
 
+  if (
+    typeof config.security?.python_version === "number" &&
+    !Number.isFinite(config.security.python_version)
+  ) {
+    throw new RepoError(
+      `${file}: in-repo config security.python_version must be finite`,
+    );
+  }
+
   if (config.merge_ci !== undefined && config.merge_ci !== null) {
     const { workflow, required_checks: requiredChecks } = config.merge_ci;
     if (new Set(requiredChecks).size !== requiredChecks.length) {
@@ -161,7 +170,14 @@ export function mergeRepoConfig(hostConfig, inRepoConfig) {
     }
   }
 
-  if (worktree && typeof worktree === "object") {
+  if (hasOwn(inRepoConfig, "worktree") && worktree === null) {
+    // An omitted worktree block inherits the host lifecycle. Explicit null is
+    // an overlay value like the other nullable portable fields: it removes
+    // every inherited lifecycle script without affecting host worktree_root.
+    merged.worktree_up = null;
+    merged.worktree_down = null;
+    merged.worktree_warm = null;
+  } else if (worktree && typeof worktree === "object") {
     for (const [nested, flat] of [
       ["up", "worktree_up"],
       ["down", "worktree_down"],

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -67,7 +67,6 @@ function repositoryRoot(relativeConfigPath, yaml) {
 const IN_REPO_YAML = `schemaVersion: factory.repo/v1
 base: develop
 deploy_branch: main
-verify: bun test
 toolchain:
   bun: ">=1.3 <2"
 owned_paths_policy:
@@ -86,10 +85,6 @@ worktree:
   up: bin/worktree-up.sh
   down: bin/worktree-down.sh
   warm: bin/worktree-warm.sh
-security:
-  python_version: "3.12"
-  semgrep_args: --exclude-rule example.rule
-  gitleaks_args: --no-git
 `;
 
 describe("factory.repo/v1 in-repo configuration", () => {
@@ -100,7 +95,6 @@ describe("factory.repo/v1 in-repo configuration", () => {
         schemaVersion: "factory.repo/v1",
         base: "develop",
         deploy_branch: "main",
-        verify: "bun test",
         toolchain: { bun: ">=1.3 <2" },
         escalate_paths: ["src/auth/**"],
         worktree: {
@@ -141,15 +135,53 @@ describe("factory.repo/v1 in-repo configuration", () => {
         "duplicate merge checks",
         "schemaVersion: factory.repo/v1\nmerge_ci:\n  workflow: CI\n  required_checks: [Verify, Verify]\n",
       ],
-      [
-        "non-finite security version",
-        "schemaVersion: factory.repo/v1\nsecurity:\n  python_version: .inf\n",
-      ],
     ];
     for (const [, yaml] of invalidCases) {
       const root = repositoryRoot(".factory.yaml", yaml);
       expect(() => loadInRepoConfig(root)).toThrow(RepoError);
     }
+  });
+
+  test("rejects host-owned verify and security by name (#1638 review)", () => {
+    // A PR that could author the verify command or the scanner flags could
+    // weaken its own verification or secret scan; those inputs to
+    // host-executed commands stay in repos.yaml.
+    const hostOwnedCases = [
+      ["verify", "schemaVersion: factory.repo/v1\nverify: bun test\n"],
+      [
+        "security",
+        "schemaVersion: factory.repo/v1\nsecurity:\n  gitleaks_args: --no-git\n",
+      ],
+      [
+        "security",
+        "schemaVersion: factory.repo/v1\nsecurity:\n  semgrep_args: --exclude-rule secrets\n",
+      ],
+      [
+        "security",
+        'schemaVersion: factory.repo/v1\nsecurity:\n  python_version: "3.12"\n',
+      ],
+      ["max_in_flight", "schemaVersion: factory.repo/v1\nmax_in_flight: 4\n"],
+      [
+        "control_plane",
+        "schemaVersion: factory.repo/v1\ncontrol_plane: linear\n",
+      ],
+    ];
+    for (const [key, yaml] of hostOwnedCases) {
+      const root = repositoryRoot(".factory.yaml", yaml);
+      expect(() => loadInRepoConfig(root)).toThrow(
+        new RegExp(`host-owned "${key}"`),
+      );
+    }
+    // Explicit null is still an attempt to own the key (it would clear the
+    // host verify command), so it is rejected the same way.
+    expect(() =>
+      loadInRepoConfig(
+        repositoryRoot(
+          ".factory.yaml",
+          "schemaVersion: factory.repo/v1\nverify: null\nsecurity: null\n",
+        ),
+      ),
+    ).toThrow(/host-owned "verify", "security"/);
   });
 
   test("overlays portable fields, unions escalation paths, and keeps host controls", () => {
@@ -158,6 +190,7 @@ describe("factory.repo/v1 in-repo configuration", () => {
       path: "/tmp/configured",
       base: "main",
       verify: "host verify",
+      security: { gitleaks_args: "--redact" },
       control_plane: "github",
       max_in_flight: 7,
       worktree_root: "/tmp/worktrees",
@@ -167,9 +200,11 @@ describe("factory.repo/v1 in-repo configuration", () => {
     const inRepo = {
       schemaVersion: "factory.repo/v1",
       base: "develop",
-      verify: "bun test",
-      // These are rejected by loadInRepoConfig's schema; direct callers still
-      // cannot use mergeRepoConfig to override host controls.
+      // These are rejected by loadInRepoConfig; direct callers still cannot
+      // use mergeRepoConfig to override host-owned controls or the inputs to
+      // host-executed commands.
+      verify: "true",
+      security: { gitleaks_args: "--no-git" },
       control_plane: "linear",
       max_in_flight: 100,
       escalate_paths: ["src/auth/**", "payments/**"],
@@ -179,11 +214,17 @@ describe("factory.repo/v1 in-repo configuration", () => {
     expect(mergeRepoConfig(host, inRepo)).toEqual({
       ...host,
       base: "develop",
-      verify: "bun test",
       escalate_paths: ["ops/**", "src/auth/**", "payments/**"],
       worktree_up: "bin/up.sh",
       worktree_down: "bin/down.sh",
     });
+    // Host-owned keys the host never set do not appear from the overlay.
+    expect(
+      mergeRepoConfig(
+        { name: "bare" },
+        { schemaVersion: "factory.repo/v1", verify: "true", security: {} },
+      ),
+    ).toEqual({ name: "bare" });
   });
 
   test("worktree omission inherits host scripts while null clears them", () => {
@@ -228,6 +269,8 @@ describe("factory.repo/v1 in-repo configuration", () => {
     path: ${configured}
     base: main
     verify: host verify
+    security:
+      gitleaks_args: --redact
     max_in_flight: 5
     control_plane: github
     escalate_paths: [ops/**]
@@ -242,7 +285,7 @@ describe("factory.repo/v1 in-repo configuration", () => {
     expect(repos.get("configured")).toMatchObject({
       base: "develop",
       deployBranch: "main",
-      verify: "bun test",
+      verify: "host verify",
       maxInFlight: 5,
       controlPlane: "github",
       escalatePaths: ["ops/**", "src/auth/**"],
@@ -252,9 +295,9 @@ describe("factory.repo/v1 in-repo configuration", () => {
       worktreeWarm: "bin/worktree-warm.sh",
       mergeCi: { workflow: "CI", requiredChecks: ["Verify"] },
       security: {
-        pythonVersion: "3.12",
-        semgrepArgs: "--exclude-rule example.rule",
-        gitleaksArgs: "--no-git",
+        pythonVersion: null,
+        semgrepArgs: null,
+        gitleaksArgs: "--redact",
       },
     });
     expect(repos.get("configured").toolchain).toEqual([
@@ -266,6 +309,50 @@ describe("factory.repo/v1 in-repo configuration", () => {
       maxInFlight: null,
       controlPlane: null,
     });
+  });
+
+  test("loadRepos skips one repo's malformed overlay with a warning instead of failing the registry", () => {
+    const broken = repositoryRoot(
+      ".factory.yaml",
+      "schemaVersion: factory.repo/v1\nsecurity:\n  gitleaks_args: --no-git\n",
+    );
+    const healthy = repositoryRoot(".factory.yaml", IN_REPO_YAML);
+    const warnings = [];
+    const originalWarn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    let repos;
+    try {
+      repos = loadRepos({
+        root: factoryRoot(`repos:
+  - name: broken
+    path: ${broken}
+    base: main
+    verify: host verify
+    security:
+      gitleaks_args: --redact
+  - name: healthy
+    path: ${healthy}
+    base: main
+`),
+      });
+    } finally {
+      console.warn = originalWarn;
+    }
+
+    // The broken checkout keeps its host config verbatim...
+    expect(repos.get("broken")).toMatchObject({
+      base: "main",
+      verify: "host verify",
+      security: { gitleaksArgs: "--redact" },
+    });
+    // ...and the other repos still get their overlay.
+    expect(repos.get("healthy")).toMatchObject({
+      base: "develop",
+      worktreeUp: "bin/worktree-up.sh",
+    });
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/repo broken: in-repo config ignored/);
+    expect(warnings[0]).toMatch(/host-owned "security"/);
   });
 });
 

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -141,6 +141,10 @@ describe("factory.repo/v1 in-repo configuration", () => {
         "duplicate merge checks",
         "schemaVersion: factory.repo/v1\nmerge_ci:\n  workflow: CI\n  required_checks: [Verify, Verify]\n",
       ],
+      [
+        "non-finite security version",
+        "schemaVersion: factory.repo/v1\nsecurity:\n  python_version: .inf\n",
+      ],
     ];
     for (const [, yaml] of invalidCases) {
       const root = repositoryRoot(".factory.yaml", yaml);
@@ -179,6 +183,39 @@ describe("factory.repo/v1 in-repo configuration", () => {
       escalate_paths: ["ops/**", "src/auth/**", "payments/**"],
       worktree_up: "bin/up.sh",
       worktree_down: "bin/down.sh",
+    });
+  });
+
+  test("worktree omission inherits host scripts while null clears them", () => {
+    const host = {
+      worktree_root: "/tmp/worktrees",
+      worktree_up: "host-up.sh",
+      worktree_down: "host-down.sh",
+      worktree_warm: "host-warm.sh",
+    };
+
+    expect(mergeRepoConfig(host, { schemaVersion: "factory.repo/v1" })).toEqual(
+      host,
+    );
+    expect(
+      mergeRepoConfig(host, {
+        schemaVersion: "factory.repo/v1",
+        worktree: null,
+      }),
+    ).toEqual({
+      worktree_root: "/tmp/worktrees",
+      worktree_up: null,
+      worktree_down: null,
+      worktree_warm: null,
+    });
+    expect(
+      mergeRepoConfig(host, {
+        schemaVersion: "factory.repo/v1",
+        worktree: { up: null },
+      }),
+    ).toEqual({
+      ...host,
+      worktree_up: null,
     });
   });
 

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -12,7 +12,9 @@ import semver from "semver";
 import { DEFAULT_MAX_IN_FLIGHT } from "./config.mjs";
 import {
   isToolchainConstraint,
+  loadInRepoConfig,
   loadRepos,
+  mergeRepoConfig,
   normalizeToolVersion,
   preflightToolchain,
   preflightToolchainSync,
@@ -50,6 +52,185 @@ function factoryRoot(yaml) {
   writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
   return root;
 }
+
+function repositoryRoot(relativeConfigPath, yaml) {
+  const root = tmpDir("evrt-in-repo-config-");
+  scratch.push(root);
+  if (relativeConfigPath) {
+    const file = path.join(root, relativeConfigPath);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, yaml);
+  }
+  return root;
+}
+
+const IN_REPO_YAML = `schemaVersion: factory.repo/v1
+base: develop
+deploy_branch: main
+verify: bun test
+toolchain:
+  bun: ">=1.3 <2"
+owned_paths_policy:
+  direct:
+    - source: shared/**
+      requires: [dist/**]
+  pin_manifests: [event-runtime/agents/*.json]
+  registry_digest:
+    inputs: [event-runtime/agents/**]
+    baseline: event-runtime/lib/registry.test.mjs
+escalate_paths: [src/auth/**]
+merge_ci:
+  workflow: CI
+  required_checks: [Verify]
+worktree:
+  up: bin/worktree-up.sh
+  down: bin/worktree-down.sh
+  warm: bin/worktree-warm.sh
+security:
+  python_version: "3.12"
+  semgrep_args: --exclude-rule example.rule
+  gitleaks_args: --no-git
+`;
+
+describe("factory.repo/v1 in-repo configuration", () => {
+  test("loads the root-level and namespaced file locations", () => {
+    for (const relative of [".factory.yaml", ".factory/config.yaml"]) {
+      const config = loadInRepoConfig(repositoryRoot(relative, IN_REPO_YAML));
+      expect(config).toMatchObject({
+        schemaVersion: "factory.repo/v1",
+        base: "develop",
+        deploy_branch: "main",
+        verify: "bun test",
+        toolchain: { bun: ">=1.3 <2" },
+        escalate_paths: ["src/auth/**"],
+        worktree: {
+          up: "bin/worktree-up.sh",
+          down: "bin/worktree-down.sh",
+          warm: "bin/worktree-warm.sh",
+        },
+      });
+    }
+  });
+
+  test("returns null when a repository has no in-repo config", () => {
+    expect(loadInRepoConfig(repositoryRoot(null, null))).toBeNull();
+  });
+
+  test("fails closed for ambiguous, malformed, unknown, and semantically invalid config", () => {
+    const ambiguous = repositoryRoot(".factory.yaml", IN_REPO_YAML);
+    mkdirSync(path.join(ambiguous, ".factory"), { recursive: true });
+    writeFileSync(path.join(ambiguous, ".factory/config.yaml"), IN_REPO_YAML);
+    expect(() => loadInRepoConfig(ambiguous)).toThrow(/both \.factory\.yaml/);
+
+    const invalidCases = [
+      ["invalid YAML", "schemaVersion: ["],
+      ["wrong version", "schemaVersion: factory.repo/v2\n"],
+      [
+        "unknown host field",
+        "schemaVersion: factory.repo/v1\nmax_in_flight: 4\n",
+      ],
+      [
+        "unknown nested field",
+        "schemaVersion: factory.repo/v1\nworktree:\n  root: /tmp/worktrees\n",
+      ],
+      [
+        "invalid toolchain range",
+        "schemaVersion: factory.repo/v1\ntoolchain:\n  bun: latest\n",
+      ],
+      [
+        "duplicate merge checks",
+        "schemaVersion: factory.repo/v1\nmerge_ci:\n  workflow: CI\n  required_checks: [Verify, Verify]\n",
+      ],
+    ];
+    for (const [, yaml] of invalidCases) {
+      const root = repositoryRoot(".factory.yaml", yaml);
+      expect(() => loadInRepoConfig(root)).toThrow(RepoError);
+    }
+  });
+
+  test("overlays portable fields, unions escalation paths, and keeps host controls", () => {
+    const host = {
+      name: "configured",
+      path: "/tmp/configured",
+      base: "main",
+      verify: "host verify",
+      control_plane: "github",
+      max_in_flight: 7,
+      worktree_root: "/tmp/worktrees",
+      worktree_up: "host-up.sh",
+      escalate_paths: ["ops/**", "src/auth/**"],
+    };
+    const inRepo = {
+      schemaVersion: "factory.repo/v1",
+      base: "develop",
+      verify: "bun test",
+      // These are rejected by loadInRepoConfig's schema; direct callers still
+      // cannot use mergeRepoConfig to override host controls.
+      control_plane: "linear",
+      max_in_flight: 100,
+      escalate_paths: ["src/auth/**", "payments/**"],
+      worktree: { up: "bin/up.sh", down: "bin/down.sh" },
+    };
+
+    expect(mergeRepoConfig(host, inRepo)).toEqual({
+      ...host,
+      base: "develop",
+      verify: "bun test",
+      escalate_paths: ["ops/**", "src/auth/**", "payments/**"],
+      worktree_up: "bin/up.sh",
+      worktree_down: "bin/down.sh",
+    });
+  });
+
+  test("loadRepos applies an in-repo overlay and preserves host-only fallback", () => {
+    const configured = repositoryRoot(".factory.yaml", IN_REPO_YAML);
+    const hostOnly = repositoryRoot(null, null);
+    const repos = loadRepos({
+      root: factoryRoot(`repos:
+  - name: configured
+    path: ${configured}
+    base: main
+    verify: host verify
+    max_in_flight: 5
+    control_plane: github
+    escalate_paths: [ops/**]
+    worktree_root: /tmp/configured-worktrees
+  - name: host-only
+    path: ${hostOnly}
+    base: release
+    verify: host-only verify
+`),
+    });
+
+    expect(repos.get("configured")).toMatchObject({
+      base: "develop",
+      deployBranch: "main",
+      verify: "bun test",
+      maxInFlight: 5,
+      controlPlane: "github",
+      escalatePaths: ["ops/**", "src/auth/**"],
+      worktreeRoot: "/tmp/configured-worktrees",
+      worktreeUp: "bin/worktree-up.sh",
+      worktreeDown: "bin/worktree-down.sh",
+      worktreeWarm: "bin/worktree-warm.sh",
+      mergeCi: { workflow: "CI", requiredChecks: ["Verify"] },
+      security: {
+        pythonVersion: "3.12",
+        semgrepArgs: "--exclude-rule example.rule",
+        gitleaksArgs: "--no-git",
+      },
+    });
+    expect(repos.get("configured").toolchain).toEqual([
+      { executable: "bun", constraint: ">=1.3 <2" },
+    ]);
+    expect(repos.get("host-only")).toMatchObject({
+      base: "release",
+      verify: "host-only verify",
+      maxInFlight: null,
+      controlPlane: null,
+    });
+  });
+});
 
 // One fully configured dispatch target and one report-only repo with nothing
 // but the minimum — between them they cover every field's present and absent

--- a/event-runtime/schemas/repo-config.schema.json
+++ b/event-runtime/schemas/repo-config.schema.json
@@ -1,6 +1,6 @@
 {
   "title": "factory.repo/v1 — portable repository-owned Factory configuration",
-  "description": "Repository-intrinsic settings read from .factory.yaml or .factory/config.yaml. Host identity, checkout paths, control-plane routing, concurrency, and credentials are deliberately excluded.",
+  "description": "Repository-intrinsic settings read from .factory.yaml or .factory/config.yaml. Host identity, checkout paths, control-plane routing, concurrency, credentials, and every input to a host-executed command (verify, security scanner flags) are deliberately excluded: they stay host-owned in repos.yaml so a pull request cannot weaken its own verification or secret scan.",
   "type": "object",
   "required": ["schemaVersion"],
   "additionalProperties": false,
@@ -8,7 +8,6 @@
     "schemaVersion": { "const": "factory.repo/v1" },
     "base": { "type": "string", "pattern": "\\S" },
     "deploy_branch": { "type": ["string", "null"], "pattern": "\\S" },
-    "verify": { "type": ["string", "null"], "pattern": "\\S" },
     "toolchain": {
       "type": ["object", "array", "null"],
       "additionalProperties": { "type": "string", "pattern": "\\S" },
@@ -85,15 +84,6 @@
         "up": { "type": ["string", "null"], "pattern": "\\S" },
         "down": { "type": ["string", "null"], "pattern": "\\S" },
         "warm": { "type": ["string", "null"], "pattern": "\\S" }
-      }
-    },
-    "security": {
-      "type": ["object", "null"],
-      "additionalProperties": false,
-      "properties": {
-        "python_version": { "type": ["string", "number"] },
-        "semgrep_args": { "type": "string" },
-        "gitleaks_args": { "type": "string" }
       }
     }
   }

--- a/event-runtime/schemas/repo-config.schema.json
+++ b/event-runtime/schemas/repo-config.schema.json
@@ -1,0 +1,100 @@
+{
+  "title": "factory.repo/v1 — portable repository-owned Factory configuration",
+  "description": "Repository-intrinsic settings read from .factory.yaml or .factory/config.yaml. Host identity, checkout paths, control-plane routing, concurrency, and credentials are deliberately excluded.",
+  "type": "object",
+  "required": ["schemaVersion"],
+  "additionalProperties": false,
+  "properties": {
+    "schemaVersion": { "const": "factory.repo/v1" },
+    "base": { "type": "string", "pattern": "\\S" },
+    "deploy_branch": { "type": ["string", "null"], "pattern": "\\S" },
+    "verify": { "type": ["string", "null"], "pattern": "\\S" },
+    "toolchain": {
+      "type": ["object", "array", "null"],
+      "additionalProperties": { "type": "string", "pattern": "\\S" },
+      "items": {
+        "type": "object",
+        "required": ["executable", "constraint"],
+        "additionalProperties": false,
+        "properties": {
+          "executable": { "type": "string", "pattern": "\\S" },
+          "constraint": { "type": "string", "pattern": "\\S" }
+        }
+      }
+    },
+    "owned_paths_policy": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "direct": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source", "requires"],
+            "additionalProperties": false,
+            "properties": {
+              "source": { "type": "string", "pattern": "\\S" },
+              "requires": {
+                "type": "array",
+                "minItems": 1,
+                "items": { "type": "string", "pattern": "\\S" }
+              }
+            }
+          }
+        },
+        "pin_manifests": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "\\S" }
+        },
+        "registry_digest": {
+          "type": "object",
+          "required": ["inputs", "baseline"],
+          "additionalProperties": false,
+          "properties": {
+            "inputs": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string", "pattern": "\\S" }
+            },
+            "baseline": { "type": "string", "pattern": "\\S" }
+          }
+        }
+      }
+    },
+    "escalate_paths": {
+      "type": ["array", "null"],
+      "items": { "type": "string", "pattern": "\\S" }
+    },
+    "merge_ci": {
+      "type": ["object", "null"],
+      "required": ["workflow", "required_checks"],
+      "additionalProperties": false,
+      "properties": {
+        "workflow": { "type": "string", "pattern": "\\S" },
+        "required_checks": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string", "pattern": "\\S" }
+        }
+      }
+    },
+    "worktree": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "up": { "type": ["string", "null"], "pattern": "\\S" },
+        "down": { "type": ["string", "null"], "pattern": "\\S" },
+        "warm": { "type": ["string", "null"], "pattern": "\\S" }
+      }
+    },
+    "security": {
+      "type": ["object", "null"],
+      "additionalProperties": false,
+      "properties": {
+        "python_version": { "type": ["string", "number"] },
+        "semgrep_args": { "type": "string" },
+        "gitleaks_args": { "type": "string" }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes watt-mind/factory#1638

Review the portable config schema and host-overlay precedence; planner consumption follow-up is tracked in #1797.

## Validation

| Check                | Command                                                                                                                       | Result  | Notes                                  |
| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs`                                                                                    | pass    | 69 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`             | pass    | 2,209 pass; emit/format/lint exit 0    |
| UX critique          | factory-ux-critic                                                                                                             | not run | backend configuration; no user surface |

UX critique: skipped — backend configuration surface has no user-facing flow

run:run_c6c15d64-1f14-4500-9efc-31f45c53c66f

## Post-review

- **Security narrowing (review finding 1):** `verify` and the whole `security` block are now host-owned like `max_in_flight`/`control_plane`. `loadInRepoConfig` rejects an in-repo file that sets any of them with an error naming the key (fail-closed), the `factory.repo/v1` schema no longer lists them, and `mergeRepoConfig` restores every host-owned key from the host entry even for direct callers. The ticket AC listed `verify` and `security` in the schema; they are deliberately excluded because they are inputs to host-executed commands and scanner flags (a PR could otherwise weaken its own verification or secret scan). Test fixture `gitleaks_args: --no-git` replaced by a rejection test.
- **Robustness (review finding 2):** `loadRepos` now catches a malformed `.factory.yaml` per repo, warns (`warning: repo <name>: in-repo config ignored, host config applies: ...`), and keeps that repo's host config instead of failing the whole registry load. Test added.
- **Follow-up (not done here):** `loadRepos` now costs two `existsSync` calls plus a YAML parse per repo on every call; callers that reload the registry frequently may want an mtime-keyed cache of the overlay. No caching was added in this PR.
- Rebased onto the updated branch tip (`c79fe2c5`); head `4f086b21f11cd4fb815c20c8440d6d2733ca535b`.
