### PR TITLE
fix(serve): bound Linear rate-limit planning

### DIFF
--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -289,6 +289,104 @@ describe("serve command", () => {
     expect(health.ok).toBe(true);
   });
 
+  test("a stalled Linear ticket read cannot wedge /health past the tick budget (#1835 AC3)", async () => {
+    const home = tmpDir("evrt-serve-linear-stall-");
+    const reposRoot = tmpDir("evrt-serve-linear-stall-repos-");
+    mkdirSync(path.join(reposRoot, "config"), { recursive: true });
+    writeFileSync(
+      path.join(reposRoot, "config", "repos.yaml"),
+      [
+        "repos:",
+        "  - name: gated",
+        "    path: /tmp/nowhere",
+        "    base: develop",
+        "    team: WM",
+        "    project: Factory",
+        "    worktree_up: bin/up",
+        "    worktree_down: bin/down",
+        "    worktree_root: /tmp/worktrees",
+        "    escalate_paths: []",
+        "",
+      ].join("\n"),
+    );
+    // Minimal literal policy: the registry needs full model tier mappings and
+    // must not inherit the checkout's instance config/policy.yaml.
+    writeFileSync(
+      path.join(reposRoot, "config", "policy.yaml"),
+      [
+        "packs: []",
+        "models:",
+        "  claude: { strong: default, standard: sonnet, light: haiku }",
+        "  pi: { strong: pi-strong, standard: pi-standard, light: pi-light }",
+        "  agy: { strong: agy, standard: agy, light: agy }",
+        "  cursor: { strong: cursor, standard: cursor, light: cursor }",
+        "",
+      ].join("\n"),
+    );
+    // A Linear CLI stand-in that never answers: without a read timeout the
+    // planner's synchronous execFileSync would block the serve event loop for
+    // the child's full lifetime and /health would miss the web proxy's 10s.
+    const slowCli = path.join(home, "slow-linear.mjs");
+    writeFileSync(
+      slowCli,
+      "await new Promise((resolve) => setTimeout(resolve, 60_000));\n",
+    );
+    const port = freePort();
+    const box = spawnServeBox(["--port", port], {
+      FACTORY_EVENT_HOME: home,
+      FACTORY_REPOS_ROOT: reposRoot,
+      FACTORY_LINEAR_CLI: slowCli,
+      FACTORY_LINEAR_READ_TIMEOUT_MS: "1500",
+    });
+    try {
+      expect(await waitFor(box, "control API on", 8000)).toBe(true);
+      const { admitEvent } = await import("../lib/intake.mjs");
+      const { loadRegistry } = await import("../lib/registry.mjs");
+      const db = openDb(path.join(home, "runtime.db"));
+      const result = admitEvent(
+        db,
+        loadRegistry(),
+        {
+          schemaVersion: "factory.event/v1",
+          eventId: "linear-stall-1",
+          type: "factory.dispatch.requested",
+          source: "operator-webhook",
+          subject: "factory",
+          occurredAt: new Date().toISOString(),
+          correlationId: "linear-stall-1",
+          causationId: null,
+          payload: { repo: "gated", ticket: "WM-1835" },
+        },
+        { now: Date.now() },
+      );
+      expect(result.admitted).toBe(true);
+      // The next tick stalls in the fake CLI; the execFileSync timeout must
+      // abort it and record a bounded read failure instead of sleeping 60s.
+      const planError = {
+        get out() {
+          const row = db
+            .query(
+              `SELECT last_plan_error FROM events WHERE event_id = 'linear-stall-1'`,
+            )
+            .get();
+          return String(row?.last_plan_error ?? "");
+        },
+      };
+      expect(await waitFor(planError, "ETIMEDOUT", 15_000)).toBe(true);
+      // Retries keep stalling one bounded read per tick; a /health probe that
+      // lands mid-stall still answers inside the web proxy's 10s budget.
+      const started = Date.now();
+      const res = await fetch(`http://127.0.0.1:${port}/health`, {
+        signal: AbortSignal.timeout(9_000),
+      });
+      expect(res.ok).toBe(true);
+      expect(Date.now() - started).toBeLessThan(9_000);
+    } finally {
+      box.child.kill("SIGTERM");
+      await exitOf(box.child);
+    }
+  }, 60_000);
+
   test("serve clearly warns when FACTORY_CONTROL_API_TOKEN is unset", async () => {
     const home = tmpDir("evrt-serve-no-token-");
     const port = freePort();

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -398,6 +398,7 @@ export async function handleIntakeApiRoute({
   nowMs,
   onEvent,
   getTickStats,
+  getLinearBudget,
   send,
   readBody,
   parseJson,
@@ -410,6 +411,14 @@ export async function handleIntakeApiRoute({
       nowMs,
       configured: Boolean(githubSecret),
     });
+    const budget =
+      typeof getLinearBudget === "function" ? getLinearBudget() : null;
+    const resetAt = budget?.resetAt ?? null;
+    const resetMs = resetAt ? Date.parse(resetAt) : NaN;
+    const rateLimited =
+      budget?.rateLimited === true &&
+      Number.isFinite(resetMs) &&
+      resetMs > nowMs;
     return send(200, {
       ok: true,
       policyVersion,
@@ -418,6 +427,7 @@ export async function handleIntakeApiRoute({
       githubWebhookSecret: githubSecret ? "set" : "absent",
       registry: registryHealth ?? null,
       githubIntake,
+      linear: { rateLimited, resetAt },
       tick: {
         lastMs: tickStats?.lastMs ?? 0,
         overruns: tickStats?.overruns ?? 0,

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -68,6 +68,7 @@ import { loadRepos, reposRoot } from "./repos.mjs";
 import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
+import { loadLinearBudget } from "../../tools/ticket.mjs";
 
 export {
   isLoopbackHost,
@@ -155,6 +156,7 @@ export function createApi({
   buildArtifactReferenceIndex = artifactReferenceIndex,
   buildArtifactInventory = artifactInventory,
   getTickStats = null,
+  getLinearBudget = loadLinearBudget,
 } = {}) {
   const actor = "operator";
   const staticRegistryLoadedAt = new Date(now()).toISOString();
@@ -282,6 +284,7 @@ export function createApi({
         actor,
         onEvent,
         getTickStats,
+        getLinearBudget,
         send,
         readBody,
         parseJson,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -595,6 +595,21 @@ describe("environment identity (webui chip)", () => {
       server.close();
     }
   });
+
+  test("health exposes an active Linear rate-limit reset clock", async () => {
+    const nowMs = Date.parse("2026-08-30T12:00:00.000Z");
+    const resetAt = "2026-08-30T12:15:00.000Z";
+    const s = await makeServer({
+      now: () => nowMs,
+      getLinearBudget: () => ({ rateLimited: true, resetAt }),
+    });
+    try {
+      const health = await s.client.health();
+      expect(health.linear).toEqual({ rateLimited: true, resetAt });
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("bearer-token auth on the control API (WM-1152)", () => {

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -87,6 +87,8 @@ import {
   LinearRateLimitError,
   isLinearRateLimitMessage,
   isLinearRateLimited,
+  linearRateLimitState,
+  loadLinearBudget,
 } from "../../tools/linear.mjs";
 
 /** In-flight issues list is stable across one scan; 60s is the ticket cap. */
@@ -585,12 +587,33 @@ export function createLinearReadCache() {
  * in-flight lists by team+project for ≤60s. A rate-limit throw is remembered
  * so later candidates in the same pass do not hit Linear again.
  */
-export function wrapLinearReads(dispatch = {}, cache, now) {
+export function wrapLinearReads(
+  dispatch = {},
+  cache,
+  now,
+  configSnapshot = null,
+) {
   const resolveNow = () => {
     const clock = now ?? Date.now;
     return typeof clock === "function" ? clock() : clock;
   };
-  const throwIfLimited = () => {
+  const linearRateLimit = cache.budgetRateLimit ?? null;
+  const repoUsesLinear = (repoOrName) => {
+    if (repoOrName && typeof repoOrName === "object")
+      return repoOrName.controlPlane !== "github";
+    try {
+      return (
+        getRepo(snapshotRepos(configSnapshot), repoOrName).controlPlane !==
+        "github"
+      );
+    } catch {
+      // The normal eligibility proof supplies the useful unknown-repo refusal.
+      return false;
+    }
+  };
+  const throwIfLimited = (repo) => {
+    if (!repoUsesLinear(repo)) return;
+    if (linearRateLimit) throw linearRateLimit;
     if (!cache.rateLimitError) return;
     if (resolveNow() < cache.rateLimitedUntil) throw cache.rateLimitError;
     cache.rateLimitError = null;
@@ -612,7 +635,7 @@ export function wrapLinearReads(dispatch = {}, cache, now) {
   return {
     ...dispatch,
     fetchTicket: (id, repo) => {
-      throwIfLimited();
+      throwIfLimited(repo);
       // Cache per (id, repo): the same identifier read against different
       // control planes is a different lookup.
       const key = repo ? `${repo}::${id}` : id;
@@ -627,7 +650,7 @@ export function wrapLinearReads(dispatch = {}, cache, now) {
       }
     },
     fetchViewer: (repo) => {
-      throwIfLimited();
+      throwIfLimited(repo);
       const key = repo ?? "__default__";
       if (cache.viewers.has(key)) return cache.viewers.get(key);
       try {
@@ -640,7 +663,7 @@ export function wrapLinearReads(dispatch = {}, cache, now) {
       }
     },
     fetchInFlight: (repo) => {
-      throwIfLimited();
+      throwIfLimited(repo);
       const key = `${repo?.team ?? ""}::${repo?.project ?? ""}`;
       const hit = cache.inFlight.get(key);
       const at = resolveNow();
@@ -3065,14 +3088,42 @@ export function planAdmittedEvents(db, registry, opts = {}) {
       `SELECT source, event_id, type FROM events WHERE status = 'admitted' ORDER BY admitted_at, rowid`,
     )
     .all();
-  const cache = opts.linearReadCache ?? createLinearReadCache();
-  const dispatch = wrapLinearReads(opts.dispatch ?? {}, cache, opts.now);
   const configSnapshot = opts.configSnapshot ?? policySnapshot();
+  const cache = opts.linearReadCache ?? createLinearReadCache();
+  // Unit tests must not inherit the operator's shared cache. Production reads
+  // the persisted clock once per planner pass; an injected budget keeps this
+  // deterministic for the rate-limit regression tests.
+  const budget =
+    opts.linearBudget ??
+    (process.env.BUN_TEST || process.env.NODE_ENV === "test"
+      ? null
+      : loadLinearBudget());
+  const limited = linearRateLimitState(budget, resolveNow(opts.now));
+  if (limited) {
+    cache.budgetRateLimit = new LinearRateLimitError(limited.resetAt);
+  } else {
+    cache.budgetRateLimit = null;
+  }
+  const dispatch = wrapLinearReads(
+    opts.dispatch ?? {},
+    cache,
+    opts.now,
+    configSnapshot,
+  );
   const planOpts = { ...opts, dispatch, configSnapshot };
   let planned = 0;
   let failed = 0;
   let deadLettered = 0;
   const log = opts.log ?? console.log;
+  if (limited) {
+    try {
+      log(
+        `planner: Linear rate-limited until ${limited.resetAt} — skipping Linear reads`,
+      );
+    } catch {
+      // Logging must not turn a bounded refusal into a retryable failure.
+    }
+  }
   for (const { source, event_id: eventId, type } of rows) {
     try {
       const outcome = planEvent(db, registry, { source, eventId }, planOpts);

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -541,8 +541,21 @@ function resolveNow(now) {
   return typeof now === "function" ? now() : now;
 }
 
+// The web proxy gives /health 10 seconds. The planner tick runs its Linear
+// CLI reads synchronously on the serve event loop, so a single stalled child
+// must abort well inside that budget or serve wedges (#1835 AC3). The env
+// override exists for the serve regression test, not for operators.
+const LINEAR_READ_TIMEOUT_MS = (() => {
+  const n = Number(process.env.FACTORY_LINEAR_READ_TIMEOUT_MS);
+  return Number.isFinite(n) && n > 0 ? n : 8_000;
+})();
+
 function linearCli() {
-  return path.join(FACTORY_ROOT, "tools", "linear.mjs");
+  // Test seam: point the planner's ticket reads at a stand-in CLI.
+  return (
+    process.env.FACTORY_LINEAR_CLI ||
+    path.join(FACTORY_ROOT, "tools", "linear.mjs")
+  );
 }
 
 function throwIfLinearCliRateLimited(err) {
@@ -694,6 +707,7 @@ function fetchTicketDefault(ticketId, repo) {
       execFileSync("bun", args, {
         encoding: "utf8",
         stdio: ["ignore", "pipe", "pipe"],
+        timeout: LINEAR_READ_TIMEOUT_MS,
       }),
     );
   } catch (err) {
@@ -723,6 +737,7 @@ function fetchViewerDefault(repoName, configSnapshot = null) {
     const out = execFileSync("bun", args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: LINEAR_READ_TIMEOUT_MS,
     });
     const parsed = JSON.parse(out);
     if (repo?.controlPlane === "github") {
@@ -884,6 +899,7 @@ function fetchInFlightDefault(repoConfig) {
     const out = execFileSync("bun", args, {
       encoding: "utf8",
       stdio: ["ignore", "pipe", "pipe"],
+      timeout: LINEAR_READ_TIMEOUT_MS,
     });
     const rows = JSON.parse(out);
     return Array.isArray(rows) ? rows : [];
@@ -3090,14 +3106,11 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     .all();
   const configSnapshot = opts.configSnapshot ?? policySnapshot();
   const cache = opts.linearReadCache ?? createLinearReadCache();
-  // Unit tests must not inherit the operator's shared cache. Production reads
-  // the persisted clock once per planner pass; an injected budget keeps this
-  // deterministic for the rate-limit regression tests.
-  const budget =
-    opts.linearBudget ??
-    (process.env.BUN_TEST || process.env.NODE_ENV === "test"
-      ? null
-      : loadLinearBudget());
+  // Production reads the persisted clock once per planner pass; an injected
+  // budget keeps the rate-limit regression tests deterministic. The cache
+  // path itself is scoped by FACTORY_EVENT_HOME (tools/ticket.mjs), so test
+  // processes never observe the operator's shared budget capture.
+  const budget = opts.linearBudget ?? loadLinearBudget();
   const limited = linearRateLimitState(budget, resolveNow(opts.now));
   if (limited) {
     cache.budgetRateLimit = new LinearRateLimitError(limited.resetAt);

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4387,6 +4387,52 @@ describe("Linear rate limit (WM-878)", () => {
     });
   });
 
+  test("an active cached Linear budget skips planner reads and logs its reset clock once", () => {
+    withReposRoot(gatedYaml, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "cached-rate-limit-1",
+        correlationId: "cached-rate-limit-1",
+        payload: { repo: "gated", ticket: "WM-1835" },
+      });
+      const resetAt = "2026-08-19T13:00:00.000Z";
+      const logs = [];
+      let ticketReads = 0;
+
+      const counts = planAdmittedEvents(db, registry, {
+        now: NOW,
+        policyVersion: "git:test",
+        linearBudget: { rateLimited: true, resetAt },
+        log: (line) => logs.push(line),
+        dispatch: {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: () => {
+            ticketReads += 1;
+            return readyTicket("WM-1835");
+          },
+        },
+      });
+
+      expect(counts).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+      expect(ticketReads).toBe(0);
+      expect(logs).toEqual([
+        `planner: Linear rate-limited until ${resetAt} — skipping Linear reads`,
+      ]);
+      expect(
+        db
+          .query(
+            `SELECT status, last_plan_error FROM events WHERE event_id = ?`,
+          )
+          .get(ref.eventId),
+      ).toMatchObject({
+        status: "admitted",
+        last_plan_error: `linear_rate_limited: resetAt=${resetAt}`,
+      });
+    });
+  });
+
   test("one planning pass over 10 candidates makes at most 3 in-flight queries", () => {
     withReposRoot(gatedYaml, () => {
       const db = openDb(":memory:");

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -31,10 +31,9 @@ import {
 // names are per-team config, the types are Linear's own enum.
 const BLOCKERS = `inverseRelations(first:250){ nodes{ type issue{ identifier state{ type } } } pageInfo{ hasNextPage endCursor } }`;
 const PAGE_CAP = 2_000;
-// Five retried responses can wait 1+2+4+8 seconds. Leave that retry budget
-// outside the original 30-second request allowance rather than timing out a
-// healthy response midway through its documented backoff schedule.
-const DEFAULT_REQUEST_TIMEOUT_MS = 45_000;
+// Requests must leave enough time for the serve planner to make a bounded
+// refusal. Rate-limit replies do not retry; transient retries remain abortable.
+const DEFAULT_REQUEST_TIMEOUT_MS = 15_000;
 const ISSUE_FIELDS = `id identifier title url description createdAt startedAt updatedAt priority
   state{ id name type } assignee{ id name }
   team{ key } project{ name }

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -43,6 +43,7 @@ import { loadRepos } from "../event-runtime/lib/repos.mjs";
 import { dbPath } from "../event-runtime/lib/config.mjs";
 import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 import { ticketSlug } from "../lib/ticket-slug.mjs";
+import { parseRateLimitReset } from "../tools/ticket.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
 
@@ -175,7 +176,11 @@ function retryDelay(ms, signal) {
 }
 
 function rateLimitError(message, response) {
-  const resetAt = response?.headers?.get("x-ratelimit-requests-reset") ?? null;
+  // Linear's reset header is a raw unix epoch; downstream consumers
+  // (Date.parse in the planner cache, budget.json) expect ISO-8601.
+  const resetAt = parseRateLimitReset(
+    response?.headers?.get("x-ratelimit-requests-reset"),
+  );
   const error = new Error(
     `linear_rate_limited: resetAt=${resetAt ?? "unknown"}${message ? `: ${message}` : ""}`,
   );

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -174,6 +174,16 @@ function retryDelay(ms, signal) {
   });
 }
 
+function rateLimitError(message, response) {
+  const resetAt = response?.headers?.get("x-ratelimit-requests-reset") ?? null;
+  const error = new Error(
+    `linear_rate_limited: resetAt=${resetAt ?? "unknown"}${message ? `: ${message}` : ""}`,
+  );
+  error.rateLimited = true;
+  error.resetAt = resetAt;
+  return error;
+}
+
 /**
  * Send a Linear GraphQL request, retrying transient responses unless cancelled.
  *
@@ -213,8 +223,11 @@ export async function gql(
       });
 
       if (!res.ok) {
+        if (res.status === 429) {
+          throw rateLimitError((await res.text()).slice(0, 500), res);
+        }
         if (
-          [429, 500, 502, 503, 504].includes(res.status) &&
+          [500, 502, 503, 504].includes(res.status) &&
           attempt < retries - 1
         ) {
           await retryDelay(delay, signal);
@@ -228,20 +241,15 @@ export async function gql(
       const data = await res.json();
       if (data.errors && data.errors.length > 0) {
         const msg = JSON.stringify(data.errors);
-        if (
-          msg.toUpperCase().includes("RATELIMITED") &&
-          attempt < retries - 1
-        ) {
-          await retryDelay(delay, signal);
-          delay *= 2;
-          continue;
-        }
+        if (msg.toUpperCase().includes("RATELIMITED"))
+          throw rateLimitError(msg, res);
         throw new Error(msg);
       }
 
       return data.data || {};
     } catch (err) {
       if (signal?.aborted) throw abortReason(signal);
+      if (err?.rateLimited) throw err;
       if (
         attempt < retries - 1 &&
         !(err.message && err.message.startsWith("HTTP 4"))

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -278,6 +278,19 @@ export function loadLinearBudget() {
   }
 }
 
+/**
+ * Return the currently actionable Linear rate-limit state, if any.
+ *
+ * A stale cache entry must not hold the control plane offline forever: Linear
+ * gives us a reset clock, and only a future clock represents a live refusal.
+ */
+export function linearRateLimitState(budget, now = Date.now()) {
+  if (!budget?.rateLimited || !budget.resetAt) return null;
+  const resetMs = Date.parse(budget.resetAt);
+  if (!Number.isFinite(resetMs) || resetMs <= now) return null;
+  return { rateLimited: true, resetAt: new Date(resetMs).toISOString() };
+}
+
 export function saveLinearBudget(budget) {
   try {
     mkdirSync(linearCacheDir(), { recursive: true });
@@ -324,7 +337,10 @@ function recordLinearBudgetFromResponse(res) {
       parsed?.remaining ?? (rateLimited ? 0 : (prior.remaining ?? null)),
     limit: parsed?.limit ?? prior.limit ?? LINEAR_REQUESTS_LIMIT,
     resetAt: parsed?.resetAt ?? prior.resetAt ?? null,
-    rateLimited: Boolean(rateLimited || prior.rateLimited),
+    // A successful response with capacity clears a previous refusal. Keeping
+    // `prior.rateLimited` here made a recovered account appear offline until
+    // somebody manually removed budget.json.
+    rateLimited,
     status: res.status,
   });
 }

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -265,7 +265,14 @@ export function parseRateLimitHeaders(headers, now = Date.now()) {
 }
 
 export function linearCacheDir() {
-  return process.env.LINEAR_CACHE_DIR || CACHE_DIR;
+  if (process.env.LINEAR_CACHE_DIR) return process.env.LINEAR_CACHE_DIR;
+  // A scoped runtime home owns its own budget capture: tests and isolated
+  // stacks (FACTORY_EVENT_HOME) must never read or spend the operator's
+  // shared ~/.factory budget clock.
+  if (process.env.FACTORY_EVENT_HOME) {
+    return path.join(process.env.FACTORY_EVENT_HOME, "cache", "linear");
+  }
+  return CACHE_DIR;
 }
 
 export function loadLinearBudget() {

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -88,9 +88,15 @@ test("the Linear transport does not retry a 429 rate-limit response", async () =
   };
 
   try {
-    await expect(gql("query { ping }", {}, { retries: 5 })).rejects.toThrow(
-      "linear_rate_limited",
-    );
+    let thrown = null;
+    try {
+      await gql("query { ping }", {}, { retries: 5 });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(String(thrown?.message)).toContain("linear_rate_limited");
+    // The raw header is a unix epoch; consumers get the ISO reset clock.
+    expect(thrown?.resetAt).toBe(new Date(1786539600 * 1000).toISOString());
     expect(calls).toBe(1);
   } finally {
     globalThis.fetch = previousFetch;

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -44,6 +44,7 @@ import {
   assertLinearNetworkAllowed,
   linearNetworkIsOffline,
 } from "./ticket.mjs";
+import { gql } from "../orchestrator/reaper.mjs";
 
 const LABELS = [
   { id: "l-ready", name: "ai:agent-ready" },
@@ -68,6 +69,34 @@ test("the Linear offline guard rejects api.linear.app before fetch", () => {
       FACTORY_LINEAR_ALLOW_NETWORK: "1",
     }),
   ).not.toThrow();
+});
+
+test("the Linear transport does not retry a 429 rate-limit response", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousKey = process.env.LINEAR_API_KEY;
+  let calls = 0;
+  process.env.LINEAR_API_KEY = "test-key";
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response('{"errors":[{"message":"RATELIMITED"}]}', {
+      status: 429,
+      headers: {
+        "x-ratelimit-requests-remaining": "0",
+        "x-ratelimit-requests-reset": "1786539600",
+      },
+    });
+  };
+
+  try {
+    await expect(gql("query { ping }", {}, { retries: 5 })).rejects.toThrow(
+      "linear_rate_limited",
+    );
+    expect(calls).toBe(1);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previousKey;
+  }
 });
 
 // ------------------------------------------------------------ label math ---


### PR DESCRIPTION
Fixes watt-mind/factory#1835

Planner now short-circuits active Linear rate limits, keeps retries bounded, and exposes the reset clock on health.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) bun test event-runtime/lib/planner.test.mjs lib/control-plane/linear.test.mjs tools/ticket.test.mjs event-runtime/lib/api.test.mjs && bun run lint` | pass | 207 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | configured checks passed |
| UX critique          | factory-ux-critic                | skipped | no user-facing surface |

UX critique: skipped

run:run_b6654d0c-b86a-4ed5-8f4c-44ab2c346665

## Post-review

Review verdict FIX; addressed in 2f31a45:

- **AC3 regression test** — `event-runtime/cli/serve.test.mjs` spawns a live serve against a never-answering Linear CLI stand-in (`FACTORY_LINEAR_CLI` seam) and asserts the planner's stalled ticket read aborts bounded (`ETIMEDOUT` recorded as `last_plan_error`) and `/health` still answers inside the web proxy's 10 s budget. To make it pass, the planner's synchronous Linear CLI `execFileSync` reads (`fetchTicket`/`fetchViewer`/`fetchInFlight` defaults) now carry an explicit `timeout` of 8 s, env-overridable via `FACTORY_LINEAR_READ_TIMEOUT_MS`.
- **Budget cache scoping** — `planAdmittedEvents` no longer gates `loadLinearBudget()` on `BUN_TEST`/`NODE_ENV`; instead `linearCacheDir()` in `tools/ticket.mjs` scopes the cache under `FACTORY_EVENT_HOME` when set, so tests never read the operator's real `~/.factory/cache/linear/budget.json` and production behaviour is not env-var-gated. `LINEAR_CACHE_DIR` still takes precedence.
- **ISO reset clock** — `orchestrator/reaper.mjs` `rateLimitError` runs the raw `x-ratelimit-requests-reset` epoch through `parseRateLimitReset` before setting `error.resetAt`; `tools/ticket.test.mjs` asserts the ISO normalization.
- **Deliberate behaviour note** — a 429 / `RATELIMITED` response no longer retries inside `gql`: the transport throws a typed `rateLimited` error immediately so callers (planner, budget cache) make one bounded refusal instead of burning the retry schedule against an exhausted budget.
