### PR TITLE
feat(watchdog): surface registry health

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -11,7 +11,7 @@
 #   factory tail                 # tail all live logs (serve.log, worker.log, web.log)
 #   factory tail worker          # tail a specific daemon log
 #   factory logs rotate          # rotate oversized daemon logs now
-#   factory status               # report total bytes held by daemon logs (+ archives)
+#   factory status               # report control API and registry health plus log bytes
 #
 # Log rotation knobs (read by `up`, `logs rotate`, and the web supervisor tick):
 #   FACTORY_LOG_ROTATE_BYTES     # rotate a daemon log once it exceeds this many
@@ -204,6 +204,30 @@ validate_timing_knobs() {
     die "FACTORY_WORKER_READY_TIMEOUT must be a non-negative integer"
   [[ "$WEB_SUPERVISOR_INTERVAL" =~ ^([1-9][0-9]*(\.[0-9]+)?|0\.[0-9]*[1-9][0-9]*)$ ]] ||
     die "FACTORY_WEB_SUPERVISOR_INTERVAL must be a positive number"
+}
+
+print_health_status() {
+  local health health_lines
+  if ! health="$(curl -sf -m 3 "http://127.0.0.1:$API_PORT/health" 2>/dev/null)"; then
+    printf 'control API: unreachable on :%s\n' "$API_PORT"
+    return 0
+  fi
+  if ! health_lines="$(printf '%s' "$health" | bun -e '
+const health = JSON.parse(await Bun.stdin.text());
+const registry = health?.registry;
+const compact = (value) => String(value ?? "").replace(/\s+/g, " ").trim();
+console.log("control API: reachable");
+console.log(`registry: stamp ${registry?.stamp ?? "unknown"}; loaded ${registry?.loadedAt ?? "unknown"}`);
+console.log(`registry reload: ${registry?.lastReloadError?.message ? compact(registry.lastReloadError.message) : "none"}`);
+if (Object.hasOwn(health ?? {}, "planner")) {
+  const planner = health.planner;
+  console.log(`planner: last success ${planner?.lastSuccessAt ?? planner?.lastPlannedAt ?? planner?.lastPlanAt ?? planner?.lastCompletedAt ?? planner?.lastRunAt ?? planner?.lastAt ?? "unknown"}`);
+}
+' 2>/dev/null)"; then
+    printf 'control API: invalid health response on :%s\n' "$API_PORT"
+    return 0
+  fi
+  printf '%s\n' "$health_lines"
 }
 
 # Reject knob values before anything touches a log. A threshold below 1 MiB
@@ -922,6 +946,7 @@ case "$ACTION" in
     ;;
 
   status)
+    print_health_status
     printf 'total log bytes: %s\n' "$(run_log_total_bytes "$RUN_DIR")"
     ;;
 

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -24,6 +24,7 @@ import { spawnSync } from "node:child_process";
 import path from "node:path";
 import { homedir } from "node:os";
 import { factoryRoot } from "../lib/factory-root.mjs";
+import { PLANNER_STALE_MS } from "./watchdog.mjs";
 import {
   controlPlaneKindFromPolicy,
   loadControlPlane,
@@ -440,20 +441,29 @@ function defaultProcessProbe(pid) {
   }
 }
 
