### PR TITLE
fix(cli): paginate cancel state selection

### DIFF
--- a/event-runtime/cli/cancel.mjs
+++ b/event-runtime/cli/cancel.mjs
@@ -1,6 +1,16 @@
 import { fail, withClient } from "./shared.mjs";
 
 export const CANCEL_CONCURRENCY = 4;
+// A state selection is intentionally exhaustive, but must not follow a
+// malformed server cursor indefinitely. This matches the 50-page bound used
+// by `factory runs` (at most 10,000 rows at the API's maximum page size).
+export const CANCEL_MAX_PAGES = 50;
+
+function pagingError(message) {
+  // `withClient` reserves an absent status for connection failures. Mark local
+  // pagination validation errors so its CLI wrapper preserves this message.
+  return Object.assign(new Error(message), { status: 400 });
+}
 
 function optionValue(args, index, option) {
   const value = args[index + 1];
@@ -93,26 +103,53 @@ async function cancelAll(client, ids, reason) {
   return !failed;
 }
 
-export default function cancel(args) {
+export async function stateRunIds(client, options) {
+  const ids = [];
+  let before = null;
+  let pages = 0;
+
+  while (true) {
+    const page = await client.runs({
+      state: options.state,
+      ...(options.agent ? { agent: options.agent } : {}),
+      ...(before ? { before } : {}),
+    });
+    pages += 1;
+    ids.push(...(page.runs ?? []).map((run) => run.runId));
+
+    if (page.nextBefore == null) return ids;
+    if (typeof page.nextBefore !== "string" || page.nextBefore === "") {
+      throw pagingError(
+        "runs response has a next page but no nextBefore cursor",
+      );
+    }
+    if (pages >= CANCEL_MAX_PAGES) {
+      throw pagingError(
+        `cancel state selection exceeded the ${CANCEL_MAX_PAGES} page cap; narrow the state or agent filter`,
+      );
+    }
+    before = page.nextBefore;
+  }
+}
+
+export async function cancelWithClient(client, args) {
   const options = parseCancelArgs(args);
-  return withClient(async (client) => {
-    let ids = options.ids;
-    if (options.state) {
-      const page = await client.runs({
-        state: options.state,
-        ...(options.agent ? { agent: options.agent } : {}),
-      });
-      ids = (page.runs ?? []).map((run) => run.runId);
-      printTargets(ids);
-      if (options.dryRun || !ids.length) return;
-      if (ids.length > 1 && !options.yes) {
-        console.error("refusing to cancel multiple runs without --yes");
-        process.exitCode = 1;
-        return;
-      }
-    }
-    if (!(await cancelAll(client, ids, options.reason))) {
+  let ids = options.ids;
+  if (options.state) {
+    ids = await stateRunIds(client, options);
+    printTargets(ids);
+    if (options.dryRun || !ids.length) return;
+    if (ids.length > 1 && !options.yes) {
+      console.error("refusing to cancel multiple runs without --yes");
       process.exitCode = 1;
+      return;
     }
-  });
+  }
+  if (!(await cancelAll(client, ids, options.reason))) {
+    process.exitCode = 1;
+  }
+}
+
+export default function cancel(args) {
+  return withClient((client) => cancelWithClient(client, args));
 }

--- a/event-runtime/cli/cancel.test.mjs
+++ b/event-runtime/cli/cancel.test.mjs
@@ -1,0 +1,121 @@
+import { describe, expect, test } from "bun:test";
+import { CANCEL_MAX_PAGES, cancelWithClient, stateRunIds } from "./cancel.mjs";
+
+function captureConsole() {
+  const out = [];
+  const err = [];
+  const log = console.log;
+  const error = console.error;
+  console.log = (...values) => out.push(values.join(" "));
+  console.error = (...values) => err.push(values.join(" "));
+  return {
+    out,
+    err,
+    restore: () => ((console.log = log), (console.error = error)),
+  };
+}
+
+describe("cancel", () => {
+  test("cancels every ID in a multi-page state selection", async () => {
+    const runCalls = [];
+    const cancelled = [];
+    const client = {
+      runs: async (options) => {
+        runCalls.push(options);
+        return options.before
+          ? { runs: [{ runId: "run-2" }], nextBefore: null }
+          : { runs: [{ runId: "run-1" }], nextBefore: "cursor-1" };
+      },
+      cancel: async (runId, reason) => cancelled.push([runId, reason]),
+    };
+    const consoleCapture = captureConsole();
+    try {
+      await cancelWithClient(client, ["--state", "proposed", "--yes"]);
+    } finally {
+      consoleCapture.restore();
+    }
+
+    expect(runCalls).toEqual([
+      { state: "PROPOSED" },
+      { state: "PROPOSED", before: "cursor-1" },
+    ]);
+    expect(cancelled.sort()).toEqual([
+      ["run-1", undefined],
+      ["run-2", undefined],
+    ]);
+    expect(consoleCapture.out).toEqual([
+      "run-1",
+      "run-2",
+      "cancelled run-1",
+      "cancelled run-2",
+    ]);
+  });
+
+  test("dry-run prints every multi-page target without cancelling", async () => {
+    const runCalls = [];
+    const client = {
+      runs: async (options) => {
+        runCalls.push(options);
+        return options.before
+          ? { runs: [{ runId: "run-2" }], nextBefore: null }
+          : { runs: [{ runId: "run-1" }], nextBefore: "cursor-1" };
+      },
+      cancel: async () => {
+        throw new Error("dry-run must not cancel");
+      },
+    };
+    const consoleCapture = captureConsole();
+    try {
+      await cancelWithClient(client, [
+        "--state",
+        "PROPOSED",
+        "--agent",
+        "worker@1",
+        "--dry-run",
+      ]);
+    } finally {
+      consoleCapture.restore();
+    }
+
+    expect(runCalls).toEqual([
+      { state: "PROPOSED", agent: "worker@1" },
+      { state: "PROPOSED", agent: "worker@1", before: "cursor-1" },
+    ]);
+    expect(consoleCapture.out).toEqual(["run-1", "run-2"]);
+  });
+
+  test("preserves explicit-ID cancellation", async () => {
+    const cancelled = [];
+    const client = {
+      runs: async () => {
+        throw new Error("explicit IDs must not list runs");
+      },
+      cancel: async (runId, reason) => cancelled.push([runId, reason]),
+    };
+
+    await cancelWithClient(client, ["run-1", "run-2", "--reason", "cleanup"]);
+
+    expect(cancelled.sort()).toEqual([
+      ["run-1", "cleanup"],
+      ["run-2", "cleanup"],
+    ]);
+  });
+
+  test("rejects an unbounded state selection before cancelling targets", async () => {
+    let calls = 0;
+    const client = {
+      runs: async () => {
+        calls += 1;
+        return {
+          runs: [{ runId: `run-${calls}` }],
+          nextBefore: `cursor-${calls}`,
+        };
+      },
+    };
+
+    await expect(stateRunIds(client, { state: "PROPOSED" })).rejects.toThrow(
+      `${CANCEL_MAX_PAGES} page cap`,
+    );
+    expect(calls).toBe(CANCEL_MAX_PAGES);
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1826

Canceling by state now exhaustively collects paginated run IDs before printing or acting on the selection.

## Validation

| Check                | Command                                                                                                           | Result  | Notes                            |
| -------------------- | ----------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------- |
| Verification Command | `bun test event-runtime/cli/cancel.test.mjs`                                                                     | pass    | 4 tests, 0 failures             |
| Verification Command | `bun run lint`                                                                                                   | pass    | 0 errors; 613 existing warnings |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,236 tests; clean formatting   |
| UX critique          | factory-ux-critic                                                                                                 | not run | no user-facing surface           |

UX critique: skipped — CLI-only behavior with no user-facing surface

run:run_60c865cd-74a1-4a53-a704-925834927bf0
