### PR TITLE
fix(tests): fail closed before Linear API access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,12 @@ on:
 permissions:
   contents: read
 
+# CI runs on a self-hosted operator machine too. Never allow tests or their
+# spawned tracker CLIs to consume the real Linear API budget from that host.
+env:
+  FACTORY_LINEAR_OFFLINE: "1"
+  LINEAR_API_KEY: ""
+
 # One live run per PR, and one per pushed branch: a newer push to develop
 # supersedes the older develop run (WM-773 item 6) — a stale develop SHA green
 # proves nothing and used to cost a full lane hold per merge.

--- a/bunfig.toml
+++ b/bunfig.toml
@@ -10,4 +10,4 @@
 # one worktree and failed in another (#1285, #1223). Preloading the helper
 # makes the isolated home a property of the process, not of the file order.
 [test]
-preload = ["./event-runtime/test-helpers.mjs"]
+preload = ["./event-runtime/test-helpers.mjs", "./event-runtime/lib/test-helpers.mjs"]

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -217,6 +217,17 @@ Linear API; a follow-up re-pin of `dispatch@1` plus `verify.mjs`
 `linear_rate_limited` without a contract violation. The planner and
 auto-approval path above is what stops the inbox escalation.
 
+### Linear test/offline guard
+
+`bun test` preloads `FACTORY_LINEAR_OFFLINE=1`, and CI sets it for every job.
+While it is set (or `NODE_ENV=test` / `BUN_TEST` is present),
+`tools/ticket.mjs` rejects any `api.linear.app` fetch with
+`linear_offline_guard` before a connection opens. The guard is inherited by
+spawned tracker CLIs. A deliberately networked integration probe must opt in
+with `FACTORY_LINEAR_ALLOW_NETWORK=1`. Worker credential lookup reads only
+`LINEAR_API_KEY` by default; use `FACTORY_LINEAR_ENV_FILE=/path/to/.env` to
+opt into an env-file fallback. Offline/test mode never reads that file.
+
 ---
 
 ## 3. Capacity: one budget, checked at plan and again at execute

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -464,6 +464,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
   test("an approved dispatch run builds the worktree by delegation, completes, and tears it down", async () => {
     const db = openDb(path.join(tmpDir("evrt-dispatch-db-"), "runtime.db"));
     const workspaces = tmpDir("evrt-dispatch-ws-");
+    const trackerCalls = [];
     fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
 
     admitEvent(
@@ -508,7 +509,19 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
         workspacesRoot: workspaces,
         owner: "w-test",
         policyVersion: PV,
-        dispatch: openWorld(),
+        // The verified PR handoff performs tracker state/comment projections.
+        // Keep this end-to-end worker test hermetic and make both projections
+        // explicit rather than falling through to the real tracker CLI.
+        dispatch: openWorld({
+          reconcileVerifiedHandoffTicket: ({ ticket }) => {
+            trackerCalls.push(`state ${ticket} In Review`);
+            return true;
+          },
+          commentTicket: ({ ticket }) => {
+            trackerCalls.push(`comment ${ticket}`);
+            return true;
+          },
+        }),
       },
     );
 
@@ -518,6 +531,7 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     expect(calls()).toContain("up WM-501");
     expect(calls()).toContain("down WM-501"); // torn down on completion
     expect(existsSync(path.join(wtRoot, "WM-501"))).toBe(false);
+    expect(trackerCalls).toEqual(["state WM-501 In Review", "comment WM-501"]);
 
     const row = db
       .query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`)

--- a/event-runtime/lib/test-helpers.mjs
+++ b/event-runtime/lib/test-helpers.mjs
@@ -7,6 +7,40 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-test-help
 // before it can open a connection to api.linear.app.
 process.env.FACTORY_LINEAR_OFFLINE = "1";
 
+const LINEAR_API_HOST = "api.linear.app";
+
+/**
+ * Process-wide fail-closed guard for the test process itself. The CLI guard in
+ * tools/ticket.mjs only covers spawned children; in-process Linear clients
+ * (orchestrator/reaper.mjs `gql`, lib/control-plane/linear.mjs) resolve
+ * `globalThis.fetch` at call time, so wrapping it here makes every
+ * api.linear.app request from a `bun test` process throw `linear_offline_guard`
+ * before a connection opens — regardless of which key is in the environment.
+ * `FACTORY_LINEAR_ALLOW_NETWORK=1` is the explicit escape hatch.
+ */
+export function installTestLinearOfflineGuard(env = process.env) {
+  if (globalThis.fetch?.__factoryLinearOfflineGuard) return;
+  const originalFetch = globalThis.fetch.bind(globalThis);
+  const guarded = async function factoryLinearOfflineGuardFetch(input, init) {
+    const url = String(input?.url ?? input);
+    if (
+      url.includes(LINEAR_API_HOST) &&
+      env.FACTORY_LINEAR_ALLOW_NETWORK !== "1"
+    ) {
+      const error = new Error(
+        "linear_offline_guard: Linear network access is disabled under tests",
+      );
+      error.code = "linear_offline_guard";
+      throw error;
+    }
+    return originalFetch(input, init);
+  };
+  guarded.__factoryLinearOfflineGuard = true;
+  globalThis.fetch = guarded;
+}
+
+installTestLinearOfflineGuard();
+
 /**
  * Put a fake `bun` ahead of PATH while a test exercises an un-injected worker
  * seam. The fake logs argv so callers can assert a tracker CLI did not escape.

--- a/event-runtime/lib/test-helpers.mjs
+++ b/event-runtime/lib/test-helpers.mjs
@@ -1,0 +1,26 @@
+/** Shared guardrails for worker tests that can spawn the tracker CLI. */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-test-helpers-mjs";
+
+// Preloaded from bunfig.toml so every spawned `tools/ticket.mjs` fails closed
+// before it can open a connection to api.linear.app.
+process.env.FACTORY_LINEAR_OFFLINE = "1";
+
+/**
+ * Put a fake `bun` ahead of PATH while a test exercises an un-injected worker
+ * seam. The fake logs argv so callers can assert a tracker CLI did not escape.
+ */
+export function fakeTrackerCli() {
+  const dir = tmpDir("evrt-tracker-cli-");
+  const spawnLog = path.join(dir, "spawned.log");
+  writeFileSync(
+    path.join(dir, "bun"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(spawnLog)}\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  return {
+    path: dir,
+    calls: () => (existsSync(spawnLog) ? readFileSync(spawnLog, "utf8") : ""),
+  };
+}

--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -2,6 +2,7 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-worker-di
 import "../test-helpers.mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
+import { fakeTrackerCli } from "./test-helpers.mjs";
 import { insideHandoffSandbox } from "./verify.mjs";
 import { createHash } from "node:crypto";
 import { execFileSync, spawnSync } from "node:child_process";
@@ -31,6 +32,7 @@ import {
   releaseClaimLock,
   resolveLinearApiKey,
   retryRun,
+  runLinearCli,
   runOnce,
 } from "./worker.mjs";
 import { liveWorkerLeases } from "../../lib/worker-leases.mjs";
@@ -752,7 +754,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     db.close();
   });
 
-  test("resolves Linear credentials from env first, then the shared env file", () => {
+  test("resolves Linear credentials from env first, then an opt-in env file", () => {
     const dir = tmpDir("evrt-linear-key-");
     const envFile = path.join(dir, ".env");
     writeFileSync(envFile, "OTHER=value\nLINEAR_API_KEY='file-key'\n", "utf8");
@@ -760,9 +762,21 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     const fromEnv = { LINEAR_API_KEY: "process-key" };
     expect(resolveLinearApiKey({ env: fromEnv, envFile })).toBe("process-key");
 
-    const fromFile = {};
-    expect(resolveLinearApiKey({ env: fromFile, envFile })).toBe("file-key");
+    const fromFile = { FACTORY_LINEAR_ENV_FILE: envFile };
+    expect(resolveLinearApiKey({ env: fromFile })).toBe("file-key");
     expect(fromFile.LINEAR_API_KEY).toBe("file-key");
+
+    expect(
+      resolveLinearApiKey({
+        env: { FACTORY_LINEAR_ENV_FILE: envFile, FACTORY_LINEAR_OFFLINE: "1" },
+      }),
+    ).toBeNull();
+  });
+
+  test("offline tests reject a tracker CLI spawn before invoking bun", () => {
+    expect(() => runLinearCli(["get", "WM-501"])).toThrow(
+      "linear_offline_guard",
+    );
   });
 
   test("missing process credentials never activate the dispatch stub implicitly (WM-533)", async () => {
@@ -871,17 +885,11 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // handoff comment — fell through to the real tracker CLI. A fake-adapter run
   // then spawned `bun tools/linear.mjs comment` per run: real Linear writes
   // from the test suite, and a wall-clock dependency that timed the burst test
-  // out on CI. Shim `bun` on PATH and assert nothing reaches the tracker CLI.
+  // out on CI. Use the shared fake tracker CLI and assert nothing reaches it.
   test("a partial dispatch override still never reaches the tracker CLI under the fake adapter", async () => {
-    const shimDir = tmpDir("evrt-bun-shim-");
-    const spawnLog = path.join(shimDir, "spawned.log");
-    writeFileSync(
-      path.join(shimDir, "bun"),
-      `#!/bin/sh\nprintf '%s\\n' "$*" >> ${JSON.stringify(spawnLog)}\nexit 0\n`,
-      { mode: 0o755 },
-    );
+    const fakeCli = fakeTrackerCli();
     const previousPath = process.env.PATH;