-function defaultControlApiProbe(pathname, { port, token = null }) {
-  const headers = [];
-  if (token && pathname !== "/health")
-    headers.push("-H", `Authorization: Bearer ${token}`);
-  const result = spawnSync(
+export function defaultControlApiProbe(
+  pathname,
+  { port, token = null, spawn = spawnSync },
+) {
+  // The bearer travels on stdin via `--config -`, never in argv: anything in
+  // the argument vector is world-readable through /proc/*/cmdline for the
+  // lifetime of the curl process.
+  const useAuth = Boolean(token) && pathname !== "/health";
+  const result = spawn(
     "curl",
     [
       "-fsS",
       "--max-time",
       "3",
-      ...headers,
+      ...(useAuth ? ["--config", "-"] : []),
       `http://127.0.0.1:${port}${pathname}`,
     ],
-    { encoding: "utf8" },
+    {
+      encoding: "utf8",
+      ...(useAuth
+        ? { input: `header = "Authorization: Bearer ${token}"\n` }
+        : {}),
+    },
   );
   if (result.status !== 0) {
     return {
@@ -466,18 +476,6 @@ function defaultControlApiProbe(pathname, { port, token = null }) {
   } catch {
     return { ok: false, detail: "control API returned invalid JSON" };
   }
-}
-
-function plannerLastSuccessAt(planner) {
-  return (
-    planner?.lastSuccessAt ??
-    planner?.lastPlannedAt ??
-    planner?.lastPlanAt ??
-    planner?.lastCompletedAt ??
-    planner?.lastRunAt ??
-    planner?.lastAt ??
-    null
-  );
 }
 
 function plannerAgeMs(value, now) {
@@ -770,10 +768,10 @@ export function stackDaemonDiagnostics({
         ? admitted.count
         : 0;
     const age = plannerAgeMs(
-      plannerLastSuccessAt(healthProbe.body.planner),
+      healthProbe.body.planner?.lastPlannedAt ?? null,
       now,
     );
-    if (queued > 0 && (age === null || age > 5 * 60 * 1000)) {
+    if (queued > 0 && (age === null || age > PLANNER_STALE_MS)) {
       diagnostics.push({
         ok: false,
         label: "planner health",

--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -35,6 +35,10 @@ import {
   reposRoot,
 } from "../event-runtime/lib/repos.mjs";
 import {
+  codeStamp,
+  REGISTRY_STAMP_PATHS,
+} from "../event-runtime/lib/worker.mjs";
+import {
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
   loadChainAutoApprovalPolicy,
 } from "../event-runtime/lib/auto-approval.mjs";
@@ -436,6 +440,56 @@ function defaultProcessProbe(pid) {
   }
 }
 
+function defaultControlApiProbe(pathname, { port, token = null }) {
+  const headers = [];
+  if (token && pathname !== "/health")
+    headers.push("-H", `Authorization: Bearer ${token}`);
+  const result = spawnSync(
+    "curl",
+    [
+      "-fsS",
+      "--max-time",
+      "3",
+      ...headers,
+      `http://127.0.0.1:${port}${pathname}`,
+    ],
+    { encoding: "utf8" },
+  );
+  if (result.status !== 0) {
+    return {
+      ok: false,
+      detail: String(result.stderr ?? "control API did not respond").trim(),
+    };
+  }
+  try {
+    return { ok: true, body: JSON.parse(result.stdout) };
+  } catch {
+    return { ok: false, detail: "control API returned invalid JSON" };
+  }
+}
+
+function plannerLastSuccessAt(planner) {
+  return (
+    planner?.lastSuccessAt ??
+    planner?.lastPlannedAt ??
+    planner?.lastPlanAt ??
+    planner?.lastCompletedAt ??
+    planner?.lastRunAt ??
+    planner?.lastAt ??
+    null
+  );
+}
+
+function plannerAgeMs(value, now) {
+  const parsed =
+    typeof value === "number"
+      ? value < 1_000_000_000_000
+        ? value * 1000
+        : value
+      : Date.parse(String(value ?? ""));
+  return Number.isFinite(parsed) ? now() - parsed : null;
+}
+
 /**
  * Reports the two daemons that make a local factory stack usable. Process and
  * pidfile probes are injectable so a test never has to manufacture a real
@@ -448,6 +502,9 @@ export function stackDaemonDiagnostics({
   listProcesses = defaultProcessTable,
   readPidFile = (file) => readFileSync(file, "utf8"),
   probeProcess = defaultProcessProbe,
+  controlApiProbe = defaultControlApiProbe,
+  registryStamp = (checkout) => codeStamp(checkout, REGISTRY_STAMP_PATHS),
+  now = () => Date.now(),
 } = {}) {
   const appConfigured = Boolean(
     env.FACTORY_GH_APP_ID &&
@@ -624,6 +681,124 @@ export function stackDaemonDiagnostics({
       ok: true,
       label: "serve.pid identity",
       detail: `PID ${pid} is event-runtime/cli.mjs serve`,
+      fix: null,
+    });
+  }
+
+  // A matching process is necessary but not sufficient: it can be serving a
+  // last-good registry while the checkout has moved. Health stays bearer-free
+  // precisely so doctor can make this local liveness check without reading a
+  // credential.
+  const port = Number(env.FACTORY_EVENT_PORT ?? 7381);
+  const probeOptions = {
+    port,
+    token:
+      env.FACTORY_CONTROL_API_TOKEN ?? process.env.FACTORY_CONTROL_API_TOKEN,
+  };
+  const healthProbe = controlApiProbe("/health", probeOptions);
+  if (!healthProbe?.ok) {
+    diagnostics.push({
+      ok: false,
+      label: "control API health",
+      detail: `unreachable on :${port}${healthProbe?.detail ? ` — ${healthProbe.detail}` : ""}`,
+      fix: "run `factory down && factory up`, then run `factory doctor` again",
+    });
+    return diagnostics;
+  }
+  diagnostics.push({
+    ok: true,
+    label: "control API health",
+    detail: `reachable on :${port}`,
+    fix: null,
+  });
+
+  const registry = healthProbe.body?.registry;
+  const expectedStamp = registryStamp(root);
+  if (!registry?.stamp) {
+    diagnostics.push({
+      ok: "warn",
+      label: "registry health",
+      detail: "not reported by this serve",
+      fix: "restart serve from the current checkout to expose registry health",
+    });
+  } else if (registry.stamp !== expectedStamp) {
+    diagnostics.push({
+      ok: false,
+      label: "registry health",
+      detail: `stale — served ${registry.stamp}, local ${expectedStamp}`,
+      fix: "restart serve so it loads the current registry",
+    });
+  } else {
+    diagnostics.push({
+      ok: true,
+      label: "registry health",
+      detail: `current (${registry.stamp}; loaded ${registry.loadedAt ?? "unknown"})`,
+      fix: null,
+    });
+  }
+  if (registry?.lastReloadError?.message) {
+    diagnostics.push({
+      ok: "warn",
+      label: "registry reload",
+      detail: registry.lastReloadError.message,
+      fix: "repair the rejected registry change, then restart or wait for a successful reload",
+    });
+  } else {
+    diagnostics.push({
+      ok: true,
+      label: "registry reload",
+      detail: "no reload error reported",
+      fix: null,
+    });
+  }
+
+  if (Object.hasOwn(healthProbe.body ?? {}, "planner")) {
+    const statusProbe = controlApiProbe("/status", probeOptions);
+    if (!statusProbe?.ok) {
+      diagnostics.push({
+        ok: "warn",
+        label: "planner health",
+        detail: `cannot read admitted events${statusProbe?.detail ? ` — ${statusProbe.detail}` : ""}`,
+        fix: "restore control API access, then run `factory doctor` again",
+      });
+      return diagnostics;
+    }
+    const admitted = statusProbe?.body?.events?.admitted;
+    const queued = Number.isFinite(admitted)
+      ? admitted
+      : Number.isFinite(admitted?.count)
+        ? admitted.count
+        : 0;
+    const age = plannerAgeMs(
+      plannerLastSuccessAt(healthProbe.body.planner),
+      now,
+    );
+    if (queued > 0 && (age === null || age > 5 * 60 * 1000)) {
+      diagnostics.push({
+        ok: false,
+        label: "planner health",
+        detail:
+          age === null
+            ? `${queued} admitted event(s) queued; planner recency unavailable`
+            : `${queued} admitted event(s) queued; planner last succeeded ${Math.round(age / 60000)}m ago`,
+        fix: "inspect serve logs and restart the planner after resolving its error",
+      });
+    } else {
+      diagnostics.push({
+        ok: true,
+        label: "planner health",
+        detail:
+          queued > 0
+            ? `current with ${queued} admitted event(s)`
+            : "no admitted events waiting",
+        fix: null,
+      });
+    }
+  } else {
+    diagnostics.push({
+      ok: "warn",
+      label: "planner health",
+      detail: "not reported by this serve",
       fix: null,
     });
   }

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -31,6 +31,7 @@ import {
 import {
   compareCliVersions,
   chainAutoApprovalPolicyDiagnostic,
+  defaultControlApiProbe,
   MIN_BUN_VERSION,
   MIN_GIT_VERSION,
   ossOnboardingDiagnostics,
@@ -473,7 +474,7 @@ describe("stack daemon diagnostics (#1868)", () => {
               loadedAt: "2026-08-30T12:00:00.000Z",
               lastReloadError: { message: "bad schema" },
             },
-            planner: { lastSuccessAt: "2026-08-30T11:00:00.000Z" },
+            planner: { lastPlannedAt: "2026-08-30T11:00:00.000Z" },
           },
         };
       },
@@ -490,6 +491,29 @@ describe("stack daemon diagnostics (#1868)", () => {
     expect(rows).toContainEqual(
       expect.objectContaining({ label: "planner health", ok: false }),
     );
+  });
+
+  test("control API probe keeps the bearer token out of curl argv", () => {
+    const token = "secret-bearer-token";
+    const spawned = [];
+    const spawn = (cmd, args, opts) => {
+      spawned.push({ cmd, args, opts });
+      return { status: 0, stdout: "{}", stderr: "" };
+    };
+
+    defaultControlApiProbe("/status", { port: 7381, token, spawn });
+    expect(spawned).toHaveLength(1);
+    const { args, opts } = spawned[0];
+    expect(args.join(" ")).not.toContain(token);
+    expect(args).toContain("--config");
+    expect(args).toContain("-");
+    expect(opts.input).toBe(`header = "Authorization: Bearer ${token}"\n`);
+
+    // /health stays bearer-free: no config stanza, no stdin payload.
+    defaultControlApiProbe("/health", { port: 7381, token, spawn });
+    expect(spawned[1].args).not.toContain("--config");
+    expect(spawned[1].opts.input).toBeUndefined();
+    expect(JSON.stringify(spawned[1])).not.toContain(token);
   });
 });
 

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -451,6 +451,46 @@ describe("stack daemon diagnostics (#1868)", () => {
       fix: null,
     });
   });
+
+  test("reports stale registry and planner health from the live control API", () => {
+    const rows = stackDaemonDiagnostics({
+      root,
+      env: {},
+      listProcesses: () => [],
+      readPidFile: () => "8080\n",
+      probeProcess: () => ({
+        alive: true,
+        command: "bun /factory/stack/event-runtime/cli.mjs serve --port 7381",
+      }),
+      controlApiProbe: (pathname) => {
+        if (pathname === "/status")
+          return { ok: true, body: { events: { admitted: 1 } } };
+        return {
+          ok: true,
+          body: {
+            registry: {
+              stamp: "files:stale",
+              loadedAt: "2026-08-30T12:00:00.000Z",
+              lastReloadError: { message: "bad schema" },
+            },
+            planner: { lastSuccessAt: "2026-08-30T11:00:00.000Z" },
+          },
+        };
+      },
+      registryStamp: () => "files:current",
+      now: () => Date.parse("2026-08-30T12:00:00.000Z"),
+    });
+
+    expect(rows).toContainEqual(
+      expect.objectContaining({ label: "registry health", ok: false }),
+    );
+    expect(rows).toContainEqual(
+      expect.objectContaining({ label: "registry reload", ok: "warn" }),
+    );
+    expect(rows).toContainEqual(
+      expect.objectContaining({ label: "planner health", ok: false }),
+    );
+  });
 });
 
 describe("chain auto-approval policy diagnostic (#1779)", () => {

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -151,14 +151,9 @@ export function assessServeHealth(
 
   if (health && Object.hasOwn(health, "planner") && queuedEvents > 0) {
     const planner = health.planner;
-    const lastAt = timestampMs(
-      planner?.lastSuccessAt ??
-        planner?.lastPlannedAt ??
-        planner?.lastPlanAt ??
-        planner?.lastCompletedAt ??
-        planner?.lastRunAt ??
-        planner?.lastAt,
-    );
+    // #1903 landed the canonical `lastPlannedAt` recency field on /health;
+    // the old guess chain over speculative field names is gone with it.
+    const lastAt = timestampMs(planner?.lastPlannedAt);
     if (lastAt === null) {
       issues.push({
         severity: "WARNING",
@@ -1151,7 +1146,11 @@ export function liveIdleWatchdogDeps({
           if (Object.hasOwn(health ?? {}, "planner")) {
             queuedEvents = admittedEventCount(await api("/status"));
           }
-          return assessServeHealth(health, { queuedEvents }).ok;
+          // Gate the idle loop on planner recency only: a reachable serve on
+          // last-good code (REGISTRY_STALE) can still plan and drain work, so
+          // the watchdog report surfaces it without halting injection here.
+          const { issues } = assessServeHealth(health, { queuedEvents });
+          return !issues.some((issue) => issue.code?.startsWith("PLANNER_"));
         } catch {
           if (attempt === 1) return false;
         }

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -33,6 +33,10 @@ import { budgetExhausted } from "../lib/spend.mjs";
 import { loadForge } from "../lib/forge/index.mjs";
 import { resolveConfigPath } from "../event-runtime/lib/config.mjs";
 import { reposRoot } from "../event-runtime/lib/repos.mjs";
+import {
+  codeStamp,
+  REGISTRY_STAMP_PATHS,
+} from "../event-runtime/lib/worker.mjs";
 
 const c = {
   bold: (s) => `\x1b[1m${s}\x1b[0m`,
@@ -92,6 +96,86 @@ export const SANDBOX_REFUSAL_DETAIL_CONCURRENCY = 4;
 export const SANDBOX_REFUSAL_BUDGET_MS = 5_000;
 export const CONTROL_API_TIMEOUT_MS = 3_000;
 export const FLEET_CHECK_TIMEOUT_MS = 10_000;
+export const PLANNER_STALE_MS = 5 * 60 * 1000;
+
+function timestampMs(value) {
+  if (typeof value === "number" && Number.isFinite(value))
+    return value < 1_000_000_000_000 ? value * 1000 : value;
+  const parsed = Date.parse(String(value ?? ""));
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function admittedEventCount(status) {
+  const admitted = status?.events?.admitted;
+  if (Number.isFinite(admitted) && admitted >= 0) return admitted;
+  if (Number.isFinite(admitted?.count) && admitted.count >= 0)
+    return admitted.count;
+  return 0;
+}
+
+/**
+ * Decide whether a reachable serve is also running the current registry and,
+ * when it reports one, a planner able to drain admitted work.  Older serves
+ * did not expose `planner`, so its absence remains a compatible liveness
+ * result rather than a fabricated failure.
+ */
+export function assessServeHealth(
+  health,
+  {
+    expectedRegistryStamp = codeStamp(undefined, REGISTRY_STAMP_PATHS),
+    queuedEvents = 0,
+    now = Date.now(),
+    plannerStaleMs = PLANNER_STALE_MS,
+  } = {},
+) {
+  const issues = [];
+  const registry = health?.registry;
+  if (
+    registry?.stamp &&
+    expectedRegistryStamp &&
+    registry.stamp !== expectedRegistryStamp
+  ) {
+    issues.push({
+      severity: "CRITICAL",
+      code: "REGISTRY_STALE",
+      message: `Control API registry ${registry.stamp} differs from local ${expectedRegistryStamp}`,
+    });
+  }
+  if (registry?.lastReloadError?.message) {
+    issues.push({
+      severity: "WARNING",
+      code: "REGISTRY_RELOAD_ERROR",
+      message: `Control API registry reload failed: ${registry.lastReloadError.message}`,
+    });
+  }
+
+  if (health && Object.hasOwn(health, "planner") && queuedEvents > 0) {
+    const planner = health.planner;
+    const lastAt = timestampMs(
+      planner?.lastSuccessAt ??
+        planner?.lastPlannedAt ??
+        planner?.lastPlanAt ??
+        planner?.lastCompletedAt ??
+        planner?.lastRunAt ??
+        planner?.lastAt,
+    );
+    if (lastAt === null) {
+      issues.push({
+        severity: "WARNING",
+        code: "PLANNER_UNAVAILABLE",
+        message: `${queuedEvents} admitted event(s) are queued but planner recency is unavailable`,
+      });
+    } else if (now - lastAt > plannerStaleMs) {
+      issues.push({
+        severity: "CRITICAL",
+        code: "PLANNER_STALE",
+        message: `${queuedEvents} admitted event(s) are queued; planner last succeeded ${Math.round((now - lastAt) / 60000)}m ago`,
+      });
+    }
+  }
+
+  return { ok: issues.length === 0, issues };
+}
 
 /**
  * Read a control-API endpoint with the loopback bearer and a bounded timeout.
@@ -324,10 +408,11 @@ export async function runWatchdogCheck({
     sandboxRefusals: [],
     anomalies: [],
   };
+  let health = null;
 
   // 1. Control API Health
   try {
-    const health = await controlApi("/health", { host, port });
+    health = await controlApi("/health", { host, port });
     metrics.apiOk = true;
     metrics.tick = health?.tick ?? null;
     if (health?.tick?.overruns > 0) {
@@ -433,6 +518,10 @@ export async function runWatchdogCheck({
     }
 
     metrics.queuedRuns = byState.QUEUED ?? 0;
+    const serveHealth = assessServeHealth(health, {
+      queuedEvents: admittedEventCount(statusRes),
+    });
+    issues.push(...serveHealth.issues);
     metrics.sandboxRefusals = sandboxRefusals;
     if (metrics.sandboxRefusals.length > 0) {
       const agents = [
@@ -1055,8 +1144,14 @@ export function liveIdleWatchdogDeps({
       // retry separates "wedged" from "was mid-tick when we asked".
       for (const attempt of [0, 1]) {
         try {
-          await api("/health", { timeoutMs: 15000 });
-          return true;
+          const health = await api("/health", { timeoutMs: 15000 });
+          let queuedEvents = 0;
+          // The planner block is new; do not add a status read for older
+          // serves that cannot report planner recency yet.
+          if (Object.hasOwn(health ?? {}, "planner")) {
+            queuedEvents = admittedEventCount(await api("/status"));
+          }
+          return assessServeHealth(health, { queuedEvents }).ok;
         } catch {
           if (attempt === 1) return false;
         }

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -55,7 +55,7 @@ test("assessServeHealth rejects a stale planner while admitted events wait", () 
   const result = assessServeHealth(
     {
       registry: { stamp: "files:current", lastReloadError: null },
-      planner: { lastSuccessAt: "2026-08-30T11:45:00.000Z" },
+      planner: { lastPlannedAt: "2026-08-30T11:45:00.000Z" },
     },
     {
       expectedRegistryStamp: "files:current",
@@ -1273,6 +1273,35 @@ test("live deps page open proposals newest-first and keep every page", async () 
     expect(rows.map((r) => r.id)).toEqual(["new", "old"]);
     expect(seen).toHaveLength(2);
     expect(seen[1]).toContain("before=cursor1");
+  } finally {
+    server.stop(true);
+  }
+});
+
+test("live serveOk tolerates a stale registry but halts on a stale planner", async () => {
+  let plannerLastPlannedAt = new Date().toISOString();
+  const server = Bun.serve({
+    port: 0,
+    fetch(req) {
+      const url = new URL(req.url);
+      if (url.pathname === "/health")
+        return Response.json({
+          registry: { stamp: "files:definitely-stale", lastReloadError: null },
+          planner: { lastPlannedAt: plannerLastPlannedAt },
+        });
+      if (url.pathname === "/status")
+        return Response.json({ events: { admitted: 3 } });
+      return new Response("{}");
+    },
+  });
+  try {
+    const { serveOk } = liveIdleWatchdogDeps({ port: server.port });
+    // REGISTRY_STALE alone must not stop idle-loop injection: a reachable
+    // serve on last-good code still plans and drains admitted work.
+    expect(await serveOk()).toBe(true);
+    // A planner that has not succeeded within the staleness window does.
+    plannerLastPlannedAt = "2020-01-01T00:00:00.000Z";
+    expect(await serveOk()).toBe(false);
   } finally {
     server.stop(true);
   }

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -2,6 +2,7 @@ import { test, expect } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 import {
+  assessServeHealth,
   controlApiFailureCode,
   fetchRecentSandboxRefusals,
   formatWatchdogReport,
@@ -17,6 +18,57 @@ import {
   SANDBOX_REFUSAL_MAX_RUNS,
   SCAN_LOOP_AGENTS,
 } from "./watchdog.mjs";
+
+test("assessServeHealth flags a served stale registry and reload error", () => {
+  const result = assessServeHealth(
+    {
+      registry: {
+        stamp: "files:old",
+        loadedAt: "2026-08-30T12:00:00.000Z",
+        lastReloadError: {
+          at: "2026-08-30T12:01:00.000Z",
+          message: "invalid agent pin",
+        },
+      },
+    },
+    { expectedRegistryStamp: "files:current" },
+  );
+
+  expect(result.ok).toBe(false);
+  expect(result.issues.map((issue) => issue.code)).toEqual([
+    "REGISTRY_STALE",
+    "REGISTRY_RELOAD_ERROR",
+  ]);
+});
+
+test("assessServeHealth tolerates an absent planner block", () => {
+  const result = assessServeHealth(
+    { registry: { stamp: "files:current", lastReloadError: null } },
+    { expectedRegistryStamp: "files:current", queuedEvents: 4 },
+  );
+
+  expect(result.ok).toBe(true);
+  expect(result.issues).toEqual([]);
+});
+
+test("assessServeHealth rejects a stale planner while admitted events wait", () => {
+  const result = assessServeHealth(
+    {
+      registry: { stamp: "files:current", lastReloadError: null },
+      planner: { lastSuccessAt: "2026-08-30T11:45:00.000Z" },
+    },
+    {
+      expectedRegistryStamp: "files:current",
+      queuedEvents: 2,
+      now: Date.parse("2026-08-30T12:00:00.000Z"),
+    },
+  );
+
+  expect(result.ok).toBe(false);
+  expect(result.issues).toContainEqual(
+    expect.objectContaining({ code: "PLANNER_STALE" }),
+  );
+});
 
 test("formatWatchdogReport formats clean watchdog status", () => {
   const cleanResult = {


### PR DESCRIPTION
Fixes #1904

Surface stale registry, reload-error, and optional planner health so operators can restart a bad serve before it silently accepts work.

## Validation

| Check                | Command                                                                                                                       | Result  | Notes                           |
| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------- |
| Verification Command | `bun test orchestrator/watchdog.test.mjs && bun test orchestrator/doctor.test.mjs`                                         | pass    | 93 tests, 0 failures            |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`        | pass    | 2,264 tests, emit, format, lint |
| UX critique          | factory-ux-critic                                                                                                             | skipped | no user-facing surface          |

UX critique: skipped

run:run_659a0fb4-9552-4d66-a0c7-c71c7817c17f
