### PR TITLE
feat(cli): batch cancellation controls

### DIFF
--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -493,6 +493,142 @@ describe("cli routing", () => {
     ]);
   });
 
+  test("cancel attempts every explicit run ID when one cancellation fails", async () => {
+    const attempted = [];
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        const runId = decodeURIComponent(
+          new URL(request.url).pathname.split("/")[2],
+        );
+        attempted.push(runId);
+        return runId === "run_fail"
+          ? Response.json({ error: "cannot cancel" }, { status: 409 })
+          : Response.json({});
+      },
+    });
+    try {
+      const child = Bun.spawn(
+        [
+          "bun",
+          CLI,
+          "cancel",
+          "run_one",
+          "run_fail",
+          "run_three",
+          "--reason",
+          "cleanup",
+        ],
+        {
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_PORT: String(server.port),
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [status, stdout] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+      ]);
+      expect(status).toBe(1);
+      expect(stdout).toContain("cancelled run_one");
+      expect(stdout).toContain("cancel failed run_fail: cannot cancel");
+      expect(stdout).toContain("cancelled run_three");
+    } finally {
+      server.stop(true);
+    }
+    expect(attempted.sort()).toEqual(["run_fail", "run_one", "run_three"]);
+  });
+
+  test("cancel state selection refuses multiple targets without --yes", async () => {
+    const requests = [];
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push(`${url.pathname}${url.search}`);
+        if (url.pathname === "/runs")
+          return Response.json({
+            runs: [{ runId: "run_one" }, { runId: "run_two" }],
+          });
+        return Response.json({});
+      },
+    });
+    try {
+      const child = Bun.spawn(["bun", CLI, "cancel", "--state", "PROPOSED"], {
+        env: {
+          ...process.env,
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+          FACTORY_EVENT_PORT: String(server.port),
+          FACTORY_RUN_DIR: throwawayRunDir(),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      expect(status).toBe(1);
+      expect(stdout).toContain("run_one");
+      expect(stdout).toContain("run_two");
+      expect(stderr).toContain("--yes");
+    } finally {
+      server.stop(true);
+    }
+    expect(requests).toEqual(["/runs?state=PROPOSED"]);
+  });
+
+  test("cancel state selection dry-run lists targets without cancellation", async () => {
+    const requests = [];
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        const url = new URL(request.url);
+        requests.push(`${url.pathname}${url.search}`);
+        return Response.json({ runs: [{ runId: "run_one" }] });
+      },
+    });
+    try {
+      const child = Bun.spawn(
+        [
+          "bun",
+          CLI,
+          "cancel",
+          "--state",
+          "PROPOSED",
+          "--agent",
+          "worker@1",
+          "--dry-run",
+        ],
+        {
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_PORT: String(server.port),
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [status, stdout] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+      ]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("run_one");
+    } finally {
+      server.stop(true);
+    }
+    expect(requests).toEqual(["/runs?state=PROPOSED&agent=worker%401"]);
+  });
+
   test("registered command set is unchanged", () => {
     expect(COMMAND_NAMES).toEqual(EXPECTED_COMMANDS);
   });

--- a/event-runtime/cli/cancel.mjs
+++ b/event-runtime/cli/cancel.mjs
@@ -1,15 +1,118 @@
 import { fail, withClient } from "./shared.mjs";
 
