### PR TITLE
fix(stack): verify worker startup before ready

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -24,6 +24,10 @@
 #   FACTORY_API_READY_TIMEOUT    # seconds `up` waits for the runtime /health
 #                                # endpoint before tearing its daemons down;
 #                                # default 60
+#   FACTORY_WORKER_READY_TIMEOUT # seconds `up` confirms a newly started worker
+#                                # (and pool supervisor, when configured) stays
+#                                # alive before declaring the stack ready;
+#                                # default 5
 #   FACTORY_POOL_DRAIN_TIMEOUT   # seconds `down` lets a supervised worker pool
 #                                # drain before ordinary teardown; default 180
 #   FACTORY_WEB_SUPERVISOR_INTERVAL  # seconds between web supervisor ticks;
@@ -181,13 +185,14 @@ LOG_KEEP="${FACTORY_LOG_KEEP:-3}"
 LOG_ROTATE_INTERVAL="${FACTORY_LOG_ROTATE_INTERVAL:-300}"
 LOG_ROTATE_MIN_BYTES=1048576
 API_READY_TIMEOUT="${FACTORY_API_READY_TIMEOUT:-60}"
+WORKER_READY_TIMEOUT="${FACTORY_WORKER_READY_TIMEOUT:-5}"
 POOL_DRAIN_TIMEOUT="${FACTORY_POOL_DRAIN_TIMEOUT:-180}"
 WEB_SUPERVISOR_INTERVAL="${FACTORY_WEB_SUPERVISOR_INTERVAL:-1}"
 
 # These values feed shell arithmetic and sleep below. Validate them before an
 # action can snapshot, spawn, or signal a daemon so malformed environment
 # overrides leave an existing stack untouched.
