### PR TITLE
fix(web): reset Runs pagination cursor

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -200,6 +200,72 @@ describe("Runs API pagination (WM-976)", () => {
       },
     );
   });
+
+  test("resets the cursor when switching status tabs", async () => {
+    const newest = stubListItem("run-page-new", "COMPLETED", {
+      maxAttempts: undefined,
+      spec: undefined,
+    });
+    const older = stubListItem("run-page-old", "FAILED", {
+      maxAttempts: undefined,
+      spec: undefined,
+    });
+    const runs = mock(async (_state?: string, filters?: { before?: string }) =>
+      filters?.before
+        ? { runs: [older], nextBefore: null }
+        : { runs: [newest], nextBefore: "older-page" },
+    );
+    await withApi(
+      { runs, status: async () => createStatusFixture() },
+      async () => {
+        const r = renderRuns();
+        await r.findByTitle("run-page-new");
+
+        fireEvent.click(r.getByRole("button", { name: "Older" }));
+        await r.findByTitle("run-page-old");
+        fireEvent.click(r.getByRole("tab", { name: /^Completed/i }));
+
+        await waitFor(() =>
+          expect(runs).toHaveBeenLastCalledWith(undefined, {
+            before: undefined,
+          }),
+        );
+      },
+    );
+  });
+
+  test("returns to the newest page from the pager", async () => {
+    const newest = stubListItem("run-page-new", "COMPLETED", {
+      maxAttempts: undefined,
+      spec: undefined,
+    });
+    const older = stubListItem("run-page-old", "FAILED", {
+      maxAttempts: undefined,
+      spec: undefined,
+    });
+    const runs = mock(async (_state?: string, filters?: { before?: string }) =>
+      filters?.before
+        ? { runs: [older], nextBefore: null }
+        : { runs: [newest], nextBefore: "older-page" },
+    );
+    await withApi(
+      { runs, status: async () => createStatusFixture() },
+      async () => {
+        const r = renderRuns();
+        await r.findByTitle("run-page-new");
+
+        fireEvent.click(r.getByRole("button", { name: "Older" }));
+        await r.findByTitle("run-page-old");
+        fireEvent.click(r.getByRole("button", { name: "Newest" }));
+
+        await waitFor(() =>
+          expect(runs).toHaveBeenLastCalledWith(undefined, {
+            before: undefined,
+          }),
+        );
+      },
+    );
+  });
 });
 
 function ticketSchemaRegistry(): AgentsView {

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -619,6 +619,13 @@ export function Runs({
   // A project / In-flight filter is client-side; fetching only the active
   // status tab would make every other tab's badge a factory-wide lie.
   const fetchAll = context.kind !== "all" || drilldown !== null;
+
+  // A cursor identifies a boundary in one particular list. Carrying it into a
+  // different tab, drilldown, or context can hide that list's newest runs.
+  useEffect(() => {
+    setRunCursor(null);
+  }, [tab, drilldownKey, context.kind]);
+
   const list = useQuery({
     queryKey: ["runs", fetchAll ? "ALL" : tab, drilldownKey, runCursor],
     queryFn: () =>
@@ -1532,12 +1539,17 @@ export function Runs({
               range={[windowStart, windowEnd, tokens.length]}
               move={moveWindow}
             />
-            {nextBefore && (
+            {(nextBefore || runCursor) && (
               <tr>
                 <td>
-                  <button onClick={() => setRunCursor(nextBefore)}>
-                    Older
-                  </button>
+                  {runCursor && (
+                    <button onClick={() => setRunCursor(null)}>Newest</button>
+                  )}
+                  {nextBefore && (
+                    <button onClick={() => setRunCursor(nextBefore)}>
+                      Older
+                    </button>
+                  )}
                 </td>
               </tr>
             )}


### PR DESCRIPTION
Fixes watt-mind/factory#1801

Reset Runs pagination when its list scope changes and provide a Newest return action.

## Validation

| Check                | Command                                                                                                          | Result       | Notes                                              |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------------ | -------------------------------------------------- |
| Verification Command | `bun test event-runtime/web/src/views/Runs.test.tsx && bun run --cwd event-runtime/web typecheck`              | pass         | 44 tests, 0 failures; TypeScript clean             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass         | 2,224 tests passed, 10 VM-dependent skips          |
| UX critique          | factory-ux-critic                                                                                                | NOT-ASSESSED | isolated Chrome could not reach worktree loopback  |

UX critique: required — NOT-ASSESSED, isolated Chrome DevTools received ERR_CONNECTION_REFUSED for the running worktree URL after one retry.

run:run_9ae114dd-6c30-44b3-8f38-a7b88699f667