### PR TITLE
feat(dispatch): surface dispatch pause in status

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -488,6 +488,13 @@ read-only `factory.ci-diagnose.requested`; missing or malformed policy means
 watched. The event must have been admitted with source `chain`, and the normal
 proposal, lifecycle, journal, budget, and worker gates remain in force.
 
+`dispatch.paused: true` (shown in `config/policy.example.yaml`) is the
+operator brake for unattended dispatch. A non-operator
+`factory.dispatch.requested` becomes a durable NOOP with reason
+`dispatch_paused`, and the auto-approver leaves an already-open proposal with
+`auto_approval_ineligible:dispatch_paused`. Set `dispatch.paused: false` to
+resume on the next pass; no restart is required.
+
 `factory.ci-diagnose.requested` runs `ci-doctor@2`, which is non-mutating and
 limited to `gh:read`; its downstream `ci-rerun` and `dispatch` edges retain
 their separate approval gates.
@@ -522,6 +529,7 @@ brackets.
 | `merge_policy_invalid`            | Supply valid merge fix rounds, auto-merge bases, and owners.                     |
 | `policy_unknown`                  | Load a policy which supplies a typed refusal reason.                             |
 | `event_type_not_allowlisted`      | Add the supported event type to the explicit allowlist, or use watched approval. |
+| `dispatch_paused`                 | Set `dispatch.paused: false`; the next pass resumes without a restart.           |
 
 **Capacity**
 

