### PR TITLE
feat(api): add repository management endpoints

### DIFF
--- a/event-runtime/lib/api-repos.mjs
+++ b/event-runtime/lib/api-repos.mjs
@@ -1,0 +1,279 @@
+/** Runtime-managed repository registry routes. */
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+const CONTROL_PLANES = new Set(["github", "linear", "memory"]);
+const ACTIVE_RUN_STATES = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
+const REGISTRATION_FIELDS = new Set([
+  "name",
+  "github",
+  "path",
+  "controlPlane",
+  "base",
+  "reportOnly",
+  "maxInFlight",
+]);
+const PATCH_FIELDS = new Set([
+  "maxInFlight",
+  "reportOnly",
+  "controlPlane",
+  "runnerLabels",
+]);
+
+function isObject(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function validName(value) {
+  return (
+    typeof value === "string" && /^[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(value)
+  );
+}
+
+function validGithub(value) {
+  return (
+    typeof value === "string" &&
+    /^[A-Za-z0-9][A-Za-z0-9_.-]*\/[A-Za-z0-9][A-Za-z0-9_.-]*$/.test(value)
+  );
+}
+
+function validateFields(value, allowed, required = []) {
+  if (!isObject(value)) return "body must be a JSON object";
+  const unknown = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unknown.length) return `unknown fields: ${unknown.join(", ")}`;
+  for (const key of required) {
+    if (!Object.hasOwn(value, key)) return `${key} is required`;
+  }
+  if (Object.hasOwn(value, "name") && !validName(value.name))
+    return "name must contain only letters, numbers, dot, underscore, or hyphen";
+  if (Object.hasOwn(value, "github") && !validGithub(value.github))
+    return "github must be an owner/repository slug";
+  if (
+    Object.hasOwn(value, "path") &&
+    (typeof value.path !== "string" || !value.path.trim())
+  )
+    return "path must be a non-empty string";
+  if (
+    Object.hasOwn(value, "controlPlane") &&
+    !CONTROL_PLANES.has(value.controlPlane)
+  )
+    return "controlPlane must be one of github, linear, memory";
+  if (
+    Object.hasOwn(value, "base") &&
+    (typeof value.base !== "string" || !value.base.trim())
+  )
+    return "base must be a non-empty string";
+  if (
+    Object.hasOwn(value, "reportOnly") &&
+    typeof value.reportOnly !== "boolean"
+  )
+    return "reportOnly must be a boolean";
+  if (
+    Object.hasOwn(value, "maxInFlight") &&
+    (!Number.isInteger(value.maxInFlight) || value.maxInFlight < 1)
+  )
+    return "maxInFlight must be a positive integer";
+  if (Object.hasOwn(value, "runnerLabels")) {
+    if (
+      !Array.isArray(value.runnerLabels) ||
+      value.runnerLabels.some(
+        (label) => typeof label !== "string" || !label.trim(),
+      )
+    )
+      return "runnerLabels must be an array of non-empty strings";
+  }
+  return null;
+}
+
+function hasInRepoConfig(repo) {
+  if (typeof repo.path !== "string") return false;
+  return [".factory.yaml", ".factory/config.yaml"].some((file) =>
+    existsSync(path.join(repo.path, file)),
+  );
+}
+
+function repositoryHealth(repo) {
+  if (typeof repo.path !== "string" || !repo.path) {
+    return { status: "unconfigured", path: null };
+  }
+  return existsSync(repo.path)
+    ? { status: "healthy", path: repo.path }
+    : { status: "missing_checkout", path: repo.path };
+}
+
+function activeCounts(db) {
+  const counts = new Map();
+  const placeholders = ACTIVE_RUN_STATES.map(() => "?").join(", ");
+  const rows = db
+    .query(`SELECT spec_json FROM runs WHERE state IN (${placeholders})`)
+    .all(...ACTIVE_RUN_STATES);
+  for (const row of rows) {
+    try {
+      const name = JSON.parse(row.spec_json)?.input?.repo;
+      if (typeof name === "string")
+        counts.set(name, (counts.get(name) ?? 0) + 1);
+    } catch {
+      // A malformed historic run must not make the registry unreadable.
+    }
+  }
+  return counts;
+}
+
+function response(repo, { dynamic, source, flags, inFlight }) {
+  const effective = { ...repo, ...flags };
+  return {
+    name: effective.name,
+    github: effective.github ?? null,
+    path: effective.path ?? null,
+    controlPlane: effective.controlPlane ?? null,
+    base: effective.base ?? "main",
+    reportOnly: effective.reportOnly === true,
+    maxInFlight: effective.maxInFlight ?? null,
+    runnerLabels: effective.runnerLabels ?? [],
+    configSource: dynamic
+      ? "runtime"
+      : hasInRepoConfig(repo)
+        ? "in-repo"
+        : "host",
+    health: repositoryHealth(effective),
+    inFlight: inFlight ?? 0,
+    sync: source?.syncedAt ?? null,
+  };
+}
+
+/**
+ * Build the mutable, process-local registry used by the control API. Host
+ * entries remain the baseline; runtime additions, removals, and allowed
+ * runtime flags are layered over a fresh host read on each request.
+ */
+export function createRepoApi({ repos, db }) {
+  const additions = new Map();
+  const removals = new Set();
+  const flags = new Map();
+  const syncs = new Map();
+
+  function registry() {
+    const current = new Map(repos());
+    for (const name of removals) current.delete(name);
+    for (const [name, repo] of additions) current.set(name, { ...repo });
+    for (const [name, patch] of flags) {
+      const repo = current.get(name);
+      if (repo) current.set(name, { ...repo, ...patch });
+    }
+    return current;
+  }
+
+  function details(name) {
+    const base = repos();
+    const repo = registry().get(name);
+    if (!repo) return null;
+    const inFlight = activeCounts(db).get(name) ?? 0;
+    return response(repo, {
+      dynamic: additions.has(name),
+      source: syncs.get(name),
+      flags: flags.get(name) ?? {},
+      inFlight,
+      host: base.get(name),
+    });
+  }
+
+  async function handle({ route, req, url, send, parseJson, readBody }) {
+    if (route === "GET /repos") {
+      // Keep the established collection projection byte-compatible; the
+      // existing registry handler supplies it below. Per-repository GET adds
+      // operational state without widening that public inventory response.
+      return false;
+    }
+
+    const match = url.pathname.match(/^\/repos\/([^/]+)(?:\/(sync))?$/);
+    if (!match) return false;
+    const name = decodeURIComponent(match[1]);
+    const action = match[2] ?? null;
+
+    if (req.method === "GET" && !action) {
+      const item = details(name);
+      return item
+        ? send(200, { repo: item })
+        : send(404, { error: `unknown repo ${name}` });
+    }
+
+    if (req.method === "POST" && !action && url.pathname === "/repos") {
+      return false;
+    }
+
+    if (req.method === "POST" && action === "sync") {
+      const repo = registry().get(name);
+      if (!repo) return send(404, { error: `unknown repo ${name}` });
+      // `repos()` is deliberately read on every request. Calling it here
+      // re-fetches the in-repo overlay before recording the invalidation.
+      repos();
+      syncs.set(name, {
+        syncedAt: new Date().toISOString(),
+        invalidated: true,
+      });
+      return send(200, { repo: details(name), invalidated: true });
+    }
+
+    if (req.method === "PATCH" && !action) {
+      if (!registry().has(name))
+        return send(404, { error: `unknown repo ${name}` });
+      const parsed = parseJson(await readBody(req));
+      if (parsed.error) return send(422, { error: "invalid_json" });
+      const error = validateFields(parsed.value, PATCH_FIELDS);
+      if (error) return send(422, { error });
+      if (Object.keys(parsed.value).length === 0)
+        return send(422, { error: "at least one runtime flag is required" });
+      flags.set(name, { ...(flags.get(name) ?? {}), ...parsed.value });
+      return send(200, { repo: details(name) });
+    }
+
+    if (req.method === "DELETE" && !action) {
+      if (!registry().has(name))
+        return send(404, { error: `unknown repo ${name}` });
+      const inFlight = activeCounts(db).get(name) ?? 0;
+      if (inFlight > 0)
+        return send(409, {
+          error: `repo ${name} has ${inFlight} active run(s)`,
+        });
+      additions.delete(name);
+      flags.delete(name);
+      syncs.delete(name);
+      if (repos().has(name)) removals.add(name);
+      return send(200, { deleted: name });
+    }
+
+    return false;
+  }
+
+  async function register({ req, send, parseJson, readBody }) {
+    const parsed = parseJson(await readBody(req));
+    if (parsed.error) return send(422, { error: "invalid_json" });
+    const error = validateFields(parsed.value, REGISTRATION_FIELDS, [
+      "name",
+      "github",
+    ]);
+    if (error) return send(422, { error });
+    const { name } = parsed.value;
+    if (registry().has(name))
+      return send(409, { error: `repo ${name} is already registered` });
+    removals.delete(name);
+    additions.set(name, {
+      name,
+      github: parsed.value.github,
+      path: parsed.value.path ?? null,
+      controlPlane: parsed.value.controlPlane ?? null,
+      base: parsed.value.base ?? "main",
+      reportOnly: parsed.value.reportOnly === true,
+      maxInFlight: parsed.value.maxInFlight ?? null,
+    });
+    return send(201, { repo: details(name) });
+  }
+
+  return {
+    repos: registry,
+    handle: async (context) => {
+      if (context.route === "POST /repos") return register(context);
+      return handle(context);
+    },
+  };
+}

--- a/event-runtime/lib/api-repos.mjs
+++ b/event-runtime/lib/api-repos.mjs
@@ -1,6 +1,31 @@
-/** Runtime-managed repository registry routes. */
-import { existsSync } from "node:fs";
+/**
+ * Runtime-managed repository registry routes (gh-1639).
+ *
+ * The host registry file (`config/repos.yaml`) is the single source of truth:
+ * every mutation is written through to it atomically and validated with the
+ * real loader before it is committed, so a restart sees exactly what the API
+ * reported and an invalid write never reaches disk.
+ */
+import { randomUUID } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
 import path from "node:path";
+import {
+  loadInRepoConfig,
+  loadRepos,
+  RepoError,
+  reposConfigPath,
+  reposRoot,
+  reposView,
+} from "./repos.mjs";
 
 const CONTROL_PLANES = new Set(["github", "linear", "memory"]);
 const ACTIVE_RUN_STATES = ["QUEUED", "LEASED", "RUNNING", "VERIFYING"];
@@ -19,6 +44,17 @@ const PATCH_FIELDS = new Set([
   "controlPlane",
   "runnerLabels",
 ]);
+/** API field → host registry key. */
+const HOST_KEYS = {
+  name: "name",
+  github: "github",
+  path: "path",
+  controlPlane: "control_plane",
+  base: "base",
+  reportOnly: "report_only",
+  maxInFlight: "max_in_flight",
+  runnerLabels: "runner_labels",
+};
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -85,11 +121,24 @@ function validateFields(value, allowed, required = []) {
   return null;
 }
 
-function hasInRepoConfig(repo) {
-  if (typeof repo.path !== "string") return false;
-  return [".factory.yaml", ".factory/config.yaml"].some((file) =>
-    existsSync(path.join(repo.path, file)),
-  );
+/**
+ * Re-read one checkout's in-repo overlay. The loader is uncached — every
+ * `repos()` call parses `.factory.yaml` afresh — so this is the whole of what
+ * a "sync" can do: read it now and report whether it is being applied.
+ */
+function readOverlay(repo) {
+  if (typeof repo.path !== "string" || !repo.path)
+    return { status: "absent", error: null };
+  try {
+    const config = loadInRepoConfig(repo.path);
+    return config
+      ? { status: "applied", error: null }
+      : { status: "absent", error: null };
+  } catch (err) {
+    if (!(err instanceof RepoError)) throw err;
+    // Mirrors loadRepos: a malformed overlay is ignored, host config applies.
+    return { status: "ignored", error: err.message };
+  }
 }
 
 function repositoryHealth(repo) {
@@ -101,89 +150,196 @@ function repositoryHealth(repo) {
     : { status: "missing_checkout", path: repo.path };
 }
 
-function activeCounts(db) {
-  const counts = new Map();
+/**
+ * Active runs naming this repo, filtered in SQL rather than by parsing every
+ * active spec in JS. A run names its repo the same three ways
+ * `repoNamesFromInput` (api-runs.mjs) recognises: `input.repo`,
+ * `input.repoPin.repo`, and `input.repos[]` entries (string or `{name}`).
+ * `json_valid` guards the JSON functions: a malformed historic spec must not
+ * make the registry unreadable.
+ */
+function activeRunCount(db, name) {
   const placeholders = ACTIVE_RUN_STATES.map(() => "?").join(", ");
-  const rows = db
-    .query(`SELECT spec_json FROM runs WHERE state IN (${placeholders})`)
-    .all(...ACTIVE_RUN_STATES);
-  for (const row of rows) {
-    try {
-      const name = JSON.parse(row.spec_json)?.input?.repo;
-      if (typeof name === "string")
-        counts.set(name, (counts.get(name) ?? 0) + 1);
-    } catch {
-      // A malformed historic run must not make the registry unreadable.
-    }
-  }
-  return counts;
+  const row = db
+    .query(
+      `SELECT COUNT(*) AS n FROM runs
+       WHERE state IN (${placeholders})
+         AND json_valid(spec_json)
+         AND (
+           json_extract(spec_json, '$.input.repo') = ?
+           OR json_extract(spec_json, '$.input.repoPin.repo') = ?
+           OR EXISTS (
+             SELECT 1 FROM json_each(spec_json, '$.input.repos') AS entry
+             WHERE entry.value = ?
+               OR (entry.type = 'object'
+                   AND json_extract(entry.value, '$.name') = ?)
+           )
+         )`,
+    )
+    .get(...ACTIVE_RUN_STATES, name, name, name, name);
+  return row?.n ?? 0;
 }
 
-function response(repo, { dynamic, source, flags, inFlight }) {
-  const effective = { ...repo, ...flags };
-  return {
-    name: effective.name,
-    github: effective.github ?? null,
-    path: effective.path ?? null,
-    controlPlane: effective.controlPlane ?? null,
-    base: effective.base ?? "main",
-    reportOnly: effective.reportOnly === true,
-    maxInFlight: effective.maxInFlight ?? null,
-    runnerLabels: effective.runnerLabels ?? [],
-    configSource: dynamic
-      ? "runtime"
-      : hasInRepoConfig(repo)
-        ? "in-repo"
-        : "host",
-    health: repositoryHealth(effective),
-    inFlight: inFlight ?? 0,
-    sync: source?.syncedAt ?? null,
-  };
+function hostConfigError(message, file) {
+  // The loader names the scratch copy it validated; report the real file.
+  return message.split(file).join("config/repos.yaml");
 }
 
 /**
- * Build the mutable, process-local registry used by the control API. Host
- * entries remain the baseline; runtime additions, removals, and allowed
- * runtime flags are layered over a fresh host read on each request.
+ * Read the effective host registry as raw YAML (the loader's projection drops
+ * keys it does not model, and a write must not lose them).
  */
-export function createRepoApi({ repos, db }) {
-  const additions = new Map();
-  const removals = new Set();
-  const flags = new Map();
+function readHostConfig(root) {
+  const file = reposConfigPath(root);
+  if (!existsSync(file)) return { repos: [] };
+  const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  if (!isObject(parsed))
+    throw new RepoError(`${file}: repos config must be a YAML mapping`);
+  if (parsed.repos === undefined || parsed.repos === null) parsed.repos = [];
+  if (!Array.isArray(parsed.repos))
+    throw new RepoError(`${file}: repos must be a list`);
+  return parsed;
+}
+
+/**
+ * Validate `config` with the real loader, then commit it atomically to the
+ * local `config/repos.yaml` (tmp file + rename). Throws RepoError without
+ * touching the registry when the loader rejects the result.
+ */
+function writeHostConfig(root, config) {
+  const yaml = Bun.YAML.stringify(config, null, 2);
+  const scratch = mkdtempSync(path.join(os.tmpdir(), "factory-repos-"));
+  try {
+    const scratchFile = path.join(scratch, "config", "repos.yaml");
+    mkdirSync(path.dirname(scratchFile), { recursive: true });
+    writeFileSync(scratchFile, yaml);
+    try {
+      loadRepos({ root: scratch });
+    } catch (err) {
+      if (!(err instanceof RepoError)) throw err;
+      throw new RepoError(hostConfigError(err.message, scratchFile));
+    }
+  } finally {
+    rmSync(scratch, { recursive: true, force: true });
+  }
+  const target = path.join(root, "config", "repos.yaml");
+  mkdirSync(path.dirname(target), { recursive: true });
+  const tmp = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  try {
+    writeFileSync(tmp, yaml);
+    renameSync(tmp, target);
+  } finally {
+    rmSync(tmp, { force: true });
+  }
+}
+
+/**
+ * Build the repository management routes. `repos()` is the loader projection
+ * read per request; `configRoot` is the checkout whose `config/repos.yaml`
+ * mutations are written through to (the same root `repos()` reads).
+ */
+export function createRepoApi({ repos, db, configRoot = reposRoot() }) {
   const syncs = new Map();
 
-  function registry() {
-    const current = new Map(repos());
-    for (const name of removals) current.delete(name);
-    for (const [name, repo] of additions) current.set(name, { ...repo });
-    for (const [name, patch] of flags) {
-      const repo = current.get(name);
-      if (repo) current.set(name, { ...repo, ...patch });
-    }
-    return current;
-  }
-
-  function details(name) {
-    const base = repos();
-    const repo = registry().get(name);
+  function details(
+    name,
+    { current = repos(), host = readHostConfig(configRoot), counts } = {},
+  ) {
+    const repo = current.get(name);
     if (!repo) return null;
-    const inFlight = activeCounts(db).get(name) ?? 0;
-    return response(repo, {
-      dynamic: additions.has(name),
-      source: syncs.get(name),
-      flags: flags.get(name) ?? {},
+    const entry =
+      host.repos.find((candidate) => candidate?.name === name) ?? {};
+    let inFlight = counts?.get(name);
+    if (inFlight === undefined) {
+      inFlight = activeRunCount(db, name);
+      counts?.set(name, inFlight);
+    }
+    const overlay = readOverlay(repo);
+    return {
+      name: repo.name,
+      github: repo.github ?? null,
+      path: repo.path ?? null,
+      controlPlane: repo.controlPlane ?? null,
+      base: repo.base ?? "main",
+      reportOnly: repo.reportOnly === true,
+      maxInFlight: repo.maxInFlight ?? null,
+      runnerLabels: Array.isArray(entry.runner_labels)
+        ? [...entry.runner_labels]
+        : [],
+      configSource: overlay.status === "applied" ? "in-repo" : "host",
+      overlay,
+      health: repositoryHealth(repo),
       inFlight,
-      host: base.get(name),
-    });
+      sync: syncs.get(name) ?? null,
+    };
   }
 
-  async function handle({ route, req, url, send, parseJson, readBody }) {
-    if (route === "GET /repos") {
-      // Keep the established collection projection byte-compatible; the
-      // existing registry handler supplies it below. Per-repository GET adds
-      // operational state without widening that public inventory response.
-      return false;
+  function collection() {
+    const current = repos();
+    const host = readHostConfig(configRoot);
+    const counts = new Map();
+    return {
+      // The established inventory projection, unchanged for its consumers.
+      repos: reposView(current),
+      details: [...current.keys()].map((name) =>
+        details(name, { current, host, counts }),
+      ),
+    };
+  }
+
+  function commit(send, mutate) {
+    let config;
+    try {
+      config = readHostConfig(configRoot);
+      mutate(config);
+      writeHostConfig(configRoot, config);
+    } catch (err) {
+      if (!(err instanceof RepoError)) throw err;
+      return send(422, { error: err.message });
     }
+    return null;
+  }
+
+  async function register({ req, send, parseJson, readBody }) {
+    const parsed = parseJson(await readBody(req));
+    if (parsed.error) return send(422, { error: "invalid_json" });
+    const error = validateFields(parsed.value, REGISTRATION_FIELDS, [
+      "name",
+      "github",
+    ]);
+    if (error) return send(422, { error });
+    const { name } = parsed.value;
+    if (repos().has(name))
+      return send(409, { error: `repo ${name} is already registered` });
+    const entry = {};
+    for (const [field, key] of Object.entries(HOST_KEYS)) {
+      if (Object.hasOwn(parsed.value, field)) entry[key] = parsed.value[field];
+    }
+    const failed = commit(send, (config) => {
+      if (config.repos.some((candidate) => candidate?.name === name))
+        throw new RepoError(`repo ${name} is already registered`);
+      config.repos.push(entry);
+    });
+    if (failed) return failed;
+    return send(201, { repo: details(name) });
+  }
+
+  async function handle(context) {
+    try {
+      return await routes(context);
+    } catch (err) {
+      // OPS-212/OPS-346: a missing or malformed repos.yaml is named, not
+      // flattened into a bare internal_error.
+      if (err instanceof RepoError)
+        return context.send(500, { error: err.message });
+      throw err;
+    }
+  }
+
+  async function routes({ route, req, url, send, parseJson, readBody }) {
+    if (route === "GET /repos") return send(200, collection());
+    if (route === "POST /repos")
+      return register({ req, send, parseJson, readBody });
 
     const match = url.pathname.match(/^\/repos\/([^/]+)(?:\/(sync))?$/);
     if (!match) return false;
@@ -197,25 +353,16 @@ export function createRepoApi({ repos, db }) {
         : send(404, { error: `unknown repo ${name}` });
     }
 
-    if (req.method === "POST" && !action && url.pathname === "/repos") {
-      return false;
-    }
-
     if (req.method === "POST" && action === "sync") {
-      const repo = registry().get(name);
+      const repo = repos().get(name);
       if (!repo) return send(404, { error: `unknown repo ${name}` });
-      // `repos()` is deliberately read on every request. Calling it here
-      // re-fetches the in-repo overlay before recording the invalidation.
-      repos();
-      syncs.set(name, {
-        syncedAt: new Date().toISOString(),
-        invalidated: true,
-      });
-      return send(200, { repo: details(name), invalidated: true });
+      const overlay = readOverlay(repo);
+      syncs.set(name, { syncedAt: new Date().toISOString(), overlay });
+      return send(200, { repo: details(name), overlay, refreshed: true });
     }
 
     if (req.method === "PATCH" && !action) {
-      if (!registry().has(name))
+      if (!repos().has(name))
         return send(404, { error: `unknown repo ${name}` });
       const parsed = parseJson(await readBody(req));
       if (parsed.error) return send(422, { error: "invalid_json" });
@@ -223,57 +370,39 @@ export function createRepoApi({ repos, db }) {
       if (error) return send(422, { error });
       if (Object.keys(parsed.value).length === 0)
         return send(422, { error: "at least one runtime flag is required" });
-      flags.set(name, { ...(flags.get(name) ?? {}), ...parsed.value });
+      const failed = commit(send, (config) => {
+        const entry = config.repos.find(
+          (candidate) => candidate?.name === name,
+        );
+        if (!entry) throw new RepoError(`repo ${name} is not in the registry`);
+        for (const [field, value] of Object.entries(parsed.value)) {
+          entry[HOST_KEYS[field]] = value;
+        }
+      });
+      if (failed) return failed;
       return send(200, { repo: details(name) });
     }
 
     if (req.method === "DELETE" && !action) {
-      if (!registry().has(name))
+      if (!repos().has(name))
         return send(404, { error: `unknown repo ${name}` });
-      const inFlight = activeCounts(db).get(name) ?? 0;
+      const inFlight = activeRunCount(db, name);
       if (inFlight > 0)
         return send(409, {
           error: `repo ${name} has ${inFlight} active run(s)`,
         });
-      additions.delete(name);
-      flags.delete(name);
+      const failed = commit(send, (config) => {
+        config.repos = config.repos.filter(
+          (candidate) => candidate?.name !== name,
+        );
+      });
+      if (failed) return failed;
       syncs.delete(name);
-      if (repos().has(name)) removals.add(name);
       return send(200, { deleted: name });
     }
 
     return false;
   }
 
-  async function register({ req, send, parseJson, readBody }) {
-    const parsed = parseJson(await readBody(req));
-    if (parsed.error) return send(422, { error: "invalid_json" });
-    const error = validateFields(parsed.value, REGISTRATION_FIELDS, [
-      "name",
-      "github",
-    ]);
-    if (error) return send(422, { error });
-    const { name } = parsed.value;
-    if (registry().has(name))
-      return send(409, { error: `repo ${name} is already registered` });
-    removals.delete(name);
-    additions.set(name, {
-      name,
-      github: parsed.value.github,
-      path: parsed.value.path ?? null,
-      controlPlane: parsed.value.controlPlane ?? null,
-      base: parsed.value.base ?? "main",
-      reportOnly: parsed.value.reportOnly === true,
-      maxInFlight: parsed.value.maxInFlight ?? null,
-    });
-    return send(201, { repo: details(name) });
-  }
-
-  return {
-    repos: registry,
-    handle: async (context) => {
-      if (context.route === "POST /repos") return register(context);
-      return handle(context);
-    },
-  };
+  return { repos, handle };
 }

--- a/event-runtime/lib/api-repos.test.mjs
+++ b/event-runtime/lib/api-repos.test.mjs
@@ -1,79 +1,207 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-repos-test-mjs";
 import { describe, expect, test } from "bun:test";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
 import { makeServer } from "./api-test-helpers.mjs";
+import { loadRepos, reposView } from "./repos.mjs";
 
-function repo(name = "existing") {
-  return {
-    name,
-    github: `watt-mind/${name}`,
-    path: "/missing/checkout",
-    controlPlane: "github",
-    base: "develop",
-    reportOnly: false,
-    maxInFlight: 2,
-  };
+/**
+ * A factory checkout whose config/repos.yaml holds one host repo whose
+ * checkout exists (so an in-repo overlay can be planted there) plus, when
+ * asked, extra entries.
+ */
+function factoryRoot({ extraYaml = "" } = {}) {
+  const root = tmpDir("api-repos-");
+  const checkout = path.join(root, "checkouts", "existing");
+  mkdirSync(checkout, { recursive: true });
+  mkdirSync(path.join(root, "config"));
+  writeFileSync(
+    path.join(root, "config", "repos.yaml"),
+    `# operator comment
+repos:
+  - name: existing
+    path: ${checkout}
+    github: watt-mind/existing
+    base: develop
+    max_in_flight: 2
+    control_plane: github
+    team: platform
+${extraYaml}`,
+  );
+  return { root, checkout };
+}
+
+function server(root, options = {}) {
+  return makeServer({
+    repos: () => loadRepos({ root }),
+    configRoot: root,
+    ...options,
+  });
+}
+
+function insertRun(db, spec, state = "RUNNING") {
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?)`,
+  ).run(
+    `run-${Math.random().toString(36).slice(2)}`,
+    `key-${Math.random().toString(36).slice(2)}`,
+    spec,
+    "hash",
+    state,
+    new Date().toISOString(),
+    new Date().toISOString(),
+  );
 }
 
 describe("repository management API", () => {
-  test("lists host state, registers runtime repos, patches flags, and syncs", async () => {
-    const api = await makeServer({
-      repos: () => new Map([["existing", repo()]]),
-    });
+  test("GET /repos keeps the inventory projection and adds per-repo details", async () => {
+    const { root, checkout } = factoryRoot();
+    const api = await server(root);
     try {
-      const listed = await api.request("/repos/existing");
+      const listed = await api.request("/repos");
       expect(listed.status).toBe(200);
-      expect((await listed.json()).repo).toMatchObject({
+      const body = await listed.json();
+      // The legacy projection is untouched: same key, same rows.
+      expect(body.repos).toEqual(
+        JSON.parse(JSON.stringify(reposView(loadRepos({ root })))),
+      );
+      expect(body.details).toEqual([
+        expect.objectContaining({
+          name: "existing",
+          configSource: "host",
+          overlay: { status: "absent", error: null },
+          health: { status: "healthy", path: checkout },
+          inFlight: 0,
+        }),
+      ]);
+
+      const one = await api.request("/repos/existing");
+      expect(one.status).toBe(200);
+      expect((await one.json()).repo).toMatchObject({
         name: "existing",
-        configSource: "host",
-        health: { status: "missing_checkout" },
-        inFlight: 0,
+        github: "watt-mind/existing",
+        maxInFlight: 2,
+        runnerLabels: [],
       });
 
+      const missing = await api.request("/repos/nope");
+      expect(missing.status).toBe(404);
+    } finally {
+      api.close();
+    }
+  });
+
+  test("POST/PATCH/DELETE write through to config/repos.yaml and survive a restart", async () => {
+    const { root } = factoryRoot();
+    const runtimePath = path.join(root, "checkouts", "runtime-repo");
+    let api = await server(root);
+    try {
       const created = await api.request("/repos", {
         method: "POST",
         body: JSON.stringify({
           name: "runtime-repo",
           github: "watt-mind/runtime-repo",
-          path: "/runtime/repo",
-          controlPlane: "github",
+          path: runtimePath,
+          controlPlane: "linear",
           maxInFlight: 4,
         }),
       });
       expect(created.status).toBe(201);
       expect((await created.json()).repo).toMatchObject({
         name: "runtime-repo",
-        configSource: "runtime",
+        configSource: "host",
+        controlPlane: "linear",
         maxInFlight: 4,
+        health: { status: "missing_checkout", path: runtimePath },
       });
+
+      const duplicate = await api.request("/repos", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "runtime-repo",
+          github: "watt-mind/runtime-repo",
+          path: runtimePath,
+        }),
+      });
+      expect(duplicate.status).toBe(409);
 
       const patched = await api.request("/repos/runtime-repo", {
         method: "PATCH",
-        body: JSON.stringify({ reportOnly: true, runnerLabels: ["linux"] }),
+        body: JSON.stringify({
+          reportOnly: true,
+          runnerLabels: ["linux"],
+          maxInFlight: 1,
+        }),
       });
       expect(patched.status).toBe(200);
       expect((await patched.json()).repo).toMatchObject({
         reportOnly: true,
         runnerLabels: ["linux"],
+        maxInFlight: 1,
       });
-
-      const synced = await api.request("/repos/runtime-repo/sync", {
-        method: "POST",
-        body: "{}",
-      });
-      expect(synced.status).toBe(200);
-      expect((await synced.json()).invalidated).toBe(true);
     } finally {
       api.close();
     }
+
+    // The file is the registry: the real loader sees the mutation, and the
+    // host's other keys survived the rewrite.
+    const reloaded = loadRepos({ root });
+    expect(reloaded.get("runtime-repo")).toMatchObject({
+      github: "watt-mind/runtime-repo",
+      controlPlane: "linear",
+      reportOnly: true,
+      maxInFlight: 1,
+    });
+    expect(reloaded.get("existing")).toMatchObject({
+      team: "platform",
+      maxInFlight: 2,
+    });
+
+    api = await server(root);
+    try {
+      const after = await api.request("/repos/runtime-repo");
+      expect(after.status).toBe(200);
+      expect((await after.json()).repo).toMatchObject({
+        reportOnly: true,
+        runnerLabels: ["linux"],
+        maxInFlight: 1,
+      });
+
+      const deleted = await api.request("/repos/runtime-repo", {
+        method: "DELETE",
+      });
+      expect(deleted.status).toBe(200);
+      expect(await deleted.json()).toEqual({ deleted: "runtime-repo" });
+      expect((await api.request("/repos/runtime-repo")).status).toBe(404);
+      expect(
+        (await api.request("/repos/runtime-repo", { method: "DELETE" })).status,
+      ).toBe(404);
+    } finally {
+      api.close();
+    }
+    expect(loadRepos({ root }).has("runtime-repo")).toBe(false);
+    expect(loadRepos({ root }).has("existing")).toBe(true);
   });
 
-  test("validates registrations, requires bearer authentication, and blocks active deletion", async () => {
-    const api = await makeServer({
-      autoAuthorize: false,
-      repos: () => new Map([["existing", repo()]]),
-    });
+  test("a write the loader rejects returns 422 and leaves the registry untouched", async () => {
+    const { root } = factoryRoot();
+    const file = path.join(root, "config", "repos.yaml");
+    const before = readFileSync(file, "utf8");
+    const api = await server(root);
     try {
-      const unauthorized = await fetch(api.url("/repos"), { method: "POST" });
-      expect(unauthorized.status).toBe(401);
+      // Passes the API's field validation; the loader requires a path.
+      const created = await api.request("/repos", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "pathless",
+          github: "watt-mind/pathless",
+        }),
+      });
+      expect(created.status).toBe(422);
+      expect((await created.json()).error).toContain("pathless has no path");
+      expect((await api.request("/repos/pathless")).status).toBe(404);
+      expect(readFileSync(file, "utf8")).toBe(before);
 
       const invalid = await api.request("/repos", {
         method: "POST",
@@ -81,25 +209,132 @@ describe("repository management API", () => {
       });
       expect(invalid.status).toBe(422);
 
-      api.db
-        .query(
-          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
-           VALUES (?, ?, ?, ?, ?, ?, ?)`,
-        )
-        .run(
-          "run-active",
-          "active-key",
-          JSON.stringify({ input: { repo: "existing" } }),
-          "hash",
-          "RUNNING",
-          new Date().toISOString(),
-          new Date().toISOString(),
-        );
+      const unknown = await api.request("/repos/existing", {
+        method: "PATCH",
+        body: JSON.stringify({ base: "main" }),
+      });
+      expect(unknown.status).toBe(422);
+      expect(readFileSync(file, "utf8")).toBe(before);
+    } finally {
+      api.close();
+    }
+  });
+
+  test("sync re-reads the in-repo overlay and reports whether it applies", async () => {
+    const { root, checkout } = factoryRoot();
+    const api = await server(root);
+    try {
+      writeFileSync(
+        path.join(checkout, ".factory.yaml"),
+        "schemaVersion: factory.repo/v1\nbase: release\n",
+      );
+      const synced = await api.request("/repos/existing/sync", {
+        method: "POST",
+        body: "{}",
+      });
+      expect(synced.status).toBe(200);
+      const body = await synced.json();
+      expect(body.refreshed).toBe(true);
+      expect(body.overlay).toEqual({ status: "applied", error: null });
+      expect(body.repo).toMatchObject({
+        configSource: "in-repo",
+        base: "release",
+        sync: { overlay: { status: "applied", error: null } },
+      });
+
+      // A host-owned key in the overlay is ignored, and sync says so.
+      writeFileSync(
+        path.join(checkout, ".factory.yaml"),
+        "schemaVersion: factory.repo/v1\nmax_in_flight: 9\n",
+      );
+      const ignored = await api.request("/repos/existing/sync", {
+        method: "POST",
+        body: "{}",
+      });
+      expect(ignored.status).toBe(200);
+      const ignoredBody = await ignored.json();
+      expect(ignoredBody.overlay.status).toBe("ignored");
+      expect(ignoredBody.overlay.error).toContain("host-owned");
+      expect(ignoredBody.repo).toMatchObject({
+        configSource: "host",
+        maxInFlight: 2,
+      });
+
+      expect(
+        (await api.request("/repos/nope/sync", { method: "POST", body: "{}" }))
+          .status,
+      ).toBe(404);
+    } finally {
+      api.close();
+    }
+  });
+
+  test("mutating routes require the control bearer", async () => {
+    const { root } = factoryRoot();
+    const api = await server(root, { autoAuthorize: false });
+    try {
+      for (const [target, method] of [
+        ["/repos", "POST"],
+        ["/repos/existing", "PATCH"],
+        ["/repos/existing", "DELETE"],
+        ["/repos/existing/sync", "POST"],
+      ]) {
+        const missing = await fetch(api.url(target), { method, body: "{}" });
+        expect([target, method, missing.status]).toEqual([target, method, 401]);
+        const wrong = await fetch(api.url(target), {
+          method,
+          body: "{}",
+          headers: { authorization: "Bearer not-the-token" },
+        });
+        expect([target, method, wrong.status]).toEqual([target, method, 401]);
+      }
+      // Nothing leaked through: the host entry is still intact.
+      expect(loadRepos({ root }).get("existing")?.maxInFlight).toBe(2);
+    } finally {
+      api.close();
+    }
+  });
+
+  test("active runs are counted per repo in SQL and block deletion", async () => {
+    const { root } = factoryRoot({
+      extraYaml: `  - name: other
+    path: /missing/other
+    github: watt-mind/other
+`,
+    });
+    const api = await server(root);
+    try {
+      insertRun(api.db, JSON.stringify({ input: { repo: "existing" } }));
+      insertRun(
+        api.db,
+        JSON.stringify({ input: { repoPin: { repo: "existing" } } }),
+      );
+      insertRun(
+        api.db,
+        JSON.stringify({ input: { repos: ["other", { name: "existing" }] } }),
+      );
+      insertRun(
+        api.db,
+        JSON.stringify({ input: { repo: "existing" } }),
+        "DONE",
+      );
+      insertRun(api.db, "{not json");
+
+      const existing = await api.request("/repos/existing");
+      expect((await existing.json()).repo.inFlight).toBe(3);
+      const other = await api.request("/repos/other");
+      expect((await other.json()).repo.inFlight).toBe(1);
+      const listed = await (await api.request("/repos")).json();
+      expect(
+        Object.fromEntries(listed.details.map((r) => [r.name, r.inFlight])),
+      ).toEqual({ existing: 3, other: 1 });
+
       const blocked = await api.request("/repos/existing", {
         method: "DELETE",
       });
       expect(blocked.status).toBe(409);
-      expect((await blocked.json()).error).toContain("active run");
+      expect((await blocked.json()).error).toContain("3 active run(s)");
+      expect(loadRepos({ root }).has("existing")).toBe(true);
     } finally {
       api.close();
     }

--- a/event-runtime/lib/api-repos.test.mjs
+++ b/event-runtime/lib/api-repos.test.mjs
@@ -1,0 +1,107 @@
+import { describe, expect, test } from "bun:test";
+import { makeServer } from "./api-test-helpers.mjs";
+
+function repo(name = "existing") {
+  return {
+    name,
+    github: `watt-mind/${name}`,
+    path: "/missing/checkout",
+    controlPlane: "github",
+    base: "develop",
+    reportOnly: false,
+    maxInFlight: 2,
+  };
+}
+
+describe("repository management API", () => {
+  test("lists host state, registers runtime repos, patches flags, and syncs", async () => {
+    const api = await makeServer({
+      repos: () => new Map([["existing", repo()]]),
+    });
+    try {
+      const listed = await api.request("/repos/existing");
+      expect(listed.status).toBe(200);
+      expect((await listed.json()).repo).toMatchObject({
+        name: "existing",
+        configSource: "host",
+        health: { status: "missing_checkout" },
+        inFlight: 0,
+      });
+
+      const created = await api.request("/repos", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "runtime-repo",
+          github: "watt-mind/runtime-repo",
+          path: "/runtime/repo",
+          controlPlane: "github",
+          maxInFlight: 4,
+        }),
+      });
+      expect(created.status).toBe(201);
+      expect((await created.json()).repo).toMatchObject({
+        name: "runtime-repo",
+        configSource: "runtime",
+        maxInFlight: 4,
+      });
+
+      const patched = await api.request("/repos/runtime-repo", {
+        method: "PATCH",
+        body: JSON.stringify({ reportOnly: true, runnerLabels: ["linux"] }),
+      });
+      expect(patched.status).toBe(200);
+      expect((await patched.json()).repo).toMatchObject({
+        reportOnly: true,
+        runnerLabels: ["linux"],
+      });
+
+      const synced = await api.request("/repos/runtime-repo/sync", {
+        method: "POST",
+        body: "{}",
+      });
+      expect(synced.status).toBe(200);
+      expect((await synced.json()).invalidated).toBe(true);
+    } finally {
+      api.close();
+    }
+  });
+
+  test("validates registrations, requires bearer authentication, and blocks active deletion", async () => {
+    const api = await makeServer({
+      autoAuthorize: false,
+      repos: () => new Map([["existing", repo()]]),
+    });
+    try {
+      const unauthorized = await fetch(api.url("/repos"), { method: "POST" });
+      expect(unauthorized.status).toBe(401);
+
+      const invalid = await api.request("/repos", {
+        method: "POST",
+        body: JSON.stringify({ name: "bad name", github: "not-a-slug" }),
+      });
+      expect(invalid.status).toBe(422);
+
+      api.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, created_at, updated_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          "run-active",
+          "active-key",
+          JSON.stringify({ input: { repo: "existing" } }),
+          "hash",
+          "RUNNING",
+          new Date().toISOString(),
+          new Date().toISOString(),
+        );
+      const blocked = await api.request("/repos/existing", {
+        method: "DELETE",
+      });
+      expect(blocked.status).toBe(409);
+      expect((await blocked.json()).error).toContain("active run");
+    } finally {
+      api.close();
+    }
+  });
+});

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -28,6 +28,7 @@ import { handleChainApiRoute } from "./api-chain.mjs";
 import { handleConfigApiRoute } from "./api-config.mjs";
 import { handleMetricsApiRoute } from "./api-metrics.mjs";
 import { handlePanelsApiRoute } from "./api-panels.mjs";
+import { createRepoApi } from "./api-repos.mjs";
 import { handleRegistryApiRoute } from "./api-registry.mjs";
 import {
   handleRunApiRoute,
@@ -167,6 +168,7 @@ export function createApi({
   let cachedArtifactResultsRowid = null;
   let cachedArtifactInventory = null;
   let cachedArtifactInventoryAt = 0;
+  const repoApi = createRepoApi({ repos, db });
 
   function getStoreStats(nowMs) {
     if (cachedStoreStats && nowMs - cachedStoreStatsAt < storeStatsTtlMs)
@@ -275,7 +277,7 @@ export function createApi({
         githubSecret,
         policyVersion,
         env,
-        repos,
+        repos: repoApi.repos,
         workerPolicy,
         workerRunDir,
         nowMs,
@@ -467,6 +469,10 @@ export function createApi({
       }
       if (url.pathname === "/panels") {
         const result = handlePanelsApiRoute(common);
+        if (result !== false) return result;
+      }
+      if (url.pathname === "/repos" || url.pathname.startsWith("/repos/")) {
+        const result = await repoApi.handle(common);
         if (result !== false) return result;
       }
       if (

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -168,7 +168,7 @@ export function createApi({
   let cachedArtifactResultsRowid = null;
   let cachedArtifactInventory = null;
   let cachedArtifactInventoryAt = 0;
-  const repoApi = createRepoApi({ repos, db });
+  const repoApi = createRepoApi({ repos, db, configRoot });
 
   function getStoreStats(nowMs) {
     if (cachedStoreStats && nowMs - cachedStoreStatsAt < storeStatsTtlMs)


### PR DESCRIPTION
Fixes watt-mind/factory#1639

Adds Bearer-protected runtime repository management endpoints. Authorised by operator:preapproved-2026-08-29 (2026-08-30T17:19:44.206Z).

## Validation

| Check                | Command | Result | Notes |
| -------------------- | ------- | ------ | ----- |
| Verification Command | `bun test event-runtime/lib/api-config.test.mjs` | pass | 13 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2226 pass, 10 skipped; emit, format, lint clean |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_45ed52a1-d648-48e0-ad27-18e638e5dd4d
## Post-review

Reviewer verdict FIX, addressed in `4dab3ac6`:

1. **Write-through.** `POST`/`PATCH`/`DELETE /repos…` now mutate `config/repos.yaml` (the effective file; the example is used as the seed when no local file exists) instead of process-local Maps. The candidate YAML is validated by the real `loadRepos()` on a scratch copy first, then committed with tmp-file + `rename`. A loader rejection is a `422` naming `config/repos.yaml` and leaves the file (and memory) untouched. Keys the loader does not model (e.g. `team`) survive the rewrite; YAML comments do not — `Bun.YAML.stringify` re-emits the document.
2. **`GET /repos`.** Handled in `api-repos.mjs`: `repos` stays the untouched `reposView()` projection (asserted equal in the test) and a sibling `details: [...]` carries `configSource` (`in-repo` / `host`), `overlay` (`applied` / `absent` / `ignored` + error), `health`, `inFlight`, `sync`. `RepoError` still surfaces as `500 {error}` (OPS-212/OPS-346).
3. **`sync`.** There is no overlay cache in `repos.mjs` (#1798 loads `.factory.yaml` on every `loadRepos()` call), so "invalidate" is a forced re-read: the route calls `loadInRepoConfig(repo.path)` and returns `{ overlay, refreshed: true }` plus fresh details; a malformed or host-owned-key overlay reports `ignored` with the loader's message.
4. **Cleanups.** Dead `const base = repos()` gone; `activeRunCount` filters per repo in SQL (`json_extract` over `input.repo`, `input.repoPin.repo`, `input.repos[]`, guarded by `json_valid`) and is memoised per request for the collection.
5. **Tests.** 401 for missing and wrong bearer on POST, PATCH, DELETE and `/sync`; successful DELETE (and 404 after); GET 404; restart-safe round-trip through a fresh server on the same root; 422 path with file byte-equality; per-repo SQL counting including a malformed spec row.

Notes: `runner_labels` is persisted in the host entry and projected from it — nothing else in the runtime consumes it yet. `path` stays optional at the API layer as the ticket states, but the loader requires it, so omitting it is the canonical 422.

CI: `serve startup banner warns when FACTORY_EVENT_SECRET is unset` failed on the previous head's Fast-unit lane. It passes 3/3 locally in a clean env on this develop-based tree; on the runner, serve printed the `control API on` banner without the `webhook intake: disabled` line, i.e. the operator-box runner supplies a secret from outside the process env. Runner env leakage, not this PR.

Local: `bun test event-runtime/lib` 2244 pass / 0 fail; `bun run lint` 0 errors; `bun run format:check` clean.