-# The two timeouts accept 0 (an immediate deadline: no wait, then the usual
+# The three timeouts accept 0 (an immediate deadline: no wait, then the usual
 # teardown / fall-through); the supervisor interval must stay positive because
 # it is the sleep between ticks.
 validate_timing_knobs() {
@@ -195,6 +200,8 @@ validate_timing_knobs() {
     die "FACTORY_POOL_DRAIN_TIMEOUT must be a non-negative integer"
   [[ "$API_READY_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] ||
     die "FACTORY_API_READY_TIMEOUT must be a non-negative integer"
+  [[ "$WORKER_READY_TIMEOUT" =~ ^(0|[1-9][0-9]*)$ ]] ||
+    die "FACTORY_WORKER_READY_TIMEOUT must be a non-negative integer"
   [[ "$WEB_SUPERVISOR_INTERVAL" =~ ^([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$ ]] ||
     die "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number"
 }
@@ -217,6 +224,30 @@ validate_log_knobs() {
 rotate_stack_logs() {
   [[ "$LOG_ROTATE_BYTES" -gt 0 ]] || return 0
   rotate_run_logs "$RUN_DIR" "$LOG_ROTATE_BYTES" "$LOG_KEEP"
+}
+
+worker_startup_failed() { # <message>
+  warn "worker startup failed; tail of $RUN_DIR/worker.log:"
+  tail -n 50 "$RUN_DIR/worker.log" >&2 || true
+  die "$1 — check logs at $RUN_DIR/worker.log"
+}
+
+wait_for_worker_ready() {
+  local started
+  started=$SECONDS
+  while true; do
+    if ! pid_alive "$RUN_DIR/worker.pid"; then
+      worker_startup_failed "worker exited during startup"
+    fi
+    if [[ "$POOL" -eq 1 ]] && ! pid_alive "$RUN_DIR/supervisor.pid"; then
+      if (( SECONDS - started >= WORKER_READY_TIMEOUT )); then
+        worker_startup_failed "worker pool supervisor did not start within ${WORKER_READY_TIMEOUT}s"
+      fi
+    elif (( SECONDS - started >= WORKER_READY_TIMEOUT )); then
+      return 0
+    fi
+    sleep 0.1
+  done
 }
 
 # Validate before actions touch disk or daemon lifecycle state. `up` validates
@@ -630,6 +661,7 @@ case "$ACTION" in
       spawn_daemon_tracked "worker" "$RUN_DIR/worker.pid" "$RUN_DIR/worker.log" "$REPO" \
         env FACTORY_EVENT_HOME="$HOME_DIR" FACTORY_EVENT_PORT="$API_PORT" \
         "${WORKER_ARGS[@]}"
+      wait_for_worker_ready
     fi
 
     # 4. Start or verify web server

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -58,6 +58,11 @@ pid_alive() {
   if [[ "$(basename "$1")" == "serve.pid" && -f "$1" ]]; then
     return 0
   fi
+  if [[ "$(basename "$1")" == "worker.pid" || "$(basename "$1")" == "supervisor.pid" ]]; then
+    [[ -f "$1" ]] || return 1
+    [[ -f "$1.terminated" || -f "$1.exited" ]] && return 1
+    return 0
+  fi
   [[ "\${FAKE_ALIVE:-0}" == "1" ]] || return 1
   [[ -f "$1" ]] || return 1
   [[ -f "$1.terminated" ]] && return 1
@@ -69,10 +74,16 @@ spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
   printf 'SPAWN pid=%s workdir=%s cmd=%s\\n' "$(basename "$pidfile")" "$workdir" "$*" >>"$SPAWN_LOG"
   if [[ "$(basename "$pidfile")" == "\${FAKE_SPAWN_FAIL_PIDFILE:-}" ]]; then return 1; fi
   printf '1\\n' >"$pidfile"
-  if [[ "\${FAKE_POOL_CHILDREN:-0}" == "1" && "$*" == *"cli.mjs supervise"* ]]; then
+  if [[ -n "\${FAKE_DAEMON_DIES_FOR:-}" && "$*" == *"\${FAKE_DAEMON_DIES_FOR}"* ]]; then
+    printf 'fake daemon exited 1\\n' >"$logfile"
+    touch "$pidfile.exited"
+  fi
+  if [[ "\${FAKE_SUPERVISOR_MISSING:-0}" != "1" && "$*" == *"cli.mjs supervise"* ]]; then
     printf '2\\n' >"$(dirname "$pidfile")/supervisor.pid"
-    printf '3\\n' >"$(dirname "$pidfile")/worker-1.pid"
-    printf 'worker_test\\n' >"$(dirname "$pidfile")/worker-1.id"
+    if [[ "\${FAKE_POOL_CHILDREN:-0}" == "1" ]]; then
+      printf '3\\n' >"$(dirname "$pidfile")/worker-1.pid"
+      printf 'worker_test\\n' >"$(dirname "$pidfile")/worker-1.id"
+    fi
   fi
 }
 term_daemon() {
@@ -271,6 +282,9 @@ function runStack(fixture, args, extraEnv = {}) {
       BUILD_LOG: fixture.buildLog,
       FACTORY_RUN_DIR: path.join(fixture.root, "run"),
       FACTORY_EVENT_HOME: path.join(fixture.root, "home"),
+      // Startup survival is covered by focused cases below. Keep unrelated
+      // command-wiring tests immediate instead of paying the production 5s.
+      FACTORY_WORKER_READY_TIMEOUT: "0",
       ...extraEnv,
     },
   });
@@ -304,6 +318,7 @@ test("plain `up` spawns serve, worker, and the static web server — unchanged b
     expect(spawnFor(r.spawns, "worker.pid")).not.toContain(
       "__supervise-worker",
     );
+    expect(existsSync(path.join(f.runDir, "worker.pid"))).toBe(true);
 
     const web = spawnFor(r.spawns, "web.pid");
     expect(web).toContain("web/serve.mjs");
@@ -315,6 +330,29 @@ test("plain `up` spawns serve, worker, and the static web server — unchanged b
     f.cleanup();
   }
 });
+
+test.each([
+  ["work", ["up"], "cli.mjs work"],
+  ["supervise", ["up", "--workers", "1:1"], "cli.mjs supervise"],
+])(
+  "a worker daemon that exits during %s startup fails `up` and cleans up its pidfiles",
+  (_command, args, failingCommand) => {
+    const f = makeFixture();
+    try {
+      const r = runStack(f, args, { FAKE_DAEMON_DIES_FOR: failingCommand });
+      expect(r.status).not.toBe(0);
+      expect(r.stderr).toContain("worker exited during startup");
+      expect(r.stderr).toContain("worker.log");
+      expect(r.stderr).toContain("fake daemon exited 1");
+      expect(r.spawns).toContain("TERM worker");
+      expect(r.spawns).toContain("TERM event runtime");
+      for (const file of ["worker.pid", "serve.pid"])
+        expect(existsSync(path.join(f.runDir, file))).toBe(false);
+    } finally {
+      f.cleanup();
+    }
+  },
+);
 
 test("`up --dry-run` prints the resolved daemon plan without spawning", () => {
   const f = makeFixture();
@@ -383,6 +421,10 @@ test("malformed timing knobs fail before `up` snapshots or starts daemons", () =
       "FACTORY_API_READY_TIMEOUT must be a non-negative integer",
     ],
     [
+      { FACTORY_WORKER_READY_TIMEOUT: "soon" },
+      "FACTORY_WORKER_READY_TIMEOUT must be a non-negative integer",
+    ],
+    [
       { FACTORY_WEB_SUPERVISOR_INTERVAL: "0" },
       "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number",
     ],
@@ -401,6 +443,26 @@ test("malformed timing knobs fail before `up` snapshots or starts daemons", () =
     } finally {
       f.cleanup();
     }
+  }
+});
+
+test("a pool without a supervisor pidfile fails worker readiness and cleans up", () => {
+  const f = makeFixture();
+  try {
+    const r = runStack(f, ["up", "--workers", "1:1"], {
+      FAKE_SUPERVISOR_MISSING: "1",
+    });
+    expect(r.status).not.toBe(0);
+    expect(r.stderr).toContain(
+      "worker pool supervisor did not start within 0s",
+    );
+    expect(r.stderr).toContain("worker.log");
+    expect(r.spawns).toContain("TERM worker");
+    expect(r.spawns).toContain("TERM event runtime");
+    for (const file of ["worker.pid", "serve.pid"])
+      expect(existsSync(path.join(f.runDir, file))).toBe(false);
+  } finally {
+    f.cleanup();
   }
 });
 


### PR DESCRIPTION
Fixes #1791

Reject an `up` ready banner when a newly spawned worker or pool supervisor exits during boot.

## Validation

| Check                | Command                                                                                | Result  | Notes                    |
| -------------------- | -------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test bin/live-stack.test.mjs && bun run lint && bun run format:check`            | pass    | 50 tests, 0 failures     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2220 pass, 10 skipped    |
| UX critique          | factory-ux-critic                                                                      | not run | no user-facing surface   |

UX critique: skipped

run:$FACTORY_RUN_ID