### PR TITLE
fix(orchestrator): distinguish spawn failures from gate failures

### DIFF
--- a/orchestrator/run.mjs
+++ b/orchestrator/run.mjs
@@ -176,74 +176,84 @@ export function createJobRunner({
     running.add(job.name);
     refreshTitle();
     try {
-      // A gate is what makes frequent polling affordable: checking costs one
-      // cheap query, spawning an agent costs budget. Exit 0 = work exists,
-      // 1 = idle, anything else is surfaced rather than silently skipped.
-      if (job.gate_command && shouldProbeGate) {
-        const { code, out } = await probe(job.gate_command);
-        if (code === 1) {
+      try {
+        // A gate is what makes frequent polling affordable: checking costs one
+        // cheap query, spawning an agent costs budget. Exit 0 = work exists,
+        // 1 = idle, anything else is surfaced rather than silently skipped.
+        if (job.gate_command && shouldProbeGate) {
+          const { code, out } = await probe(job.gate_command);
+          if (code === 1) {
+            log(
+              `${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`,
+            );
+            return;
+          }
+          if (code !== 0) {
+            onFailed();
+            log(
+              `${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`,
+            );
+            return;
+          }
           log(
-            `${c.dim(clock())} ${c.dim("idle")}  ${job.name} ${c.dim(`— ${out.split("\n").pop() || "nothing to do"}`)}`,
+            `${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`,
           );
-          return;
         }
-        if (code !== 0) {
-          onFailed();
-          log(
-            `${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(`exit ${code}: ${out.split("\n").pop()}`)}`,
-          );
-          return;
-        }
-        log(
-          `${c.dim(clock())} ${c.green("gate")}  ${job.name} ${c.dim(out.split("\n").pop() || "")}`,
-        );
-      }
-
-      const cmd = commandFor(job);
-      const started = Date.now();
-      log(
-        `${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`,
-      );
-
-      const code = await new Promise((resolve, reject) => {
-        const child = spawnCommand(cmd);
-        const prefix = c.dim("  │ ");
-        const pipe = (stream, color) => {
-          let buf = "";
-          stream.on("data", (data) => {
-            buf += data.toString();
-            const lines = buf.split("\n");
-            buf = lines.pop();
-            for (const line of lines)
-              log(prefix + (color ? color(line) : line));
-          });
-          stream.on("end", () => {
-            if (buf.trim()) log(prefix + (color ? color(buf) : buf));
-          });
-        };
-        pipe(child.stdout);
-        pipe(child.stderr, c.red);
-        child.once("error", reject);
-        child.once("close", resolve);
-      });
-
-      const secs = ((Date.now() - started) / 1000).toFixed(1);
-      if (code === 0) {
-        onCompleted();
-        log(
-          `${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`,
-        );
-      } else {
+      } catch (error) {
         onFailed();
         log(
-          `${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`,
+          `${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(error instanceof Error ? error.message : String(error))}`,
+        );
+        return;
+      }
+
+      try {
+        const cmd = commandFor(job);
+        const started = Date.now();
+        log(
+          `${c.dim(clock())} ${c.cyan("start")} ${c.bold(job.name)} ${c.dim(cmd)}`,
+        );
+
+        const code = await new Promise((resolve, reject) => {
+          const child = spawnCommand(cmd);
+          const prefix = c.dim("  │ ");
+          const pipe = (stream, color) => {
+            let buf = "";
+            stream.on("data", (data) => {
+              buf += data.toString();
+              const lines = buf.split("\n");
+              buf = lines.pop();
+              for (const line of lines)
+                log(prefix + (color ? color(line) : line));
+            });
+            stream.on("end", () => {
+              if (buf.trim()) log(prefix + (color ? color(buf) : buf));
+            });
+          };
+          pipe(child.stdout);
+          pipe(child.stderr, c.red);
+          child.once("error", reject);
+          child.once("close", resolve);
+        });
+
+        const secs = ((Date.now() - started) / 1000).toFixed(1);
+        if (code === 0) {
+          onCompleted();
+          log(
+            `${c.dim(clock())} ${c.green("done")}  ${job.name} ${c.dim(`(${secs}s)`)}`,
+          );
+        } else {
+          onFailed();
+          log(
+            `${c.dim(clock())} ${c.red("FAIL")}  ${job.name} ${c.dim(`exit ${code}, ${secs}s`)}`,
+          );
+        }
+      } catch (error) {
+        onFailed();
+        log(
+          `${c.dim(clock())} ${c.red("SPAWN FAIL")} ${job.name} ${c.dim(error instanceof Error ? error.message : String(error))}`,
         );
       }
-    } catch (error) {
-      onFailed();
-      log(
-        `${c.dim(clock())} ${c.red("GATE FAIL")} ${job.name} ${c.dim(error instanceof Error ? error.message : String(error))}`,
-      );
     } finally {
       running.delete(job.name);
       refreshTitle();

--- a/orchestrator/run.test.mjs
+++ b/orchestrator/run.test.mjs
@@ -194,6 +194,8 @@ test("an idle gate releases its job for the next tick", async () => {
 
 test("a rejected gate probe releases its job for the next tick", async () => {
   const running = new Set();
+  const logs = [];
+  let failed = 0;
   let probes = 0;
   const runJob = createJobRunner({
     running,
@@ -206,7 +208,10 @@ test("a rejected gate probe releases its job for the next tick", async () => {
     },
     commandFor: () => "echo work",
     shouldProbeGate: true,
-    log: () => {},
+    log: (message) => logs.push(message),
+    onFailed: () => {
+      failed++;
+    },
   });
   const job = { name: "dispatch", gate_command: "queue --gate" };
 
@@ -214,5 +219,61 @@ test("a rejected gate probe releases its job for the next tick", async () => {
   await runJob(job);
 
   expect(probes).toBe(2);
+  expect(failed).toBe(2);
+  expect(logs.every((message) => message.includes("GATE FAIL"))).toBe(true);
+  expect(running.size).toBe(0);
+});
+
+test("a synchronous spawn failure is labeled separately from a gate failure", async () => {
+  const running = new Set();
+  const logs = [];
+  let failed = 0;
+  const runJob = createJobRunner({
+    running,
+    probe: () => Promise.resolve({ code: 0, out: "work found" }),
+    spawnCommand: () => {
+      throw new Error("spawn unavailable");
+    },
+    commandFor: () => "echo work",
+    shouldProbeGate: false,
+    log: (message) => logs.push(message),
+    onFailed: () => {
+      failed++;
+    },
+  });
+
+  await runJob({ name: "dispatch" });
+
+  expect(failed).toBe(1);
+  expect(logs.some((message) => message.includes("SPAWN FAIL"))).toBe(true);
+  expect(logs.some((message) => message.includes("GATE FAIL"))).toBe(false);
+  expect(running.size).toBe(0);
+});
+
+test("a child error is labeled separately from a gate failure", async () => {
+  const running = new Set();
+  const logs = [];
+  let failed = 0;
+  const child = runnableChild();
+  const runJob = createJobRunner({
+    running,
+    probe: () => Promise.resolve({ code: 0, out: "work found" }),
+    spawnCommand: () => child,
+    commandFor: () => "echo work",
+    shouldProbeGate: false,
+    log: (message) => logs.push(message),
+    onFailed: () => {
+      failed++;
+    },
+  });
+
+  const run = runJob({ name: "dispatch" });
+  await Promise.resolve();
+  child.emit("error", new Error("ENOENT"));
+  await run;
+
+  expect(failed).toBe(1);
+  expect(logs.some((message) => message.includes("SPAWN FAIL"))).toBe(true);
+  expect(logs.some((message) => message.includes("GATE FAIL"))).toBe(false);
   expect(running.size).toBe(0);
 });


### PR DESCRIPTION
Fixes #1827

Supervisor logs now distinguish gate-probe failures from job-spawn failures, so operators can investigate the failing phase.

## Validation

| Check                | Command                                                                          | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test orchestrator/run.test.mjs && bun run lint`                             | pass    | 9 tests, 0 failures; lint 0 errors         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,240 tests, 0 failures; clean emit/format |
| UX critique          | `factory-ux-critic`                                                             | not run | no user-facing surface                     |

UX critique: skipped

run:$FACTORY_RUN_ID
