### PR TITLE
fix(repos): cache in-repo config (GH-1806)

### DIFF
--- a/event-runtime/lib/repos.mjs
+++ b/event-runtime/lib/repos.mjs
@@ -15,7 +15,7 @@
  */
 import { createHash } from "node:crypto";
 import { spawnSync } from "node:child_process";
-import { existsSync, readFileSync, realpathSync } from "node:fs";
+import { existsSync, readFileSync, realpathSync, statSync } from "node:fs";
 import path from "node:path";
 import {
   DEFAULT_MAX_IN_FLIGHT,
@@ -68,6 +68,14 @@ const IN_REPO_CONFIG_SCHEMA_PATH = new URL(
   import.meta.url,
 );
 let inRepoConfigSchema;
+const inRepoConfigCache = new Map();
+const ignoredInRepoConfigWarnings = new Map();
+
+/** Clear in-repo config and warning caches, primarily for isolated tests. */
+export function resetInRepoConfigCache() {
+  inRepoConfigCache.clear();
+  ignoredInRepoConfigWarnings.clear();
+}
 
 function repoConfigSchema() {
   if (inRepoConfigSchema) return inRepoConfigSchema;
@@ -115,43 +123,81 @@ function validateInRepoConfigSemantics(config, file) {
  * null; malformed or ambiguous declarations fail closed before host overlay.
  */
 export function loadInRepoConfig(repoRoot = process.cwd()) {
-  const files = IN_REPO_CONFIG_PATHS.map((relative) =>
-    path.join(repoRoot, relative),
-  ).filter((file) => existsSync(file));
+  const candidates = IN_REPO_CONFIG_PATHS.map((relative) => {
+    const file = path.resolve(repoRoot, relative);
+    const stat = statSync(file, { throwIfNoEntry: false });
+    if (!stat) {
+      inRepoConfigCache.delete(file);
+      return null;
+    }
+    return { file, mtimeMs: stat.mtimeMs, size: stat.size };
+  });
+  const files = candidates.filter(Boolean);
+  const fingerprint = candidates
+    .map((candidate) =>
+      candidate
+        ? `${candidate.file}:${candidate.mtimeMs}:${candidate.size}`
+        : "missing",
+    )
+    .join("|");
   if (files.length === 0) return null;
   if (files.length > 1) {
-    throw new RepoError(
+    const error = new RepoError(
       `${repoRoot}: both .factory.yaml and .factory/config.yaml exist; keep exactly one in-repo config`,
     );
+    error.inRepoConfigFingerprint = fingerprint;
+    throw error;
   }
 
-  const file = files[0];
-  let parsed;
+  const { file, mtimeMs, size } = files[0];
+  const cached = inRepoConfigCache.get(file);
+  if (cached?.mtimeMs === mtimeMs && cached.size === size) {
+    if (cached.error) throw cached.error;
+    return cached.config;
+  }
+
   try {
-    parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    const hostOwned = IN_REPO_HOST_OWNED_KEYS.filter((key) =>
+      hasOwn(parsed, key),
+    );
+    if (hostOwned.length > 0) {
+      throw new RepoError(
+        `${file}: in-repo config may not set host-owned ${hostOwned
+          .map((key) => `"${key}"`)
+          .join(
+            ", ",
+          )}; the host repos.yaml owns ${IN_REPO_HOST_OWNED_KEYS.join(", ")}`,
+      );
+    }
+    const result = validate(repoConfigSchema(), parsed);
+    if (!result.valid) {
+      throw new RepoError(
+        `${file}: invalid factory.repo/v1 config: ${result.errors.join("; ")}`,
+      );
+    }
+    validateInRepoConfigSemantics(parsed, file);
+    inRepoConfigCache.set(file, { mtimeMs, size, config: parsed });
+    return parsed;
   } catch (error) {
-    throw new RepoError(`${file}: invalid YAML: ${error.message}`);
+    const wrapped =
+      error instanceof RepoError
+        ? error
+        : new RepoError(`${file}: invalid YAML: ${error.message}`);
+    wrapped.inRepoConfigFingerprint = fingerprint;
+    inRepoConfigCache.set(file, { mtimeMs, size, error: wrapped });
+    throw wrapped;
   }
-  const hostOwned = IN_REPO_HOST_OWNED_KEYS.filter((key) =>
-    hasOwn(parsed, key),
+}
+
+function warnInRepoConfigIgnored(repoName, error) {
+  const key = `${repoName}\u0000${error.message}`;
+  const fingerprint = error.inRepoConfigFingerprint;
+  if (ignoredInRepoConfigWarnings.get(key) === fingerprint) return;
+  ignoredInRepoConfigWarnings.set(key, fingerprint);
+  console.warn(
+    `warning: repo ${repoName}: in-repo config ignored, host config applies: ${error.message}`,
   );
-  if (hostOwned.length > 0) {
-    throw new RepoError(
-      `${file}: in-repo config may not set host-owned ${hostOwned
-        .map((key) => `"${key}"`)
-        .join(
-          ", ",
-        )}; the host repos.yaml owns ${IN_REPO_HOST_OWNED_KEYS.join(", ")}`,
-    );
-  }
-  const result = validate(repoConfigSchema(), parsed);
-  if (!result.valid) {
-    throw new RepoError(
-      `${file}: invalid factory.repo/v1 config: ${result.errors.join("; ")}`,
-    );
-  }
-  validateInRepoConfigSemantics(parsed, file);
-  return parsed;
 }
 
 /**
@@ -1124,9 +1170,7 @@ export function loadRepos({ root = reposRoot() } = {}) {
       inRepoConfig = loadInRepoConfig(expandHome(hostEntry.path));
     } catch (err) {
       if (!(err instanceof RepoError)) throw err;
-      console.warn(
-        `warning: repo ${hostEntry.name}: in-repo config ignored, host config applies: ${err.message}`,
-      );
+      warnInRepoConfigIgnored(hostEntry.name, err);
     }
     const entry = mergeRepoConfig(hostEntry, inRepoConfig);
     let maxInFlight = null;

--- a/event-runtime/lib/repos.test.mjs
+++ b/event-runtime/lib/repos.test.mjs
@@ -27,6 +27,7 @@ import {
   repoDispatchPreflight,
   repoDispatchPreflightSync,
   repoReadiness,
+  resetInRepoConfigCache,
   reposView,
   resolvePromotionTarget,
   selectMergeCheckGate,
@@ -108,6 +109,37 @@ describe("factory.repo/v1 in-repo configuration", () => {
 
   test("returns null when a repository has no in-repo config", () => {
     expect(loadInRepoConfig(repositoryRoot(null, null))).toBeNull();
+  });
+
+  test("caches unchanged in-repo config files and invalidates changed or removed files", () => {
+    const root = repositoryRoot(".factory.yaml", IN_REPO_YAML);
+    const file = path.join(root, ".factory.yaml");
+    const originalParse = Bun.YAML.parse;
+    let parseCount = 0;
+    resetInRepoConfigCache();
+    Bun.YAML.parse = (...args) => {
+      parseCount += 1;
+      return originalParse(...args);
+    };
+
+    try {
+      expect(loadInRepoConfig(root).base).toBe("develop");
+      expect(loadInRepoConfig(root).base).toBe("develop");
+      expect(parseCount).toBe(1);
+
+      writeFileSync(file, IN_REPO_YAML.replace("base: develop", "base: main"));
+      expect(loadInRepoConfig(root).base).toBe("main");
+      expect(parseCount).toBe(2);
+
+      rmSync(file);
+      expect(loadInRepoConfig(root)).toBeNull();
+      writeFileSync(file, IN_REPO_YAML);
+      expect(loadInRepoConfig(root).base).toBe("develop");
+      expect(parseCount).toBe(3);
+    } finally {
+      Bun.YAML.parse = originalParse;
+      resetInRepoConfigCache();
+    }
   });
 
   test("fails closed for ambiguous, malformed, unknown, and semantically invalid config", () => {
@@ -321,9 +353,7 @@ describe("factory.repo/v1 in-repo configuration", () => {
     const originalWarn = console.warn;
     console.warn = (...args) => warnings.push(args.join(" "));
     let repos;
-    try {
-      repos = loadRepos({
-        root: factoryRoot(`repos:
+    const root = factoryRoot(`repos:
   - name: broken
     path: ${broken}
     base: main
@@ -333,10 +363,22 @@ describe("factory.repo/v1 in-repo configuration", () => {
   - name: healthy
     path: ${healthy}
     base: main
-`),
+`);
+    resetInRepoConfigCache();
+    try {
+      repos = loadRepos({ root });
+      expect(loadRepos({ root }).get("broken")).toMatchObject({
+        base: "main",
+        verify: "host verify",
       });
+      writeFileSync(
+        path.join(broken, ".factory.yaml"),
+        "schemaVersion: factory.repo/v1\nsecurity:\n  gitleaks_args: --no-git\n# changed\n",
+      );
+      loadRepos({ root });
     } finally {
       console.warn = originalWarn;
+      resetInRepoConfigCache();
     }
 
     // The broken checkout keeps its host config verbatim...
@@ -350,9 +392,10 @@ describe("factory.repo/v1 in-repo configuration", () => {
       base: "develop",
       worktreeUp: "bin/worktree-up.sh",
     });
-    expect(warnings).toHaveLength(1);
+    expect(warnings).toHaveLength(2);
     expect(warnings[0]).toMatch(/repo broken: in-repo config ignored/);
     expect(warnings[0]).toMatch(/host-owned "security"/);
+    expect(warnings[1]).toMatch(/host-owned "security"/);
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1806

Review the cache invalidation and warning-deduplication regression coverage.

## Validation

| Check                | Command                                                                                       | Result  | Notes                    |
| -------------------- | --------------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test event-runtime/lib/repos.test.mjs && bun test event-runtime/lib/planner.test.mjs`   | pass    | 182 tests, 0 failures    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2237 pass, 0 failures    |
| UX critique          | factory-ux-critic                                                                             | not run | backend cache; no user-facing surface |

UX critique: skipped

run:run_6c481afd-1c24-4c12-99a3-b5f28d3d4a80