--- a/event-runtime/cli/status.mjs
+++ b/event-runtime/cli/status.mjs
@@ -152,7 +152,11 @@ export function getPoolLines(pool, s) {
 export async function status(client, args = []) {
   const s = await client.status();
   const pool = getPoolLines(readPool(), s);
-  const anomalyLines = [...getAnomalyLines(s), ...pool.anomalies];
+  const anomalyLines = [
+    ...getAnomalyLines(s),
+    ...(s?.policy?.dispatchPaused ? ["dispatch_paused"] : []),
+    ...pool.anomalies,
+  ];
   if (args.includes("--json")) {
     console.log(
       JSON.stringify({
@@ -181,6 +185,11 @@ export async function status(client, args = []) {
       "dead_lettered",
     ]),
   );
+  if (s?.policy?.dispatchPaused) {
+    console.log(
+      `${pad("dispatch", 11)}PAUSED (config/policy.yaml dispatch.paused)`,
+    );
+  }
   console.log(countLine("proposals", s.proposals, ["open", "expired"]));
   if (s.inbox) console.log(countLine("inbox", s.inbox, ["open", "acked"]));
   const states = Object.keys(s.runs.byState);

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -39,6 +39,12 @@ describe("status and doctor commands", () => {
       writes.length = 0;
       await status({ status: async () => payload }, ["--json"]);
       expect(JSON.parse(writes[0]).anomalies).toContain("dispatch_paused");
+
+      writes.length = 0;
+      await status({
+        status: async () => ({ ...payload, policy: { dispatchPaused: false } }),
+      });
+      expect(writes.some((line) => line.startsWith("dispatch"))).toBe(false);
     } finally {
       console.log = originalLog;
     }

--- a/event-runtime/cli/status.test.mjs
+++ b/event-runtime/cli/status.test.mjs
@@ -17,6 +17,33 @@ import {
 registerCliTmpCleanup();
 
 describe("status and doctor commands", () => {
+  test("status shows an operator dispatch pause in text and JSON anomalies", async () => {
+    const { status } = await import("../cli.mjs");
+    const writes = [];
+    const originalLog = console.log;
+    console.log = (line) => writes.push(line);
+    const payload = {
+      events: {},
+      policy: { dispatchPaused: true },
+      proposals: {},
+      runs: { byState: {} },
+      anomalies: {},
+    };
+
+    try {
+      await status({ status: async () => payload });
+      expect(writes).toContain(
+        "dispatch   PAUSED (config/policy.yaml dispatch.paused)",
+      );
+
+      writes.length = 0;
+      await status({ status: async () => payload }, ["--json"]);
+      expect(JSON.parse(writes[0]).anomalies).toContain("dispatch_paused");
+    } finally {
+      console.log = originalLog;
+    }
+  });
+
   test(
     "status --json reports in-flight counts from a live seeded serve",
     async () => {

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -226,6 +226,7 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
       const expectedStatusKeys =
         extractDirectProperties(statusViewBlock).sort();
       expect(Object.keys(status).sort()).toEqual(expectedStatusKeys);
+      expect(status.policy).toEqual({ dispatchPaused: expect.any(Boolean) });
       expect(status.inbox).toEqual({ open: 0, acked: 0, byKind: {} });
       expect(status.githubIntake).toEqual({
         configured: true,

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -8,6 +8,7 @@ import { usageSpend } from "./db.mjs";
 import { hookDecisionCounts } from "./hooks.mjs";
 import { inboxCounts } from "./inbox.mjs";
 import { githubIntakeView } from "./intake.mjs";
+import { policyDispatchPaused } from "./planner.mjs";
 import { ambiguousOpenProposalRuns, openProposals } from "./proposals.mjs";
 import { proposalsPilingUp, scheduleView } from "./schedules.mjs";
 import {
@@ -188,6 +189,7 @@ export function statusView(
     getStoreStats,
     workerPolicy,
     workerRunDir,
+    dispatchPaused = policyDispatchPaused,
   } = {},
 ) {
   const open = openProposals(db, { now: nowMs });
@@ -249,6 +251,7 @@ export function statusView(
     : storeStats(db, artifactsRoot(env?.home), { now: nowMs });
   const stalled = stalledWorkers(db, { now: nowMs });
   const runs = { ...runCounts(db), spend: usageSpend(db, { now: nowMs }) };
+  const policy = { dispatchPaused: dispatchPaused() };
 
   const configAnomalies = [];
   const githubIntake = githubIntakeView(db, {
@@ -283,6 +286,7 @@ export function statusView(
   return {
     events: eventCounts(db),
     githubIntake,
+    policy,
     proposals: { open: open.length, expired: expiredOpen.length },
     inbox: inboxCounts(db),
     runs,

--- a/event-runtime/lib/status-view.test.mjs
+++ b/event-runtime/lib/status-view.test.mjs
@@ -3,6 +3,21 @@ import { openDb } from "./db.mjs";
 import { statusView } from "./status-view.mjs";
 
 describe("statusView outbox counts", () => {
+  test("publishes whether an operator has paused unattended dispatch", () => {
+    const db = openDb(":memory:");
+
+    expect(
+      statusView(db, { schedules: [] }, Date.now(), {
+        dispatchPaused: () => true,
+      }).policy,
+    ).toEqual({ dispatchPaused: true });
+    expect(
+      statusView(db, { schedules: [] }, Date.now(), {
+        dispatchPaused: () => false,
+      }).policy,
+    ).toEqual({ dispatchPaused: false });
+  });
+
   test("reports parked rows separately from unpublished rows", () => {
     const db = openDb(":memory:");
     const now = Date.now();

--- a/event-runtime/web/src/reasons.ts
+++ b/event-runtime/web/src/reasons.ts
@@ -67,6 +67,7 @@ export const REASONS: Record<string, string> = {
   dispatch_ineligible: "Dispatch ineligible",
   dispatch_recheck_failed: "Dispatch re-check failed",
   dispatch_recheck_unavailable: "Dispatch re-check unavailable",
+  dispatch_paused: "Dispatch paused by operator",
   evidence_changed_since_plan: "evidence changed since plan",
   event_human_approval_only: "Event requires human approval",
   merge_barrier_unverified: "Merge barrier unverified",

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -843,6 +843,8 @@ export interface UnmatchedPlacementRun {
 export interface StatusView {
   env: EnvIdentity;
   events: Record<string, number>;
+  /** Operator-controlled pause for unattended dispatches. */
+  policy?: { dispatchPaused: boolean };
   /** GitHub webhook intake health; absent on pre-#1632 control APIs. */
   githubIntake?: GithubIntakeStatus;
   proposals: { open: number; expired: number };


### PR DESCRIPTION
Fixes watt-mind/factory#1853

Show the operator dispatch brake in API, CLI, web labels, and dispatch guidance.

## Validation

| Check                | Command                                                                        | Result  | Notes                       |
| -------------------- | ------------------------------------------------------------------------------ | ------- | --------------------------- |
| Verification Command | `bun test event-runtime/cli/status.test.mjs event-runtime/lib/api-runs.test.mjs` | pass    | 55 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2243 pass, 10 skip; lint clean |
| TypeScript           | `cd event-runtime/web && bun x tsc --noEmit`                                  | pass    | clean                       |
| UX critique          | `factory-ux-critic`                                                           | not run | no user-completable flow    |

UX critique: skipped — status visibility, reason label, and documentation only

run:run_232ad59b-03dd-47a9-af52-c75d32fed420