### PR TITLE
fix(merge-scan): avoid rebasing active landing CI

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -114,6 +114,7 @@ them to native labels of the same spelling.
 | `ai:needs-review` | PR is up; merge stage owns it.                                                        |
 | `ai:blocked`      | Waiting on a human.                                                                   |
 | `ai:escalated`    | Security-relevant (or intent-changing) diff; a human must merge.                      |
+| `ai:landing`      | An external lander owns the branch; merge-scan must not rebase it.                    |
 | `agent:<harness>` | Which harness holds the claim. CLI `claude` maps to `agent:claude-code`.              |
 | `type:*`          | `bug` `feature` `ui-ux` `security` `performance` `maintenance` `docs` `a11y`          |
 | `source:*`        | `agent` `human` `sentry` `client-support`                                             |

--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:abfdf9be239b636bcf825b62b422754ccf6c5b905222d08761dcc40655fe886e",
+    "agents/merge-fix.md": "sha256:42015b3e724645bfa3d445ce85818c692db631595462af4f48ad68267d197ad7",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -41,6 +41,26 @@ isolated worktree for the ticket. This is not a general implementation run.
      expectedRemoteSha=$(git rev-parse "origin/<headRef>")
      ```
 
+     Before either rebase, query check runs on that exact
+     `expectedRemoteSha` (not a branch-name lookup). If `Full verification` is
+     `QUEUED` or `IN_PROGRESS`, return `outcome: "BLOCKED"` with a summary
+     beginning `ci_in_flight:` and do not edit or push. Also leave the branch
+     alone when that check concluded `SUCCESS` within
+     `FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES` (default `60`) minutes,
+     returning a summary beginning `ci_fresh:`. For example, inspect the
+     exact head with:
+
+     ```sh
+     gh api "repos/<github>/commits/${expectedRemoteSha}/check-runs?per_page=100"
+     ```
+
+     A `CONFLICTING` PR still needs a rebase even when CI is running or fresh.
+     Query the live PR labels too (`gh pr view <pr> --repo <github> --json
+labels`); an `ai:landing` label always blocks this mechanical rebase with
+     a summary beginning `ai_landing:`. Treat an
+     unreadable check response conservatively as `ci_in_flight:` rather than
+     risking an external lander's branch.
+
      Compare `expectedRemoteSha` with the pinned `input.json` `headSha`. Only
      when they differ, query the live PR with
      `gh pr view <pr> --repo <github> --json headRefOid,updatedAt`. Refuse with

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -11,31 +11,19 @@
     "scan"
   ],
   "writesResult": true,
-  "workspace": {
-    "type": "ephemeral",
-    "retainOnFailure": true
-  },
-  "capabilities": {
-    "filesystem": "workspace-only",
-    "services": ["gh:read"]
-  },
-  "limits": {
-    "timeout_seconds": 120,
-    "attempts": 1
-  },
+  "workspace": { "type": "ephemeral", "retainOnFailure": true },
+  "capabilities": { "filesystem": "workspace-only", "services": ["gh:read"] },
+  "limits": { "timeout_seconds": 120, "attempts": 1 },
   "mutating": false,
   "memos": [
     {
-      "subject": {
-        "type": "repo",
-        "id": "$.input.repo"
-      },
+      "subject": { "type": "repo", "id": "$.input.repo" },
       "kinds": ["decision"],
       "max": 10
     }
   ],
   "pins": {
-    "agents/merge-scan.md": "sha256:b407f14519ebb7b505ce7ddf80ca7929fe3a25798f3c4f89fd42a5ad6d583931",
+    "agents/merge-scan.md": "sha256:7bd516697f5330f3700f7e5a50ebc20e804b73fbe3a03abb3fcb205e864883a4",
     "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
     "schemas/merge-scan.output.json": "sha256:e7edeca34a7a702ab35301de599b3a8dcb137e62f33f5a63df399318df04a636"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -13,9 +13,14 @@ ledger (`baseSha` is recorded, not part of the key), and emits `reviews[]` only
 for misses — a moved head. A moved base with the same head is a hit. A selected
 scan (`prNumbers`) forces a review even on a ledger hit. For a hit whose live
 state is CONFLICTING or BEHIND (or whose recorded `baseSha` differs from the
-live base tip), emit an operational `rebase_onto_base` item in `fix[]` with
+live base tip), normally emit an operational `rebase_onto_base` item in `fix[]` with
 `mechanical: true`, `withinOwnedPaths: true`, and `round` from the ledger; do
-not start a review run. Do not emit a review item when an open, queued, or
+not start a review run. Never emit a rebase for a PR labelled `ai:landing`.
+For a non-conflicting rebase candidate, also skip the rebase when the current
+head has a `Full verification` check that is queued/running or succeeded within
+the `FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES` fresh-CI window (default 60);
+the scan summary names the skip reason. A
+CONFLICTING PR still emits a rebase unless it carries `ai:landing`. Do not emit a review item when an open, queued, or
 running `merge-review@1` proposal or run already exists at the same
 `(pr, headSha)`. MERGE ledger hits are not stubbed into `plan[]` — they are
 queued as `planRequests[]` so `merge-plan@1` can batch them. `plan[]` on a

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -290,7 +290,9 @@ function fullVerificationRebaseSkip({ forge, github, pr, now }) {
       ),
     )?.check_runs;
   } catch {
-    return null;
+    // Conservative: if the check-run state cannot be read, assume CI may be
+    // in flight rather than rebasing over a potentially live landing run.
+    return "ci_in_flight";
   }
   if (!Array.isArray(checkRuns)) return null;
 

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -46,9 +46,12 @@ const PR_LIST_FIELDS = [
   "body",
   "mergeable",
   "mergeStateStatus",
+  "labels",
 ];
-const PR_VIEW_FIELDS = [...PR_LIST_FIELDS, "labels"];
+const PR_VIEW_FIELDS = PR_LIST_FIELDS;
 const REBASE_FINDING = "rebase_onto_base";
+const FULL_VERIFICATION_CHECK = "Full verification";
+const REBASE_SKIP_FRESH_CI_DEFAULT_MINUTES = 60;
 const IN_FLIGHT_RUN_STATES = [
   "PROPOSED",
   "APPROVED",
@@ -57,7 +60,7 @@ const IN_FLIGHT_RUN_STATES = [
   "RUNNING",
   "VERIFYING",
 ];
-const GITHUB_HOLD_LABELS = new Set(["escalated", "ai:escalated"]);
+const GITHUB_HOLD_LABELS = new Set(["escalated", "ai:escalated", "ai:landing"]);
 
 function iso(now = Date.now()) {
   return new Date(now).toISOString();
@@ -262,7 +265,61 @@ function normalizeListedPr(raw, baseSha, github) {
       typeof raw.mergeStateStatus === "string"
         ? raw.mergeStateStatus.toUpperCase()
         : "",
+    labels: githubLabelsOf(raw),
   };
+}
+
+function rebaseSkipFreshCiMinutes(env = process.env) {
+  const value = Number(env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES);
+  return Number.isInteger(value) && value > 0
+    ? value
+    : REBASE_SKIP_FRESH_CI_DEFAULT_MINUTES;
+}
+
+function fullVerificationRebaseSkip({ forge, github, pr, now }) {
+  if (pr.labels?.some((label) => label.toLowerCase() === "ai:landing")) {
+    return "ai_landing";
+  }
+  if (pr.mergeable === "CONFLICTING") return null;
+
+  let checkRuns;
+  try {
+    checkRuns = JSON.parse(
+      forge.apiRaw(
+        `repos/${github}/commits/${pr.headSha}/check-runs?per_page=100`,
+      ),
+    )?.check_runs;
+  } catch {
+    return null;
+  }
+  if (!Array.isArray(checkRuns)) return null;
+
+  const fullVerification = checkRuns.filter(
+    (check) => check?.name === FULL_VERIFICATION_CHECK,
+  );
+  if (
+    fullVerification.some((check) => {
+      const status = String(check?.status ?? "").toUpperCase();
+      return status === "IN_PROGRESS" || status === "QUEUED";
+    })
+  ) {
+    return "ci_in_flight";
+  }
+
+  const freshAfter = now - rebaseSkipFreshCiMinutes() * 60 * 1000;
+  if (
+    fullVerification.some((check) => {
+      const completedAt = Date.parse(check?.completed_at ?? "");
+      return (
+        String(check?.conclusion ?? "").toUpperCase() === "SUCCESS" &&
+        Number.isFinite(completedAt) &&
+        completedAt >= freshAfter
+      );
+    })
+  ) {
+    return "ci_fresh";
+  }
+  return null;
 }
 
 function classifySelectedPr(raw, { base, baseSha, github }) {
@@ -521,6 +578,7 @@ export function enumerateMergeScan({
       targets,
       forceReview: true,
       listedCount: targets.length,
+      now,
     });
   }
 
@@ -562,10 +620,12 @@ function assemble({
   wrongBase = [],
   forceReview,
   listedCount,
+  now,
 }) {
   const reviews = [];
   const mergeHits = [];
   const fix = [];
+  const rebaseSkipped = [];
   for (const pr of targets) {
     const hit = lookupMergeReview(db, {
       github,
@@ -586,6 +646,11 @@ function assemble({
       continue;
     }
     if (isBehindOrConflicting(pr, hit)) {
+      const skip = fullVerificationRebaseSkip({ forge, github, pr, now });
+      if (skip) {
+        rebaseSkipped.push({ pr: pr.number, reason: skip });
+        continue;
+      }
       if (
         hasInFlightAgent(db, "merge-fix@1", {
           github,
@@ -637,6 +702,7 @@ function assemble({
       wrongBase,
       forceReview,
       planRequests,
+      rebaseSkipped,
     }),
   };
   const noopReason = noopReasonOf({
@@ -660,6 +726,7 @@ function summaryFor({
   wrongBase = [],
   forceReview,
   planRequests = [],
+  rebaseSkipped = [],
 }) {
   const bits = [];
   if (forceReview) bits.push(`selected scan of ${listedCount} PR(s)`);
@@ -673,6 +740,9 @@ function summaryFor({
   }
   bits.push(`${reviews.length} review(s) to run`);
   if (fix.length > 0) bits.push(`${fix.length} rebase fix(es)`);
+  for (const { pr, reason } of rebaseSkipped) {
+    bits.push(`rebase_skipped:${reason} #${pr}`);
+  }
   if (planRequests.length > 0) bits.push("MERGE hits queued for planning");
   if (plan.length > 0) bits.push(`lowest MERGE candidate is #${plan[0].pr}`);
   return bits.join("; ") + ".";

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -120,13 +120,21 @@ function insertOpenProposal(db, { id, agent, pr, headSha, github = GITHUB }) {
   ).run(id, `evt-${id}`, runId, spec, `idem-${id}`, now);
 }
 
