### PR TITLE
fix(cli): centralize dispatch-class agent checks

### DIFF
--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -351,7 +351,7 @@ describe("cli routing", () => {
     expect(lines).toEqual(["0"]);
   });
 
-  test("dispatch-only keeps dispatch agents by id, prefix, or contract and drops unregistered ones", () => {
+  test("dispatch-only keeps only explicit dispatch-class agents", () => {
     const keep = dispatchOnlyPredicate([
       { id: "dispatch", ref: "dispatch@1" },
       { id: "dispatch-hotfix", ref: "dispatch-hotfix@2" },
@@ -364,14 +364,11 @@ describe("cli routing", () => {
       { id: "merge-review", ref: "merge-review@1" },
       { id: "work-scan", ref: "work-scan@1" },
     ]);
-    const kept = [
-      "dispatch@1",
+    const kept = ["dispatch@1", "dispatch@7"];
+    const dropped = [
       "dispatch-hotfix@2",
       "lander@1",
       "worker@1",
-      "dispatch@7",
-    ];
-    const dropped = [
       "merge-fix@1",
       "merge-review@1",
       "work-scan@1",

--- a/event-runtime/cli/runs.mjs
+++ b/event-runtime/cli/runs.mjs
@@ -1,27 +1,11 @@
 import { pad, withClient } from "./shared.mjs";
+import { isDispatchClassAgent } from "../lib/proposal-subject.mjs";
 
 /**
- * `--dispatch-only` allowlist. A run counts as dispatch work when its agent
- * definition matches any of these, in order:
- *
- * 1. its `id` is in DISPATCH_AGENT_IDS (`dispatch`; `worker` is the legacy
- *    name some fixtures and older registries still use);
- * 2. its `id` starts with `dispatch-` (repo-local dispatch variants);
- * 3. its `outputContract` is a dispatch result contract — the registry field
- *    that actually marks "this agent lands a ticket", so a renamed dispatch
- *    agent still counts without touching this file.
- *
- * Everything else the registry knows (merge-review, merge-fix, ci-doctor,
- * ci-notify, merge-notify, triage-scan, merge-scan, work-scan, reaper, the
- * smoke probes, ...) is excluded, and so is any row whose agent is not in the
- * registry at all: a drain (`until [ "$(factory runs RUNNING --dispatch-only
- * --count)" = 0 ]`) must not be kept busy by an agent that was since removed.
+ * `--dispatch-only` includes only the explicit dispatch class: runs that hold
+ * a ticket lease and worktree (including their tier continuation). A
+ * dispatch-like name or output contract is not sufficient.
  */
-export const DISPATCH_AGENT_IDS = new Set(["dispatch", "worker"]);
-export const DISPATCH_OUTPUT_CONTRACTS = new Set([
-  "factory.dispatch-result/v1",
-]);
-
 /**
  * Hard limits for the cursor walk. The control API clamps a page to
  * RUN_LIST_MAX_LIMIT (200, `lib/api-runs.mjs`) and rejects anything larger,
@@ -71,34 +55,18 @@ export function parseRunsArgs(args) {
   return options;
 }
 
-export function isDispatchWorkerAgent(def) {
-  const id = typeof def?.id === "string" ? def.id : "";
-  return (
-    DISPATCH_AGENT_IDS.has(id) ||
-    id.startsWith("dispatch-") ||
-    DISPATCH_OUTPUT_CONTRACTS.has(def?.outputContract)
-  );
-}
-
-/** Agent id of a run row's `agent` ref (`dispatch@1` -> `dispatch`). */
-function agentIdOf(ref) {
-  return typeof ref === "string" ? ref.split("@")[0] : "";
-}
-
 /**
- * Build the row predicate for `--dispatch-only` from the registry: keep rows
- * whose agent ref (or bare id) belongs to a dispatch definition, or whose id
- * is a known dispatch id even when the registry no longer lists it.
+ * Build the row predicate for `--dispatch-only` from the explicit
+ * dispatch-class membership shared with metrics.
  */
 export function dispatchOnlyPredicate(agents) {
   const refs = new Set();
   for (const def of agents ?? []) {
-    if (!isDispatchWorkerAgent(def)) continue;
+    if (!isDispatchClassAgent(def?.id)) continue;
     if (typeof def.ref === "string") refs.add(def.ref);
     if (typeof def.id === "string") refs.add(def.id);
   }
-  return (row) =>
-    refs.has(row.agent) || isDispatchWorkerAgent({ id: agentIdOf(row.agent) });
+  return (row) => refs.has(row.agent) || isDispatchClassAgent(row.agent);
 }
 
 export async function runs(client, stateFilter, options = {}) {

--- a/event-runtime/lib/metrics.mjs
+++ b/event-runtime/lib/metrics.mjs
@@ -1,3 +1,5 @@
+import { isDispatchClassAgent } from "./proposal-subject.mjs";
+
 const DURATIONS_MS = Object.freeze({
   "15m": 15 * 60_000,
   "1h": 60 * 60_000,
@@ -554,7 +556,7 @@ export function modelTierEconomicsView(
     if (
       typeof run.modelTier === "string" &&
       typeof run.agent === "string" &&
-      run.agent.startsWith("dispatch@") &&
+      isDispatchClassAgent(run.agent) &&
       (!entry.dispatch || run.createdAt < entry.dispatch.createdAt)
     ) {
       entry.dispatch = run;

--- a/event-runtime/lib/proposal-subject.mjs
+++ b/event-runtime/lib/proposal-subject.mjs
@@ -42,6 +42,18 @@ export function agentFamily(agent) {
   return agent.trim().replace(/@\d+$/, "");
 }
 
+/**
+ * Agent IDs whose runs hold a ticket lease and worktree, including their
+ * strong-tier escalation continuation. Keep this explicit: a dispatch-like
+ * name alone does not make an agent dispatch-class work.
+ */
+export const DISPATCH_CLASS_AGENT_IDS = new Set(["dispatch"]);
+
+/** Whether an agent id or versioned ref belongs to the dispatch class. */
+export function isDispatchClassAgent(agent) {
+  return DISPATCH_CLASS_AGENT_IDS.has(agentFamily(agent));
+}
+
 /** Title-case the agent family so it reads as a verb (`ci-doctor` → `Ci-doctor`). */
 export function agentVerb(agent) {
   const family = agentFamily(agent);

--- a/event-runtime/lib/proposal-subject.test.mjs
+++ b/event-runtime/lib/proposal-subject.test.mjs
@@ -1,7 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  DISPATCH_CLASS_AGENT_IDS,
   agentFamily,
   agentVerb,
+  isDispatchClassAgent,
   primaryInput,
   proposalDecisionContext,
   proposalQuestion,
@@ -18,6 +20,15 @@ const dispatchSpec = {
   model: "cursor-grok-4.6-high",
   input: { ticket: "WM-862", repo: "factory" },
 };
+
+describe("dispatch-class agents", () => {
+  test("matches only explicitly-listed ids and their versioned refs", () => {
+    expect([...DISPATCH_CLASS_AGENT_IDS]).toEqual(["dispatch"]);
+    expect(isDispatchClassAgent("dispatch")).toBe(true);
+    expect(isDispatchClassAgent("dispatch@1")).toBe(true);
+    expect(isDispatchClassAgent("dispatch-hotfix@1")).toBe(false);
+  });
+});
 
 describe("proposalSubject (WM-897)", () => {
   test("delegates to the view subject when the agent's sidecar defines one", () => {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -31,6 +31,7 @@ import {
 import { computeDefHash } from "./receipts.mjs";
 import { updateHarnessPins } from "./pins.mjs";
 import { validate } from "./schema.mjs";
+import { DISPATCH_CLASS_AGENT_IDS } from "./proposal-subject.mjs";
 
 /** Copy the real registry into a temp root so tests can corrupt it safely. */
 function tempRegistry(root = tmpDir("event-registry-")) {
@@ -123,6 +124,12 @@ const PI_TIERS = {
 };
 
 describe("registry", () => {
+  test("every dispatch-class agent id resolves to a loaded registry definition", () => {
+    const registry = loadRegistry();
+    const ids = new Set([...registry.agents.values()].map((def) => def.id));
+    for (const id of DISPATCH_CLASS_AGENT_IDS) expect(ids).toContain(id);
+  });
+
   test("loads the committed registry (pins verified)", () => {
     const registry = loadRegistry();
     const def = getAgent(registry, "factory-status-report@1");


### PR DESCRIPTION
Fixes watt-mind/factory#1778

Use one explicit dispatch-class allowlist across CLI filtering and ticket economics.

## Validation

| Check                | Command                                                                            | Result  | Notes                          |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test event-runtime/cli.test.mjs event-runtime/lib/registry.test.mjs event-runtime/lib/proposal-subject.test.mjs --timeout 20000` | pass | 91 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | completed with existing warnings |
| UX critique          | factory-ux-critic                                                                  | not run | internal CLI and metrics change |

UX critique: skipped
run:run_07ffa2da-7bc3-45c6-8762-a3f52352bc5f
