### PR TITLE
fix(serve): bound orphaned proposal sweep per tick

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -231,6 +231,7 @@ export async function tick({
   announceTransitions = () => {},
   subsystems = {},
   skipPlan = false,
+  proposalSweepLimit,
 } = {}) {
   const tickStart = Date.now();
   const stepMs = {};
@@ -314,10 +315,13 @@ export async function tick({
   });
 
   await runStep("proposals", () => {
-    const expired = sweepOrphanedNonRunProposals(db, { now });
+    const { expired, remaining } = sweepOrphanedNonRunProposals(db, {
+      now,
+      limit: proposalSweepLimit,
+    });
     if (expired > 0)
       logLine(
-        `proposals: expired ${expired} orphaned human_needed/noop row(s)`,
+        `proposals: expired ${expired} orphaned human_needed/noop row(s) (${remaining} remaining)`,
       );
   });
 

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -634,7 +634,7 @@ export default async function start() {
     db.close();
   });
 
-  test("tick expires orphaned non-run proposals and logs only when it does", async () => {
+  test("tick bounds orphaned non-run proposal sweeps and logs the remainder", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");
     const db = openDb(":memory:");
@@ -644,13 +644,17 @@ export default async function start() {
       `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at, status)
        VALUES ('test', ?, 'test.event', ?, ?, '{}', 'hash', ?, ?)`,
     );
-    insertEvent.run("moved-on", at, at, at, "admitted");
+    insertEvent.run("moved-on-1", at, at, at, "admitted");
+    insertEvent.run("moved-on-2", at, at, at, "admitted");
+    insertEvent.run("moved-on-3", at, at, at, "admitted");
     insertEvent.run("still-parked", at, at, at, "human_needed");
     const insertProposal = db.query(
       `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
        VALUES (?, 'test', ?, 'human_needed', 'open', ?, 1800)`,
     );
-    insertProposal.run("orphaned", "moved-on", at);
+    insertProposal.run("orphaned-1", "moved-on-1", at);
+    insertProposal.run("orphaned-2", "moved-on-2", at);
+    insertProposal.run("orphaned-3", "moved-on-3", at);
     insertProposal.run("parked", "still-parked", at);
     const logs = [];
 
@@ -660,17 +664,24 @@ export default async function start() {
       now,
       policyVersion: "git:test",
       skipPlan: true,
+      proposalSweepLimit: 2,
       log: (line) => logs.push(line),
     });
 
     expect(
-      db.query("SELECT status FROM proposals WHERE id = 'orphaned'").get(),
+      db.query("SELECT status FROM proposals WHERE id = 'orphaned-1'").get(),
     ).toEqual({ status: "expired" });
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = 'orphaned-2'").get(),
+    ).toEqual({ status: "expired" });
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = 'orphaned-3'").get(),
+    ).toEqual({ status: "open" });
     expect(
       db.query("SELECT status FROM proposals WHERE id = 'parked'").get(),
     ).toEqual({ status: "open" });
     expect(logs).toContain(
-      "proposals: expired 1 orphaned human_needed/noop row(s)",
+      "proposals: expired 2 orphaned human_needed/noop row(s) (1 remaining)",
     );
 
     logs.length = 0;
@@ -680,10 +691,14 @@ export default async function start() {
       now: now + 1_000,
       policyVersion: "git:test",
       skipPlan: true,
+      proposalSweepLimit: 2,
       log: (line) => logs.push(line),
     });
