### PR TITLE
fix(artifacts): surface held artifact GC

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -393,6 +393,10 @@ export async function tick({
         logLine(
           `artifacts: pruned ${pruned.deleted} orphan(s), freed ${pruned.freedBytes}B`,
         );
+      if (pruned.invalidResults > 0)
+        logLine(
+          `artifacts: GC held — ${pruned.invalidResults} unparsable results row(s); ${pruned.remainingOrphans} orphan(s) retained`,
+        );
     });
     gcStep("notify", () => {
       const swept = sweepNotifyLog(db, { now });

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -859,6 +859,39 @@ export default async function start() {
     db.close();
   });
 
+  test("tick warns when unparsable results hold artifact GC", async () => {
+    const { tick } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-18T14:02:11.000Z");
+    const storeRoot = tmpDir("evrt-gc-held-store-");
+    const orphan = path.join(storeRoot, "c".repeat(64));
+    writeFileSync(orphan, "orphan bytes");
+    const stale = new Date(now - 8 * 24 * 60 * 60 * 1000);
+    utimesSync(orphan, stale, stale);
+    db.query(
+      `INSERT INTO results (run_id, attempt, result_json, artifact_hash, verification_json, receipt_json, accepted_at)
+       VALUES ('invalid-result', 1, '{not json', 'sha256:x', '{}', '{}', ?)`,
+    ).run(new Date(now).toISOString());
+    const logs = [];
+
+    await tick({
+      db,
+      registry: loadRegistry(),
+      now,
+      policyVersion: "git:test",
+      lastPrune: 0,
+      storeRoot,
+      log: (line) => logs.push(line),
+    });
+
+    expect(logs).toContain(
+      "artifacts: GC held — 1 unparsable results row(s); 1 orphan(s) retained",
+    );
+    expect(existsSync(orphan)).toBe(true);
+    db.close();
+  });
+
   test("tick sweeps stale notify-log markers on the hourly GC cadence", async () => {
     const { tick, PRUNE_INTERVAL_MS } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -48,8 +48,9 @@ export function getAnomalyLines(s) {
   if (a.unreferencedArtifacts > 0) {
     anomalyLines.push(`unreferenced artifacts: ${a.unreferencedArtifacts}`);
   } else if (s?.artifacts?.orphans > 0) {
+    const heldBy = s.artifacts.invalidResults ?? 0;
     anomalyLines.push(
-      `unreferenced artifacts: ${s.artifacts.orphans} (${s.artifacts.orphanBytes ?? 0}B)`,
+      `unreferenced artifacts: ${s.artifacts.orphans} (${s.artifacts.orphanBytes ?? 0}B)${heldBy > 0 ? ` — GC held by ${heldBy} unparsable result row(s)` : ""}`,
     );
   }
   if (Array.isArray(a.orphanedWorkspaces)) {

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -159,6 +159,21 @@ describe("status and doctor commands", () => {
     ).toBe(true);
   });
 
+  test("reports an artifact GC hold beside unreferenced artifacts", async () => {
+    const { getAnomalyLines } = await import("../cli.mjs");
+    const lines = getAnomalyLines({
+      artifacts: {
+        orphans: 3,
+        orphanBytes: 2048,
+        invalidResults: 2,
+      },
+    });
+
+    expect(lines).toContain(
+      "unreferenced artifacts: 3 (2048B) — GC held by 2 unparsable result row(s)",
+    );
+  });
+
   test(
     "doctor against a healthy live serve outputs anomalies none and exits 0",
     async () => {

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -575,16 +575,17 @@ export function listArtifactPage(
  * `tempBytes`; they are not content-addressed artifacts or orphan candidates.
  */
 export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
+  const referenced = referencedHashes(db);
   if (!existsSync(storeRoot))
     return {
       files: 0,
       bytes: 0,
       orphans: 0,
       orphanBytes: 0,
+      invalidResults: referenced.invalid,
       tempFiles: 0,
       tempBytes: 0,
     };
-  const referenced = referencedHashes(db);
   let files = 0;
   let bytes = 0;
   let orphans = 0;
@@ -616,6 +617,7 @@ export function storeStats(db, storeRoot, { now = Date.now() } = {}) {
     bytes,
     orphans,
     orphanBytes,
+    invalidResults: referenced.invalid,
     tempFiles,
     tempBytes,
     at: new Date(now).toISOString(),

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -636,6 +636,10 @@ describe("store maintenance: referencedHashes, storeStats, pruneArtifacts, pinRu
     const hashes = referencedHashes(db);
     expect(hashes.has(referencedHash)).toBe(true);
     expect(hashes.invalid).toBe(1);
+    expect(storeStats(db, storeRoot)).toMatchObject({
+      orphans: 1,
+      invalidResults: 1,
+    });
     expect(artifactReferenceIndex(db).get(referencedHash)).toEqual([
       expect.objectContaining({ runId: "run_valid", kind: "transcript" }),
     ]);

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -297,6 +297,7 @@ export function statusView(
       bytes: store.bytes,
       orphans: store.orphans,
       orphanBytes: store.orphanBytes,
+      invalidResults: store.invalidResults ?? 0,
       ...(store.at ? { at: store.at } : {}),
     },
     // `approve.before` hook decisions in the trailing 24h, by hook id

--- a/event-runtime/lib/status-view.test.mjs
+++ b/event-runtime/lib/status-view.test.mjs
@@ -67,6 +67,26 @@ describe("statusView outbox counts", () => {
       "GitHub webhook intake is stale (last admission was 86400000ms ago; threshold 43200000ms)",
     );
   });
+
+  test("exposes unparsable result counts with artifact statistics", () => {
+    const db = openDb(":memory:");
+    const view = statusView(db, { schedules: [] }, Date.now(), {
+      getStoreStats: () => ({
+        files: 1,
+        bytes: 1024,
+        orphans: 1,
+        orphanBytes: 1024,
+        invalidResults: 2,
+      }),
+    });
+
+    expect(view.artifacts).toMatchObject({
+      orphans: 1,
+      orphanBytes: 1024,
+      invalidResults: 2,
+    });
+    db.close();
+  });
 });
 
 function seedGithubEvent(db, admittedAt) {


### PR DESCRIPTION
Fixes #1858

Surface malformed result rows that hold artifact GC in serve logs and status output.

## Validation

| Check                | Command                                                                                                                                    | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/artifacts.test.mjs event-runtime/cli/serve.test.mjs event-runtime/lib/status-view.test.mjs event-runtime/cli/status.test.mjs` | pass    | 68 pass, 0 fail                        |
| Ticket lint          | `bun run lint`                                                                                                                             | pass    | 0 errors; 614 existing warnings        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                       | pass    | 2,243 pass, 10 skipped; emit/format OK |
| UX critique          | `factory-ux-critic`                                                                                                                       | not run | backend/operator status observability  |

UX critique: skipped

run:run_4edb3f22-edfb-497f-9d05-40d8bb0584ca