### PR TITLE
fix(ci): align #1835 AC3 with the #1886 bounded-read outcome

### DIFF
--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -22,7 +22,7 @@ import {
   stopBounded,
 } from "./serve.mjs";
 import { openDb } from "../lib/db.mjs";
-import { freePort } from "../lib/test-helpers-timing.mjs";
+import { freePort, until } from "../lib/test-helpers-timing.mjs";
 import {
   CLI,
   DEAD_PORT,
@@ -362,17 +362,29 @@ describe("serve command", () => {
       expect(result.admitted).toBe(true);
       // The next tick stalls in the fake CLI; the execFileSync timeout must
       // abort it and record a bounded read failure instead of sleeping 60s.
-      const planError = {
-        get out() {
-          const row = db
-            .query(
-              `SELECT last_plan_error FROM events WHERE event_id = 'linear-stall-1'`,
-            )
-            .get();
-          return String(row?.last_plan_error ?? "");
-        },
+      // The exact reason is not the acceptance criterion and has already
+      // shifted once with the read-refusal work (#1886): the tick may record
+      // the raw ETIMEDOUT, or refuse the read outright once the bounded read
+      // budget is spent. Either is a correct non-wedge outcome, so match the
+      // family of bounded-read refusals rather than one spelling. What stays
+      // strict is the /health assertion below.
+      const planError = () => {
+        const row = db
+          .query(
+            `SELECT last_plan_error FROM events WHERE event_id = 'linear-stall-1'`,
+          )
+          .get();
+        return String(row?.last_plan_error ?? "");
       };
-      expect(await waitFor(planError, "ETIMEDOUT", 15_000)).toBe(true);
+      const reason = await until(
+        "the stalled Linear read to be recorded as bounded",
+        () => {
+          const out = planError();
+          return /ETIMEDOUT|linear_read_|read_budget/.test(out) ? out : null;
+        },
+        { timeoutMs: 15_000 },
+      );
+      expect(reason).toMatch(/ETIMEDOUT|linear_read_|read_budget/);
       // Retries keep stalling one bounded read per tick; a /health probe that
       // lands mid-stall still answers inside the web proxy's 10s budget.
       const started = Date.now();


### PR DESCRIPTION
Scope reduced: the `repository management API > returns 409 instead of clobbering an external registry writer` flake that made develop red is fixed deterministically by #1906 (which replaces the racy subprocess writer with a direct `writeHostConfig` call), so this PR no longer touches `api-repos.test.mjs` and rebases on top of it.

## `serve command > a stalled Linear ticket read cannot wedge /health past the tick budget (#1835 AC3)`

The test waited for the literal substring `ETIMEDOUT` in `last_plan_error`. The acceptance criterion is that a stalled Linear read cannot wedge `/health` past the tick budget — not which reason string the tick happens to record, and that string has already moved once with the deferred rate-limited handoff reads (#1886, `4a90c37c`), where a spent read budget refuses the read outright instead of surfacing the raw errno.

The wait now accepts the family of bounded-read refusals (`ETIMEDOUT`, `linear_read_*`, `*read_budget*`) via `until` rather than one spelling. The real assertion — `/health` answering inside the web proxy's 9 s budget — stays strict and unchanged.

## Verification

- `bun test event-runtime/cli/serve.test.mjs -t AC3` — 3x clean
- `bun test event-runtime/lib/api-repos.test.mjs` — 9 pass (develop's #1906 version, untouched here)
- full `event-runtime/lib` suite as CI runs it (`--timeout 20000 --max-concurrency=4`, timing group excluded) — 2260 pass, 0 fail on the pre-rebase branch
- `bun run lint` (0 errors), `bun run format:check` clean

No ticket — fix-forward.