### PR TITLE
fix(web): paginate artifact inventory

### DIFF
--- a/event-runtime/web/src/views/Artifacts.test.tsx
+++ b/event-runtime/web/src/views/Artifacts.test.tsx
@@ -105,8 +105,13 @@ function renderArtifacts(
       initialFilters.search,
     ],
     {
-      artifacts: seed.items ?? ITEMS,
-      nextBefore: seed.nextBefore,
+      pages: [
+        {
+          artifacts: seed.items ?? ITEMS,
+          nextBefore: seed.nextBefore,
+        },
+      ],
+      pageParams: [undefined],
     },
   );
   if (seed.agents)
@@ -239,20 +244,24 @@ describe("Artifacts inventory (WM-207)", () => {
   });
 
   test("filters by kind and orphan status facets", async () => {
+    globalThis.fetch = mock(
+      async () =>
+        new Response(JSON.stringify({ artifacts: ITEMS }), { status: 200 }),
+    ) as unknown as typeof fetch;
     const view = renderArtifacts();
     await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
 
     fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
       target: { value: "report" },
     });
-    expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy();
+    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
     expect(view.queryByText("bbbbbbbbbbbb")).toBeNull();
 
     fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
       target: { value: "" },
     });
     fireEvent.click(view.getByRole("tab", { name: "Orphans 28" }));
-    expect(view.getByText("cccccccccccc")).toBeTruthy();
+    await waitFor(() => expect(view.getByText("cccccccccccc")).toBeTruthy());
     expect(view.queryByText("aaaaaaaaaaaa")).toBeNull();
   });
 
@@ -381,28 +390,64 @@ describe("Artifacts inventory (WM-207)", () => {
     expect(view.queryByText(/run_trace/)).toBeNull();
   });
 
