### PR TITLE
fix(dispatch): reject literal run trailers

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:66fb358bd8f192a768fc0101923095b3164fdd2ce270af163c28b9c62c0ec3cb",
+    "agents/dispatch.md": "sha256:60d9694697d98b2d5828fc41c449105b08a87fd114922ba42ed6297d915da367",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:60d9694697d98b2d5828fc41c449105b08a87fd114922ba42ed6297d915da367",
+    "agents/dispatch.md": "sha256:74c8bcad35d975b55aa9f48efc3d869e1618afbc222f491d401c22d76a8f98f4",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -154,14 +154,17 @@ shell` means the spawn prompt was defective: correct its path/launch details
 
    UX critique: <status>
 
-   run:$FACTORY_RUN_ID
+   <append the concrete run ID with: printf 'run:%s\n' "$FACTORY_RUN_ID">
    ```
 
-   `Fixes <TICKET>` and the trailing `run:$FACTORY_RUN_ID` are unchanged
+   `Fixes <TICKET>` and the trailing concrete `run:<run-id>` line are unchanged
    required lines — the `## Validation` section is added between them, never
-   in place of either. Omit the `run:` line only when `$FACTORY_RUN_ID` is
-   unset (an interactive session). `UX critique: <status>` still appears in
-   the body, and the table's UX row carries the same status.
+   in place of either. Append the trailer with `printf 'run:%s\n'
+"$FACTORY_RUN_ID"`; a quoted heredoc or `--body-file` leaves the literal
+   `run:$FACTORY_RUN_ID` unexpanded and is rejected by handoff verification.
+   Omit the `run:` line only when `$FACTORY_RUN_ID` is unset (an interactive
+   session). `UX critique: <status>` still appears in the body, and the table's
+   UX row carries the same status.
 
    **Every row is an observation, not an assertion.** A row names a command you
    actually ran in `./repo` and records the exit status you actually saw:

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -154,14 +154,15 @@ shell` means the spawn prompt was defective: correct its path/launch details
 
    UX critique: <status>
 
-   <append the concrete run ID with: printf 'run:%s\n' "$FACTORY_RUN_ID">
+   run:<concrete run id, e.g. run_0e2d13da-…>
    ```
 
    `Fixes <TICKET>` and the trailing concrete `run:<run-id>` line are unchanged
    required lines — the `## Validation` section is added between them, never
