### PR TITLE
fix(api): fork example config writes

### DIFF
--- a/event-runtime/lib/api-repos.mjs
+++ b/event-runtime/lib/api-repos.mjs
@@ -200,16 +200,23 @@ function hostConfigError(message, file) {
   return message.split(file).join("config/repos.yaml");
 }
 
+function localReposConfigPath(root) {
+  return path.join(root, "config", "repos.yaml");
+}
+
 /**
  * Read the effective host registry as raw YAML (the loader's projection drops
- * keys it does not model, and a write must not lose them).
+ * keys it does not model, and a write must not lose them). A read that falls
+ * back to the tracked example still records the local path as its write
+ * target: mutations explicitly fork the example into operator-owned config.
  */
 function readHostConfig(root) {
   const file = reposConfigPath(root);
+  const target = localReposConfigPath(root);
   if (!existsSync(file)) {
     const parsed = { repos: [] };
     Object.defineProperty(parsed, HOST_CONFIG_SNAPSHOT, {
-      value: { file, contents: null, stat: null },
+      value: { file, target, contents: null, stat: null },
     });
     return parsed;
   }
@@ -221,7 +228,7 @@ function readHostConfig(root) {
   if (!Array.isArray(parsed.repos))
     throw new RepoError(`${file}: repos must be a list`);
   Object.defineProperty(parsed, HOST_CONFIG_SNAPSHOT, {
-    value: { file, contents, stat: statSync(file) },
+    value: { file, target, contents, stat: statSync(file) },
   });
   return parsed;
 }
@@ -230,13 +237,16 @@ function hostConfigUnchanged(snapshot) {
   if (!snapshot?.stat) return !existsSync(snapshot?.file);
   if (!existsSync(snapshot.file)) return false;
   const current = statSync(snapshot.file);
-  return (
+  const sourceUnchanged =
     readFileSync(snapshot.file, "utf8") === snapshot.contents &&
     current.dev === snapshot.stat.dev &&
     current.ino === snapshot.stat.ino &&
     current.size === snapshot.stat.size &&
     current.mtimeMs === snapshot.stat.mtimeMs &&
-    current.ctimeMs === snapshot.stat.ctimeMs
+    current.ctimeMs === snapshot.stat.ctimeMs;
+  return (
+    sourceUnchanged &&
+    (snapshot?.target === snapshot?.file || !existsSync(snapshot?.target))
   );
 }
 
@@ -270,7 +280,12 @@ function writeHostConfig(root, config) {
     rmSync(scratch, { recursive: true, force: true });
   }
   const snapshot = config[HOST_CONFIG_SNAPSHOT];
-  const target = snapshot?.file ?? reposConfigPath(root);
+  const target = snapshot?.target ?? localReposConfigPath(root);
+  if (snapshot?.file && snapshot.file !== target) {
+    console.warn(
+      `warning: ${snapshot.file} is an example fallback; writing registry changes to ${target}`,
+    );
+  }
   mkdirSync(path.dirname(target), { recursive: true });
   const tmp = `${target}.${process.pid}.${randomUUID()}.tmp`;
   let fd = null;

--- a/event-runtime/lib/api-repos.mjs
+++ b/event-runtime/lib/api-repos.mjs
@@ -483,3 +483,5 @@ export function createRepoApi({ repos, db, configRoot = reposRoot() }) {
 
   return { repos, handle };
 }
+
+export { HostConfigConflictError, readHostConfig, writeHostConfig };

--- a/event-runtime/lib/api-repos.test.mjs
+++ b/event-runtime/lib/api-repos.test.mjs
@@ -249,13 +249,14 @@ describe("repository management API", () => {
     }
   });
 
-  test("preserves config mode and writes the file resolved by the reader", async () => {
+  test("forks an example fallback into repos.yaml without modifying the example", async () => {
     const { root } = factoryRoot();
     const configDir = path.join(root, "config");
     const local = path.join(configDir, "repos.yaml");
     const example = path.join(configDir, "repos.example.yaml");
     chmodSync(local, 0o600);
     renameSync(local, example);
+    const exampleContents = readFileSync(example, "utf8");
     const api = await server(root);
     try {
       const patched = await api.request("/repos/existing", {
@@ -266,8 +267,8 @@ describe("repository management API", () => {
     } finally {
       api.close();
     }
-    expect(statSync(example).mode & 0o777).toBe(0o600);
-    expect(existsSync(local)).toBe(false);
+    expect(readFileSync(example, "utf8")).toBe(exampleContents);
+    expect(statSync(local).mode & 0o777).toBe(0o600);
     expect(loadRepos({ root }).get("existing")?.maxInFlight).toBe(3);
   });
 

--- a/event-runtime/lib/api-repos.test.mjs
+++ b/event-runtime/lib/api-repos.test.mjs
@@ -2,7 +2,6 @@ import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-api-repos
 import { describe, expect, test } from "bun:test";
 import {
   chmodSync,
-  existsSync,
   mkdirSync,
   readFileSync,
   renameSync,
@@ -10,6 +9,11 @@ import {
   writeFileSync,
 } from "node:fs";
 import path from "node:path";
+import {
+  HostConfigConflictError,
+  readHostConfig,
+  writeHostConfig,
+} from "./api-repos.mjs";
 import { makeServer } from "./api-test-helpers.mjs";
 import { loadRepos, reposView } from "./repos.mjs";
 
@@ -276,46 +280,14 @@ describe("repository management API", () => {
     const { root } = factoryRoot();
     const file = path.join(root, "config", "repos.yaml");
     const contents = readFileSync(file, "utf8");
-    const ready = path.join(root, "external-writer-ready");
-    const writer = Bun.spawn(
-      [
-        process.execPath,
-        "-e",
-        `import { renameSync, writeFileSync } from "node:fs";
-         const [file, contents, ready] = process.argv.slice(1);
-         const tmp = file + ".external-writer";
-         const until = Date.now() + 2000;
-         writeFileSync(tmp, contents);
-         renameSync(tmp, file);
-         writeFileSync(ready, "ready");
-         while (Date.now() < until) {
-           writeFileSync(tmp, contents);
-           renameSync(tmp, file);
-         }`,
-        file,
-        contents,
-        ready,
-      ],
-      { stdout: "ignore", stderr: "ignore" },
+    const config = readHostConfig(root);
+    writeFileSync(file, contents + "\n# external edit\n");
+    expect(() => writeHostConfig(root, config)).toThrow(
+      HostConfigConflictError,
     );
-    const api = await server(root);
-    try {
-      for (let attempts = 0; !existsSync(ready); attempts += 1) {
-        if (attempts === 10_000)
-          throw new Error("external writer did not start");
-        await new Promise(setImmediate);
-      }
-      const patched = await api.request("/repos/existing", {
-        method: "PATCH",
-        body: JSON.stringify({ maxInFlight: 3 }),
-      });
-      expect(patched.status).toBe(409);
-      expect((await patched.json()).error).toContain("changed while");
-    } finally {
-      api.close();
-      writer.kill();
-      await writer.exited;
-    }
+    expect(() => writeHostConfig(root, config)).toThrow(
+      "config/repos.yaml changed while this request was pending; retry the request",
+    );
   });
 
   test("sync re-reads the in-repo overlay and reports whether it applies", async () => {


### PR DESCRIPTION
Fixes #1889

Repository API mutations now fork example fallback config into operator-owned repos.yaml.

## Validation

| Check                | Command                                                                                         | Result  | Notes                    |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test event-runtime/lib/api-repos.test.mjs`                                                | pass    | 9 tests, 0 failures      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 existing warnings |
| UX critique          | `factory-ux-critic`                                                                           | not run | no user-facing surface   |

UX critique: skipped — backend API behavior only
run:run_4dd10404-b476-4221-bdc0-961a9927d579