-export default function cancel(args) {
-  if (!args[0]) fail("usage: cancel <run-id> [reason]");
-  return withClient(async (client) => {
-    const res = await client.cancel(args[0], args[1]);
-    if (res?.ambiguousOpenProposals?.length) {
-      console.log(
-        `cancelled ${args[0]} (warning: ${res.ambiguousOpenProposals[0].count} open proposals remain ambiguous)`,
-      );
+export const CANCEL_CONCURRENCY = 4;
+
+function optionValue(args, index, option) {
+  const value = args[index + 1];
+  if (value === undefined || value.startsWith("--")) {
+    fail(`${option} requires a value`);
+  }
+  return value;
+}
+
+/** Parse one explicit target set or an exact server-side state/agent selection. */
+export function parseCancelArgs(args) {
+  const options = { ids: [] };
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--reason") {
+      options.reason = optionValue(args, index, arg);
+      index += 1;
+    } else if (arg === "--state") {
+      options.state = optionValue(args, index, arg).toUpperCase();
+      index += 1;
+    } else if (arg === "--agent") {
+      options.agent = optionValue(args, index, arg);
+      index += 1;
+    } else if (arg === "--yes") {
+      options.yes = true;
+    } else if (arg === "--dry-run") {
+      options.dryRun = true;
+    } else if (arg.startsWith("--")) {
+      fail(`unknown cancel option: ${arg}`);
     } else {
-      console.log(`cancelled ${args[0]}`);
+      options.ids.push(arg);
+    }
+  }
+
+  if (options.state) {
+    if (options.ids.length) fail("--state cannot be combined with run IDs");
+    return options;
+  }
+  if (options.agent || options.yes || options.dryRun) {
+    fail("--agent, --yes, and --dry-run require --state");
+  }
+  if (!options.ids.length) {
+    fail(
+      "usage: cancel <run-id>... [--reason <text>] | cancel --state <state> [--agent <id>] [--reason <text>] [--yes] [--dry-run]",
+    );
+  }
+
+  // Runtime-generated IDs always start with `run_`. Preserve the old
+  // `cancel <run-id> <reason>` spelling when the second positional argument
+  // is not another canonical run ID; batches use `--reason` to be unambiguous.
+  if (
+    options.reason === undefined &&
+    options.ids.length === 2 &&
+    options.ids[0].startsWith("run_") &&
+    !options.ids[1].startsWith("run_")
+  ) {
+    options.reason = options.ids.pop();
+  }
+  return options;
+}
+
+function printTargets(ids) {
+  for (const id of ids) console.log(id);
+}
+
+async function cancelAll(client, ids, reason) {
+  let next = 0;
+  let failed = false;
+  const worker = async () => {
+    while (next < ids.length) {
+      const id = ids[next++];
+      try {
+        const res = await client.cancel(id, reason);
+        if (res?.ambiguousOpenProposals?.length) {
+          console.log(
+            `cancelled ${id} (warning: ${res.ambiguousOpenProposals[0].count} open proposals remain ambiguous)`,
+          );
+        } else {
+          console.log(`cancelled ${id}`);
+        }
+      } catch (error) {
+        failed = true;
+        console.log(`cancel failed ${id}: ${error.message}`);
+      }
+    }
+  };
+  await Promise.all(
+    Array.from({ length: Math.min(CANCEL_CONCURRENCY, ids.length) }, worker),
+  );
+  return !failed;
+}
+
+export default function cancel(args) {
+  const options = parseCancelArgs(args);
+  return withClient(async (client) => {
+    let ids = options.ids;
+    if (options.state) {
+      const page = await client.runs({
+        state: options.state,
+        ...(options.agent ? { agent: options.agent } : {}),
+      });
+      ids = (page.runs ?? []).map((run) => run.runId);
+      printTargets(ids);
+      if (options.dryRun || !ids.length) return;
+      if (ids.length > 1 && !options.yes) {
+        console.error("refusing to cancel multiple runs without --yes");
+        process.exitCode = 1;
+        return;
+      }
+    }
+    if (!(await cancelAll(client, ids, options.reason))) {
+      process.exitCode = 1;
     }
   });
 }

--- a/event-runtime/cli/usage.mjs
+++ b/event-runtime/cli/usage.mjs
@@ -66,7 +66,10 @@ usage: bun event-runtime/cli.mjs <command>
   reject <proposal-id> <reason>  reject an open proposal
   inject <envelope.json|->       replay an event envelope (same intake as the webhook)
   requeue <source> <event-id>    re-plan a dead-lettered or human_needed event
-  cancel <run-id> [reason]       cancel a run before it is RUNNING
+  cancel <run-id>... [--reason TEXT]
+                                 cancel runs before they are RUNNING
+  cancel --state STATE [--agent ID] [--reason TEXT] [--yes] [--dry-run]
+                                 select exact state/agent targets before cancelling
   retry <run-id> [--force]       re-queue a FAILED run (--force past maxAttempts)
   extend <run-id> --seconds N [--override]
                                  extend a RUNNING/VERIFYING deadline (max 3600s per call)


### PR DESCRIPTION
Fixes watt-mind/factory#1761

Batch cancellation now supports exact state/agent selection and bounded concurrent per-run outcomes.

## Validation

| Check                | Command                                                                      | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000`                        | pass    | 24 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | completed; existing warnings  |
| UX critique          | factory-ux-critic                                                           | not run | CLI-only, no user-facing flow |

UX critique: skipped

run:run_76df9e61-5502-4755-b67c-817581d8796b