### PR TITLE
fix(cli): clarify Linear offline guard

### DIFF
--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -222,11 +222,14 @@ auto-approval path above is what stops the inbox escalation.
 `bun test` preloads `FACTORY_LINEAR_OFFLINE=1`, and CI sets it for every job.
 While it is set (or `NODE_ENV=test` / `BUN_TEST` is present),
 `tools/ticket.mjs` rejects any `api.linear.app` fetch with
-`linear_offline_guard` before a connection opens. The guard is inherited by
-spawned tracker CLIs. A deliberately networked integration probe must opt in
-with `FACTORY_LINEAR_ALLOW_NETWORK=1`. Worker credential lookup reads only
-`LINEAR_API_KEY` by default; use `FACTORY_LINEAR_ENV_FILE=/path/to/.env` to
-opt into an env-file fallback. Offline/test mode never reads that file.
+`linear_offline_guard` before a connection opens. The refusal identifies the
+setting that enabled it and exits with status 4. To deliberately run a Linear
+integration probe, set `FACTORY_LINEAR_ALLOW_NETWORK=1` on that command; this
+explicit escape hatch overrides the offline/test guard. The guard is inherited
+by spawned tracker CLIs, runs before credential lookup, and is never retried.
+Worker credential lookup reads only `LINEAR_API_KEY` by default; use
+`FACTORY_LINEAR_ENV_FILE=/path/to/.env` to opt into an env-file fallback.
+Offline/test mode never reads that file.
 
 ---
 

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -43,7 +43,10 @@ import { loadRepos } from "../event-runtime/lib/repos.mjs";
 import { dbPath } from "../event-runtime/lib/config.mjs";
 import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 import { ticketSlug } from "../lib/ticket-slug.mjs";
-import { parseRateLimitReset } from "../tools/ticket.mjs";
+import {
+  assertLinearNetworkAllowed,
+  parseRateLimitReset,
+} from "../tools/ticket.mjs";
 
 export const REAPER_LOG_DIR = path.join(homedir(), ".factory/logs");
 
