### PR TITLE
fix(web): share proposal status hues

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -18,6 +18,7 @@ import {
   KVGroup,
   ListToolbar,
   notify,
+  PROPOSAL_STATUS_HUES,
   Section,
   shortId,
   StateBadge,
@@ -25,7 +26,7 @@ import {
   ToastContainer,
   Tooltip,
 } from "./ui";
-import { parseFilterQuery, RUN_FACETS } from "../filterQuery";
+import { parseFilterQuery, PROPOSAL_FACETS, RUN_FACETS } from "../filterQuery";
 import { modal } from "../hooks";
 import { changeInput, typeText } from "../test-render";
 
@@ -723,6 +724,13 @@ describe("getValueHue", () => {
     expect(getValueHue("state", "RUNNING")).toBe("var(--hue-warn)");
     expect(getValueHue("decision", "run")).toBe("var(--hue-info)");
     expect(getValueHue("status", "admitted")).toBe("var(--hue-info)");
+    expect(getValueHue("status", "expired")).toBe(PROPOSAL_STATUS_HUES.expired);
+  });
+
+  test("covers every proposal status offered by the web filter", () => {
+    for (const status of PROPOSAL_FACETS.values?.status ?? []) {
+      expect(PROPOSAL_STATUS_HUES).toHaveProperty(status);
+    }
   });
 });
 

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -65,6 +65,7 @@ export const PROPOSAL_STATUS_HUES: Record<string, string> = {
   open: "var(--hue-info)",
   approved: "var(--hue-ok)",
   rejected: "var(--hue-err)",
+  expired: "var(--hue-warn)",
   superseded: "var(--hue-idle)",
   resolved: "var(--hue-idle)",
 };

--- a/event-runtime/web/src/views/Metrics.tsx
+++ b/event-runtime/web/src/views/Metrics.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useMemo, useState } from "react";
 import { fetchMetrics, fetchMetricsBreakdown } from "../api";
 import { pollingOptions } from "../hooks";
+import { PROPOSAL_STATUS_HUES } from "../components/ui";
 import {
   Band,
   ShareBars,
@@ -47,12 +48,6 @@ const OUTCOME_HUES: Record<string, string> = {
   CANCELLED: "var(--text-faint)",
 };
 const DECISIONS = ["approved", "rejected", "expired", "superseded"] as const;
-const DECISION_HUES: Record<string, string> = {
-  approved: "var(--hue-ok)",
-  rejected: "var(--hue-err)",
-  expired: "var(--hue-warn)",
-  superseded: "var(--hue-verify)",
-};
 const SERIES_HUES = [
   "var(--hue-info)",
   "var(--hue-verify)",
@@ -361,7 +356,7 @@ function decisionBars(data: MetricsView): StackedBarDatum[] {
         key: status,
         label: status,
         value,
-        hue: DECISION_HUES[status],
+        hue: PROPOSAL_STATUS_HUES[status],
         link:
           value > 0
             ? {
@@ -574,7 +569,7 @@ export function Metrics() {
     const decisions = DECISIONS.map((status) => ({
       label: status,
       value: sum(data.series["proposals.decisions"]?.[status]),
-      hue: DECISION_HUES[status],
+      hue: PROPOSAL_STATUS_HUES[status],
     }));
     const started = sum(data.series["runs.started"]?.total);
     const retries = sum(data.series["attempts.retries"]?.total);

--- a/event-runtime/web/src/views/Proposals.tsx
+++ b/event-runtime/web/src/views/Proposals.tsx
@@ -201,7 +201,7 @@ const HISTORY_DISPLAY: DisplayConfig<Proposal> = {
       label: "Status",
       get: (p) => p.status,
       order: ["approved", "rejected", "expired", "superseded", "resolved"],
-      hue: { ...PROPOSAL_STATUS_HUES, expired: "var(--hue-idle)" },
+      hue: PROPOSAL_STATUS_HUES,
     },
     { key: "agent", label: "Agent", get: (p) => p.agent ?? "" },
   ],


### PR DESCRIPTION
Fixes watt-mind/factory#1846

Review the shared expired warning hue across proposal views, facets, and metrics.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/web/src/components/ui.test.tsx event-runtime/web/src/views/Proposals.test.tsx event-runtime/web/src/views/Metrics.test.tsx` | pass | 113 tests, 0 failures |
| Ticket lint | `bun run lint` | pass | 0 errors; 614 existing warnings |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | completed cleanly |
| TypeScript | `cd event-runtime/web && bun x tsc --noEmit` | pass | no errors |
| UX critique | `factory-ux-critic` | not run | isolated shared-color consistency change |

UX critique: skipped

run:run_6ab015b3-921e-4eb0-83aa-a68806c410bd
