### PR TITLE
fix(web): filter Runs requests by selected tab

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -227,10 +227,41 @@ describe("Runs API pagination (WM-976)", () => {
         fireEvent.click(r.getByRole("tab", { name: /^Completed/i }));
 
         await waitFor(() =>
-          expect(runs).toHaveBeenLastCalledWith(undefined, {
+          expect(runs).toHaveBeenLastCalledWith("COMPLETED", {
             before: undefined,
           }),
         );
+      },
+    );
+  });
+
+  test("requests the selected state so failed rows are not limited by the newest all-runs page", async () => {
+    const newestCompleted = stubListItem("run-newest-completed", "COMPLETED");
+    const olderFailed = stubListItem("run-older-failed", "FAILED");
+    const runs = mock(async (state?: string) => ({
+      runs: state === "FAILED" ? [olderFailed] : [newestCompleted],
+    }));
+
+    await withApi(
+      {
+        runs,
+        status: async () =>
+          createStatusFixture({
+            runs: { byState: { COMPLETED: 1, FAILED: 1 } },
+          }),
+      },
+      async () => {
+        const r = renderRuns();
+        await r.findByTitle("run-newest-completed");
+
+        fireEvent.click(r.getByRole("tab", { name: /^Failed/i }));
+
+        await r.findByTitle("run-older-failed");
+        expect(r.queryByTitle("run-newest-completed")).toBeNull();
+        expect(runs).toHaveBeenLastCalledWith("FAILED", {
+          before: undefined,
+        });
+        expect(r.getByRole("tab", { name: /^Failed 1$/i })).toBeTruthy();
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -630,7 +630,7 @@ export function Runs({
   const list = useQuery({
     queryKey: ["runs", fetchAll ? "ALL" : tab, drilldownKey, runCursor],
     queryFn: () =>
-      api.runs(undefined, {
+      api.runs(fetchAll || tab === "ALL" ? undefined : tab, {
         ...(drilldown ?? {}),
         before: runCursor ?? undefined,
       }),


### PR DESCRIPTION
Fixes watt-mind/factory#1871

Closed: final repository verification is blocked by a pre-existing `api-repos` concurrency test outside this ticket’s owned paths.

## Validation

| Check                | Command                                                                    | Result | Notes                         |
| -------------------- | -------------------------------------------------------------------------- | ------ | ----------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Runs.test.tsx`                | pass   | 49 tests, 0 failures          |
| Typecheck            | `cd event-runtime/web && bun run typecheck`                               | pass   | clean                         |
| Web build            | `cd event-runtime/web && bun run build`                                   | pass   | production bundle built       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | fail | api-repos 409 external-writer test (2 retries) |
| UX critique          | `factory-ux-critic`                                                       | pass   | SHIP, round 2                 |

UX critique: required

run:run_3ce8e816-4136-48b0-8557-2d3384f8ca54