@@ -209,6 +212,9 @@ export async function gql(
         ? { retries: 5, signal: retriesOrOptions }
         : (retriesOrOptions ?? {});
   const { retries = 5, signal } = options;
+  // This must precede credential loading: offline/test invocations should
+  // explain the deterministic network refusal, not report a missing key.
+  assertLinearNetworkAllowed(LINEAR_API_URL);
   const apiKey = getApiKey();
   const headers = {
     "Content-Type": "application/json",
@@ -254,6 +260,7 @@ export async function gql(
       return data.data || {};
     } catch (err) {
       if (signal?.aborted) throw abortReason(signal);
+      if (err?.code === "linear_offline_guard") throw err;
       if (err?.rateLimited) throw err;
       if (
         attempt < retries - 1 &&

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -13,9 +13,11 @@ describe("Linear GraphQL cancellation", () => {
   test("forwards an AbortSignal to fetch and stops retrying when aborted", async () => {
     const previousFetch = globalThis.fetch;
     const previousKey = process.env.LINEAR_API_KEY;
+    const previousAllow = process.env.FACTORY_LINEAR_ALLOW_NETWORK;
     const controller = new AbortController();
     let observed;
     process.env.LINEAR_API_KEY = "test-key";
+    process.env.FACTORY_LINEAR_ALLOW_NETWORK = "1";
     globalThis.fetch = (_url, options) => {
       observed = options.signal;
       return new Promise((_, reject) =>
@@ -42,6 +44,9 @@ describe("Linear GraphQL cancellation", () => {
       globalThis.fetch = previousFetch;
       if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
       else process.env.LINEAR_API_KEY = previousKey;
+      if (previousAllow === undefined)
+        delete process.env.FACTORY_LINEAR_ALLOW_NETWORK;
+      else process.env.FACTORY_LINEAR_ALLOW_NETWORK = previousAllow;
     }
   });
 });

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -25,6 +25,10 @@
  *   bun tools/ticket.mjs budget
  *   bun tools/ticket.mjs raw '<graphql>' --var key=value
  *
+ * Linear network safety: requests are blocked when `FACTORY_LINEAR_OFFLINE=1`,
+ * `NODE_ENV=test`, or `BUN_TEST` is set. For a deliberate integration probe,
+ * set `FACTORY_LINEAR_ALLOW_NETWORK=1` on that command to opt in explicitly.
+ *
  * WHY THIS EXISTS, given a perfectly good Linear MCP. (These reasons are
  * Linear-specific and still true; they are why the factory does not depend on
  * that connector, not a claim that the tracker is always Linear.)
@@ -151,26 +155,45 @@ const LINEAR_API_HOST = "api.linear.app";
  * deliberately inherited by CLI children through their environment.
  */
 export function linearNetworkIsOffline(env = process.env) {
-  if (env.FACTORY_LINEAR_ALLOW_NETWORK === "1") return false;
-  return (
-    env.FACTORY_LINEAR_OFFLINE === "1" ||
-    env.NODE_ENV === "test" ||
-    Boolean(env.BUN_TEST)
-  );
+  return linearOfflineGuardTrigger(env) !== null;
 }
 
+/** Return the exact environment setting which enabled the offline guard. */
+export function linearOfflineGuardTrigger(env = process.env) {
+  if (env.FACTORY_LINEAR_ALLOW_NETWORK === "1") return null;
+  if (env.FACTORY_LINEAR_OFFLINE === "1") return "FACTORY_LINEAR_OFFLINE=1";
+  if (env.NODE_ENV === "test") return "NODE_ENV=test";
+  if (env.BUN_TEST) return `BUN_TEST=${env.BUN_TEST}`;
+  return null;
+}
+
+/** Dedicated refusal distinct from generic CLI failure and rate limiting. */
+export const LINEAR_OFFLINE_GUARD_EXIT = 4;
+
 export class LinearOfflineGuardError extends Error {
-  constructor() {
-    super("linear_offline_guard: Linear network access is disabled");
+  constructor(trigger) {
+    super(
+      `linear_offline_guard: Linear network access is disabled by ${trigger}; set FACTORY_LINEAR_ALLOW_NETWORK=1 to allow Linear network access`,
+    );
     this.name = "LinearOfflineGuardError";
     this.code = "linear_offline_guard";
+    this.exitCode = LINEAR_OFFLINE_GUARD_EXIT;
   }
 }
 
 export function assertLinearNetworkAllowed(url, env = process.env) {
-  if (String(url).includes(LINEAR_API_HOST) && linearNetworkIsOffline(env)) {
-    throw new LinearOfflineGuardError();
+  const trigger = linearOfflineGuardTrigger(env);
+  if (String(url).includes(LINEAR_API_HOST) && trigger) {
+    throw new LinearOfflineGuardError(trigger);
   }
+}
+
+/** Adapters may preserve the operator-facing message but not error fields. */
+export function isLinearOfflineGuardError(err) {
+  return (
+    err?.code === "linear_offline_guard" ||
+    String(err?.message ?? "").startsWith("linear_offline_guard:")
+  );
 }
 
 /** Distinct from generic CLI failure (exit 1) so planners can retry-later. */
@@ -1083,7 +1106,11 @@ export async function main() {
       process.exit(LINEAR_RATE_LIMIT_EXIT);
     }
     console.error(`ticket ${verb}: ${e.message}`);
-    process.exit(e.exitCode ?? 1);
+    process.exit(
+      isLinearOfflineGuardError(e)
+        ? LINEAR_OFFLINE_GUARD_EXIT
+        : (e.exitCode ?? 1),
+    );
   }
 }
 

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -42,6 +42,8 @@ import {
   InstanceConfigMissingError,
   __resetLinearReposCache,
   assertLinearNetworkAllowed,
+  LinearOfflineGuardError,
+  LINEAR_OFFLINE_GUARD_EXIT,
   linearNetworkIsOffline,
 } from "./ticket.mjs";
 import { gql } from "../orchestrator/reaper.mjs";
@@ -56,13 +58,21 @@ const LABELS = [
   { id: "l-review", name: "ai:needs-review" },
 ];
 
-test("the Linear offline guard rejects api.linear.app before fetch", () => {
+test("the Linear offline guard identifies its trigger and escape hatch", () => {
   expect(linearNetworkIsOffline({ FACTORY_LINEAR_OFFLINE: "1" })).toBe(true);
-  expect(() =>
+  let thrown;
+  try {
     assertLinearNetworkAllowed("https://api.linear.app/graphql", {
       FACTORY_LINEAR_OFFLINE: "1",
-    }),
-  ).toThrow("linear_offline_guard");
+    });
+  } catch (err) {
+    thrown = err;
+  }
+  expect(thrown).toBeInstanceOf(LinearOfflineGuardError);
+  expect(thrown?.message).toBe(
+    "linear_offline_guard: Linear network access is disabled by FACTORY_LINEAR_OFFLINE=1; set FACTORY_LINEAR_ALLOW_NETWORK=1 to allow Linear network access",
+  );
+  expect(thrown?.exitCode).toBe(LINEAR_OFFLINE_GUARD_EXIT);
   expect(() =>
     assertLinearNetworkAllowed("https://api.linear.app/graphql", {
       FACTORY_LINEAR_OFFLINE: "1",
@@ -71,11 +81,50 @@ test("the Linear offline guard rejects api.linear.app before fetch", () => {
   ).not.toThrow();
 });
 
+test("the Linear transport fails offline before credential lookup or retry", async () => {
+  const previousFetch = globalThis.fetch;
+  const previousKey = process.env.LINEAR_API_KEY;
+  const previousOffline = process.env.FACTORY_LINEAR_OFFLINE;
+  const previousAllow = process.env.FACTORY_LINEAR_ALLOW_NETWORK;
+  let calls = 0;
+  delete process.env.LINEAR_API_KEY;
+  process.env.FACTORY_LINEAR_OFFLINE = "1";
+  delete process.env.FACTORY_LINEAR_ALLOW_NETWORK;
+  globalThis.fetch = async () => {
+    calls += 1;
+    return new Response("{}", { status: 200 });
+  };
+
+  try {
+    let thrown;
+    try {
+      await gql("query { ping }", {}, { retries: 5 });
+    } catch (err) {
+      thrown = err;
+    }
+    expect(thrown).toBeInstanceOf(LinearOfflineGuardError);
+    expect(thrown?.exitCode).toBe(LINEAR_OFFLINE_GUARD_EXIT);
+    expect(calls).toBe(0);
+  } finally {
+    globalThis.fetch = previousFetch;
+    if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
+    else process.env.LINEAR_API_KEY = previousKey;
+    if (previousOffline === undefined)
+      delete process.env.FACTORY_LINEAR_OFFLINE;
+    else process.env.FACTORY_LINEAR_OFFLINE = previousOffline;
+    if (previousAllow === undefined)
+      delete process.env.FACTORY_LINEAR_ALLOW_NETWORK;
+    else process.env.FACTORY_LINEAR_ALLOW_NETWORK = previousAllow;
+  }
+});
+
 test("the Linear transport does not retry a 429 rate-limit response", async () => {
   const previousFetch = globalThis.fetch;
   const previousKey = process.env.LINEAR_API_KEY;
+  const previousAllow = process.env.FACTORY_LINEAR_ALLOW_NETWORK;
   let calls = 0;
   process.env.LINEAR_API_KEY = "test-key";
+  process.env.FACTORY_LINEAR_ALLOW_NETWORK = "1";
   globalThis.fetch = async () => {
     calls += 1;
     return new Response('{"errors":[{"message":"RATELIMITED"}]}', {
@@ -102,6 +151,9 @@ test("the Linear transport does not retry a 429 rate-limit response", async () =
     globalThis.fetch = previousFetch;
     if (previousKey === undefined) delete process.env.LINEAR_API_KEY;
     else process.env.LINEAR_API_KEY = previousKey;
+    if (previousAllow === undefined)
+      delete process.env.FACTORY_LINEAR_ALLOW_NETWORK;
+    else process.env.FACTORY_LINEAR_ALLOW_NETWORK = previousAllow;
   }
 });
 
@@ -1059,9 +1111,14 @@ test("file --from <Linear-id> --team reaches the Linear plane from an unresolvab
     "--title",
     "finding",
   ]);
-  expect(result.exitCode).toBe(1);
-  // The default (Linear) plane was selected and went looking for its key.
-  expect(result.stderr).toContain("LINEAR_API_KEY not found");
+  expect(result.exitCode).toBe(LINEAR_OFFLINE_GUARD_EXIT);
+  // The default (Linear) plane was selected, but offline mode wins before
+  // credential lookup so the operator gets an actionable refusal instead.
+  expect(result.stderr).toContain(
+    "linear_offline_guard: Linear network access is disabled by FACTORY_LINEAR_OFFLINE=1",
+  );
+  expect(result.stderr).toContain("FACTORY_LINEAR_ALLOW_NETWORK=1");
+  expect(result.stderr).not.toContain("LINEAR_API_KEY not found");
   expect(result.stderr).not.toContain("--repo <name> or --from <owner/repo#N>");
   expect(result.ghCalls).toBe("");
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1902

Make offline Linear refusals actionable, fail fast, and exit with status 4.

## Validation

| Check                | Command                                                                                                          | Result  | Notes                              |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test tools/ticket.test.mjs && bun run lint`     | pass    | 67 tests; lint passed              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, and lint passed |
| UX critique          | factory-ux-critic                                                                                                | not run | no user-facing surface             |

UX critique: skipped

run:run_e1fdecd3-da4f-4984-a657-21e0919db741

## Post-review

- Reviewer fix applied: `orchestrator/reaper.test.mjs` abort-signal test sets `FACTORY_LINEAR_ALLOW_NETWORK=1` (restored in `finally`) so the offline guard does not preempt the timeout rejection.
- Note: the `isLinearOfflineGuardError` string-prefix fallback (tools/ticket.mjs:1109) also matches the unrelated `linear_offline_guard:` errors in worker.mjs/test-helpers; filed to triage.
