### PR TITLE
fix(web): page Inbox status tabs

### DIFF
--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -417,7 +417,9 @@ describe("Inbox view", () => {
     expect(tabs[0]).toContain("2");
     expect(tabs[1]).toContain("Acked");
     expect(tabs[1]).toContain("1");
+    // The Resolved badge comes from its own query, not the Open tab's rows.
     expect(tabs[2]).toContain("Resolved");
+    expect(tabs[2]).toContain("1");
     expect(tabs[3]).toContain("All");
     expect(tabs[3]).toContain("4");
     // Group headers in triage order.
@@ -466,6 +468,86 @@ describe("Inbox view", () => {
     );
   });
 
+  test("renders after Overview cached its single-page open query", async () => {
+    // Overview stores `{ items }` under ["inbox", "open"]; the Inbox cursor
+    // queries must not read that entry as `{ pages }`.
+    const client = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    client.setQueryData(["inbox", "open"], {
+      items: ledger.filter((entry) => itemStatus(entry) === "open"),
+    });
+    const view = render(
+      <QueryClientProvider client={client}>
+        <Inbox
+          connected
+          focusItemId={null}
+          onSelectItem={() => {}}
+          onJumpRun={() => {}}
+          onJumpProposal={() => {}}
+          onJumpEvent={() => {}}
+        />
+      </QueryClientProvider>,
+    );
+    await waitFor(() => view.getByText("decide X"));
+    expect(view.getByText("WM-2/PR #9")).toBeTruthy();
+    const tabs = view.getAllByRole("tab").map((t) => t.textContent);
+    expect(tabs[0]).toContain("2");
+    expect(tabs[2]).toContain("1");
+    // Overview's cache entry is left intact for Overview.
+    expect(client.getQueryData<unknown>(["inbox", "open"])).toEqual({
+      items: ledger.filter((entry) => itemStatus(entry) === "open"),
+    });
+  });
+
+  test("Resolved badge counts resolved rows while the Open tab is showing", async () => {
+    ledger = [
+      item({ id: "open-a", kind: "BLOCKED", title: "Open A" }),
+      ...Array.from({ length: 3 }, (_, index) =>
+        item({
+          id: `resolved-${index}`,
+          kind: "RC READY",
+          title: `Resolved ${index}`,
+          ackedAt: T1,
+          resolvedAt: T2,
+        }),
+      ),
+    ];
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("Open A"));
+    expect(view.getByRole("tab", { name: /Resolved/ }).textContent).toContain(
+      "3",
+    );
+    expect(view.getByRole("tab", { name: /All/ }).textContent).toContain("4");
+  });
+
+  test("Open badge excludes expired rows even when /status counts them", async () => {
+    ledger = [
+      item({ id: "active", kind: "BLOCKED", title: "Active decision" }),
+      item({ id: "expired-kind", kind: "proposal_expired", title: "Expired" }),
+    ];
+    // Legacy server: no `expired` field on rows and an open total that still
+    // includes the expired row; the open status has another page.
+    ledger = ledger.map(({ expired: _expired, ...rest }) => rest as InboxItem);
+    api.inbox = mock(async (status, page = {}) => {
+      if (status === "open")
+        return page.before
+          ? { items: [] }
+          : {
+              items: ledger,
+              nextBefore: "open-page-2",
+            };
+      return { items: [] };
+    });
+    api.status = mock(async () => ({
+      inbox: { open: 2, acked: 0 },
+    })) as unknown as typeof api.status;
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("Active decision"));
+    expect(view.getByRole("tab", { name: /Open/ }).textContent).toContain("1");
+    expect(view.getByRole("button", { name: "Expired (1)" })).toBeTruthy();
+  });
+
   test("hides expired open items by default and shows only them from the Expired chip", async () => {
     ledger = [
       item({ id: "active", kind: "BLOCKED", title: "Active decision" }),
@@ -500,6 +582,17 @@ describe("Inbox view", () => {
     await waitFor(() => view.getByText("Expired by kind"));
     expect(view.getByText("Expired by proposal")).toBeTruthy();
     expect(view.queryByText("Active decision")).toBeNull();
+
+    // The chip count is derived from the open query, so visiting another tab
+    // and coming back does not change it.
+    fireEvent.click(view.getByRole("tab", { name: /Resolved/ }));
+    await waitFor(() =>
+      expect(view.queryByRole("button", { name: /Expired/ })).toBeNull(),
+    );
+    fireEvent.click(view.getByRole("tab", { name: /Open/ }));
+    await waitFor(() =>
+      expect(view.getByRole("button", { name: "Expired (2)" })).toBeTruthy(),
+    );
   });
 
   test("proposal rows show a live right-aligned TTL and hide it without one", async () => {

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -301,6 +301,7 @@ const origInbox = api.inbox;
 const origAck = api.ackInbox;
 const origResolve = api.resolveInbox;
 const origProposals = api.proposals;
+const origStatus = api.status;
 
 let ledger: InboxItem[] = [];
 
@@ -340,7 +341,19 @@ beforeEach(() => {
       resolvedBy: "operator",
     }),
   ];
-  api.inbox = mock(async () => ({ items: ledger }));
+  api.inbox = mock(async (status) => ({
+    items: ledger.filter(
+      (entry) => status === "all" || itemStatus(entry) === status,
+    ),
+  }));
+  api.status = mock(async () => ({
+    inbox: {
+      open: ledger.filter(
+        (entry) => itemStatus(entry) === "open" && !entry.expired,
+      ).length,
+      acked: ledger.filter((entry) => itemStatus(entry) === "acked").length,
+    },
+  })) as unknown as typeof api.status;
   api.proposals = mock(async () => ({ proposals: [] }));
   api.ackInbox = mock(async (id: string) => {
     ledger = ledger.map((it) => (it.id === id ? { ...it, ackedAt: T2 } : it));
@@ -366,6 +379,7 @@ afterEach(() => {
   api.ackInbox = origAck;
   api.resolveInbox = origResolve;
   api.proposals = origProposals;
+  api.status = origStatus;
 });
 
 function renderInbox(props: Partial<React.ComponentProps<typeof Inbox>> = {}) {
@@ -414,6 +428,44 @@ describe("Inbox view", () => {
     expect(view.queryByText("CI RED")).toBeNull();
   });
 
+  test("keeps open items and their badge visible past a resolved cursor page", async () => {
+    const resolved = Array.from({ length: 100 }, (_, index) =>
+      item({
+        id: `resolved-${index}`,
+        kind: "RC READY",
+        ackedAt: T1,
+        resolvedAt: T2,
+      }),
+    );
+    const olderOpen = item({
+      id: "older-open",
+      kind: "BLOCKED",
+      title: "Open item behind resolved history",
+    });
+    api.inbox = mock(async (status, page = {}) => {
+      if (status === "open") return { items: [olderOpen] };
+      if (status === "resolved")
+        return page.before
+          ? { items: [] }
+          : { items: resolved, nextBefore: "resolved-page-2" };
+      return { items: [] };
+    });
+    api.status = mock(async () => ({
+      inbox: { open: 1, acked: 0 },
+    })) as unknown as typeof api.status;
+
+    const { view } = renderInbox();
+    await waitFor(() => view.getByText("Open item behind resolved history"));
+    expect(view.getByRole("tab", { name: /Open/ }).textContent).toContain("1");
+
+    fireEvent.click(view.getByRole("tab", { name: /Resolved/ }));
+    await waitFor(() =>
+      expect(
+        view.getByRole("button", { name: "Load older inbox items" }),
+      ).toBeTruthy(),
+    );
+  });
+
   test("hides expired open items by default and shows only them from the Expired chip", async () => {
     ledger = [
       item({ id: "active", kind: "BLOCKED", title: "Active decision" }),
@@ -433,6 +485,9 @@ describe("Inbox view", () => {
     api.proposals = mock(async () => ({
       proposals: [],
     }));
+    api.status = mock(async () => ({
+      inbox: { open: 1, acked: 0 },
+    })) as unknown as typeof api.status;
 
     const { view } = renderInbox();
     await waitFor(() => view.getByText("Active decision"));

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -1,4 +1,9 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import {
   Fragment,
   useEffect,
@@ -794,14 +799,56 @@ export function Inbox({
 }) {
   const now = useNow();
   const queryClient = useQueryClient();
-  // One fetch of the whole ledger: it is small, every tab is a client-side
-  // filter, and a deep link to a resolved item still resolves from the Open tab.
-  const query = useQuery({
-    queryKey: ["inbox", "all"],
-    queryFn: () => api.inbox("all"),
+  // The ledger is paginated. Keep an independent cursor for each status so
+  // old resolved rows can never push actionable rows out of the Open tab.
+  const openQuery = useInfiniteQuery({
+    queryKey: ["inbox", "open"],
+    queryFn: ({ pageParam }) => api.inbox("open", { before: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     ...refetchIntervals.primary,
   });
-  const items = query.data?.items ?? [];
+  const ackedQuery = useInfiniteQuery({
+    queryKey: ["inbox", "acked"],
+    queryFn: ({ pageParam }) => api.inbox("acked", { before: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
+    ...refetchIntervals.primary,
+  });
+  const resolvedQuery = useInfiniteQuery({
+    queryKey: ["inbox", "resolved"],
+    queryFn: ({ pageParam }) => api.inbox("resolved", { before: pageParam }),
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
+    ...refetchIntervals.primary,
+  });
+  const inboxQueries = {
+    open: openQuery,
+    acked: ackedQuery,
+    resolved: resolvedQuery,
+  };
+  const statusQuery = useQuery({
+    queryKey: ["status"],
+    queryFn: api.status,
+    ...refetchIntervals.primary,
+  });
+  const [tab, setTab] = useState<InboxTab>("open");
+  const activeQueries =
+    tab === "all"
+      ? [openQuery, ackedQuery, resolvedQuery]
+      : [inboxQueries[tab]];
+  const items = activeQueries.flatMap(
+    (inbox) => inbox.data?.pages.flatMap((page) => page.items) ?? [],
+  );
+  const allItems = [openQuery, ackedQuery, resolvedQuery].flatMap(
+    (inbox) => inbox.data?.pages.flatMap((page) => page.items) ?? [],
+  );
+  const query = {
+    isSuccess: activeQueries.every((inbox) => inbox.isSuccess),
+    isPending: activeQueries.some((inbox) => inbox.isPending),
+    isError: activeQueries.some((inbox) => inbox.isError),
+    data: activeQueries.some((inbox) => inbox.data) ? items : undefined,
+  };
   const proposalsQuery = useQuery({
     queryKey: ["proposals"],
     queryFn: api.proposals,
@@ -815,7 +862,6 @@ export function Inbox({
     return map;
   }, [proposalsQuery.data]);
 
-  const [tab, setTab] = useState<InboxTab>("open");
   const [expiredOnly, setExpiredOnly] = useState(false);
   const [filter, setFilter] = useState("");
   const expiredOpenItems = useMemo(
@@ -846,8 +892,15 @@ export function Inbox({
       c[itemStatus(it)] += 1;
       c.all += 1;
     }
+    // `/status` is an aggregate rather than a cursor page. Its open and acked
+    // totals remain correct even when a status has more than one page.
+    if (statusQuery.data?.inbox) {
+      c.open = statusQuery.data.inbox.open;
+      c.acked = statusQuery.data.inbox.acked;
+      c.all = c.open + c.acked + c.resolved;
+    }
     return c;
-  }, [items, now, proposalsById]);
+  }, [items, now, proposalsById, statusQuery.data?.inbox]);
 
   const byTab = useMemo(
     () =>
@@ -999,7 +1052,7 @@ export function Inbox({
   };
 
   const sel = focusItemId
-    ? (items.find((it) => it.id === focusItemId) ?? null)
+    ? (allItems.find((it) => it.id === focusItemId) ?? null)
     : null;
   const selectedIndex = sel ? visible.findIndex((it) => it.id === sel.id) : -1;
   // A deep link is only "unknown" once the ledger has actually answered.
@@ -1021,8 +1074,9 @@ export function Inbox({
   };
   const ack = useMutation({
     mutationFn: (id: string) => api.ackInbox(id),
-    onSuccess: (_out, id) => {
+    onSuccess: (out, id) => {
       invalidate();
+      if (focusItemId === id) setTab(itemStatus(out.item));
       notify(`Acked ${shortId(id)}`, "ok");
     },
     onError: (err) => notify(`Ack failed: ${(err as Error).message}`, "err"),
@@ -1033,8 +1087,9 @@ export function Inbox({
   const resolve = useMutation({
     mutationFn: ({ id, reason }: { id: string; reason: string }) =>
       api.resolveInbox(id, reason),
-    onSuccess: (_out, { id }) => {
+    onSuccess: (out, { id }) => {
       invalidate();
+      if (focusItemId === id) setTab(itemStatus(out.item));
       setConfirmResolve(false);
       setResolveReason("");
       notify(`Resolved ${shortId(id)}`, "ok");
@@ -1325,6 +1380,15 @@ export function Inbox({
   const tdCls = "border-b border-(--border) px-3 py-1.5 whitespace-nowrap";
   const openEmpty =
     tab === "open" && byTab.length === 0 && !filter.trim() && query.isSuccess;
+  const hasOlderItems = activeQueries.some((inbox) => inbox.hasNextPage);
+  const isLoadingOlder = activeQueries.some(
+    (inbox) => inbox.isFetchingNextPage,
+  );
+  const loadOlderItems = () => {
+    for (const inbox of activeQueries) {
+      if (inbox.hasNextPage) void inbox.fetchNextPage();
+    }
+  };
   const handleExport = () => {
     const sorted = sortRows(filtered, INBOX_DISPLAY, display);
     const dateStr = new Date().toISOString().slice(0, 10);
@@ -1684,6 +1748,26 @@ export function Inbox({
                     }
                     escHint={Boolean(filter.trim())}
                   />
+                )}
+                {hasOlderItems && (
+                  <tr>
+                    <td
+                      colSpan={Math.max(
+                        cols.length + (selectionEnabled ? 1 : 0),
+                        1,
+                      )}
+                      className="px-3 py-3 text-center"
+                    >
+                      <Button
+                        onClick={loadOlderItems}
+                        disabled={isLoadingOlder}
+                      >
+                        {isLoadingOlder
+                          ? "Loading older inbox items…"
+                          : "Load older inbox items"}
+                      </Button>
+                    </td>
+                  </tr>
                 )}
               </tbody>
             </Table>

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -801,22 +801,26 @@ export function Inbox({
   const queryClient = useQueryClient();
   // The ledger is paginated. Keep an independent cursor for each status so
   // old resolved rows can never push actionable rows out of the Open tab.
+  // The keys carry an "infinite" segment: Overview caches a single-page
+  // `["inbox", "open"]` entry with a different shape, and sharing a key would
+  // hand this view that plain page instead of `{ pages }`. The `["inbox"]`
+  // prefix is kept so `invalidate()` still refreshes both views.
   const openQuery = useInfiniteQuery({
-    queryKey: ["inbox", "open"],
+    queryKey: ["inbox", "infinite", "open"],
     queryFn: ({ pageParam }) => api.inbox("open", { before: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     ...refetchIntervals.primary,
   });
   const ackedQuery = useInfiniteQuery({
-    queryKey: ["inbox", "acked"],
+    queryKey: ["inbox", "infinite", "acked"],
     queryFn: ({ pageParam }) => api.inbox("acked", { before: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     ...refetchIntervals.primary,
   });
   const resolvedQuery = useInfiniteQuery({
-    queryKey: ["inbox", "resolved"],
+    queryKey: ["inbox", "infinite", "resolved"],
     queryFn: ({ pageParam }) => api.inbox("resolved", { before: pageParam }),
     initialPageParam: undefined as string | undefined,
     getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
@@ -837,11 +841,28 @@ export function Inbox({
     tab === "all"
       ? [openQuery, ackedQuery, resolvedQuery]
       : [inboxQueries[tab]];
-  const items = activeQueries.flatMap(
-    (inbox) => inbox.data?.pages.flatMap((page) => page.items) ?? [],
+  const pageItems = (inbox: typeof openQuery): InboxItem[] =>
+    inbox.data?.pages.flatMap((page) => page.items) ?? [];
+  const openItems = useMemo(() => pageItems(openQuery), [openQuery.data]);
+  const ackedItems = useMemo(() => pageItems(ackedQuery), [ackedQuery.data]);
+  const resolvedItems = useMemo(
+    () => pageItems(resolvedQuery),
+    [resolvedQuery.data],
   );
-  const allItems = [openQuery, ackedQuery, resolvedQuery].flatMap(
-    (inbox) => inbox.data?.pages.flatMap((page) => page.items) ?? [],
+  const items = useMemo(
+    () =>
+      tab === "all"
+        ? [...openItems, ...ackedItems, ...resolvedItems]
+        : tab === "open"
+          ? openItems
+          : tab === "acked"
+            ? ackedItems
+            : resolvedItems,
+    [tab, openItems, ackedItems, resolvedItems],
+  );
+  const allItems = useMemo(
+    () => [...openItems, ...ackedItems, ...resolvedItems],
+    [openItems, ackedItems, resolvedItems],
   );
   const query = {
     isSuccess: activeQueries.every((inbox) => inbox.isSuccess),
@@ -864,43 +885,65 @@ export function Inbox({
 
   const [expiredOnly, setExpiredOnly] = useState(false);
   const [filter, setFilter] = useState("");
+  // Derived from the open pages, not the active tab's rows, so the Expired
+  // chip count is the same whichever tab is showing.
   const expiredOpenItems = useMemo(
     () =>
-      items.filter(
+      openItems.filter(
         (item) =>
           itemStatus(item) === "open" &&
           isExpiredInboxItem(item, proposalsById, now),
       ),
-    [items, now, proposalsById],
+    [openItems, now, proposalsById],
   );
   const counts = useMemo(() => {
+    // Every badge is built from its own status query, independent of the
+    // active tab, so the Resolved badge is right while the Open tab shows.
+    // Expired open items live behind the Expired chip, so the open count
+    // excludes them and open + acked + resolved === all.
+    const liveOpen = openItems.filter(
+      (it) =>
+        itemStatus(it) === "open" &&
+        !isExpiredInboxItem(it, proposalsById, now),
+    ).length;
     const c: Record<InboxTab, number> = {
-      open: 0,
-      acked: 0,
-      resolved: 0,
+      open: liveOpen,
+      acked: ackedItems.filter((it) => itemStatus(it) === "acked").length,
+      resolved: resolvedItems.filter((it) => itemStatus(it) === "resolved")
+        .length,
       all: 0,
     };
-    // Expired open items live behind the Expired chip, so every tab count
-    // excludes them and open + acked + resolved === all.
-    for (const it of items) {
-      if (
-        itemStatus(it) === "open" &&
-        isExpiredInboxItem(it, proposalsById, now)
-      ) {
-        continue;
+    // `/status` is an aggregate rather than a cursor page. Once a status has
+    // more pages than are loaded, its totals are the only untruncated source.
+    // The server's open total already excludes expired rows; subtract any
+    // expired rows found in the loaded pages only when an older server still
+    // counts them (it then omits `item.expired`).
+    const totals = statusQuery.data?.inbox;
+    if (totals) {
+      if (openQuery.hasNextPage) {
+        const serverCountsExpired = openItems.some(
+          (it) => it.expired === undefined,
+        );
+        c.open = Math.max(
+          0,
+          totals.open - (serverCountsExpired ? expiredOpenItems.length : 0),
+        );
       }
-      c[itemStatus(it)] += 1;
-      c.all += 1;
+      if (ackedQuery.hasNextPage) c.acked = totals.acked;
     }
-    // `/status` is an aggregate rather than a cursor page. Its open and acked
-    // totals remain correct even when a status has more than one page.
-    if (statusQuery.data?.inbox) {
-      c.open = statusQuery.data.inbox.open;
-      c.acked = statusQuery.data.inbox.acked;
-      c.all = c.open + c.acked + c.resolved;
-    }
+    c.all = c.open + c.acked + c.resolved;
     return c;
-  }, [items, now, proposalsById, statusQuery.data?.inbox]);
+  }, [
+    openItems,
+    ackedItems,
+    resolvedItems,
+    expiredOpenItems,
+    now,
+    proposalsById,
+    statusQuery.data?.inbox,
+    openQuery.hasNextPage,
+    ackedQuery.hasNextPage,
+  ]);
 
   const byTab = useMemo(
     () =>

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -40,6 +40,22 @@ afterEach(() => {
   cleanup();
 });
 
+// Bun restores its fetch mock when each test begins. Reassert the fail-closed
+// DOM-test contract in tests that intentionally exercise an unmocked request.
+function installFetchGuard() {
+  globalThis.fetch = (async (
+    input: Parameters<typeof fetch>[0],
+    init?: Parameters<typeof fetch>[1],
+  ) => {
+    const request = input instanceof Request ? input : null;
+    const method = (init?.method ?? request?.method ?? "GET").toUpperCase();
+    const rawUrl = request?.url ?? String(input);
+    const url = new URL(rawUrl, "http://localhost/");
+    const path = `${url.pathname}${url.search}`.replace(/^\/api(?=\/)/, "");
+    throw new Error(`unmocked api call: ${method} ${path}`);
+  }) as unknown as typeof fetch;
+}
+
 function renderWithClient(ui: React.ReactElement) {
   const client = new QueryClient({
     defaultOptions: { queries: { retry: false } },
@@ -541,6 +557,7 @@ describe("Overview keyboard navigation (WM-292)", () => {
 
 describe("Overview anomaly deck (WM-95, WM-979)", () => {
   test("an incomplete api stub fails closed without reaching the network", async () => {
+    installFetchGuard();
     const originalProposals = api.proposals;
     api.proposals = async () => ({ proposals: [] });
     try {
@@ -555,6 +572,7 @@ describe("Overview anomaly deck (WM-95, WM-979)", () => {
   });
 
   test("the network guard reports mutating methods and normalized api paths", async () => {
+    installFetchGuard();
     await expect(
       globalThis.fetch("/api/events", { method: "POST" }),
     ).rejects.toThrow("unmocked api call: POST /events");
@@ -963,6 +981,28 @@ describe("Overview needs you (WM-596)", () => {
 
       fireEvent.keyDown(document.body, { key: "Enter" });
       expect(onNavigate).toHaveBeenCalledWith("inbox/blocked-0");
+    } finally {
+      restore();
+    }
+  });
+
+  test("requests open inbox rows rather than a mixed-status ledger page", async () => {
+    const calls: string[] = [];
+    const restore = stubNeedsYou([]);
+    api.inbox = async (status) => {
+      calls.push(status ?? "open");
+      return {
+        items:
+          status === "open"
+            ? [inboxItem("open-only", "BLOCKED", "2026-08-17T00:00:00.000Z")]
+            : [],
+      };
+    };
+
+    try {
+      const view = renderOverview();
+      await waitFor(() => view.getByTitle("Attention open-only"));
+      expect(calls).toEqual(["open"]);
     } finally {
       restore();
     }

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -885,12 +885,11 @@ export function Overview({
     queryFn: api.status,
     ...refetchIntervals.primary,
   });
-  // Overview uses the ledger itself rather than a status summary so rows stay
-  // in the exact Inbox order and acknowledgement never needs an optimistic
-  // local rewrite.
+  // Ask for open rows directly: a mixed-status cursor can otherwise spend its
+  // first page on historical resolved items and hide an actionable row here.
   const inbox = useQuery({
-    queryKey: ["inbox", "all"],
-    queryFn: () => api.inbox("all"),
+    queryKey: ["inbox", "open"],
+    queryFn: () => api.inbox("open"),
     ...refetchIntervals.primary,
   });
   const outbox = useQuery({


### PR DESCRIPTION
Fixes watt-mind/factory#1789

Inbox status tabs now page independently so historical resolved rows cannot hide actionable items.

## Validation

| Check                | Command                                                                                                 | Result | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------ | ----------------------------- |
| Verification Command | `bun test event-runtime/web/src/views/Inbox.test.tsx event-runtime/web/src/views/Overview.test.tsx && cd event-runtime/web && bun run typecheck && cd ../.. && bun run lint && bun run format:check` | pass   | 95 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass   | clean; 611 existing warnings  |
| UX critique          | `factory-ux-critic`                                                                                    | pass   | required — SHIP, round 2     |

UX critique: required

run:run_1dcfb97a-7273-47c3-85fe-787dbaa2bf6b

## Post-review

Reviewer verdict FIX, addressed in 1e9e86334d6ff15cf68952729f60ab61e480e2b1:

1. Query-key collision: Inbox infinite queries now use `["inbox","infinite",<status>]`; Overview keeps `["inbox","open"]`; `invalidate()` still targets the `["inbox"]` prefix.
2. Badges: open/acked/resolved/all are computed from their own status queries regardless of the active tab (Resolved badge is correct on the Open tab).
3. Open badge excludes expired rows; `/status` totals are only consulted when a status has unloaded pages. `expiredOpenItems` derives from the open pages, not the active tab.

Tests added in `Inbox.test.tsx`: Overview-cached `["inbox","open"]` then Inbox render (no throw, cache intact), Resolved badge on Open tab, expired chip stable across tab switches, expired-excluded Open badge on a legacy server. Verification: `bun test Inbox.test.tsx Overview.test.tsx` 98 pass; `bun run check`, `bun run lint` (0 errors), `bun run format:check` pass.