-    process.env.PATH = `${shimDir}:${previousPath}`;
+    process.env.PATH = `${fakeCli.path}:${previousPath}`;
     try {
       const db = openDb(":memory:");
       const spec = queueRun(
@@ -907,10 +915,7 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         reasonCode: "ok",
       });
       expect(runState(db, spec.runId)).toBe("COMPLETED");
-      const spawned = existsSync(spawnLog)
-        ? readFileSync(spawnLog, "utf8")
-        : "";
-      expect(spawned).not.toContain("linear.mjs");
+      expect(fakeCli.calls()).not.toContain("linear.mjs");
     } finally {
       process.env.PATH = previousPath;
     }

--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -779,6 +779,31 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     );
   });
 
+  // Regression for #1816: a real key in the environment must not be enough to
+  // open a connection from a test process. The preloaded guard rejects the
+  // fetch itself, so even an in-process Linear client cannot spend budget.
+  test("a real LINEAR_API_KEY in the test environment never reaches api.linear.app", async () => {
+    const previousKey = process.env.LINEAR_API_KEY;
+    process.env.LINEAR_API_KEY = "lin_api_FAKE_REAL_LOOKING_KEY";
+    try {
+      expect(process.env.FACTORY_LINEAR_OFFLINE).toBe("1");
+      expect(globalThis.fetch.__factoryLinearOfflineGuard).toBe(true);
+      await expect(
+        fetch("https://api.linear.app/graphql", {
+          method: "POST",
+          headers: { Authorization: process.env.LINEAR_API_KEY },
+          body: "{}",
+        }),
+      ).rejects.toThrow("linear_offline_guard");
+      expect(() => runLinearCli(["comment", "WM-501", "handoff"])).toThrow(
+        "linear_offline_guard",
+      );
+    } finally {
+      if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
+      else process.env.LINEAR_API_KEY = previousKey;
+    }
+  });
+
   test("missing process credentials never activate the dispatch stub implicitly (WM-533)", async () => {
     const previousHome = process.env.FACTORY_EVENT_HOME;
     const previousKey = process.env.LINEAR_API_KEY;

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2507,15 +2507,22 @@ export function createReloadWatcher({
 const linearCli = () => path.join(FACTORY_ROOT, "tools", "linear.mjs");
 
 /**
- * Resolve Linear credentials the same way the CLI does: process env first,
- * then the operator's shared env file. The resolved value is copied into the
- * supplied env so every Linear CLI child inherits it; it is never logged.
+ * Resolve Linear credentials from the environment, optionally reading an
+ * explicitly configured env file. Tests and offline runs never read disk for
+ * a key; their children inherit the same offline guard through process.env.
  */
 export function resolveLinearApiKey({
   env = process.env,
-  envFile = path.join(homedir(), "Develop", "hdkiller", ".env"),
+  envFile = env.FACTORY_LINEAR_ENV_FILE,
 } = {}) {
   if (env.LINEAR_API_KEY) return env.LINEAR_API_KEY;
+  if (
+    env.FACTORY_LINEAR_OFFLINE === "1" ||
+    env.NODE_ENV === "test" ||
+    env.BUN_TEST
+  )
+    return null;
+  if (!envFile) return null;
   if (!existsSync(envFile)) return null;
 
   try {
@@ -2544,6 +2551,21 @@ export function runLinearCli(
   args,
   { command = "bun", timeoutMs = workerSubprocessTimeoutMs(), repo } = {},
 ) {
+  // Do not even spawn the tracker CLI in test/offline mode. Besides making the
+  // child inherit tools/ticket.mjs's fetch guard, this makes an omitted test
+  // seam observable before a real executable can escape the test process.
+  if (
+    process.env.FACTORY_LINEAR_ALLOW_NETWORK !== "1" &&
+    (process.env.FACTORY_LINEAR_OFFLINE === "1" ||
+      process.env.NODE_ENV === "test" ||
+      process.env.BUN_TEST)
+  ) {
+    const error = new Error(
+      "linear_offline_guard: tracker CLI spawn is disabled in test/offline mode",
+    );
+    error.code = "linear_offline_guard";
+    throw error;
+  }
   // --repo so ticket.mjs resolves the ticket's OWN control plane. Without it a
   // Linear-repo claim/read runs against the worker cwd's plane (github) and
   // silently no-ops — the claim read-back then reports ticket_claim_lost,

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -142,6 +142,34 @@ const CACHE_DIR = path.join(homedir(), ".factory/cache/linear");
 const BUDGET_FILE = "budget.json";
 const LINEAR_API_HOST = "api.linear.app";
 
+/**
+ * Test processes must never spend the operator's shared Linear budget. The
+ * explicit allow escape hatch exists for the rare integration probe and is
+ * deliberately inherited by CLI children through their environment.
+ */
+export function linearNetworkIsOffline(env = process.env) {
+  if (env.FACTORY_LINEAR_ALLOW_NETWORK === "1") return false;
+  return (
+    env.FACTORY_LINEAR_OFFLINE === "1" ||
+    env.NODE_ENV === "test" ||
+    Boolean(env.BUN_TEST)
+  );
+}
+
+export class LinearOfflineGuardError extends Error {
+  constructor() {
+    super("linear_offline_guard: Linear network access is disabled");
+    this.name = "LinearOfflineGuardError";
+    this.code = "linear_offline_guard";
+  }
+}
+
+export function assertLinearNetworkAllowed(url, env = process.env) {
+  if (String(url).includes(LINEAR_API_HOST) && linearNetworkIsOffline(env)) {
+    throw new LinearOfflineGuardError();
+  }
+}
+
 /** Distinct from generic CLI failure (exit 1) so planners can retry-later. */
 export const LINEAR_RATE_LIMIT_EXIT = 3;
 export const LINEAR_REQUESTS_LIMIT = 2500;
@@ -306,6 +334,7 @@ export function installLinearBudgetCapture() {
   fetchHookInstalled = true;
   globalThis.fetch = async function linearBudgetFetch(input, init) {
     const url = String(input?.url ?? input);
+    assertLinearNetworkAllowed(url);
     const res = await originalFetch(input, init);
     if (url.includes(LINEAR_API_HOST)) recordLinearBudgetFromResponse(res);
     return res;

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -41,6 +41,8 @@ import {
   instanceConfigRoot,
   InstanceConfigMissingError,
   __resetLinearReposCache,
+  assertLinearNetworkAllowed,
+  linearNetworkIsOffline,
 } from "./ticket.mjs";
 
 const LABELS = [
@@ -52,6 +54,21 @@ const LABELS = [
   { id: "l-area", name: "area:api" },
   { id: "l-review", name: "ai:needs-review" },
 ];
+
+test("the Linear offline guard rejects api.linear.app before fetch", () => {
+  expect(linearNetworkIsOffline({ FACTORY_LINEAR_OFFLINE: "1" })).toBe(true);
+  expect(() =>
+    assertLinearNetworkAllowed("https://api.linear.app/graphql", {
+      FACTORY_LINEAR_OFFLINE: "1",
+    }),
+  ).toThrow("linear_offline_guard");
+  expect(() =>
+    assertLinearNetworkAllowed("https://api.linear.app/graphql", {
+      FACTORY_LINEAR_OFFLINE: "1",
+      FACTORY_LINEAR_ALLOW_NETWORK: "1",
+    }),
+  ).not.toThrow();
+});
 
 // ------------------------------------------------------------ label math ---
 test("adding a label KEEPS the labels already on the ticket", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1816

Prevent test and CI Linear calls before they can consume the shared API budget.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) bun test tools/ticket.test.mjs event-runtime/lib/worker-dispatch-hardening.test.mjs event-runtime/lib/dispatch.test.mjs event-runtime/lib/chain.test.mjs && FACTORY_EVENT_HOME=$(mktemp -d) LINEAR_API_KEY=lin_api_FAKE bun test event-runtime/lib event-runtime/loop.test.mjs event-runtime/merge.test.mjs` | pass | 2,430 pass, 10 skipped |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,221 pass, 10 skipped; emit and formatting clean; lint warnings only |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_2895835d-f479-4fac-a92d-52ea3b3e39d8

## Post-review

Reviewed inline against #1816 acceptance criteria (all changed files inside Owned Paths; `tools/ticket.mjs` fails closed on `NODE_ENV=test`/`BUN_TEST`/`FACTORY_LINEAR_OFFLINE=1` unless `FACTORY_LINEAR_ALLOW_NETWORK=1`; `resolveLinearApiKey` no longer reads `~/Develop/hdkiller/.env` implicitly, opt-in via `FACTORY_LINEAR_ENV_FILE`; worker tests use the shared fake tracker CLI; bunfig preload + ci.yml set the offline env).

Gap fixed in the review commit: the `tools/ticket.mjs` fetch guard is only installed by the CLI `main()`, so an in-process Linear client under `bun test` (`orchestrator/reaper.mjs` `gql`, `lib/control-plane/linear.mjs`) could still open a connection with whatever key the environment carried. The preloaded `event-runtime/lib/test-helpers.mjs` now wraps `globalThis.fetch` process-wide and a regression test asserts a real-looking `LINEAR_API_KEY` never reaches `api.linear.app` nor spawns the tracker CLI.

Follow-up (outside Owned Paths, not changed here): `orchestrator/reaper.mjs` `loadEnv()` still reads `~/Develop/hdkiller/.env` and `./.env` into `process.env` when `LINEAR_API_KEY` is unset; it is now neutralised under tests by the preload guard, but the implicit disk fallback itself should get the same `FACTORY_LINEAR_ENV_FILE` treatment.

Verification: targeted suite 152 pass; `LINEAR_API_KEY=lin_api_FAKE bun test event-runtime/lib event-runtime/loop.test.mjs event-runtime/merge.test.mjs` 2280 pass / 10 skip / 0 fail; lint 0 errors; format clean.
