### PR TITLE
fix(doctor): scope gh-app-auth daemon diagnostics

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -440,6 +440,7 @@ function defaultProcessProbe(pid) {
 export function stackDaemonDiagnostics({
   env = process.env,
   runDir = env.FACTORY_RUN_DIR || path.join(homedir(), ".factory", "run"),
+  root = factoryRoot(),
   listProcesses = defaultProcessTable,
   readPidFile = (file) => readFileSync(file, "utf8"),
   probeProcess = defaultProcessProbe,
@@ -463,8 +464,18 @@ export function stackDaemonDiagnostics({
   }
   const processes = Array.isArray(table) ? table : (table?.processes ?? []);
   const processTableOk = Array.isArray(table) || table?.ok !== false;
+  const ghAppEntrypoint = path.join(
+    path.resolve(root),
+    "lib",
+    "control-plane",
+    "gh-app-auth.mjs",
+  );
+  const isThisStackGhAppDaemon = (command) => {
+    const value = String(command ?? "");
+    return GH_APP_DAEMON.test(value) && value.includes(ghAppEntrypoint);
+  };
   const ghAppDaemons = processes.filter(({ command }) =>
-    GH_APP_DAEMON.test(String(command ?? "")),
+    isThisStackGhAppDaemon(command),
   );
   if (!processTableOk) {
     diagnostics.push({
@@ -480,27 +491,73 @@ export function stackDaemonDiagnostics({
       detail: `duplicate daemons — found ${ghAppDaemons.length} (${ghAppDaemons.map(({ pid }) => pid).join(", ")})`,
       fix: "stop duplicate gh-app-auth.mjs --daemon processes, leaving exactly one",
     });
-  } else if (ghAppDaemons.length === 1) {
-    diagnostics.push({
-      ok: true,
-      label: "gh-app-auth daemon",
-      detail: `one daemon running (pid ${ghAppDaemons[0].pid})`,
-      fix: null,
-    });
-  } else if (appConfigured) {
-    diagnostics.push({
-      ok: false,
-      label: "gh-app-auth daemon",
-      detail: "GitHub App auth is configured but no daemon is running",
-      fix: "run `factory up` to start gh-app-auth.mjs --daemon",
-    });
   } else {
-    diagnostics.push({
-      ok: "warn",
-      label: "gh-app-auth daemon",
-      detail: "not applicable — GitHub App auth is not configured",
-      fix: null,
-    });
+    const ghAppPidFile = path.join(runDir, "gh-app-auth.pid");
+    let pidText = null;
+    try {
+      pidText = readPidFile(ghAppPidFile);
+    } catch (error) {
+      if (error?.code === "ENOENT") {
+        diagnostics.push({
+          ok: appConfigured ? false : "warn",
+          label: "gh-app-auth daemon",
+          detail: appConfigured
+            ? "GitHub App auth is configured but no daemon is running"
+            : "not applicable — GitHub App auth is not configured",
+          fix: appConfigured
+            ? "run `factory up` to start gh-app-auth.mjs --daemon"
+            : null,
+        });
+      } else {
+        diagnostics.push({
+          ok: false,
+          label: "gh-app-auth daemon",
+          detail: `cannot read ${ghAppPidFile} — ${error?.message ?? String(error)}`,
+          fix: "repair or remove the unreadable gh-app-auth.pid, then run `factory up`",
+        });
+      }
+    }
+
+    if (pidText !== null) {
+      const pid = Number(String(pidText).trim());
+      if (!Number.isSafeInteger(pid) || pid <= 0) {
+        diagnostics.push({
+          ok: false,
+          label: "gh-app-auth daemon",
+          detail: `stale gh-app-auth.pid — invalid PID ${JSON.stringify(String(pidText).trim())}`,
+          fix: "remove the stale gh-app-auth.pid and run `factory up`",
+        });
+      } else {
+        let probe;
+        try {
+          probe = probeProcess(pid);
+        } catch (error) {
+          probe = { alive: false, detail: error?.message ?? String(error) };
+        }
+        if (!probe?.alive) {
+          diagnostics.push({
+            ok: false,
+            label: "gh-app-auth daemon",
+            detail: `stale gh-app-auth.pid — PID ${pid} is not running${probe?.detail ? ` (${probe.detail})` : ""}`,
+            fix: "remove the stale gh-app-auth.pid and run `factory up`",
+          });
+        } else if (!isThisStackGhAppDaemon(probe.command)) {
+          diagnostics.push({
+            ok: false,
+            label: "gh-app-auth daemon",
+            detail: `recycled gh-app-auth.pid — PID ${pid} belongs to ${probe.command || "an unidentifiable process"}`,
+            fix: "remove the recycled gh-app-auth.pid and run `factory up`",
+          });
+        } else {
+          diagnostics.push({
+            ok: true,
+            label: "gh-app-auth daemon",
+            detail: `one daemon running (pid ${pid})`,
+            fix: null,
+          });
+        }
+      }
+    }
   }
 
   const servePidFile = path.join(runDir, "serve.pid");

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -263,6 +263,7 @@ describe("repo toolchain diagnostics (#1097)", () => {
 });
 
 describe("stack daemon diagnostics (#1868)", () => {
+  const root = "/factory/stack";
   const appEnv = {
     FACTORY_GH_APP_ID: "123",
     FACTORY_GH_APP_INSTALLATION_ID: "456",
@@ -273,9 +274,12 @@ describe("stack daemon diagnostics (#1868)", () => {
     error.code = "ENOENT";
     throw error;
   };
+  const pidFileFor = (pid) => (file) =>
+    file.endsWith("gh-app-auth.pid") ? `${pid}\n` : absentPidFile();
 
   test("fails when configured App auth has no daemon", () => {
     const rows = stackDaemonDiagnostics({
+      root,
       env: appEnv,
       listProcesses: () => [],
       readPidFile: absentPidFile,
@@ -294,16 +298,27 @@ describe("stack daemon diagnostics (#1868)", () => {
     });
   });
 
-  test("accepts exactly one gh-app-auth daemon from the process table", () => {
+  test("ignores a foreign daemon when this stack's pidfile owns a healthy daemon", () => {
     const rows = stackDaemonDiagnostics({
+      root,
       env: appEnv,
       listProcesses: () => [
         {
           pid: 41,
-          command: "bun /repo/lib/control-plane/gh-app-auth.mjs --daemon",
+          command:
+            "bun /factory/stack/lib/control-plane/gh-app-auth.mjs --daemon",
+        },
+        {
+          pid: 42,
+          command:
+            "bun /factory/other/lib/control-plane/gh-app-auth.mjs --daemon",
         },
       ],
-      readPidFile: absentPidFile,
+      readPidFile: pidFileFor(41),
+      probeProcess: (pid) => ({
+        alive: true,
+        command: `bun ${pid === 41 ? root : "/factory/other"}/lib/control-plane/gh-app-auth.mjs --daemon`,
+      }),
     });
     expect(rows.find((row) => row.label === "gh-app-auth daemon")).toEqual({
       ok: true,
@@ -313,20 +328,69 @@ describe("stack daemon diagnostics (#1868)", () => {
     });
   });
 
-  test("fails on duplicate gh-app-auth daemons even without App configuration", () => {
+  test("fails when a foreign daemon exists but this stack's daemon is missing", () => {
     const rows = stackDaemonDiagnostics({
-      env: {},
+      root,
+      env: appEnv,
       listProcesses: () => [
         {
           pid: 41,
-          command: "bun /repo/lib/control-plane/gh-app-auth.mjs --daemon",
-        },
-        {
-          pid: 42,
-          command: "bun /repo/lib/control-plane/gh-app-auth.mjs --daemon",
+          command:
+            "bun /factory/other/lib/control-plane/gh-app-auth.mjs --daemon",
         },
       ],
       readPidFile: absentPidFile,
+    });
+    expect(rows.find((row) => row.label === "gh-app-auth daemon")).toEqual({
+      ok: false,
+      label: "gh-app-auth daemon",
+      detail: "GitHub App auth is configured but no daemon is running",
+      fix: "run `factory up` to start gh-app-auth.mjs --daemon",
+    });
+  });
+
+  test("fails when this stack's daemon pidfile points at another process", () => {
+    const rows = stackDaemonDiagnostics({
+      root,
+      env: appEnv,
+      listProcesses: () => [],
+      readPidFile: pidFileFor(41),
+      probeProcess: () => ({
+        alive: true,
+        command: "bun unrelated-worker.mjs",
+      }),
+    });
+    expect(
+      rows.find((row) => row.label === "gh-app-auth daemon"),
+    ).toMatchObject({
+      ok: false,
+      detail:
+        "recycled gh-app-auth.pid — PID 41 belongs to bun unrelated-worker.mjs",
+    });
+  });
+
+  test("fails on duplicate gh-app-auth daemons serving this stack", () => {
+    const rows = stackDaemonDiagnostics({
+      root,
+      env: appEnv,
+      listProcesses: () => [
+        {
+          pid: 41,
+          command:
+            "bun /factory/stack/lib/control-plane/gh-app-auth.mjs --daemon",
+        },
+        {
+          pid: 42,
+          command:
+            "bun /factory/stack/lib/control-plane/gh-app-auth.mjs --daemon",
+        },
+      ],
+      readPidFile: pidFileFor(41),
+      probeProcess: () => ({
+        alive: true,
+        command:
+          "bun /factory/stack/lib/control-plane/gh-app-auth.mjs --daemon",
+      }),
     });
     expect(
       rows.find((row) => row.label === "gh-app-auth daemon"),


### PR DESCRIPTION
Fixes watt-mind/factory#1892

Doctor now verifies only this stack's gh-app-auth pidfile and reports local duplicate daemons.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test orchestrator/doctor.test.mjs` | pass | 42 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,263 pass; lint 0 errors |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped
run:run_0d988d56-0287-4c6c-b19a-498fad86f2d0