### PR TITLE
fix(artifacts): refresh dedup blob mtime

### DIFF
--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -21,6 +21,7 @@ import {
   renameSync,
   rmSync,
   statSync,
+  utimesSync,
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
@@ -43,12 +44,27 @@ function resultDigest(artifactHash) {
   return SHA256.exec(artifactHash ?? "")?.[1] ?? null;
 }
 
+/** Refresh a deduplicated blob's prune grace period without blocking publish. */
+function refreshArtifactMtime(dest) {
+  try {
+    const now = new Date();
+    utimesSync(dest, now, now);
+  } catch (err) {
+    console.warn(
+      `artifact store mtime refresh failed for ${dest}: ${err?.message ?? err}`,
+    );
+  }
+}
+
 /** Atomically persist bytes whose digest is already known. */
 function storeBytes({ bytes, sha256hex, storeRoot }) {
   mkdirSync(storeRoot, { recursive: true });
   const dest = artifactPath(storeRoot, sha256hex);
   if (existsSync(dest)) {
-    if (hashFile(dest) === sha256hex) return dest;
+    if (hashFile(dest) === sha256hex) {
+      refreshArtifactMtime(dest);
+      return dest;
+    }
     rmSync(dest, { force: true });
   }
 
@@ -153,6 +169,7 @@ export function storeCollected({ entries, storeRoot, workspaceDir = null }) {
     if (existsSync(dest)) {
       const destHash = hashFile(dest);
       if (destHash === entry.sha256) {
+        refreshArtifactMtime(dest);
         return {
           ...entry,
           uri: `file://${dest}`,

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -6,6 +6,7 @@ import {
   mkdirSync,
   readFileSync,
   readdirSync,
+  statSync,
   symlinkSync,
   utimesSync,
   writeFileSync,
@@ -199,6 +200,49 @@ describe("storeCollected (OPS-406)", () => {
     expect(stored[0].sizeBytes).toBe(Buffer.byteLength("identical content"));
   });
 
+  test("refreshes a stale deduplicated blob so pruning preserves it", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmp("evrt-store-");
+    const workspaceDir = tmp("evrt-ws-");
+    const file = path.join(workspaceDir, "valid.log");
+    const bytes = "identical content";
+    const hash = sha256Hex(Buffer.from(bytes));
+    const dest = path.join(storeRoot, hash);
+    const olderThanMs = 7 * 24 * 60 * 60 * 1000;
+    const staleAt = new Date(Date.now() - olderThanMs - 1);
+    writeFileSync(file, bytes);
+    mkdirSync(storeRoot, { recursive: true });
+    writeFileSync(dest, bytes);
+    utimesSync(dest, staleAt, staleAt);
+
+    storeCollected({
+      entries: [{ kind: "log", uri: `file://${file}`, sha256: hash }],
+      storeRoot,
+      workspaceDir,
+    });
+
+    expect(statSync(dest).mtimeMs).toBeGreaterThan(staleAt.getTime());
+    expect(pruneArtifacts(db, storeRoot, { olderThanMs })).toMatchObject({
+      deleted: 0,
+    });
+    expect(existsSync(dest)).toBe(true);
+
+    const untouched = makeStore(bytes);
+    utimesSync(
+      path.join(untouched.storeRoot, untouched.hash),
+      staleAt,
+      staleAt,
+    );
+    expect(
+      pruneArtifacts(db, untouched.storeRoot, { olderThanMs }),
+    ).toMatchObject({
+      deleted: 1,
+    });
+    expect(existsSync(path.join(untouched.storeRoot, untouched.hash))).toBe(
+      false,
+    );
+  });
+
   test("interrupted or failed write leaves no tmp files and no readable entry (OPS-439)", () => {
     const storeRoot = tmp("evrt-store-");
     const workspaceDir = tmp("evrt-ws-");
@@ -262,6 +306,27 @@ describe("result artifacts (WM-858)", () => {
     expect(storeResultArtifact({ artifact, artifactHash, storeRoot })).toEqual(
       stored,
     );
+  });
+
+  test("refreshes a stale deduplicated result blob so pruning preserves it", () => {
+    const db = openDb(":memory:");
+    const storeRoot = tmp("evrt-result-store-");
+    const artifact = { outcome: "UPDATED", pr: 669 };
+    const artifactHash = hashJson(artifact);
+    const hash = artifactHash.slice("sha256:".length);
+    const dest = path.join(storeRoot, hash);
+    const olderThanMs = 7 * 24 * 60 * 60 * 1000;
+    const staleAt = new Date(Date.now() - olderThanMs - 1);
+
+    storeResultArtifact({ artifact, artifactHash, storeRoot });
+    utimesSync(dest, staleAt, staleAt);
+    storeResultArtifact({ artifact, artifactHash, storeRoot });
+
+    expect(statSync(dest).mtimeMs).toBeGreaterThan(staleAt.getTime());
+    expect(pruneArtifacts(db, storeRoot, { olderThanMs })).toMatchObject({
+      deleted: 0,
+    });
+    expect(existsSync(dest)).toBe(true);
   });
 
   test("inventory and prune treat the singular result artifact as a live result reference", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1805

Refreshes deduplicated artifact blobs so a re-published stale blob remains within the prune grace period.

## Validation

| Check                | Command                                                                                             | Result  | Notes                            |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | -------------------------------- |
| Verification Command | `bun test event-runtime/lib/artifacts.test.mjs`                                                     | pass    | 32 tests, 0 failures             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,226 passed, 0 failures         |
| UX critique          | factory-ux-critic                                                                                   | not run | no user-facing surface           |

UX critique: skipped

run:$FACTORY_RUN_ID