-    expect(logs).not.toContain(
-      "proposals: expired 0 orphaned human_needed/noop row(s)",
+    expect(
+      db.query("SELECT status FROM proposals WHERE id = 'orphaned-3'").get(),
+    ).toEqual({ status: "expired" });
+    expect(logs).toContain(
+      "proposals: expired 1 orphaned human_needed/noop row(s) (0 remaining)",
     );
     db.close();
   });

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -81,11 +81,32 @@ export function openProposals(db, { now = Date.now() } = {}) {
  * proposals, human-needed and noop rows do not expire by TTL: they remain
  * open while the event is still parked so the inbox can surface the decision.
  */
-export function sweepOrphanedNonRunProposals(db, { now = Date.now() } = {}) {
+export function sweepOrphanedNonRunProposals(
+  db,
+  { now = Date.now(), limit = 200 } = {},
+) {
   const result = db
     .query(
       `UPDATE proposals AS p
        SET status = 'expired', decided_by = 'serve', reason = 'event_moved_on', decided_at = ?
+       WHERE p.rowid IN (
+         SELECT rowid FROM proposals AS candidate
+         WHERE candidate.status = 'open'
+           AND candidate.decision IN ('human_needed', 'noop')
+           AND NOT EXISTS (
+             SELECT 1 FROM events AS e
+             WHERE e.source = candidate.event_source
+               AND e.event_id = candidate.event_id
+               AND e.status IN ('human_needed', 'noop')
+           )
+         ORDER BY candidate.created_at, candidate.rowid
+         LIMIT ?
+       )`,
+    )
+    .run(new Date(now).toISOString(), limit);
+  const remaining = db
+    .query(
+      `SELECT COUNT(*) AS count FROM proposals AS p
        WHERE p.status = 'open'
          AND p.decision IN ('human_needed', 'noop')
          AND NOT EXISTS (
@@ -95,8 +116,8 @@ export function sweepOrphanedNonRunProposals(db, { now = Date.now() } = {}) {
              AND e.status IN ('human_needed', 'noop')
          )`,
     )
-    .run(new Date(now).toISOString());
-  return result.changes;
+    .get().count;
+  return { expired: result.changes, remaining };
 }
 
 /**

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -212,7 +212,10 @@ describe("sweepOrphanedNonRunProposals", () => {
       "UPDATE events SET status = 'admitted' WHERE source = ? AND event_id = ?",
     ).run(orphaned.proposal.event_source, orphaned.proposal.event_id);
 
-    expect(sweepOrphanedNonRunProposals(db, { now: NOW + 1_000 })).toBe(1);
+    expect(sweepOrphanedNonRunProposals(db, { now: NOW + 1_000 })).toEqual({
+      expired: 1,
+      remaining: 0,
+    });
     expect(getProposal(db, orphaned.proposal.id)).toMatchObject({
       status: "expired",
       decided_by: "serve",
@@ -220,6 +223,37 @@ describe("sweepOrphanedNonRunProposals", () => {
       decided_at: new Date(NOW + 1_000).toISOString(),
     });
     expect(getProposal(db, parked.proposal.id).status).toBe("open");
+  });
+
+  test("caps the oldest orphaned rows before newer rows", () => {
+    const db = openDb(":memory:");
+    const at = new Date(NOW).toISOString();
+    const later = new Date(NOW + 1_000).toISOString();
+    const insertEvent = db.query(
+      `INSERT INTO events (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at, status)
+       VALUES ('test', ?, 'test.event', ?, ?, '{}', 'hash', ?, 'admitted')`,
+    );
+    const insertProposal = db.query(
+      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, 'human_needed', 'open', ?, 1800)`,
+    );
+
+    for (const [id, createdAt] of [
+      ["oldest-first", at],
+      ["oldest-second", at],
+      ["newest", later],
+    ]) {
+      insertEvent.run(id, at, at, at);
+      insertProposal.run(id, id, createdAt);
+    }
+
+    expect(
+      sweepOrphanedNonRunProposals(db, { now: NOW + 2_000, limit: 2 }),
+    ).toEqual({ expired: 2, remaining: 1 });
+    expect(getProposal(db, "oldest-first").status).toBe("expired");
+    expect(getProposal(db, "oldest-second").status).toBe("expired");
+    expect(getProposal(db, "newest").status).toBe("open");
+    db.close();
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1776

Bound orphaned proposal expiry to 200 oldest rows per serve tick and report the backlog.

## Validation

| Check                | Command                                                                            | Result  | Notes                                 |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | ------------------------------------- |
| Verification Command | `bun test event-runtime/lib/proposals.test.mjs event-runtime/cli/serve.test.mjs --timeout 60000` | pass    | 48 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2221 pass, 10 environment skips       |
| UX critique          | factory-ux-critic                                                                  | not run | no user-facing surface                |

UX critique: skipped

run:run_f019821b-06d4-4cae-9203-cb41f6278481