### PR TITLE
fix(web): reset Runs cursor on repo switch

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -234,6 +234,53 @@ describe("Runs API pagination (WM-976)", () => {
     );
   });
 
+  test("resets the cursor when switching repository contexts", async () => {
+    const newest = stubListItem("run-page-new", "COMPLETED", {
+      maxAttempts: undefined,
+      spec: undefined,
+      repos: ["repo-a", "repo-b"],
+    });
+    const older = stubListItem("run-page-old", "FAILED", {
+      maxAttempts: undefined,
+      spec: undefined,
+      repos: ["repo-a"],
+    });
+    const runs = mock(async (_state?: string, filters?: { before?: string }) =>
+      filters?.before
+        ? { runs: [older], nextBefore: null }
+        : { runs: [newest], nextBefore: "older-page" },
+    );
+    await withApi(
+      { runs, status: async () => createStatusFixture() },
+      async () => {
+        const r = renderRuns({ context: { kind: "repo", name: "repo-a" } });
+        await r.findByTitle("run-page-new");
+
+        fireEvent.click(r.getByRole("button", { name: "Older" }));
+        await r.findByTitle("run-page-old");
+        r.rerender(
+          <Runs
+            connected={true}
+            context={{ kind: "repo", name: "repo-b" }}
+            focusRunId={null}
+            onSelectRun={noop}
+            onOpenFull={noop}
+            focusState={null}
+            onFocusStateConsumed={noop}
+            onJumpAgent={noop}
+            onJumpEvent={noop}
+          />,
+        );
+
+        await waitFor(() =>
+          expect(runs).toHaveBeenLastCalledWith(undefined, {
+            before: undefined,
+          }),
+        );
+      },
+    );
+  });
+
   test("returns to the newest page from the pager", async () => {
     const newest = stubListItem("run-page-new", "COMPLETED", {
       maxAttempts: undefined,

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -58,7 +58,7 @@ import {
 } from "../components/RunDetailBlocks";
 import { readPinnedRuns, savePinnedRuns } from "../components/ContextTabs";
 import type { OperatorContext } from "../context";
-import { matchesInFlight, matchesRepo } from "../context";
+import { matchesInFlight, matchesRepo, projectFromContext } from "../context";
 import {
   RUN_FACETS,
   matchesFilterQuery,
@@ -600,6 +600,7 @@ export function Runs({
   const [cancelReason, setCancelReason] = useState("");
   const drilldown = runDrilldownFilters(window.location.hash);
   const drilldownKey = JSON.stringify(drilldown);
+  const contextProject = projectFromContext(context);
   const [runCursor, setRunCursor] = useState<string | null>(null);
 
   const proposalsQ = useQuery({
@@ -624,7 +625,7 @@ export function Runs({
   // different tab, drilldown, or context can hide that list's newest runs.
   useEffect(() => {
     setRunCursor(null);
-  }, [tab, drilldownKey, context.kind]);
+  }, [tab, drilldownKey, contextProject]);
 
   const list = useQuery({
     queryKey: ["runs", fetchAll ? "ALL" : tab, drilldownKey, runCursor],


### PR DESCRIPTION
Fixes watt-mind/factory#1847

Switching repository contexts now returns Runs to the newest page instead of carrying a stale cursor.

## Validation

| Check                | Command                                                                                                      | Result       | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------------ | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web/src/views/Runs.test.tsx`                                                        | pass         | 45 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass         | 2254 pass, 10 skipped, 0 failures          |
| UX critique          | factory-ux-critic                                                                                            | not assessed | repository contexts had no paginatable runs |

UX critique: required — NOT-ASSESSED (repository data lacked paginatable runs)

run:run_b7fa2b6b-2537-4d70-a7bc-d35651221c15
