### PR TITLE
fix(api): harden repository config writes

### DIFF
--- a/event-runtime/lib/api-repos.mjs
+++ b/event-runtime/lib/api-repos.mjs
@@ -8,12 +8,17 @@
  */
 import { randomUUID } from "node:crypto";
 import {
+  closeSync,
   existsSync,
+  fchmodSync,
+  fsyncSync,
   mkdirSync,
   mkdtempSync,
+  openSync,
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   writeFileSync,
 } from "node:fs";
 import os from "node:os";
@@ -55,6 +60,9 @@ const HOST_KEYS = {
   maxInFlight: "max_in_flight",
   runnerLabels: "runner_labels",
 };
+const HOST_CONFIG_SNAPSHOT = Symbol("host config snapshot");
+
+class HostConfigConflictError extends RepoError {}
 
 function isObject(value) {
   return value !== null && typeof value === "object" && !Array.isArray(value);
@@ -89,6 +97,13 @@ function validateFields(value, allowed, required = []) {
     (typeof value.path !== "string" || !value.path.trim())
   )
     return "path must be a non-empty string";
+  if (
+    Object.hasOwn(value, "path") &&
+    !path.isAbsolute(value.path) &&
+    value.path !== "~" &&
+    !value.path.startsWith("~/")
+  )
+    return "path must be absolute or ~-prefixed";
   if (
     Object.hasOwn(value, "controlPlane") &&
     !CONTROL_PLANES.has(value.controlPlane)
@@ -191,14 +206,46 @@ function hostConfigError(message, file) {
  */
 function readHostConfig(root) {
   const file = reposConfigPath(root);
-  if (!existsSync(file)) return { repos: [] };
-  const parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+  if (!existsSync(file)) {
+    const parsed = { repos: [] };
+    Object.defineProperty(parsed, HOST_CONFIG_SNAPSHOT, {
+      value: { file, contents: null, stat: null },
+    });
+    return parsed;
+  }
+  const contents = readFileSync(file, "utf8");
+  const parsed = Bun.YAML.parse(contents);
   if (!isObject(parsed))
     throw new RepoError(`${file}: repos config must be a YAML mapping`);
   if (parsed.repos === undefined || parsed.repos === null) parsed.repos = [];
   if (!Array.isArray(parsed.repos))
     throw new RepoError(`${file}: repos must be a list`);
+  Object.defineProperty(parsed, HOST_CONFIG_SNAPSHOT, {
+    value: { file, contents, stat: statSync(file) },
+  });
   return parsed;
+}
+
+function hostConfigUnchanged(snapshot) {
+  if (!snapshot?.stat) return !existsSync(snapshot?.file);
+  if (!existsSync(snapshot.file)) return false;
+  const current = statSync(snapshot.file);
+  return (
+    readFileSync(snapshot.file, "utf8") === snapshot.contents &&
+    current.dev === snapshot.stat.dev &&
+    current.ino === snapshot.stat.ino &&
+    current.size === snapshot.stat.size &&
+    current.mtimeMs === snapshot.stat.mtimeMs &&
+    current.ctimeMs === snapshot.stat.ctimeMs
+  );
+}
+
+function assertHostConfigUnchanged(snapshot) {
+  if (!hostConfigUnchanged(snapshot)) {
+    throw new HostConfigConflictError(
+      "config/repos.yaml changed while this request was pending; retry the request",
+    );
+  }
 }
 
 /**
@@ -222,13 +269,26 @@ function writeHostConfig(root, config) {
   } finally {
     rmSync(scratch, { recursive: true, force: true });
   }
-  const target = path.join(root, "config", "repos.yaml");
+  const snapshot = config[HOST_CONFIG_SNAPSHOT];
+  const target = snapshot?.file ?? reposConfigPath(root);
   mkdirSync(path.dirname(target), { recursive: true });
   const tmp = `${target}.${process.pid}.${randomUUID()}.tmp`;
+  let fd = null;
   try {
-    writeFileSync(tmp, yaml);
+    fd = openSync(tmp, "w", snapshot?.stat?.mode & 0o777 || 0o666);
+    if (snapshot?.stat) fchmodSync(fd, snapshot.stat.mode & 0o777);
+    writeFileSync(fd, yaml);
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
+    assertHostConfigUnchanged(snapshot);
     renameSync(tmp, target);
+    fd = openSync(path.dirname(target), "r");
+    fsyncSync(fd);
+    closeSync(fd);
+    fd = null;
   } finally {
+    if (fd !== null) closeSync(fd);
     rmSync(tmp, { force: true });
   }
 }
@@ -294,6 +354,8 @@ export function createRepoApi({ repos, db, configRoot = reposRoot() }) {
       mutate(config);
       writeHostConfig(configRoot, config);
     } catch (err) {
+      if (err instanceof HostConfigConflictError)
+        return send(409, { error: err.message });
       if (!(err instanceof RepoError)) throw err;
       return send(422, { error: err.message });
     }

--- a/event-runtime/lib/api-repos.test.mjs
+++ b/event-runtime/lib/api-repos.test.mjs
@@ -1,6 +1,14 @@
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-repos-test-mjs";
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import path from "node:path";
 import { makeServer } from "./api-test-helpers.mjs";
 import { loadRepos, reposView } from "./repos.mjs";
@@ -217,6 +225,95 @@ describe("repository management API", () => {
       expect(readFileSync(file, "utf8")).toBe(before);
     } finally {
       api.close();
+    }
+  });
+
+  test("rejects relative checkout paths before writing", async () => {
+    const { root } = factoryRoot();
+    const api = await server(root);
+    try {
+      const created = await api.request("/repos", {
+        method: "POST",
+        body: JSON.stringify({
+          name: "relative",
+          github: "watt-mind/relative",
+          path: "checkouts/relative",
+        }),
+      });
+      expect(created.status).toBe(422);
+      expect((await created.json()).error).toBe(
+        "path must be absolute or ~-prefixed",
+      );
+    } finally {
+      api.close();
+    }
+  });
+
+  test("preserves config mode and writes the file resolved by the reader", async () => {
+    const { root } = factoryRoot();
+    const configDir = path.join(root, "config");
+    const local = path.join(configDir, "repos.yaml");
+    const example = path.join(configDir, "repos.example.yaml");
+    chmodSync(local, 0o600);
+    renameSync(local, example);
+    const api = await server(root);
+    try {
+      const patched = await api.request("/repos/existing", {
+        method: "PATCH",
+        body: JSON.stringify({ maxInFlight: 3 }),
+      });
+      expect(patched.status).toBe(200);
+    } finally {
+      api.close();
+    }
+    expect(statSync(example).mode & 0o777).toBe(0o600);
+    expect(existsSync(local)).toBe(false);
+    expect(loadRepos({ root }).get("existing")?.maxInFlight).toBe(3);
+  });
+
+  test("returns 409 instead of clobbering an external registry writer", async () => {
+    const { root } = factoryRoot();
+    const file = path.join(root, "config", "repos.yaml");
+    const contents = readFileSync(file, "utf8");
+    const ready = path.join(root, "external-writer-ready");
+    const writer = Bun.spawn(
+      [
+        process.execPath,
+        "-e",
+        `import { renameSync, writeFileSync } from "node:fs";
+         const [file, contents, ready] = process.argv.slice(1);
+         const tmp = file + ".external-writer";
+         const until = Date.now() + 2000;
+         writeFileSync(tmp, contents);
+         renameSync(tmp, file);
+         writeFileSync(ready, "ready");
+         while (Date.now() < until) {
+           writeFileSync(tmp, contents);
+           renameSync(tmp, file);
+         }`,
+        file,
+        contents,
+        ready,
+      ],
+      { stdout: "ignore", stderr: "ignore" },
+    );
+    const api = await server(root);
+    try {
+      for (let attempts = 0; !existsSync(ready); attempts += 1) {
+        if (attempts === 10_000)
+          throw new Error("external writer did not start");
+        await new Promise(setImmediate);
+      }
+      const patched = await api.request("/repos/existing", {
+        method: "PATCH",
+        body: JSON.stringify({ maxInFlight: 3 }),
+      });
+      expect(patched.status).toBe(409);
+      expect((await patched.json()).error).toContain("changed while");
+    } finally {
+      api.close();
+      writer.kill();
+      await writer.exited;
     }
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1867

Protect repository registry updates from external writes and preserve durable file semantics.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/api-repos.test.mjs` | pass | 9 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2250 pass, 10 skipped; emit, format, lint clean |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend API and filesystem durability change with no user-facing surface

run:run_d4cd7c97-61d3-4360-9e82-6331dd12ee61
