### PR TITLE
fix(web): enrich worker runs beyond summary page

### DIFF
--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -19,8 +19,13 @@ import {
   workerDisplayState,
 } from "./Workers";
 import { api } from "../api";
-import { changeInput } from "../test-render";
+import {
+  changeInput,
+  createRunDetailFixture,
+  createRunSpecFixture,
+} from "../test-render";
 import type {
+  RunDetail,
   RunListItem,
   Worker,
   WorkerCapacity,
@@ -719,6 +724,56 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
       expect(container.textContent).not.toContain("factory · WM-253");
       expect(container.textContent).not.toContain("undefined");
     });
+  });
+
+  test("fetches an active run absent from the bounded summary (factory#1857)", async () => {
+    const runId = "run_older_active_1857";
+    const workerBusy: Worker = {
+      ...stubWorker("w_busy_active", "busy"),
+      currentRun: runId,
+    };
+    const detail = createRunDetailFixture({
+      run: {
+        runId,
+        state: "RUNNING",
+        attempts: 1,
+        spec: createRunSpecFixture(runId, {
+          agent: "dispatch@1",
+          adapter: "pi",
+          model: "openai-codex/gpt-5.6-sol",
+          input: { repo: "factory", ticket: "WM-253" },
+        }),
+      } as RunDetail["run"],
+    });
+    const origRun = api.run;
+    const requested: string[] = [];
+    api.run = async (id) => {
+      requested.push(id);
+      return detail;
+    };
+
+    try {
+      await withRunsAndWorkers([workerBusy], [], async () => {
+        const view = renderWithClient(
+          <Workers
+            context={{ kind: "all" }}
+            focusWorkerId="w_busy_active"
+            onSelectWorker={noop}
+          />,
+        );
+
+        await waitFor(() => {
+          expect(view.getAllByText("dispatch@1").length).toBeGreaterThan(0);
+          expect(view.container.textContent).toContain("factory · WM-253");
+          expect(
+            view.getAllByText("openai-codex/gpt-5.6-sol").length,
+          ).toBeGreaterThan(0);
+        });
+        expect(requested).toEqual([runId]);
+      });
+    } finally {
+      api.run = origRun;
+    }
   });
 
   test("uses the compact default column set and renders optional adapters as a titled count", async () => {

--- a/event-runtime/web/src/views/Workers.test.tsx
+++ b/event-runtime/web/src/views/Workers.test.tsx
@@ -13,12 +13,14 @@ import {
   Workers,
   capacityFromWorkers,
   defaultWorkerTab,
+  enrichWorker,
   fleetBanner,
   isLive,
   partitionWorkers,
   workerDisplayState,
 } from "./Workers";
 import { api } from "../api";
+import { EMPTY } from "../format";
 import {
   changeInput,
   createRunDetailFixture,
@@ -774,6 +776,23 @@ describe("Active agent, target, and model columns in Workers view (WM-463)", () 
     } finally {
       api.run = origRun;
     }
+  });
+
+  test("shows the Loading placeholder for agent, target, and model while the missing-run fetch is pending (factory#1857)", () => {
+    const w: Worker = {
+      ...stubWorker("w_busy_pending", "busy"),
+      currentRun: "run_pending_1857",
+    };
+
+    const pending = enrichWorker(w, new Map(), new Set(["run_pending_1857"]));
+    expect(pending.activeAgent).toBe("Loading…");
+    expect(pending.activeTarget).toBe("Loading…");
+    expect(pending.activeModel).toBe("Loading…");
+
+    const settledMissing = enrichWorker(w, new Map(), new Set());
+    expect(settledMissing.activeAgent).toBe(EMPTY);
+    expect(settledMissing.activeTarget).toBe(EMPTY);
+    expect(settledMissing.activeModel).toBe(EMPTY);
   });
 
   test("uses the compact default column set and renders optional adapters as a titled count", async () => {

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -280,7 +280,9 @@ export function enrichWorker(
   const activeTarget =
     repos && ticketMatch && !repos.includes(ticketMatch)
       ? `${repos} · ${ticketMatch}`
-      : repos || ticketMatch || (r?.eventId ? shortId(r.eventId) : EMPTY);
+      : repos ||
+        ticketMatch ||
+        (r?.eventId ? shortId(r.eventId) : loading ? LOADING : EMPTY);
   const activeModel = r
     ? pinnedModelText(r.adapter, r.model)
     : loading
@@ -672,7 +674,10 @@ export function Workers({
           query.isPending ? [missingRunIds[index]] : [],
         ),
       ),
-    [missingRunIds, missingRunQueries],
+    // useQueries returns a new array every render; its data timestamps are
+    // the stable inputs that should recompute this projection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [missingRunIds, missingRunDataKey],
   );
   const allRuns = useMemo(
     () => new Map([...runMap, ...missingRunMap]),

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -1,4 +1,4 @@
-import { useQuery } from "@tanstack/react-query";
+import { useQueries, useQuery } from "@tanstack/react-query";
 import { Fragment, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import {
@@ -24,7 +24,7 @@ import { DisplayOptions } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { TicketText } from "../components/TicketHoverCard";
 import { setContextActions } from "../palette";
-import type { RunListItem, Worker, WorkerCapacity } from "../types";
+import type { RunDetail, RunListItem, Worker, WorkerCapacity } from "../types";
 import type { OperatorContext } from "../context";
 import { pinnedModelText } from "../components/RunDetailBlocks";
 import {
@@ -201,12 +201,79 @@ export interface EnrichedWorker extends Worker {
   runItem: RunListItem | null;
 }
 
+const LOADING = "Loading…";
+
+function runContext(input: unknown): {
+  repos: string[];
+  eventId: string | null;
+} {
+  const repos = new Set<string>();
+  let eventId: string | null = null;
+  const visit = (value: unknown): void => {
+    if (!value || typeof value !== "object") return;
+    if (Array.isArray(value)) {
+      value.forEach(visit);
+      return;
+    }
+    for (const [key, entry] of Object.entries(value)) {
+      if (key === "repo" && typeof entry === "string") repos.add(entry);
+      if (
+        key === "repos" &&
+        Array.isArray(entry) &&
+        entry.every((item) => typeof item === "string")
+      ) {
+        entry.forEach((repo) => repos.add(repo));
+      }
+      if (
+        !eventId &&
+        /^(ticket|ticketId|issue|issueId|linearId|subject)$/i.test(key) &&
+        typeof entry === "string"
+      ) {
+        eventId = entry;
+      }
+      visit(entry);
+    }
+  };
+  visit(input);
+  return { repos: [...repos], eventId };
+}
+
+/**
+ * The run list is intentionally a bounded summary, but a worker's current
+ * run is a direct reference and must remain resolvable after it falls off
+ * that page. Adapt the detail response to the display fields this view uses.
+ */
+function runItemFromDetail(detail: RunDetail): RunListItem {
+  const { run } = detail;
+  const { spec } = run;
+  const { repos, eventId } = runContext(spec.input);
+  return {
+    runId: run.runId,
+    state: run.state,
+    attempts: run.attempts,
+    maxAttempts: spec.maxAttempts,
+    agent: spec.agent,
+    adapter: spec.adapter,
+    reasonCode: detail.result?.reasonCode ?? null,
+    eventId,
+    eventSource: null,
+    created_at: run.created_at,
+    updated_at: run.updated_at,
+    modelTier: spec.modelTier ?? null,
+    model: spec.model ?? null,
+    repos,
+    spec,
+  };
+}
+
 export function enrichWorker(
   w: Worker,
   runMap: Map<string, RunListItem>,
+  loadingRunIds: Set<string> = new Set(),
 ): EnrichedWorker {
   const r = w.currentRun ? (runMap.get(w.currentRun) ?? null) : null;
-  const activeAgent = r?.agent ?? EMPTY;
+  const loading = !!w.currentRun && loadingRunIds.has(w.currentRun);
+  const activeAgent = r?.agent ?? (loading ? LOADING : EMPTY);
   const repos = r?.repos?.length ? r.repos.join(", ") : "";
   const ticketMatch =
     r?.eventId?.match(/\b([A-Z]{2,10}-\d+|PR-\d+)\b/)?.[0] ?? "";
@@ -214,7 +281,11 @@ export function enrichWorker(
     repos && ticketMatch && !repos.includes(ticketMatch)
       ? `${repos} · ${ticketMatch}`
       : repos || ticketMatch || (r?.eventId ? shortId(r.eventId) : EMPTY);
-  const activeModel = r ? pinnedModelText(r.adapter, r.model) : EMPTY;
+  const activeModel = r
+    ? pinnedModelText(r.adapter, r.model)
+    : loading
+      ? LOADING
+      : EMPTY;
   return {
     ...w,
     activeAgent,
@@ -562,9 +633,54 @@ export function Workers({
   const response = query.data as
     { workers: Worker[]; capacity?: WorkerCapacity } | undefined;
   const rawRows = response?.workers ?? [];
-  const rows = useMemo(
-    () => rawRows.map((w) => enrichWorker(w, runMap)),
+  const missingRunIds = useMemo(
+    () =>
+      [...new Set(rawRows.flatMap((w) => w.currentRun ?? []))].filter(
+        (runId) => !runMap.has(runId),
+      ),
     [rawRows, runMap],
+  );
+  const missingRunQueries = useQueries({
+    queries: missingRunIds.map((id) => ({
+      queryKey: ["run", id],
+      queryFn: () => api.run(id),
+      ...refetchIntervals.primary,
+      retry: 1,
+    })),
+  });
+  const missingRunDataKey = missingRunQueries
+    .map((query) => query.dataUpdatedAt)
+    .join(",");
+  const missingRunMap = useMemo(
+    () =>
+      new Map(
+        missingRunQueries.flatMap((query) =>
+          query.data
+            ? [[query.data.run.runId, runItemFromDetail(query.data)] as const]
+            : [],
+        ),
+      ),
+    // useQueries returns a new array every render; its data timestamps are
+    // the stable inputs that should recompute this projection.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [missingRunIds, missingRunDataKey],
+  );
+  const loadingRunIds = useMemo(
+    () =>
+      new Set(
+        missingRunQueries.flatMap((query, index) =>
+          query.isPending ? [missingRunIds[index]] : [],
+        ),
+      ),
+    [missingRunIds, missingRunQueries],
+  );
+  const allRuns = useMemo(
+    () => new Map([...runMap, ...missingRunMap]),
+    [runMap, missingRunMap],
+  );
+  const rows = useMemo(
+    () => rawRows.map((w) => enrichWorker(w, allRuns, loadingRunIds)),
+    [rawRows, allRuns, loadingRunIds],
   );
   const capacity = response?.capacity ?? capacityFromWorkers(rawRows);
 


### PR DESCRIPTION
Fixes watt-mind/factory#1857

Review the draft: active workers now resolve out-of-page run metadata; #1876 tracks the unresolved direct Runs navigation.

## Validation

| Check                | Command                                                                  | Result | Notes                                      |
| -------------------- | ------------------------------------------------------------------------ | ------ | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web/src/views/Workers.test.tsx`                 | pass   | 29 tests, 0 failures                       |
| Ticket typecheck     | `bun run check:web`                                                     | pass   | TypeScript clean                           |
| Ticket lint          | `bun run lint`                                                          | pass   | 615 pre-existing warnings, 0 errors       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | configured gates clean                     |
| Web build            | `cd event-runtime/web && bun run build`                                 | pass   | Vite production build completed            |
| UX critique          | factory-ux-critic                                                       | fail   | direct Runs detail follow-up: #1876        |

UX critique: required — FIX-FIRST unresolved

run:run_6190b109-6b97-4620-8425-86f12791d369

## Post-review

- `activeTarget` now falls back to the same `Loading…` placeholder as agent/model while the missing-run fetch is pending.
- `loadingRunIds` memo now keys on `missingRunDataKey` (like `missingRunMap`) instead of the per-render `missingRunQueries` array, so it no longer recomputes every render.
- Added an `enrichWorker` unit test covering the pending-vs-settled placeholder states.