-   in place of either. Append the trailer with `printf 'run:%s\n'
-"$FACTORY_RUN_ID"`; a quoted heredoc or `--body-file` leaves the literal
-   `run:$FACTORY_RUN_ID` unexpanded and is rejected by handoff verification.
+   in place of either. Append the trailer with
+   `printf 'run:%s\n' "$FACTORY_RUN_ID"`; a quoted heredoc or `--body-file`
+   leaves the literal `run:$FACTORY_RUN_ID` unexpanded and is rejected by
+   handoff verification.
    Omit the `run:` line only when `$FACTORY_RUN_ID` is unset (an interactive
    session). `UX critique: <status>` still appears in the body, and the table's
    UX row carries the same status.

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3195,7 +3195,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:779fa866b66dd5422699118041cfa88e1545d4269468ad987d93e6db169265b7","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5ab07ac3ca2343a57082a2f66835f2480b5d27339e6b8adafff64fb8dccb8d95","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3195,7 +3195,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5ab07ac3ca2343a57082a2f66835f2480b5d27339e6b8adafff64fb8dccb8d95","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:b629b32521d6f81e9ba798403eeb8db6c7703745e42fd2ffe949d8a52a9d467d","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -408,7 +408,7 @@ describe("registry", () => {
     // Regenerated (#1829): dispatch emits a concrete run trailer and rejects
     // the literal environment-variable form during handoff verification.
     const expected =
-      "sha256:dbd5426576135c4c20545d719faacd9414ca8ffd1c2cace416f8632865f9cc94";
+      "sha256:28c5980c970e233ebefba80b8be53d94a711132b49f9666d5b5aa0b2c20e87db";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -698,7 +698,7 @@ describe("registry", () => {
     // Regenerated (#1829): dispatch emits the concrete run trailer with printf,
     // so quoted PR-body files cannot leave the environment variable literal.
     expect(computeDefHash(def)).toBe(
-      "sha256:5ab07ac3ca2343a57082a2f66835f2480b5d27339e6b8adafff64fb8dccb8d95",
+      "sha256:b629b32521d6f81e9ba798403eeb8db6c7703745e42fd2ffe949d8a52a9d467d",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -405,8 +405,10 @@ describe("registry", () => {
     // and HTML comment bodies; both prompt definitions are registry inputs.
     // Re-pinned (#1700 post-review): merge-fix templates the round cap as
     // `<max_fix_rounds>` instead of hardcoding 2.
+    // Regenerated (#1829): dispatch emits a concrete run trailer and rejects
+    // the literal environment-variable form during handoff verification.
     const expected =
-      "sha256:475609349143157c8b659367addb688b17847ea8218af380de5daba2c3b9059a";
+      "sha256:dbd5426576135c4c20545d719faacd9414ca8ffd1c2cace416f8632865f9cc94";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -693,8 +695,10 @@ describe("registry", () => {
     // waits via REST; prompt pin only, `pack` remains non-enumerable.
     // Regenerated (#1337): dispatch trusts the worker-verified authorisation;
     // prompt pin only, `pack` remains non-enumerable.
+    // Regenerated (#1829): dispatch emits the concrete run trailer with printf,
+    // so quoted PR-body files cannot leave the environment variable literal.
     expect(computeDefHash(def)).toBe(
-      "sha256:779fa866b66dd5422699118041cfa88e1545d4269468ad987d93e6db169265b7",
+      "sha256:5ab07ac3ca2343a57082a2f66835f2480b5d27339e6b8adafff64fb8dccb8d95",
     );
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2981,11 +2981,22 @@ export function assertHandoffPullRequestBase({
     typeof handoff.runId === "string" && handoff.runId.trim()
       ? bodyLines.some((line) => line.trim() === `run:${handoff.runId.trim()}`)
       : null;
+  const hasUnexpandedRunTrailer =
+    typeof handoff.runId === "string" && handoff.runId.trim()
+      ? bodyLines.some((line) => {
+          const trailer = line.trim();
+          return (
+            trailer === "run:$FACTORY_RUN_ID" ||
+            trailer === "run:${FACTORY_RUN_ID}"
+          );
+        })
+      : null;
   handoff.pr = {
     number: prNumber,
     draft: pr?.isDraft === true,
     hasFixesLine,
     hasRunTrailer,
+    hasUnexpandedRunTrailer,
   };
   handoff.prDraft = handoff.pr.draft;
   if (!actual) {
@@ -3008,6 +3019,14 @@ export function assertHandoffPullRequestBase({
         `handoff_pr_form_invalid: PR #${prNumber} is missing Fixes ${handoff.ticket}`,
       ],
       { reasonCode: "handoff_pr_form_invalid", handoff },
+    );
+  }
+  if (hasUnexpandedRunTrailer) {
+    throw new ContractViolation(
+      [
+        `run_trailer_unexpanded: PR #${prNumber} contains a literal run trailer; append the concrete run ID with printf 'run:%s\\n' "$FACTORY_RUN_ID"`,
+      ],
+      { reasonCode: "run_trailer_unexpanded", handoff },
     );
   }
 }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5395,7 +5395,7 @@ sh -c 'sleep 5 & wait'
     }
   });
 
-  test("handoff PR form records draft and body markers, refusing only a missing Fixes line", () => {
+  test("handoff PR form records draft and body markers, refusing malformed markers", () => {
     const base = {
       github: "watt-mind/factory",
       prNumber: 77,
@@ -5417,6 +5417,7 @@ sh -c 'sleep 5 & wait'
       draft: false,
       hasFixesLine: true,
       hasRunTrailer: true,
+      hasUnexpandedRunTrailer: false,
     });
 
     const warningOnly = { ...base };
@@ -5433,6 +5434,7 @@ sh -c 'sleep 5 & wait'
       draft: true,
       hasFixesLine: true,
       hasRunTrailer: false,
+      hasUnexpandedRunTrailer: false,
     });
 
     const missingFixes = { ...base };
@@ -5450,7 +5452,36 @@ sh -c 'sleep 5 & wait'
     expect(missingFixes.pr).toMatchObject({
       hasFixesLine: false,
       hasRunTrailer: true,
+      hasUnexpandedRunTrailer: false,
     });
+  });
+
+  test("handoff PR form rejects literal run trailers when a run ID is set", () => {
+    const base = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    for (const trailer of ["run:$FACTORY_RUN_ID", "run:${FACTORY_RUN_ID}"]) {
+      const handoff = { ...base };
+      expect(() =>
+        assertHandoffPullRequestBase({
+          handoff,
+          base: "develop",
+          fetchPullRequest: () => ({
+            baseRefName: "develop",
+            isDraft: false,
+            body: `Fixes watt-mind/factory#1504\n\n${trailer}`,
+          }),
+        }),
+      ).toThrow("run_trailer_unexpanded");
+      expect(handoff.pr).toMatchObject({
+        hasFixesLine: true,
+        hasRunTrailer: false,
+        hasUnexpandedRunTrailer: true,
+      });
+    }
   });
 
   test("handoff PR Fixes line tolerates the short #n form, case, and trailing punctuation", () => {
@@ -5478,6 +5509,7 @@ sh -c 'sleep 5 & wait'
       expect(handoff.pr).toMatchObject({
         hasFixesLine: true,
         hasRunTrailer: true,
+        hasUnexpandedRunTrailer: false,
       });
     }
 
@@ -5538,6 +5570,23 @@ sh -c 'sleep 5 & wait'
     expect(nullBody.pr).toMatchObject({
       hasFixesLine: false,
       hasRunTrailer: false,
+      hasUnexpandedRunTrailer: false,
+    });
+
+    const noRunId = { ...base, runId: undefined };
+    assertHandoffPullRequestBase({
+      handoff: noRunId,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: false,
+        body: "Fixes watt-mind/factory#1504\nrun:$FACTORY_RUN_ID",
+      }),
+    });
+    expect(noRunId.pr).toMatchObject({
+      hasFixesLine: true,
+      hasRunTrailer: null,
+      hasUnexpandedRunTrailer: null,
     });
 
     const noTicket = { ...base, ticket: null, runId: undefined };
@@ -5553,6 +5602,7 @@ sh -c 'sleep 5 & wait'
     expect(noTicket.pr).toMatchObject({
       hasFixesLine: null,
       hasRunTrailer: null,
+      hasUnexpandedRunTrailer: null,
     });
     expect(composeHandoffVerification(noTicket)).toContain(
       "Fixes: unknown · run trailer: unknown",


### PR DESCRIPTION
Fixes watt-mind/factory#1829

Prevent literal run trailers from passing dispatch handoff verification.

## Validation

| Check                | Command                                                                                                                        | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs` | pass    | 352 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`       | pass    | unit, emit, format, and lint completed |
| UX critique          | factory-ux-critic                                                                                                             | not run | no user-facing surface                 |

UX critique: skipped — backend dispatch/runtime validation only; no user-facing surface

run:run_0e2d13da-6b10-40a1-b516-4cf54da97a4a

## Post-review

Applied review nits in event-runtime/agents/dispatch.md: the fenced handoff template now shows a concrete run-id placeholder (printf guidance kept in prose, rewrapped for Prettier), and the continuation line is re-indented into the ordered-list item. Re-pinned the dispatch.md sha256 in dispatch.json, the defHash baseline in planner.test.mjs, and the registry digest in registry.test.mjs. bun test event-runtime/lib (2237 pass), lint, format:check all green.
