### PR TITLE
fix(web): filter Runs requests by selected tab

### DIFF
--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -227,10 +227,41 @@ describe("Runs API pagination (WM-976)", () => {
         fireEvent.click(r.getByRole("tab", { name: /^Completed/i }));
 
         await waitFor(() =>
-          expect(runs).toHaveBeenLastCalledWith(undefined, {
+          expect(runs).toHaveBeenLastCalledWith("COMPLETED", {
             before: undefined,
           }),
         );
+      },
+    );
+  });
+
+  test("requests the selected state so failed rows are not limited by the newest all-runs page", async () => {
+    const newestCompleted = stubListItem("run-newest-completed", "COMPLETED");
+    const olderFailed = stubListItem("run-older-failed", "FAILED");
+    const runs = mock(async (state?: string) => ({
+      runs: state === "FAILED" ? [olderFailed] : [newestCompleted],
+    }));
+
+    await withApi(
+      {
+        runs,
+        status: async () =>
+          createStatusFixture({
+            runs: { byState: { COMPLETED: 1, FAILED: 1 } },
+          }),
+      },
+      async () => {
+        const r = renderRuns();
+        await r.findByTitle("run-newest-completed");
+
+        fireEvent.click(r.getByRole("tab", { name: /^Failed/i }));
+
+        await r.findByTitle("run-older-failed");
+        expect(r.queryByTitle("run-newest-completed")).toBeNull();
+        expect(runs).toHaveBeenLastCalledWith("FAILED", {
+          before: undefined,
+        });
+        expect(r.getByRole("tab", { name: /^Failed 1$/i })).toBeTruthy();
       },
     );
   });

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -266,6 +266,28 @@ describe("Runs API pagination (WM-976)", () => {
     );
   });
 
+  test("keeps a wide table's empty-state copy inside the visible viewport", async () => {
+    const newestCompleted = stubListItem("run-newest-completed", "COMPLETED");
+    const runs = mock(async (state?: string) => ({
+      runs: state === "ACTIVE" ? [] : [newestCompleted],
+    }));
+
+    await withApi(
+      { runs, status: async () => createStatusFixture() },
+      async () => {
+        const r = renderRuns();
+        await r.findByTitle("run-newest-completed");
+
+        fireEvent.click(r.getByRole("tab", { name: /^Active/i }));
+
+        await r.findByText("No active runs.");
+        const table = r.getByRole("grid", { name: "Runs" });
+        expect(table.className).toContain("[&_tbody>tr>td>div]:sticky");
+        expect(table.className).toContain("[&_tbody>tr>td>div]:w-screen");
+      },
+    );
+  });
+
   test("resets the cursor when switching repository contexts", async () => {
     const newest = stubListItem("run-page-new", "COMPLETED", {
       maxAttempts: undefined,

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -1317,7 +1317,11 @@ export function Runs({
         <Table
           role="grid"
           aria-label="Runs"
-          className="w-full table-fixed border-separate border-spacing-0"
+          className={`w-full table-fixed border-separate border-spacing-0 ${
+            visible.length === 0
+              ? "[&_tbody>tr>td>div]:sticky [&_tbody>tr>td>div]:left-0 [&_tbody>tr>td>div]:w-screen"
+              : ""
+          }`}
           style={{
             minWidth: `${listCols.reduce(
               (width, c) => width + (c.key === "state" ? 176 : 112),

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -630,7 +630,7 @@ export function Runs({
   const list = useQuery({
     queryKey: ["runs", fetchAll ? "ALL" : tab, drilldownKey, runCursor],
     queryFn: () =>
-      api.runs(undefined, {
+      api.runs(fetchAll || tab === "ALL" ? undefined : tab, {
         ...(drilldown ?? {}),
         before: runCursor ?? undefined,
       }),


### PR DESCRIPTION
Fixes watt-mind/factory#1871

Runs status tabs now fetch and page within their server-filtered state universe, with regression coverage for older failed rows and badge agreement.

## Validation

| Check                | Command                                                                                                                     | Result | Notes                         |
| -------------------- | --------------------------------------------------------------------------------------------------------------------------- | ------ | ----------------------------- |
| Verification Command | `cd event-runtime/web && bun test src/views/Runs.test.tsx`                                                                  | pass   | 50 tests, 0 failures          |
| Ticket typecheck     | `cd event-runtime/web && bun run typecheck`                                                                                  | pass   | clean                         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`          | pass   | exit 0                        |
| UX critique          | `factory-ux-critic`                                                                                                         | pass | SHIP after FIX-FIRST, round 2                  |

UX critique: required — SHIP (FIX-FIRST resolved in 2 rounds)

run:run_9ed20a8e-1287-49a0-8d37-44a6d60f6848
