### PR TITLE
fix(serve): expose planner worker health

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -642,12 +642,18 @@ export default async function serve(args) {
   let tickOverruns = 0;
   let lastTickMs = 0;
   let lastOverrunAt = null;
+  let plannerWorker = null;
 
   function getTickStats() {
+    const queued =
+      db
+        .query(`SELECT COUNT(*) AS n FROM events WHERE status = 'admitted'`)
+        .get().n > 0;
     return {
       lastMs: lastTickMs,
       overruns: tickOverruns,
       ...(lastOverrunAt ? { lastOverrunAt } : {}),
+      planner: plannerWorker?.state({ queued }) ?? null,
     };
   }
 
@@ -695,7 +701,6 @@ export default async function serve(args) {
     }
   }
 
-  let plannerWorker = null;
   if (!noPlanner) {
     plannerWorker = startPlannerWorker({
       eventHome: home,

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -647,8 +647,8 @@ export default async function serve(args) {
   function getTickStats() {
     const queued =
       db
-        .query(`SELECT COUNT(*) AS n FROM events WHERE status = 'admitted'`)
-        .get().n > 0;
+        .query(`SELECT 1 FROM events WHERE status = 'admitted' LIMIT 1`)
+        .get() != null;
     return {
       lastMs: lastTickMs,
       overruns: tickOverruns,

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -58,7 +58,11 @@ test("planner worker exit is logged and exposed as dead", async () => {
   try {
     await planner.worker.terminate();
     expect(planner.state()).toMatchObject({ alive: false, stale: true });
-    expect(logs).toContain("planner worker thread exited with code 1");
+    expect(
+      logs.some((line) =>
+        /^planner worker thread exited with code \d+$/.test(line),
+      ),
+    ).toBe(true);
   } finally {
     await planner.stop();
   }

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -22,6 +22,7 @@ import {
   stopBounded,
 } from "./serve.mjs";
 import { openDb } from "../lib/db.mjs";
+import { startPlannerWorker } from "../lib/planner-worker.mjs";
 import { freePort } from "../lib/test-helpers-timing.mjs";
 import {
   CLI,
@@ -46,6 +47,22 @@ import {
 
 registerCliTmpCleanup();
 registerTestProcessCleanup(import.meta.url);
+
+test("planner worker exit is logged and exposed as dead", async () => {
+  const home = tmpDir("evrt-planner-exit-");
+  const logs = [];
+  const planner = startPlannerWorker({
+    eventHome: home,
+    log: (line) => logs.push(line),
+  });
+  try {
+    await planner.worker.terminate();
+    expect(planner.state()).toMatchObject({ alive: false, stale: true });
+    expect(logs).toContain("planner worker thread exited with code 1");
+  } finally {
+    await planner.stop();
+  }
+});
 
 /**
  * Every live `serve --adapter-override fake` whose cwd is `cwd`, by pid. Linux

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -432,6 +432,7 @@ export async function handleIntakeApiRoute({
         lastMs: tickStats?.lastMs ?? 0,
         overruns: tickStats?.overruns ?? 0,
       },
+      planner: tickStats?.planner ?? null,
     });
   }
 

--- a/event-runtime/lib/api-intake.test.mjs
+++ b/event-runtime/lib/api-intake.test.mjs
@@ -106,6 +106,25 @@ describe("webhook intake (§14)", () => {
     }
   });
 
+  test("GET /health exposes planner liveness and recency", async () => {
+    const planner = {
+      lastPlannedAt: "2026-08-30T08:00:00.000Z",
+      ageMs: 60_000,
+      stale: true,
+      staleAfterMs: 300_000,
+      alive: false,
+    };
+    const live = await makeServer({
+      getTickStats: () => ({ planner }),
+    });
+    try {
+      const body = await (await fetch(live.url("/health"))).json();
+      expect(body.planner).toEqual(planner);
+    } finally {
+      live.close();
+    }
+  });
+
   test("unknown route → 404 with an error body", async () => {
     const res = await fetch(s.url("/nope"));
     expect(res.status).toBe(404);

--- a/event-runtime/lib/off-loop-planner.test.mjs
+++ b/event-runtime/lib/off-loop-planner.test.mjs
@@ -118,6 +118,20 @@ test("planning runs off the HTTP event loop: /health p95 < 500ms while 10 events
     }
 
     expect(plannedCount).toBe(10);
+
+    // 4. The worker posts a `planned` message back to its supervisor, which
+    // records lastPlannedAt — the /health staleness signal (gh-1903).
+    const stateDeadline = Date.now() + 5_000;
+    while (
+      Date.now() < stateDeadline &&
+      plannerWorker.state().lastPlannedAt == null
+    ) {
+      await Bun.sleep(50);
+    }
+    const state = plannerWorker.state({ queued: false });
+    expect(state.lastPlannedAt).not.toBeNull();
+    expect(state.ageMs).not.toBeNull();
+    expect(state.stale).toBe(false);
   } finally {
     if (plannerWorker) await plannerWorker.stop();
     await new Promise((resolve) => server.close(resolve));

--- a/event-runtime/lib/planner-worker-thread.mjs
+++ b/event-runtime/lib/planner-worker-thread.mjs
@@ -32,10 +32,10 @@ async function tickPlanner() {
       policyVersion,
       adapterOverride,
     });
-    if (outcome && outcome.length > 0) {
+    if (outcome?.planned > 0) {
       parentPort?.postMessage({
         type: "planned",
-        count: outcome.length,
+        count: outcome.planned,
         outcome,
       });
     }

--- a/event-runtime/lib/planner-worker.mjs
+++ b/event-runtime/lib/planner-worker.mjs
@@ -6,6 +6,11 @@
 import { Worker } from "node:worker_threads";
 import { runtimeHome } from "./config.mjs";
 
+// Planning normally finishes within the worker's 250ms poll interval. Five
+// minutes leaves room for tracker/API slowness while making a wedged planner
+// visible well before queued intake becomes operationally surprising.
+export const PLANNER_STALE_AFTER_MS = 5 * 60 * 1000;
+
 export function startPlannerWorker({
   eventHome = runtimeHome(),
   policyVersion = "unknown",
@@ -22,9 +27,12 @@ export function startPlannerWorker({
       pollMs,
     },
   });
+  let lastPlannedAt = null;
+  let alive = true;
 
   worker.on("message", (msg) => {
     if (msg?.type === "planned") {
+      lastPlannedAt = new Date().toISOString();
       log(`planner worker: planned ${msg.count} event(s)`);
     } else if (msg?.type === "error") {
       log(`planner worker error: ${msg.message}`);
@@ -35,9 +43,29 @@ export function startPlannerWorker({
     log(`planner worker thread error: ${err.message}`);
   });
 
+  worker.on("exit", (code) => {
+    alive = false;
+    log(`planner worker thread exited with code ${code}`);
+  });
+
   return {
     worker,
     wake: () => worker.postMessage({ type: "wake" }),
+    state: ({ nowMs = Date.now(), queued = false } = {}) => {
+      const plannedMs = lastPlannedAt ? Date.parse(lastPlannedAt) : Number.NaN;
+      const ageMs = Number.isNaN(plannedMs)
+        ? null
+        : Math.max(0, nowMs - plannedMs);
+      return {
+        lastPlannedAt,
+        ageMs,
+        stale:
+          !alive ||
+          (queued && (ageMs === null || ageMs >= PLANNER_STALE_AFTER_MS)),
+        staleAfterMs: PLANNER_STALE_AFTER_MS,
+        alive,
+      };
+    },
     stop: async () => {
       try {
         worker.postMessage({ type: "stop" });

--- a/event-runtime/lib/planner-worker.mjs
+++ b/event-runtime/lib/planner-worker.mjs
@@ -29,6 +29,7 @@ export function startPlannerWorker({
   });
   let lastPlannedAt = null;
   let alive = true;
+  let stopping = false;
 
   worker.on("message", (msg) => {
     if (msg?.type === "planned") {
@@ -45,7 +46,9 @@ export function startPlannerWorker({
 
   worker.on("exit", (code) => {
     alive = false;
-    log(`planner worker thread exited with code ${code}`);
+    if (!(stopping && code === 0)) {
+      log(`planner worker thread exited with code ${code}`);
+    }
   });
 
   return {
@@ -67,6 +70,7 @@ export function startPlannerWorker({
       };
     },
     stop: async () => {
+      stopping = true;
       try {
         worker.postMessage({ type: "stop" });
         await worker.terminate();

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -187,12 +187,14 @@ export function statusView(
     policyVersion,
     env,
     getStoreStats,
+    getTickStats,
     workerPolicy,
     workerRunDir,
     dispatchPaused = policyDispatchPaused,
   } = {},
 ) {
   const open = openProposals(db, { now: nowMs });
+  const events = eventCounts(db);
   const expiredOpen = open.filter((p) => p.expired);
   const staleLeases = db
     .query(
@@ -258,6 +260,10 @@ export function statusView(
     nowMs,
     configured: Boolean(githubSecret),
   });
+  const planner =
+    typeof getTickStats === "function"
+      ? (getTickStats()?.planner ?? null)
+      : null;
   if (!secret)
     configAnomalies.push(
       "FACTORY_EVENT_SECRET is unset (webhook intake disabled)",
@@ -276,6 +282,17 @@ export function statusView(
       `GitHub webhook intake is stale (${age}; threshold ${githubIntake.staleAfterMs}ms)`,
     );
   }
+  if (planner && !planner.alive) {
+    configAnomalies.push("Planner worker is dead");
+  } else if (planner?.stale && events.admitted > 0) {
+    const age =
+      planner.ageMs === null
+        ? "no event has been planned"
+        : `last planning activity was ${planner.ageMs}ms ago`;
+    configAnomalies.push(
+      `Planner worker is stale (${age}; threshold ${planner.staleAfterMs}ms)`,
+    );
+  }
   if (policyVersion === "unknown")
     configAnomalies.push("policyVersion is unknown");
   if (fleet.policyError) configAnomalies.push(fleet.policyError);
@@ -284,8 +301,9 @@ export function statusView(
   configAnomalies.push(...(registry?.anomalies ?? []));
 
   return {
-    events: eventCounts(db),
+    events,
     githubIntake,
+    planner,
     policy,
     proposals: { open: open.length, expired: expiredOpen.length },
     inbox: inboxCounts(db),
@@ -349,6 +367,7 @@ export function handleStatusApiRoute({
   policyVersion,
   env,
   getStoreStats,
+  getTickStats,
   workerPolicy,
   workerRunDir,
 }) {
@@ -361,6 +380,7 @@ export function handleStatusApiRoute({
         policyVersion,
         env,
         getStoreStats,
+        getTickStats,
         workerPolicy,
         workerRunDir,
       }),

--- a/event-runtime/lib/status-view.test.mjs
+++ b/event-runtime/lib/status-view.test.mjs
@@ -83,6 +83,32 @@ describe("statusView outbox counts", () => {
     );
   });
 
+  test("reports a dead or stale planner when admitted work is waiting", () => {
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-30T08:00:00.000Z");
+    seedGithubEvent(db, "2026-08-30T07:59:00.000Z");
+    const planner = {
+      lastPlannedAt: "2026-08-30T07:54:00.000Z",
+      ageMs: 300_000,
+      stale: true,
+      staleAfterMs: 300_000,
+      alive: true,
+    };
+
+    const stale = statusView(db, { schedules: [] }, now, {
+      getTickStats: () => ({ planner }),
+    });
+    expect(stale.planner).toEqual(planner);
+    expect(stale.anomalies.configuration).toContain(
+      "Planner worker is stale (last planning activity was 300000ms ago; threshold 300000ms)",
+    );
+
+    const dead = statusView(db, { schedules: [] }, now, {
+      getTickStats: () => ({ planner: { ...planner, alive: false } }),
+    });
+    expect(dead.anomalies.configuration).toContain("Planner worker is dead");
+  });
+
   test("exposes unparsable result counts with artifact statistics", () => {
     const db = openDb(":memory:");
     const view = statusView(db, { schedules: [] }, Date.now(), {

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -847,6 +847,8 @@ export interface StatusView {
   policy?: { dispatchPaused: boolean };
   /** GitHub webhook intake health; absent on pre-#1632 control APIs. */
   githubIntake?: GithubIntakeStatus;
+  /** Background planning worker freshness; null when serve disables planning. */
+  planner?: PlannerStatus | null;
   proposals: { open: number; expired: number };
   runs: { byState: Partial<Record<RunState, number>> };
   /** Fleet counts; `live` and `busy` exclude stale workers, as the API does. */
@@ -901,6 +903,15 @@ export interface GithubIntakeStatus {
   rejected: number;
   stale: boolean;
   staleAfterMs: number;
+}
+
+/** Planner worker liveness plus recency of its last non-empty planning pass. */
+export interface PlannerStatus {
+  lastPlannedAt: string | null;
+  ageMs: number | null;
+  stale: boolean;
+  staleAfterMs: number;
+  alive: boolean;
 }
 
 export interface ApproveOutcome {


### PR DESCRIPTION
Fixes watt-mind/factory#1903

Expose planner-worker death and stale queued planning through serve health and status.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-intake.test.mjs && bun test event-runtime/lib/status-view.test.mjs && bun test event-runtime/cli/serve.test.mjs` | pass | 72 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2265 pass, 10 skipped |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped

run:run_9e774c3a-ccbe-45cc-b377-74c946ecd468
