### PR TITLE
fix(supervise): validate forwarded worker flags

### DIFF
--- a/event-runtime/cli/shared.mjs
+++ b/event-runtime/cli/shared.mjs
@@ -11,6 +11,25 @@ export function flagValue(args, flag) {
   return i === -1 ? null : args[i + 1];
 }
 
+export const WORKER_POLL_MS_MIN = 25;
+export const WORKER_POLL_MS_MAX = 5_000;
+
+export function validWorkerPollMs(value) {
+  return (
+    Number.isInteger(value) &&
+    value >= WORKER_POLL_MS_MIN &&
+    value <= WORKER_POLL_MS_MAX
+  );
+}
+
+export function parseWorkerLabel(value) {
+  const label = String(value ?? "");
+  const [key, ...rest] = label.split("=");
+  if (!label || label.startsWith("--") || !key || rest.length === 0)
+    return null;
+  return { key, value: rest.join("=") };
+}
+
 export function fail(message) {
   console.error(message);
   process.exit(1);

--- a/event-runtime/cli/supervise.mjs
+++ b/event-runtime/cli/supervise.mjs
@@ -22,7 +22,14 @@ import {
   poolCounts,
   poolDecision,
 } from "../lib/workers.mjs";
-import { CLI_PATH, fail, flagValue, log } from "./shared.mjs";
+import {
+  CLI_PATH,
+  fail,
+  flagValue,
+  log,
+  parseWorkerLabel,
+  validWorkerPollMs,
+} from "./shared.mjs";
 
 // ---------------------------------------------------------------------------
 // supervise — the worker pool supervisor (WM-226; workers doc §2a)
@@ -186,8 +193,8 @@ export function workerPassthroughArgs(args) {
   if (args.includes("--reload-on-change"))
     passthrough.push("--reload-on-change");
   for (let i = 0; i < args.length; i += 1) {
-    if (args[i] === "--label")
-      passthrough.push("--label", String(args[i + 1] ?? ""));
+    if (args[i] !== "--label") continue;
+    if (parseWorkerLabel(args[i + 1])) passthrough.push("--label", args[i + 1]);
   }
   return passthrough;
 }
@@ -275,6 +282,14 @@ export default async function supervise(
     return fail(
       "supervise: --interval-ms must be an integer between 100 and 60000",
     );
+  }
+  const pollMs = Number(flagValue(args, "--poll-ms") ?? 500);
+  if (!validWorkerPollMs(pollMs)) {
+    return fail("supervise: --poll-ms must be an integer between 25 and 5000");
+  }
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === "--label" && !parseWorkerLabel(args[i + 1]))
+      return fail("supervise: --label expects key=value");
   }
   const drainTimeoutSeconds = Number(flagValue(args, "--drain-timeout") ?? 60);
   if (

--- a/event-runtime/cli/supervise.test.mjs
+++ b/event-runtime/cli/supervise.test.mjs
@@ -53,6 +53,8 @@ describe("supervise (WM-226)", () => {
         "--reload-on-change",
         "--label",
         "node=lab",
+        "--label",
+        "can=infra-exec",
       ]),
     ).toEqual([
       "--adapter-override",
@@ -62,7 +64,10 @@ describe("supervise (WM-226)", () => {
       "--reload-on-change",
       "--label",
       "node=lab",
+      "--label",
+      "can=infra-exec",
     ]);
+    expect(workerPassthroughArgs(["--label"])).toEqual([]);
   });
 
   test("rejects bounds and intervals it cannot honour, naming the flag", () => {
@@ -81,6 +86,31 @@ describe("supervise (WM-226)", () => {
       ["supervise", "--workers", "x", "--once"],
     ]) {
       expect(runCli(args).status).not.toBe(0);
+    }
+  });
+
+  test("rejects malformed worker options before starting the pool", () => {
+    const badPoll = runCli([
+      "supervise",
+      "--workers",
+      "1:1",
+      "--poll-ms",
+      "5s",
+      "--once",
+    ]);
+    expect(badPoll.status).not.toBe(0);
+    expect(badPoll.all).toContain(
+      "supervise: --poll-ms must be an integer between 25 and 5000",
+    );
+
+    for (const args of [
+      ["supervise", "--workers", "1:1", "--once", "--label"],
+      ["supervise", "--workers", "1:1", "--label", "--once"],
+      ["supervise", "--workers", "1:1", "--label", "not-a-label", "--once"],
+    ]) {
+      const result = runCli(args);
+      expect(result.status).not.toBe(0);
+      expect(result.all).toContain("supervise: --label expects key=value");
     }
   });
 

--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -27,7 +27,13 @@ import {
   registerWorker,
   satisfiesPlacement,
 } from "../lib/workers.mjs";
-import { fail, flagValue, log } from "./shared.mjs";
+import {
+  fail,
+  flagValue,
+  log,
+  parseWorkerLabel,
+  validWorkerPollMs,
+} from "./shared.mjs";
 
 /** Bound registry diagnostics so one incompatible queue cannot bloat a row. */
 const MAX_SKIPPED_DIAGNOSTICS = 50;
@@ -50,7 +56,7 @@ const MAX_SKIPPED_DIAGNOSTICS = 50;
 export default async function work(args) {
   const adapterOverride = flagValue(args, "--adapter-override") ?? undefined;
   const pollMs = Number(flagValue(args, "--poll-ms") ?? 500);
-  if (!Number.isInteger(pollMs) || pollMs < 25 || pollMs > 5_000) {
+  if (!validWorkerPollMs(pollMs)) {
     fail("work: --poll-ms must be an integer between 25 and 5000");
   }
   const skipReportMs = Number(
@@ -86,9 +92,9 @@ export default async function work(args) {
   const labels = {};
   for (let i = 0; i < args.length; i += 1) {
     if (args[i] !== "--label") continue;
-    const [key, ...rest] = String(args[i + 1] ?? "").split("=");
-    if (!key || rest.length === 0) fail("work: --label expects key=value");
-    labels[key] = rest.join("=");
+    const label = parseWorkerLabel(args[i + 1]);
+    if (!label) fail("work: --label expects key=value");
+    labels[label.key] = label.value;
   }
 
   // Pool supervision (WM-226). The drain file is the scale-down signal: the


### PR DESCRIPTION
Fixes watt-mind/factory#1804

Reject malformed worker options before a pool can spawn.

## Validation

| Check                | Command                                                                                                                              | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/cli/supervise.test.mjs event-runtime/cli/work.test.mjs && bun event-runtime/cli.mjs supervise --workers 1 --poll-ms 5s --once; echo "exit=$?"` | pass    | 35 tests, 0 failures; exit=1       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                | pass    | 2224 pass, 10 skipped, 0 failures |
| UX critique          | factory-ux-critic                                                                                                                    | not run | no user-facing surface             |

UX critique: skipped

run:run_243a650f-ffcd-4d3f-b0e8-d98b53447f2f