### PR TITLE
fix(cli): validate queue repository names

### DIFF
--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -998,15 +998,20 @@ const VERBS = {
   async queue() {
     let team = flag("team") ?? teamOf(positional[0] ?? "");
     let project = flag("project") ?? null;
+    const repoFlag = flag("repo");
+    // Validate an explicit repository even when --team also supplied one. A
+    // typo is an operator error, not a reason to discard the repo scoping and
+    // fall through to the generic queue usage message.
+    const repos = repoFlag ? getRepos() : null;
+    const repoName = repoFlag ? resolveRepoName({ repos, repoFlag }) : null;
     if (!team) {
       // Repo-scoped read (work-scan calls `queue --repo <name>`): derive the
       // team from the repo's config. GitHub-plane repos have no meaningful
       // team of their own — listDispatchable maps it back to the repo — but
       // the verb still needs *a* team, and requiring the caller to pass it for
       // a --repo read is exactly the mismatch that made work-scan refuse.
-      const repoName = flag("repo");
       if (repoName) {
-        const cfg = getRepos().get(repoName);
+        const cfg = repos.get(repoName);
         team = cfg?.team ?? null;
         // ...and its project. Several repos share one Linear team (CLNT covers
         // BJ29 Coaching, CashMap, RiccoMoto, ...); without the project filter

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -1034,6 +1034,15 @@ function spawnTicketOutsideRepo(args, { controlPlane } = {}) {
 const spawnFileOutsideRepo = (args, options) =>
   spawnTicketOutsideRepo(["file", ...args], options);
 
+test("queue --repo rejects an unknown repository before reporting queue usage", () => {
+  const result = spawnTicketOutsideRepo(["queue", "--repo", "nosuch"]);
+  expect(result.exitCode).toBe(1);
+  expect(result.stderr).toContain('unknown --repo "nosuch"');
+  expect(result.stderr).toContain("known: factory");
+  expect(result.stderr).not.toContain("usage: queue");
+  expect(result.ghCalls).toBe("");
+});
+
 test("file refuses an unresolvable workspace with both routing flags", () => {
   const result = spawnFileOutsideRepo(["--title", "finding"]);
   expect(result.exitCode).toBe(1);


### PR DESCRIPTION
Fixes watt-mind/factory#1895

Queue now reports invalid --repo names with known registry entries.

## Validation

| Check                | Command                                                                                           | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test tools/ticket.test.mjs`                                                                  | pass    | 66 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 existing warnings |
| UX critique          | factory-ux-critic                                                                                 | not run | no user-facing surface        |

UX critique: skipped — no user-facing surface

run:run_8057340e-b42d-469f-a0fd-883d2603f578