### PR TITLE
fix(artifacts): tolerate deleted blobs during inventory

### DIFF
--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -3,6 +3,7 @@ import {
   trackTmpDir,
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-artifacts-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { symlinkSync } from "node:fs";
 import { artifactReferenceIndex } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import {
@@ -47,6 +48,42 @@ const makeServer = async (...args) => {
 };
 
 describe("artifact store and agent registry surfacing (OPS-212)", () => {
+  test("GET /artifacts ignores an entry that vanishes during inventory", async () => {
+    const home = tmpDir("evrt-artifact-page-race-");
+    const store = path.join(home, "artifacts");
+    mkdirSync(store, { recursive: true });
+    const survivingHash = "a".repeat(64);
+    const vanishedHash = "b".repeat(64);
+    writeFileSync(path.join(store, survivingHash), "survives", "utf8");
+    // statSync follows this dangling link and observes it as absent, matching
+    // a blob deleted by a concurrent prune after readdirSync.
+    symlinkSync(
+      path.join(store, "no-longer-present"),
+      path.join(store, vanishedHash),
+    );
+
+    const db = openDb(path.join(home, "runtime.db"));
+    const server = startApi({
+      db,
+      registry,
+      secret: SECRET,
+      policyVersion: PV,
+      port: 0,
+      env: { name: "test", home, adapter: "fake" },
+    });
+    await new Promise((resolve) => server.on("listening", resolve));
+    const base = `http://127.0.0.1:${server.address().port}`;
+    try {
+      const response = await fetch(`${base}/artifacts`);
+      expect(response.status).toBe(200);
+      expect(
+        (await response.json()).artifacts.map(({ sha256 }) => sha256),
+      ).toEqual([survivingHash]);
+    } finally {
+      server.close();
+    }
+  });
+
   test("GET /artifacts reuses its index until a new result arrives", async () => {
     const home = tmpDir("evrt-artifact-page-cache-");
     const store = path.join(home, "artifacts");

--- a/event-runtime/lib/artifacts.mjs
+++ b/event-runtime/lib/artifacts.mjs
@@ -485,8 +485,11 @@ export function artifactInventory(storeRoot) {
   for (const sha256 of readdirSync(storeRoot).filter((name) =>
     HEX64.test(name),
   )) {
-    const stat = statSync(path.join(storeRoot, sha256));
-    if (!stat.isFile()) continue;
+    // A concurrent prune may remove the entry between readdir and stat.
+    const stat = statSync(path.join(storeRoot, sha256), {
+      throwIfNoEntry: false,
+    });
+    if (!stat?.isFile()) continue;
     inventory.push({
       sha256,
       sizeBytes: stat.size,

--- a/event-runtime/lib/artifacts.test.mjs
+++ b/event-runtime/lib/artifacts.test.mjs
@@ -59,6 +59,26 @@ describe("artifactPath", () => {
   });
 });
 
+describe("artifactInventory", () => {
+  test("skips an entry that vanishes after the directory is read", () => {
+    const storeRoot = tmp("evrt-inventory-store-");
+    mkdirSync(storeRoot, { recursive: true });
+    const survivingHash = "a".repeat(64);
+    const vanishedHash = "b".repeat(64);
+    writeFileSync(path.join(storeRoot, survivingHash), "survives");
+    // A dangling symlink gives statSync the same ENOENT result as a blob that
+    // a concurrent prune removed after readdirSync returned its name.
+    symlinkSync(
+      path.join(storeRoot, "no-longer-present"),
+      path.join(storeRoot, vanishedHash),
+    );
+
+    expect(artifactInventory(storeRoot).map(({ sha256 }) => sha256)).toEqual([
+      survivingHash,
+    ]);
+  });
+});
+
 describe("findArtifact", () => {
   test("finds artifact when present and returns null when absent or malformed", () => {
     const { storeRoot, hash } = makeStore("test-content");


### PR DESCRIPTION
Fixes watt-mind/factory#1859

Prevent artifact catalogue 500s when a concurrent prune deletes a blob.

## Validation

| Check                | Command                                                                    | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/artifacts.test.mjs event-runtime/lib/api-artifacts.test.mjs` | pass | 39 tests, 0 failures |
| Verification Command | `bun run lint`                                                             | pass    | 614 existing warnings, 0 errors    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, lint clean |
| UX critique          | factory-ux-critic                                                          | not run | backend API resilience; no UI flow |

UX critique: skipped — backend artifact inventory/API resilience; no user-facing surface

run:run_80f58c54-eec6-47aa-a217-7d0de7e7734b