-function forgeWith(prs, { baseSha = BASE } = {}) {
+function forgeWith(prs, { baseSha = BASE, api = {} } = {}) {
   return memoryForge({
     repos: { [GITHUB]: { prs } },
     api: {
       [`repos/${GITHUB}/git/ref/heads/develop`]: baseSha,
+      ...api,
     },
   });
+}
+
+function checkRunsFor(headSha, checkRuns) {
+  return {
+    [`repos/${GITHUB}/commits/${headSha}/check-runs?per_page=100`]:
+      JSON.stringify({ check_runs: checkRuns }),
+  };
 }
 
 function planItem(prNumber = 12) {
@@ -715,7 +723,207 @@ describe("merge-scan enumerator (WM-936)", () => {
     expect(result.artifact.recommendation).toBe("FIX");
   });
 
+  test("behind-base hit skips rebase while Full verification is running", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeStateStatus: "BEHIND",
+          }),
+        ],
+        {
+          api: checkRunsFor(HEAD, [
+            { name: "Full verification", status: "in_progress" },
+          ]),
+        },
+      ),
+      repos,
+    });
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain("rebase_skipped:ci_in_flight #9");
+  });
+
+  test("behind-base hit skips rebase after a fresh successful Full verification", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeStateStatus: "BEHIND",
+          }),
+        ],
+        {
+          api: checkRunsFor(HEAD, [
+            {
+              name: "Full verification",
+              status: "completed",
+              conclusion: "success",
+              completed_at: "2026-08-30T11:30:00Z",
+            },
+          ]),
+        },
+      ),
+      repos,
+      now,
+    });
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain("rebase_skipped:ci_fresh #9");
+  });
+
+  test("behind-base hit rebases after stale Full verification", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeStateStatus: "BEHIND",
+          }),
+        ],
+        {
+          api: checkRunsFor(HEAD, [
+            {
+              name: "Full verification",
+              status: "completed",
+              conclusion: "success",
+              completed_at: "2026-08-30T10:59:00Z",
+            },
+          ]),
+        },
+      ),
+      repos,
+      now,
+    });
+    expect(result.artifact.fix).toEqual([rebaseItem(9)]);
+  });
+
+  test("fresh-CI window accepts a positive environment override", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T12:00:00Z");
+    const previous = process.env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES;
+    process.env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES = "120";
+    try {
+      upsertMergeReview(db, {
+        github: GITHUB,
+        pr: 9,
+        headSha: HEAD,
+        baseSha: BASE,
+        verdict: "MERGE",
+        plan: planItem(9),
+      });
+      const result = enumerateMergeScan({
+        input: { repo: "factory" },
+        db,
+        forge: forgeWith(
+          [
+            pr({
+              number: 9,
+              headRefName: "feat/WM-9",
+              mergeStateStatus: "BEHIND",
+            }),
+          ],
+          {
+            api: checkRunsFor(HEAD, [
+              {
+                name: "Full verification",
+                status: "completed",
+                conclusion: "success",
+                completed_at: "2026-08-30T10:30:00Z",
+              },
+            ]),
+          },
+        ),
+        repos,
+        now,
+      });
+      expect(result.artifact.fix).toEqual([]);
+    } finally {
+      if (previous === undefined) {
+        delete process.env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES;
+      } else {
+        process.env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES = previous;
+      }
+    }
+  });
+
   test("CONFLICTING hit emits rebase without a review", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "FIX",
+      fix: rebaseItem(9, { round: 2 }),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+            mergeStateStatus: "DIRTY",
+          }),
+        ],
+        {
+          api: checkRunsFor(HEAD, [
+            { name: "Full verification", status: "in_progress" },
+          ]),
+        },
+      ),
+      repos,
+    });
+    expect(result.artifact.reviews).toEqual([]);
+    expect(result.artifact.fix[0]).toMatchObject({
+      finding: "rebase_onto_base",
+      round: 2,
+      mechanical: true,
+      withinOwnedPaths: true,
+    });
+  });
+
+  test("CONFLICTING hit still emits rebase while Full verification runs", () => {
     const db = openDb(":memory:");
     upsertMergeReview(db, {
       github: GITHUB,
@@ -738,13 +946,34 @@ describe("merge-scan enumerator (WM-936)", () => {
       ]),
       repos,
     });
-    expect(result.artifact.reviews).toEqual([]);
-    expect(result.artifact.fix[0]).toMatchObject({
-      finding: "rebase_onto_base",
-      round: 2,
-      mechanical: true,
-      withinOwnedPaths: true,
+    expect(result.artifact.fix).toHaveLength(1);
+  });
+
+  test("ai:landing PR never emits a rebase item", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
     });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({
+          number: 9,
+          headRefName: "feat/WM-9",
+          mergeStateStatus: "BEHIND",
+          labels: [{ name: "ai:landing" }],
+        }),
+      ]),
+      repos,
+    });
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain("rebase_skipped:ai_landing #9");
   });
 
   test("in-flight merge-review at the same head emits no duplicate item", () => {

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -608,13 +608,16 @@ describe("merge-scan enumerator (WM-936)", () => {
     const result = enumerateMergeScan({
       input: { repo: "factory" },
       db,
-      forge: forgeWith([
-        pr({
-          number: 877,
-          headRefName: "feat/gh-877",
-          mergeStateStatus: "BEHIND",
-        }),
-      ]),
+      forge: forgeWith(
+        [
+          pr({
+            number: 877,
+            headRefName: "feat/gh-877",
+            mergeStateStatus: "BEHIND",
+          }),
+        ],
+        { api: checkRunsFor(HEAD, []) },
+      ),
       repos,
     });
 
@@ -647,7 +650,7 @@ describe("merge-scan enumerator (WM-936)", () => {
           pr({ number: 8, headRefName: "feat/WM-8" }),
           pr({ number: 20, headRefName: "feat/WM-20" }),
         ],
-        { baseSha: BASE2 },
+        { baseSha: BASE2, api: checkRunsFor(HEAD, []) },
       ),
       repos,
     });
@@ -705,14 +708,17 @@ describe("merge-scan enumerator (WM-936)", () => {
     const result = enumerateMergeScan({
       input: { repo: "factory" },
       db,
-      forge: forgeWith([
-        pr({
-          number: 9,
-          headRefName: "feat/WM-9",
-          mergeable: "MERGEABLE",
-          mergeStateStatus: "BEHIND",
-        }),
-      ]),
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "MERGEABLE",
+            mergeStateStatus: "BEHIND",
+          }),
+        ],
+        { api: checkRunsFor(HEAD, []) },
+      ),
       repos,
     });
     expect(result.artifact.reviews).toEqual([]);
