### PR TITLE
fix(lib): prefer running checkout for factory root

### DIFF
--- a/lib/factory-root.mjs
+++ b/lib/factory-root.mjs
@@ -1,5 +1,6 @@
 /**
- * Resolve the factory checkout from env, default path, or this file's location.
+ * Resolve the factory checkout from a validated env override, this module's
+ * checkout, then ~/Develop/factory as a final fallback.
  */
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
@@ -13,14 +14,14 @@ export function factoryRoot() {
   const env = process.env.FACTORY_ROOT;
   if (env && existsSync(path.join(env, MARKER))) return path.resolve(env);
 
-  const defaultPath = path.join(homedir(), "Develop/factory");
-  if (existsSync(path.join(defaultPath, MARKER))) return defaultPath;
-
   const fromLib = path.resolve(
     path.dirname(fileURLToPath(import.meta.url)),
     "..",
   );
   if (existsSync(path.join(fromLib, MARKER))) return fromLib;
+
+  const defaultPath = path.join(homedir(), "Develop/factory");
+  if (existsSync(path.join(defaultPath, MARKER))) return defaultPath;
 
   return env ? path.resolve(env) : defaultPath;
 }

--- a/lib/factory-root.test.mjs
+++ b/lib/factory-root.test.mjs
@@ -1,9 +1,40 @@
 import { test, expect } from "bun:test";
-import { existsSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 import { factoryRoot } from "./factory-root.mjs";
 
-test("factoryRoot finds the checkout from lib/ location", () => {
-  const root = factoryRoot();
-  expect(existsSync(path.join(root, "tools/linear.mjs"))).toBe(true);
+function restoreEnv(name, value) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function checkoutAt(root) {
+  mkdirSync(path.join(root, "tools"), { recursive: true });
+  writeFileSync(path.join(root, "tools", "linear.mjs"), "");
+}
+
+test("factoryRoot prefers a valid env override, then its running checkout", () => {
+  const previousFactoryRoot = process.env.FACTORY_ROOT;
+  const previousHome = process.env.HOME;
+  const tempRoot = mkdtempSync(path.join(tmpdir(), "factory-root-"));
+  const envRoot = path.join(tempRoot, "env-root");
+  const fakeHome = path.join(tempRoot, "home");
+  const runningRoot = path.resolve(import.meta.dir, "..");
+
+  try {
+    checkoutAt(envRoot);
+    checkoutAt(path.join(fakeHome, "Develop", "factory"));
+
+    process.env.FACTORY_ROOT = envRoot;
+    expect(factoryRoot()).toBe(envRoot);
+
+    delete process.env.FACTORY_ROOT;
+    process.env.HOME = fakeHome;
+    expect(factoryRoot()).toBe(runningRoot);
+  } finally {
+    restoreEnv("FACTORY_ROOT", previousFactoryRoot);
+    restoreEnv("HOME", previousHome);
+    rmSync(tempRoot, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1825

Factory commands now resolve the executing checkout before the legacy default path; `env -u FACTORY_ROOT bun orchestrator/doctor.mjs --repo factory` exited 0 from this worktree.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                          |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------ |
| Verification Command | `bun test lib/factory-root.test.mjs lib/notify.test.mjs orchestrator/doctor.test.mjs orchestrator/ps.test.mjs && bun run lint` | pass    | 78 tests, 0 failures           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2224 passed, 10 skipped        |
| Doctor worktree      | `env -u FACTORY_ROOT bun orchestrator/doctor.mjs --repo factory`                                           | pass    | worktree config, exit 0        |
| UX critique          | factory-ux-critic                                                                                            | not run | no user-facing surface         |

UX critique: skipped

run:$FACTORY_RUN_ID