### PR TITLE
fix(control-plane): keep gh app daemon timer referenced

### DIFF
--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -391,8 +391,10 @@ export async function runDaemon({
         delayMs = backoff();
       }
       delayMs = Math.max(MIN_REFRESH_DELAY_MS, delayMs);
+      // Keep the daemon's only wakeup handle referenced. In Bun, unref'ing it
+      // while top-level await is still pending can leave the process polling
+      // instead of blocking until the next refresh.
       timer = setTimeoutImpl(scheduleRefresh, delayMs);
-      if (typeof timer?.unref === "function") timer.unref();
     };
 
     void scheduleRefresh();

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -386,6 +386,46 @@ describe("runDaemon", () => {
     await daemon;
   });
 
+  test("keeps the fresh-cache wakeup timer ref'd so the daemon can sleep", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: new Date(start + 60 * 60 * 1000).toISOString(),
+      }),
+    );
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    let unrefCalls = 0;
+    const setTimeoutImpl = (callback, delayMs) => {
+      const id = timers.setTimeoutImpl(callback, delayMs);
+      return {
+        id,
+        unref() {
+          unrefCalls += 1;
+        },
+      };
+    };
+    const daemon = runDaemon({
+      ...daemonOptions(env, timers, signals, async () => {
+        throw new Error("a fresh cache must not mint on startup");
+      }),
+      setTimeoutImpl,
+      clearTimeoutImpl: (timer) => timers.clearTimeoutImpl(timer.id),
+    });
+    await flushDaemon();
+
+    expect(timers.nextDelay()).toBe(45 * 60 * 1000);
+    expect(unrefCalls).toBe(0);
+
+    signals.stop();
+    await daemon;
+  });
+
   test("retries failed refreshes with bounded backoff", async () => {
     const start = Date.parse("2026-08-29T12:00:00Z");
     const dir = tmp("gh-app-daemon-");


### PR DESCRIPTION
Fixes watt-mind/factory#1830

Restart live-stack, then confirm the gh-app-auth daemon remains idle with ps.

## Validation

| Check                | Command                                                                          | Result  | Notes                                |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------ |
| Verification Command | `bun test lib/control-plane/gh-app-auth.test.mjs && bun run lint`              | pass    | 17 tests; lint exits 0               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; 614 existing warnings |
| Idle CPU sample      | `top -b -d 10 -n 4 -p "$pid"`                                                | pass    | 0.1% after 30s with fresh fake cache |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface               |

UX critique: skipped

run:run_e8203431-4795-458e-be4d-919a621a17fa