### PR TITLE
feat(policy): honor dispatch pause

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -84,6 +84,9 @@ commitMsg:
     - '\(#[0-9]+\)'
 
 dispatch:
+  # Temporarily stop unattended dispatch and chain approvals. Operator-sourced
+  # dispatches remain available so a human can explicitly force work.
+  paused: false
   owned_paths_collision: advisory
   owned_paths_conformance: advisory
   # Whether the work loop may dispatch `type:security` tickets (WM-1060).

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -1085,6 +1085,16 @@ async function runPass(
       });
       return { approved, open, errors, skipped, memoised };
     }
+    if (rows.length === 0) return { approved, open, errors, skipped, memoised };
+
+    // Read this once per pass, rather than once per row. Passing the same
+    // snapshot to the guard avoids a second policy read; the next pass reads
+    // again, so clearing a pause resumes approvals without a restart.
+    const runtimePolicy =
+      runtimeGuardOptions.runtimePolicy ??
+      loadRuntimePolicy(runtimeGuardOptions.root ?? reposRoot());
+    const paused = runtimePolicy?.dispatch?.paused === true;
+    const passRuntimeGuardOptions = { ...runtimeGuardOptions, runtimePolicy };
 
     // Verdicts for rows that are no longer pending (decided, superseded,
     // re-planned under a new proposal id) or that were held under another
