### PR TITLE
fix(web): preserve superseded Metrics hue

### DIFF
--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -732,6 +732,13 @@ describe("getValueHue", () => {
       expect(PROPOSAL_STATUS_HUES).toHaveProperty(status);
     }
   });
+
+  test("keeps superseded distinct from resolved where both statuses render", () => {
+    expect(PROPOSAL_STATUS_HUES.superseded).toBe("var(--hue-verify)");
+    expect(PROPOSAL_STATUS_HUES.superseded).not.toBe(
+      PROPOSAL_STATUS_HUES.resolved,
+    );
+  });
 });
 
 describe("FilterInput autocomplete (OPS-506)", () => {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -66,7 +66,7 @@ export const PROPOSAL_STATUS_HUES: Record<string, string> = {
   approved: "var(--hue-ok)",
   rejected: "var(--hue-err)",
   expired: "var(--hue-warn)",
-  superseded: "var(--hue-idle)",
+  superseded: "var(--hue-verify)",
   resolved: "var(--hue-idle)",
 };
 

--- a/event-runtime/web/src/views/Metrics.test.tsx
+++ b/event-runtime/web/src/views/Metrics.test.tsx
@@ -171,6 +171,32 @@ describe("Metrics", () => {
     expect(retryBar?.querySelector('[data-segment="first"]')).toBeTruthy();
   });
 
+  test("pins all decision-mix chart hues", async () => {
+    const data = structuredClone(populated);
+    data.series["proposals.decisions"] = {
+      approved: [1, 1],
+      rejected: [1, 1],
+      expired: [1, 1],
+      superseded: [1, 1],
+    };
+    response = Response.json(data);
+
+    const view = renderMetrics();
+    const chart = await view.findByRole("img", { name: /Decision mix:/ });
+    expect(
+      chart.querySelector('[data-segment="approved"]')?.getAttribute("fill"),
+    ).toBe("var(--hue-ok)");
+    expect(
+      chart.querySelector('[data-segment="rejected"]')?.getAttribute("fill"),
+    ).toBe("var(--hue-err)");
+    expect(
+      chart.querySelector('[data-segment="expired"]')?.getAttribute("fill"),
+    ).toBe("var(--hue-warn)");
+    expect(
+      chart.querySelector('[data-segment="superseded"]')?.getAttribute("fill"),
+    ).toBe("var(--hue-verify)");
+  });
+
   test("Harness and Model share cards render ranked bars with window drilldown", async () => {
     const view = renderMetrics();
     const harness = await view.findByRole("img", {


### PR DESCRIPTION
Fixes watt-mind/factory#1891

Restores a distinct superseded decision hue and pins all Metrics decision-chart hues.

## Validation

| Check                | Command                                                                          | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Metrics.test.tsx src/components/ui.test.tsx` | pass    | 72 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2262 pass, 10 skipped; lint clean |
| UX critique          | factory-ux-critic                                                                | not run | skipped — isolated styling and tests |

UX critique: skipped — isolated styling and test coverage; no flow or interaction changed

run:run_ca852fc7-3c4a-47e3-bda0-a2eefd184296
