### PR TITLE
fix(forge): bound synchronous gh spawns

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -416,6 +416,14 @@ retry. For anything the verbs do not cover, `raw '<query>' --var k=v`
 beats inventing a new flag. Fallback when the CLI is missing:
 `bun "$FACTORY_ROOT/tools/linear.mjs"`.
 
+### GitHub CLI timeout
+
+The GitHub forge bounds every synchronous `gh` invocation with
+`FACTORY_GH_TIMEOUT_MS`, in milliseconds. It defaults to `30000`; set it to a
+positive integer to override that default. Invalid values emit a warning and
+use `30000` so a malformed environment never leaves a forge caller blocked
+indefinitely. Individual forge calls may still supply their own `timeout`.
+
 ## 14. Loops
 
 The factory commands (`/factory-work`, `/factory-merge`, `/factory-ship`,

--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -713,7 +713,7 @@ describe("github forge: REST PR reads", () => {
     const warnings = [];
     const exec = recorder({
       status: null,
-      signal: "SIGTERM",
+      signal: "SIGKILL",
       stdout: "",
       stderr: "",
       error: Object.assign(new Error("spawnSync gh ETIMEDOUT"), {

--- a/lib/forge/contract.test.mjs
+++ b/lib/forge/contract.test.mjs
@@ -690,6 +690,56 @@ describe("github forge: REST PR reads", () => {
     ]);
   });
 
+  test("gh spawns default to a validated timeout and preserve call overrides", () => {
+    const exec = recorder({ status: 0, stdout: "", stderr: "" });
+    const forge = githubForge({
+      exec,
+      env: { FACTORY_GH_TIMEOUT_MS: "45000" },
+    });
+    forge.prSetDraft("o/r", 42, false);
+    forge.prSetDraft("o/r", 42, true, { timeout: 5000 });
+    expect(exec.calls.map((call) => call.opts.timeout)).toEqual([45000, 5000]);
+    expect(exec.calls.map((call) => call.opts.killSignal)).toEqual([
+      "SIGKILL",
+      "SIGKILL",
+    ]);
+
+    const defaults = recorder({ status: 0, stdout: "", stderr: "" });
+    githubForge({ exec: defaults, env: {} }).prSetDraft("o/r", 42, false);
+    expect(defaults.calls[0].opts.timeout).toBe(30_000);
+  });
+
+  test("invalid FACTORY_GH_TIMEOUT_MS warns and timed-out gh maps to forge_timeout", () => {
+    const warnings = [];
+    const exec = recorder({
+      status: null,
+      signal: "SIGTERM",
+      stdout: "",
+      stderr: "",
+      error: Object.assign(new Error("spawnSync gh ETIMEDOUT"), {
+        code: "ETIMEDOUT",
+      }),
+    });
+    const forge = githubForge({
+      exec,
+      env: { FACTORY_GH_TIMEOUT_MS: "not-a-number" },
+      warn: (message) => warnings.push(message),
+    });
+    let err;
+    try {
+      forge.prSetDraft("o/r", 42, false);
+    } catch (cause) {
+      err = cause;
+    }
+    expect(warnings).toEqual([
+      'Invalid FACTORY_GH_TIMEOUT_MS="not-a-number"; using default 30000ms',
+    ]);
+    expect(exec.calls[0].opts.timeout).toBe(30_000);
+    expect(err).toBeInstanceOf(ForgeError);
+    expect(err.code).toBe("forge_timeout");
+    expect(err.message).toBe("gh pr timed out after 30000ms");
+  });
+
   test("prChecks required:true treats 401/403 on branch protection like 404 (App token)", () => {
     const protection = (stderr) =>
       recorder((_, args) => {

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -24,6 +24,7 @@ const text = (v) =>
 const REST_PAGE_SIZE = 100;
 const STATUS_PAGE_SIZE = 30;
 const GH_MAX_BUFFER = 64 * 1024 * 1024;
+const DEFAULT_GH_TIMEOUT_MS = 30_000;
 /** How long a hydrated `mergeable`/`mergeable_state` pair is reused. */
 const HYDRATION_TTL_MS = 120_000;
 const HYDRATION_CACHE_MAX = 2000;
@@ -34,6 +35,19 @@ const pick = (obj, fields) =>
   fields?.length
     ? Object.fromEntries(fields.map((field) => [field, obj[field]]))
     : { ...obj };
+
+function ghTimeoutMs(env, warn) {
+  const configured = env.FACTORY_GH_TIMEOUT_MS;
+  if (configured == null || configured === "") return DEFAULT_GH_TIMEOUT_MS;
+  if (/^\d+$/.test(configured)) {
+    const timeout = Number(configured);
+    if (Number.isSafeInteger(timeout) && timeout > 0) return timeout;
+  }
+  warn(
+    `Invalid FACTORY_GH_TIMEOUT_MS=${JSON.stringify(configured)}; using default ${DEFAULT_GH_TIMEOUT_MS}ms`,
+  );
+  return DEFAULT_GH_TIMEOUT_MS;
+}
 
 function restPullToPr(pull) {
   const mergeable =
@@ -165,6 +179,8 @@ function latestSuiteRuns(runs) {
 /**
  * @param {{
  *   exec?: (cmd: string, args: string[], opts: object) => { status?: number|null, exitCode?: number|null, stdout?: string|Buffer, stderr?: string|Buffer, error?: Error },
+ *   env?: Record<string, string|undefined>, // process environment (tests)
+ *   warn?: (message: string) => void, // invalid timeout configuration (tests)
  *   hydrationTtlMs?: number, // mergeability cache TTL (tests)
  *   now?: () => number,      // clock for that TTL (tests)
  * }} [options]
@@ -172,21 +188,26 @@ function latestSuiteRuns(runs) {
  */
 export function githubForge({
   exec = spawnSync,
+  env = process.env,
+  warn = console.warn,
   hydrationTtlMs = HYDRATION_TTL_MS,
   now = Date.now,
 } = {}) {
+  const defaultTimeout = ghTimeoutMs(env, warn);
   // Test fakes get a private cache so recorded call counts stay per-instance;
   // the real `gh` shares one so back-to-back loadForge() callers in a tick
   // (merge-scan lists open PRs twice) hydrate each head SHA once.
   const hydration = exec === spawnSync ? sharedHydration : new Map();
   /** Run `gh <args>`; throw ForgeError on non-zero exit or spawn failure. */
   function gh(args, { cwd, timeout } = {}) {
+    const budget = timeout === undefined ? defaultTimeout : timeout;
     const r =
       exec("gh", args, {
         cwd,
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
-        timeout,
+        timeout: budget,
+        killSignal: "SIGKILL",
         maxBuffer: GH_MAX_BUFFER,
       }) ?? {};
     // child_process shape first (`status`), Bun.spawnSync shape second
@@ -196,9 +217,12 @@ export function githubForge({
     const stderr =
       text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
     if (status !== 0) {
+      const timedOut = r.error?.code === "ETIMEDOUT" || r.signal === "SIGTERM";
       const bufferExceeded = r.error?.code === "ENOBUFS";
       const error = new ForgeError(
-        `${bufferExceeded ? "forge_read_failed: " : ""}gh ${args.slice(0, 2).join(" ")} failed (status ${status})`,
+        timedOut
+          ? `gh ${args[0]} timed out after ${budget}ms`
+          : `${bufferExceeded ? "forge_read_failed: " : ""}gh ${args.slice(0, 2).join(" ")} failed (status ${status})`,
         {
           status,
           stdout,
@@ -206,7 +230,8 @@ export function githubForge({
           cause: r.error,
         },
       );
-      if (bufferExceeded) error.code = "forge_read_failed";
+      if (timedOut) error.code = "forge_timeout";
+      else if (bufferExceeded) error.code = "forge_read_failed";
       throw error;
     }
     return stdout;

--- a/lib/forge/github.mjs
+++ b/lib/forge/github.mjs
@@ -217,7 +217,7 @@ export function githubForge({
     const stderr =
       text(r.stderr) || (r.error ? String(r.error.message ?? r.error) : "");
     if (status !== 0) {
-      const timedOut = r.error?.code === "ETIMEDOUT" || r.signal === "SIGTERM";
+      const timedOut = r.error?.code === "ETIMEDOUT" || r.signal === "SIGKILL";
       const bufferExceeded = r.error?.code === "ENOBUFS";
       const error = new ForgeError(
         timedOut

--- a/lib/forge/types.mjs
+++ b/lib/forge/types.mjs
@@ -28,7 +28,8 @@
 /**
  * @typedef {object} ForgeCallOpts
  * @property {string} [cwd]     working directory for the underlying command
- * @property {number} [timeout] milliseconds before the command is killed
+ * @property {number} [timeout] milliseconds before the command is killed;
+ *   defaults to FACTORY_GH_TIMEOUT_MS (30000) for the GitHub forge
  */
 
 /**


### PR DESCRIPTION
Fixes watt-mind/factory#1845

Set FACTORY_GH_TIMEOUT_MS to bound every synchronous forge gh invocation.

## Validation

| Check                | Command                                                                                                  | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test lib/forge && bun test event-runtime/lib/merge-reviews.test.mjs event-runtime/lib/planner.test.mjs && bun run lint` | pass    | exit 0                        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | exit 0                        |
| UX critique          | factory-ux-critic                                                                                        | not run | no user-facing surface        |

UX critique: skipped

run:run_2b6ac590-fb95-4b76-96ef-f5b8505eaf7d

## Post-review

Review fix in lib/forge/github.mjs: a timeout is now classified by r.error?.code === "ETIMEDOUT" or r.signal === "SIGKILL" (the configured killSignal), not SIGTERM; contract.test.mjs fixture updated to match. bun test lib/forge (42 pass), lint, format:check green.