@@ -1097,6 +1107,11 @@ async function runPass(
     }
 
     for (const row of rows) {
+      if (paused) {
+        noteOpenReason(db, row.id, "dispatch_paused");
+        skipped += 1;
+        continue;
+      }
       const memoKey = `${row.run_id}\0${resolvedPolicyVersion}`;
       const stale = pinnedToOlderRegistry(row, resolvedPolicyVersion);
       const held = stale ? memo.get(memoKey) : undefined;
@@ -1145,7 +1160,7 @@ async function runPass(
         }
         let guardReason;
         try {
-          guardReason = runtimeGuard(db, runtimeGuardOptions);
+          guardReason = runtimeGuard(db, passRuntimeGuardOptions);
         } catch {
           guardReason = "runtime_guard_failed";
         }

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -700,6 +700,36 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
+  test("dispatch.paused skips open chain proposals and resumes them after it clears", async () => {
+    const db = openDb(":memory:");
+    const candidate = seed(db, { id: "paused" });
+    const runtimePolicy = {
+      budget: { per_day_usd: 1 },
+      workers: { max: 2 },
+      circuit_breaker: { consecutive_env_failures: 2 },
+      dispatch: { paused: true },
+    };
+    const runtimeGuardOptions = { runtimePolicy };
+
+    const paused = await auto(db, {
+      runtimeGuardOptions,
+    });
+    expect(paused).toMatchObject({
+      approved: [],
+      open: [],
+      skipped: 1,
+    });
+    expect(runState(db, candidate.runId)).toBe("PROPOSED");
+    expect(openProposals(db, {})[0].reason).toBe(
+      "auto_approval_ineligible:dispatch_paused",
+    );
+
+    runtimePolicy.dispatch.paused = false;
+    expect((await auto(db, { runtimeGuardOptions })).approved).toEqual([
+      { proposalId: candidate.id, runId: candidate.runId },
+    ]);
+  });
+
   test("eligible chain work and triage proposals advance with an auditable actor and reason", async () => {
     const db = openDb(":memory:");
     const work = seed(db, { id: "work", type: "factory.work.requested" });

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -976,6 +976,13 @@ export function policyDispatchSecurity(root = reposRoot(), snapshot = null) {
   return value === "auto" ? "auto" : DEFAULT_DISPATCH_SECURITY;
 }
 
+/** Whether unattended dispatch admission is temporarily paused by an operator. */
+export const DEFAULT_DISPATCH_PAUSED = false;
+export function policyDispatchPaused(root = reposRoot(), snapshot = null) {
+  const value = loadRuntimePolicy(root, snapshot)?.dispatch?.paused;
+  return value === true ? true : DEFAULT_DISPATCH_PAUSED;
+}
+
 /** Fail-safe merge admission cap when policy is absent or malformed. */
 export const DEFAULT_MAX_CONCURRENT_MERGES = 1;
 
@@ -2320,6 +2327,11 @@ export function planEvent(
         worktreeGateFor(preDef) === "dispatch" &&
         typeof preEnvelope.payload?.repo === "string" &&
         typeof preEnvelope.payload?.ticket === "string" &&
+        !(
+          preEnvelope.type === "factory.dispatch.requested" &&
+          preEnvelope.source !== "operator" &&
+          policyDispatchPaused(undefined, configSnapshot)
+        ) &&
         !repoNotAllowed(preDef, preEnvelope.payload)
       ) {
         if (preEnvelope.type === "factory.dispatch.requested") {
@@ -2436,6 +2448,27 @@ export function planEvent(
     const scopeRefusal = repoNotAllowed(def, envelope.payload);
     if (scopeRefusal)
       return humanNeeded(db, event, scopeRefusal, at, ttlSeconds);
+
+    // A pause is an operator-controlled brake on unattended admission. Keep
+    // operator dispatches available so the operator can still force specific
+    // work while draining, but record every other dispatch as a durable NOOP.
+    if (
+      envelope.type === "factory.dispatch.requested" &&
+      envelope.source !== "operator" &&
+      policyDispatchPaused(undefined, configSnapshot)
+    ) {
+      const proposal = insertProposal(db, {
+        id: newProposalId(),
+        event,
+        decision: "noop",
+        status: "resolved",
+        reason: "dispatch_paused",
+        at,
+        ttlSeconds,
+      });
+      setEventStatus(db, event, "noop", "dispatch_paused");
+      return { decision: "noop", proposal, reason: "dispatch_paused" };
+    }
 
     if (
       envelope.type === "factory.dispatch.requested" &&

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -29,6 +29,7 @@ import {
   pinMemos,
   planAdmittedEvents,
   planEvent,
+  policyDispatchPaused,
   policyMaxConcurrentMerges,
   policyMergeBatchSize,
   wrapLinearReads,
@@ -1718,6 +1719,61 @@ describe("planEvent worktree gate (WM-108)", () => {
         ).toMatchObject({ decision: "noop", reason: "ticket_security" });
       }
     });
+  });
+
+  test("dispatch.paused noops unattended dispatches but keeps operator dispatch available", () => {
+    const pausedPolicy = "dispatch:\n  paused: true\n";
+    withReposRoot(
+      tierRepo,
+      () => {
+        expect(policyDispatchPaused()).toBe(true);
+        const db = openDb(":memory:");
+        let ticketReads = 0;
+        const dispatch = {
+          ...tierDispatch(),
+          fetchTicket: () => {
+            ticketReads += 1;
+            return tierTicket();
+          },
+        };
+
+        for (const source of ["schedule", "chain"]) {
+          const ref = admit(db, {
+            type: "factory.dispatch.requested",
+            source,
+            eventId: `${source}-paused-dispatch`,
+            correlationId: `${source}-paused-dispatch`,
+            causationId: source === "chain" ? "run-parent" : null,
+            payload: { repo: "tiered", ticket: "WM-694" },
+          });
+          expect(
+            planEvent(db, registry, ref, {
+              now: NOW,
+              policyVersion: "git:test",
+              dispatch,
+            }),
+          ).toMatchObject({ decision: "noop", reason: "dispatch_paused" });
+        }
+        expect(ticketReads).toBe(0);
+
+        const operator = admit(db, {
+          type: "factory.dispatch.requested",
+          source: "operator",
+          eventId: "operator-paused-dispatch",
+          correlationId: "operator-paused-dispatch",
+          payload: { repo: "tiered", ticket: "WM-694" },
+        });
+        expect(
+          planEvent(db, registry, operator, {
+            now: NOW,
+            policyVersion: "git:test",
+            dispatch,
+          }).decision,
+        ).toBe("run");
+        expect(ticketReads).toBe(1);
+      },
+      pausedPolicy,
+    );
   });
 
   test("eligible handoff dispatch pins auto-approval evidence without operator authorization", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1756

Set dispatch.paused: true during a drain; set false to resume unattended dispatch.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/auto-approval.test.mjs --timeout 20000` | pass | 153 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | completed; lint warnings only |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped

run:run_b91025dd-f8ad-4965-94e9-a245a48d2013