-  test("warns when the server has more artifacts than this page", async () => {
+  test("reports metadata query failures instead of claiming the artifact was pruned", async () => {
+    window.location.hash = `#/artifacts/${"a".repeat(64)}`;
+    globalThis.fetch = mock(
+      async () => new Response("unavailable", { status: 503 }),
+    ) as unknown as typeof fetch;
+
+    const view = renderArtifacts(undefined, undefined, { items: [] });
+
+    await view.findByText(/could not load artifact metadata/i);
+    expect(view.getByText(/cannot reach the control api/i)).toBeTruthy();
+    expect(view.getByRole("button", { name: "Retry" })).toBeTruthy();
+    expect(view.queryByText(/may have been pruned/i)).toBeNull();
+  });
+
+  test("appends an older artifact page and resets to the first page for a new filter", async () => {
+    const older = {
+      ...ITEMS[2],
+      sha256: "d".repeat(64),
+      references: [
+        {
+          runId: "run_older",
+          kind: "report",
+          agent: "reporter@1",
+          state: "COMPLETED",
+          createdAt: "2026-01-01T03:04:05.000Z",
+        },
+      ],
+    };
+    const requests: string[] = [];
+    globalThis.fetch = mock(async (input: string | URL | Request) => {
+      const url = String(input);
+      requests.push(url);
+      const params = new URL(url, "http://localhost").searchParams;
+      const artifacts = params.get("before") ? [older] : ITEMS;
+      return new Response(
+        JSON.stringify({
+          artifacts,
+          nextBefore: params.get("before") ? null : "older-artifacts",
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof fetch;
+
     const view = renderArtifacts(undefined, undefined, {
       nextBefore: "older-artifacts",
     });
-    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
+    await view.findByText("aaaaaaaaaaaa");
+    fireEvent.click(view.getByRole("button", { name: "Load older artifacts" }));
+    await view.findByText("dddddddddddd");
+    expect(requests).toContain("/api/artifacts?before=older-artifacts");
 
-    expect(view.getByRole("status").textContent).toMatch(
-      /showing 3 artifacts.*more.*narrow the filter/i,
+    fireEvent.change(view.getByRole("combobox", { name: "Artifact kind" }), {
+      target: { value: "report" },
+    });
+    await waitFor(() =>
+      expect(requests).toContain("/api/artifacts?kind=report"),
     );
-  });
-
-  test("the more-available notice counts the visible rows", async () => {
-    const view = renderArtifacts(
-      undefined,
-      { kind: "report", orphan: null, search: "" },
-      { nextBefore: "older-artifacts" },
-    );
-    await waitFor(() => expect(view.getByText("aaaaaaaaaaaa")).toBeTruthy());
-
-    expect(view.getByRole("status").textContent).toMatch(
-      /showing 1 artifacts?.*more/i,
-    );
+    expect(view.queryByText("dddddddddddd")).toBeNull();
   });
 
   test("opens a deep-linked inspector with formatted preview, actions, search, and bidirectional references", async () => {

--- a/event-runtime/web/src/views/Artifacts.tsx
+++ b/event-runtime/web/src/views/Artifacts.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useInfiniteQuery, useQuery } from "@tanstack/react-query";
 import {
   useCallback,
   useEffect,
@@ -287,18 +287,21 @@ export function Artifacts({
   formatContent?: typeof formattedContent;
 }) {
   const now = useNow();
-  const artifactsQ = useQuery({
+  const artifactsQ = useInfiniteQuery({
     queryKey: ["artifacts", filters.kind, filters.orphan, filters.search],
-    queryFn: () =>
+    queryFn: ({ pageParam }) =>
       fetchArtifacts({
         kind: filters.kind ?? undefined,
         orphan: filters.orphan ?? undefined,
         search: filters.search.trim() || undefined,
+        before: pageParam,
       }),
-    placeholderData: (previousData) => previousData,
+    initialPageParam: undefined as string | undefined,
+    getNextPageParam: (lastPage) => lastPage.nextBefore ?? undefined,
     ...refetchIntervals.primary,
   });
-  const artifacts = artifactsQ.data?.artifacts ?? [];
+  const artifacts =
+    artifactsQ.data?.pages.flatMap((page) => page.artifacts) ?? [];
   const [selectedSha, setSelectedSha] = useState(() => artifactShaFromHash());
   const [contentSearch, setContentSearch] = useState("");
 
@@ -333,6 +336,7 @@ export function Artifacts({
   const metadataPending =
     artifactsQ.isPending ||
     (fallbackQ.isPending && fallbackQ.fetchStatus !== "idle");
+  const metadataError = artifactsQ.isError || fallbackQ.isError;
   const contentQ = useQuery({
     queryKey: ["artifact-content", selectedSha],
     queryFn: async () => {
@@ -660,12 +664,6 @@ export function Artifacts({
                 </>
               }
             />
-            {artifactsQ.data?.nextBefore && (
-              <p role="status" className="mt-2 text-[12px] text-(--text-dim)">
-                Showing {visible.length.toLocaleString()} artifacts; more are
-                available. Narrow the filter to see a smaller result set.
-              </p>
-            )}
           </>
         }
       >
@@ -869,6 +867,20 @@ export function Artifacts({
                 }
               />
             )}
+            {artifactsQ.hasNextPage && (
+              <tr>
+                <td colSpan={columns.length} className="px-3 py-3 text-center">
+                  <Button
+                    onClick={() => void artifactsQ.fetchNextPage()}
+                    disabled={artifactsQ.isFetchingNextPage}
+                  >
+                    {artifactsQ.isFetchingNextPage
+                      ? "Loading older artifacts…"
+                      : "Load older artifacts"}
+                  </Button>
+                </td>
+              </tr>
+            )}
           </tbody>
         </Table>
       </ListPane>
@@ -942,7 +954,23 @@ export function Artifacts({
               Loading artifact metadata…
             </div>
           )}
-          {!selected && !metadataPending && (
+          {!selected && metadataError && (
+            <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
+              <p>
+                Cannot reach the control API — could not load artifact metadata.
+              </p>
+              <Button
+                className="mt-3"
+                onClick={() => {
+                  void artifactsQ.refetch();
+                  if (fallbackQ.isError) void fallbackQ.refetch();
+                }}
+              >
+                Retry
+              </Button>
+            </div>
+          )}
+          {!selected && !metadataPending && !metadataError && (
             <div className="mb-4 rounded-md border border-(--border) p-3 text-(--text-faint)">
               Artifact metadata is unavailable. The content may have been
               pruned.


### PR DESCRIPTION
Fixes #1856

Artifacts now append older cursor pages and distinguish metadata API failures from pruned content.

## Validation

| Check                | Command                                                                          | Result    | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------- | --------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web/src/views/Artifacts.test.tsx && bun run check:web && bun run lint` | pass      | 36 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass      | clean                                      |
| UX critique          | factory-ux-critic                                                                | FIX-FIRST | demo has 4 rows; pagination/error flow unexercised |

UX critique: FIX-FIRST

run:run_bf4e0d9e-4913-48f5-b821-b0d0da46ec82
