### PR TITLE
fix(intake): match GitHub slugs without casing drift

### DIFF
--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -180,9 +180,15 @@ const PR_ACTIONS = ["opened", "synchronize", "ready_for_review"];
 
 /** The repos.yaml entry whose `github` slug matches, or null when unconfigured. */
 function repoForSlug(repos, slug) {
-  if (typeof slug !== "string" || slug === "") return null;
+  if (typeof slug !== "string" || slug.trim() === "") return null;
+  const normalizedSlug = slug.trim().toLowerCase();
   for (const repo of repos.values()) {
-    if (repo.github === slug) return repo;
+    if (
+      typeof repo.github === "string" &&
+      repo.github.trim().toLowerCase() === normalizedSlug
+    ) {
+      return repo;
+    }
   }
   return null;
 }

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -6,6 +6,7 @@ import {
   admitExternalEvent,
   admitSignedEvent,
   githubIntakeView,
+  translateGitHubEvent,
   verifyWebhook,
 } from "./intake.mjs";
 import { loadRegistry } from "./registry.mjs";
@@ -423,5 +424,75 @@ describe("githubIntakeView", () => {
       ageMs: null,
       stale: false,
     });
+  });
+});
+
+describe("translateGitHubEvent repository slug matching (WM-1803)", () => {
+  const repos = new Map([
+    [
+      "factory",
+      {
+        name: "factory",
+        github: "Watt-Mind/Factory",
+        base: "develop",
+        reportOnly: false,
+      },
+    ],
+  ]);
+  const translate = (event, payload) =>
+    translateGitHubEvent({
+      event,
+      deliveryId: "case-insensitive-delivery",
+      payload,
+      repos,
+      now: NOW,
+    });
+
+  test("admits a pull request when the delivered repository slug differs only by case", () => {
+    expect(
+      translate("pull_request", {
+        action: "opened",
+        pull_request: { base: { ref: "develop" } },
+        repository: { full_name: "watt-mind/factory" },
+      }),
+    ).toMatchObject({
+      ok: true,
+      envelope: {
+        type: "factory.merge.requested",
+        payload: { repo: "factory" },
+      },
+    });
+  });
+
+  test("emits workflow failures for mixed-case repository slugs without changing the delivered slug", () => {
+    expect(
+      translate("workflow_run", {
+        action: "completed",
+        workflow_run: { id: 1803, conclusion: "failure" },
+        repository: { full_name: "wATT-mIND/fACTORY" },
+      }),
+    ).toMatchObject({
+      ok: true,
+      envelope: {
+        type: "github.workflow-run.failed",
+        payload: { repo: "wATT-mIND/fACTORY", runId: 1803 },
+      },
+    });
+  });
+
+  test("keeps empty and non-string repository slugs unconfigured", () => {
+    for (const full_name of ["", "   ", null, 1803]) {
+      expect(
+        translate("pull_request", {
+          action: "opened",
+          pull_request: { base: { ref: "develop" } },
+          repository: { full_name },
+        }),
+      ).toEqual({
+        ok: false,
+        ignored: true,
+        reason: "unconfigured_repo",
+      });
+    }
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1803

GitHub webhook deliveries now match configured repository slugs regardless of casing.

## Validation

| Check                | Command                                                                                      | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/intake.test.mjs`                                                  | pass    | 24 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2237 pass, 10 skipped, 0 errors            |
| UX critique          | factory-ux-critic                                                                            | not run | no user-facing surface                     |

UX critique: skipped

run:run_ca4e055c-8df3-4092-9085-352c4186b422