@@ -750,6 +756,34 @@ describe("merge-scan enumerator (WM-936)", () => {
           ]),
         },
       ),
+      repos,
+    });
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain("rebase_skipped:ci_in_flight #9");
+  });
+
+  test("behind-base hit skips rebase when check runs cannot be read", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    // No check-runs API seeded: reading the check-run state throws, and the
+    // scan must conservatively treat CI as possibly in flight.
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({
+          number: 9,
+          headRefName: "feat/WM-9",
+          mergeStateStatus: "BEHIND",
+        }),
+      ]),
       repos,
     });
     expect(result.artifact.fix).toEqual([]);

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -407,8 +407,10 @@ describe("registry", () => {
     // `<max_fix_rounds>` instead of hardcoding 2.
     // Regenerated (#1829): dispatch emits a concrete run trailer and rejects
     // the literal environment-variable form during handoff verification.
+    // Regenerated (#1843): merge-scan skips rebase churn for ai:landing and
+    // in-flight/fresh Full verification; merge-fix re-checks that CI guard.
     const expected =
-      "sha256:28c5980c970e233ebefba80b8be53d94a711132b49f9666d5b5aa0b2c20e87db";
+      "sha256:564641dee5b94b51d650f63233c467c12bed227e4a19b34c5f2a3c6dafd90c2c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -529,6 +531,10 @@ describe("registry", () => {
     );
     expect(flat).toContain("`summary` beginning `branch_in_flight:`");
     expect(flat).toContain("`summary` beginning `branch_moved:`");
+    expect(flat).toContain("Full verification");
+    expect(flat).toContain("`ci_in_flight:`");
+    expect(flat).toContain("`ci_fresh:`");
+    expect(flat).toContain("`ai:landing`");
     expect(flat).toContain("make no retry push");
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1843

Merge-scan now preserves externally landing branches and active Full verification runs instead of force-pushing over them.

## Validation

| Check                | Command                                                                                                                                                | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/merge-reviews.test.mjs && bun test event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs && bun run lint` | pass    | 201 tests passed; lint: 0 errors           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                                   | pass    | complete; lint reported 0 errors           |
| UX critique          | `factory-ux-critic`                                                                                                                                    | not run | skipped: no user-facing surface            |

UX critique: skipped — backend merge automation only; no user-facing surface

run:run_4ab55d4f-19f7-4d4d-bc1d-51a7bbf3b58e

## Post-review

- Reviewer fix applied (commit a106d329): unreadable check-runs response in `fullVerificationRebaseSkip` now returns `ci_in_flight` (conservative skip) instead of proceeding to rebase; added test "behind-base hit skips rebase when check runs cannot be read" and seeded empty check-runs in the three rebase-expecting tests.
- Validation: `bun test event-runtime/lib/merge-reviews.test.mjs` 33 pass / 0 fail; `bun run lint` 0 errors; `bun run format:check` clean.
