### PR TITLE
fix(control-plane): preserve status on reused issues

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1916,10 +1916,13 @@ export function githubControlPlane(options = {}) {
      * lag the successful POST that an immediate retry must find. Reused issues
      * preserve existing labels and receive any requested labels they lack; the
      * requested `body` is discarded on reuse (the existing issue's body wins,
-     * so a retry never rewrites what a human may have edited) and the result
-     * carries `reused: true`. Reusing a CLOSED issue is reported as a warning
-     * rather than silently re-boarding it: the caller decides whether the
-     * closed issue really covers the finding.
+     * so a retry never rewrites what a human may have edited). A reused issue
+     * that already has a board Status keeps that Status (reported as
+     * `status`); it is not re-boarded or closed even if the request says
+     * `Done`. A reused issue with no board item is still boarded at the
+     * requested state. The result carries `reused: true`. Reusing a CLOSED
+     * issue is reported as a warning rather than silently re-boarding it: the
+     * caller decides whether the closed issue really covers the finding.
      */
     async file({
       team,
@@ -2028,28 +2031,36 @@ export function githubControlPlane(options = {}) {
           });
         }
       }
+      let preservedStatus = null;
       const filed = {
         identifier: issueIdentifier(repo, created.number),
         url: created.html_url ?? "",
         ...(reused ? { reused: true } : {}),
       };
       try {
-        await setStatus(
-          repo,
-          created.number,
-          created.node_id ?? String(created.id),
-          state,
-        );
-        if (state.toLowerCase() === "done")
-          await call("PATCH", `repos/${repo}/issues/${created.number}`, {
-            body: { state: "closed" },
-          });
+        if (reused)
+          preservedStatus = (await statusOf(repo, created.number)).name;
+        if (!preservedStatus) {
+          await setStatus(
+            repo,
+            created.number,
+            created.node_id ?? String(created.id),
+            state,
+          );
+          if (state.toLowerCase() === "done")
+            await call("PATCH", `repos/${repo}/issues/${created.number}`, {
+              body: { state: "closed" },
+            });
+        }
       } catch (err) {
         warnings.push(
           `${filed.identifier} exists, but a follow-up write failed: ${err?.message ?? String(err)}`,
         );
       }
-      return warnings.length ? { ...filed, warnings } : filed;
+      const result = preservedStatus
+        ? { ...filed, status: preservedStatus }
+        : filed;
+      return warnings.length ? { ...result, warnings } : result;
     },
 
     async appendDetail(identifier, markdown) {

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -1521,6 +1521,102 @@ describe("control-plane contract: github", () => {
     ).toContain("type:bug");
   });
 
+  test("file reuse preserves an existing board status and does not close it for Done", async () => {
+    const seed = contractSeed();
+    addIssue(seed, REPO, {
+      id: 301,
+      node_id: "I_301",
+      number: 7,
+      title: "todo finding",
+      body: "<!-- factory:dedupe-key todo-finding -->\nearlier",
+      status: "Todo",
+    });
+    addIssue(seed, REPO, {
+      id: 302,
+      node_id: "I_302",
+      number: 8,
+      title: "claimed finding",
+      body: "<!-- factory:dedupe-key claimed-finding -->\nearlier",
+      assignee: { id: 99, login: "Other", name: "Other" },
+      status: "In Progress",
+    });
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+
+    const todo = await cp.file({
+      team: TEAM,
+      title: "todo finding",
+      dedupeKey: "todo-finding",
+      state: "Triage",
+    });
+    const claimed = await cp.file({
+      team: TEAM,
+      title: "claimed finding",
+      dedupeKey: "claimed-finding",
+      state: "Done",
+    });
+
+    expect(todo).toMatchObject({ reused: true, status: "Todo" });
+    expect(claimed).toMatchObject({ reused: true, status: "In Progress" });
+    expect(requireIssue(seed, REPO, 8).assignee.login).toBe("Other");
+    expect(requireIssue(seed, REPO, 8).state).toBe("open");
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "POST" &&
+          call.pathName === "graphql" &&
+          call.body?.query?.includes("SetProjectStatus"),
+      ),
+    ).toBe(false);
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "PATCH" && call.pathName === `repos/${REPO}/issues/8`,
+      ),
+    ).toBe(false);
+  });
+
+  test("file reuse without a board item applies the requested state", async () => {
+    const seed = contractSeed();
+    addIssue(seed, REPO, {
+      id: 301,
+      node_id: "I_301",
+      number: 7,
+      title: "unboarded finding",
+      body: "<!-- factory:dedupe-key unboarded-finding -->\nearlier",
+    });
+    const api = fakeApi(seed);
+    const cp = githubControlPlane({
+      api,
+      repo: REPO,
+      teams: { WM: REPO },
+      project: PROJECT,
+    });
+
+    const reused = await cp.file({
+      team: TEAM,
+      title: "unboarded finding",
+      dedupeKey: "unboarded-finding",
+      state: "Todo",
+    });
+
+    expect(reused.reused).toBe(true);
+    expect((await cp.getTicket(reused.identifier)).state.name).toBe("Todo");
+    expect(
+      api.calls.some(
+        (call) =>
+          call.method === "POST" &&
+          call.pathName === "graphql" &&
+          call.body?.query?.includes("SetProjectStatus"),
+      ),
+    ).toBe(true);
+  });
+
   test("file reports reuse and warns when the dedupe key matches a closed issue", async () => {
     const seed = contractSeed();
     addIssue(seed, REPO, {

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -103,6 +103,9 @@ export async function transitionThenComment(cp, key, state, options, comment) {
  *
  * The control plane may return `warnings` (a follow-up board write failed, or
  * the key matched a closed issue) and `reused` (no new issue was created).
+ * A reused issue that already has a board Status keeps it instead of applying
+ * the requested state (including `Done`); the preserved value is returned as
+ * `status`. A reuse with no board item is still assigned the requested state.
  * Warnings flip the structured result to `ok: false` and set a non-zero exit
  * code: the issue exists, but callers must not mistake it for a complete
  * filing. The result stays available for recovery either way.


### PR DESCRIPTION
Fixes watt-mind/factory#1788

Retries preserve promoted or claimed GitHub issue board status.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test lib/control-plane/github.test.mjs tools/ticket.test.mjs && bun run lint && bun run format:check` | pass | 192 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,220 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_2d691009-2d7d-4093-b0e1-09c549d2d071