### PR TITLE
fix(tests): fail closed before loopback port 80

### DIFF
--- a/bin/worktree-common.sh
+++ b/bin/worktree-common.sh
@@ -807,16 +807,28 @@ listen_tcp_port() { # <pidfile>
   printf '%s' "$port"
 }
 
+require_loopback_port() { # <caller> <port>
+  local caller="$1" port="${2:-}"
+  [[ -n "$port" ]] || die "$caller: port argument is unset"
+  [[ "$port" =~ ^[0-9]+$ ]] || die "$caller: port argument must be numeric (got '$port')"
+  (( 10#$port >= 1 && 10#$port <= 65535 )) \
+    || die "$caller: port argument must be between 1 and 65535 (got '$port')"
+}
+
 port_listening() { # <port>
-  (exec 3<>/dev/tcp/127.0.0.1/"$1") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
+  local port="${1:-}"
+  require_loopback_port port_listening "$port"
+  (exec 3<>/dev/tcp/127.0.0.1/"$port") 2>/dev/null && { exec 3>&- 3<&-; return 0; }
   if command -v lsof >/dev/null 2>&1; then
-    lsof -nP -iTCP:"$1" -sTCP:LISTEN >/dev/null 2>&1 && return 0
+    lsof -nP -iTCP:"$port" -sTCP:LISTEN >/dev/null 2>&1 && return 0
   fi
   return 1
 }
 
 health_json() { # <port>
-  curl -sf -m 1 "http://127.0.0.1:$1/health" 2>/dev/null || true
+  local port="${1:-}"
+  require_loopback_port health_json "$port"
+  curl -sf -m 1 "http://127.0.0.1:$port/health" 2>/dev/null || true
 }
 
 # Extract env.<field> from a /health JSON body. Empty if missing/null/unparseable.

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -115,6 +115,24 @@ function command(cmd, cwd, extraEnv = {}) {
   };
 }
 
+test("loopback helpers fail closed on unset or non-numeric ports", () => {
+  for (const helper of ["port_listening", "health_json"]) {
+    const unset = sh(`${helper} ""`);
+    expect(unset.status).not.toBe(0);
+    expect(unset.stderr).toContain(`${helper}: port argument is unset`);
+    expect(`${unset.stdout}${unset.stderr}`).not.toContain("127.0.0.1:80");
+
+    const nonNumeric = sh(`${helper} not-a-port`);
+    expect(nonNumeric.status).not.toBe(0);
+    expect(nonNumeric.stderr).toContain(
+      `${helper}: port argument must be numeric`,
+    );
+    expect(`${nonNumeric.stdout}${nonNumeric.stderr}`).not.toContain(
+      "127.0.0.1:80",
+    );
+  }
+});
+
 test("run log rotation retains bounded generations and copy-truncates a live owner", () => {
   const r = sh(`
     dir="$(mktemp -d)"

--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -384,6 +384,9 @@ else
   preferred="$(ticket_api_port "$TICKET")"
 fi
 resolve_worktree_ports "$WT" "$preferred" "$HOME_DIR"
+# worktree-common.sh runs under set -u: resolve_worktree_ports either assigns
+# numeric API_PORT/WEB_PORT values or exits, so every loopback probe below can
+# pass the helpers' new loud port validation without an unset-variable path.
 
 # ------------------------------------------------------------ dependencies ---
 info "installing dependencies (bun install, root + web)"

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -958,6 +958,11 @@ describe("work --reload-on-change (WM-213)", () => {
   test(
     "a run in flight defers reload; its supervisor restarts only once it is idle",
     async () => {
+      // gh-1781 classification: this was a distinct synchronization defect,
+      // not an HTTP/base-URL failure. gh-1423 replaced wall-clock coordination
+      // with the fake adapter's hold marker/release file, and gh-1466 made the
+      // supervisor handoff observable; the 90s ceiling is only a process-safety
+      // budget scaled for loaded runners.
       const { openDb } = await import("../lib/db.mjs");
       const { createRun, transition } = await import("../lib/lifecycle.mjs");
       const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");

--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -1217,6 +1217,10 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // may terminally REFUSE with claim_lock_starvation just because a live holder
   // still owns the lock — and the atomic claim must be preserved throughout
   // (at most one active tracker claim, each ticket claimed exactly once).
+  // gh-1781 classification: this is not related to an HTTP base URL. It is an
+  // in-memory SQLite/fake-clock stress case with 570 deliberate contention
+  // passes; any wall-clock timeout is the test's genuine load-scaled execution
+  // budget, while its liveness assertions remain deterministic.
   test("a same-repo dispatch burst never claim_lock_starves against a live holder", async () => {
     const db = openDb(":memory:");
     const lockDir = tmpDir("evrt-lock-burst20-");

--- a/event-runtime/web/src/test-dom.ts
+++ b/event-runtime/web/src/test-dom.ts
@@ -15,3 +15,19 @@
 import { GlobalRegistrator } from "@happy-dom/global-registrator";
 
 GlobalRegistrator.register();
+
+// happy-dom supplies a real fetch and defaults its document origin to
+// http://localhost/. An api method that a component test forgot to stub would
+// therefore escape to port 80. Fail closed before the network stack sees it;
+// tests that intentionally exercise fetch replace globalThis.fetch explicitly.
+globalThis.fetch = (async (
+  input: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+) => {
+  const request = input instanceof Request ? input : null;
+  const method = (init?.method ?? request?.method ?? "GET").toUpperCase();
+  const rawUrl = request?.url ?? String(input);
+  const url = new URL(rawUrl, document.location.href);
+  const path = `${url.pathname}${url.search}`.replace(/^\/api(?=\/)/, "");
+  throw new Error(`unmocked api call: ${method} ${path}`);
+}) as unknown as typeof fetch;

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -8,7 +8,11 @@ import {
   waitFor,
   within,
 } from "@testing-library/react";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import {
+  QueryClient,
+  QueryClientProvider,
+  useQuery,
+} from "@tanstack/react-query";
 import {
   Overview,
   groupJournalEntries,
@@ -21,7 +25,7 @@ import { shortId } from "../components/ui";
 import { api } from "../api";
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
-import { withApi } from "../test-render";
+import { restoreApi, withApi } from "../test-render";
 import type {
   AdmittedEvent,
   EventFocus,
@@ -46,6 +50,16 @@ function renderWithClient(ui: React.ReactElement) {
 }
 
 const noop = () => {};
+
+function UnmockedApiProbe() {
+  const query = useQuery({
+    queryKey: ["unmocked-status"],
+    queryFn: api.status,
+  });
+  return (
+    <p>{query.error instanceof Error ? query.error.message : "pending"}</p>
+  );
+}
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
@@ -526,6 +540,26 @@ describe("Overview keyboard navigation (WM-292)", () => {
 });
 
 describe("Overview anomaly deck (WM-95, WM-979)", () => {
+  test("an incomplete api stub fails closed without reaching the network", async () => {
+    const originalProposals = api.proposals;
+    api.proposals = async () => ({ proposals: [] });
+    try {
+      const view = renderWithClient(<UnmockedApiProbe />);
+      await waitFor(() =>
+        expect(view.getByText("unmocked api call: GET /status")).toBeTruthy(),
+      );
+    } finally {
+      api.proposals = originalProposals;
+      restoreApi();
+    }
+  });
+
+  test("the network guard reports mutating methods and normalized api paths", async () => {
+    await expect(
+      globalThis.fetch("/api/events", { method: "POST" }),
+    ).rejects.toThrow("unmocked api call: POST /events");
+  });
+
   test("collapses expired-open proposals to one Review-expired row (WM-979)", async () => {
     const origStatus = api.status;
     const origProposals = api.proposals;


### PR DESCRIPTION
Fixes watt-mind/factory#1781

Review the fail-closed loopback guards and deterministic shell/web regressions; all changed paths are ticket-owned.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test --timeout 20000 bin/worktree-checkout.test.mjs bin/worktree-common.test.mjs event-runtime/web/src event-runtime/lib/worker-dispatch-hardening.test.mjs event-runtime/cli/work.test.mjs && bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check` | pass | 3,776 tests, 0 failures; forbidden network strings absent |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,230 tests; emit/format clean; lint 0 errors |
| Web typecheck        | `cd event-runtime/web && bun x tsc --noEmit` | pass | clean |
| UX critique          | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — test harness and worktree helper change; no user-facing flow

run:run_1d000bda-097a-496d-90e5-3c1aa3a9efea
