### PR TITLE
perf(auto-approval): index merge eligibility history (#1900)

### DIFF
--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -685,6 +685,10 @@ function chainPredecessorReason(db, registry, candidate, envelope) {
   return null;
 }
 
+// Malformed history envelopes are permanent rows: warn about each event_id
+// once per process instead of on every approval tick.
+const warnedMalformedMergeFixEvents = new Set();
+
 function durableFixRoundReason(db, candidate, input, policy) {
   const cap = policy.maxFixRounds ?? 0;
   // A fix round is "spent" only when a merge-fix run for this PR actually
@@ -696,20 +700,39 @@ function durableFixRoundReason(db, candidate, input, policy) {
   // The indexed event type/source predicate and payload prefilter leave JS to
   // parse only entries for this exact PR, and the cap means a full history
   // cannot make this lookup unbounded.
-  const malformed = db
+  // Cheap indexed existence probe first: in the common all-valid history the
+  // per-tick cost stops here, and the detail scan below runs only when a
+  // malformed envelope is actually present.
+  const hasMalformed = db
     .query(
-      `SELECT e.event_id FROM events e
-       WHERE e.source = 'chain'
-         AND e.type = 'factory.merge-fix.requested'
-         AND e.event_id != ?
-         AND json_valid(e.envelope_json) = 0
-       LIMIT ?`,
+      `SELECT EXISTS(
+         SELECT 1 FROM events e
+         WHERE e.source = 'chain'
+           AND e.type = 'factory.merge-fix.requested'
+           AND e.event_id != ?
+           AND json_valid(e.envelope_json) = 0
+       ) AS present`,
     )
-    .all(candidate.event_id, cap);
-  for (const row of malformed) {
-    console.warn(
-      `Skipping malformed merge-fix history envelope for event ${row.event_id}`,
-    );
+    .get(candidate.event_id).present;
+  if (hasMalformed) {
+    const malformed = db
+      .query(
+        `SELECT e.event_id FROM events e
+         WHERE e.source = 'chain'
+           AND e.type = 'factory.merge-fix.requested'
+           AND e.event_id != ?
+           AND json_valid(e.envelope_json) = 0
+         ORDER BY e.rowid DESC
+         LIMIT ?`,
+      )
+      .all(candidate.event_id, cap);
+    for (const row of malformed) {
+      if (warnedMalformedMergeFixEvents.has(row.event_id)) continue;
+      warnedMalformedMergeFixEvents.add(row.event_id);
+      console.warn(
+        `Skipping malformed merge-fix history envelope for event ${row.event_id}`,
+      );
+    }
   }
 
   const rows = db
@@ -728,6 +751,7 @@ function durableFixRoundReason(db, candidate, input, policy) {
                   THEN json_extract(e.envelope_json, '$.payload.github') END = ?
          AND CASE WHEN json_valid(e.envelope_json)
                   THEN json_extract(e.envelope_json, '$.payload.pr') END = ?
+       ORDER BY e.rowid DESC
        LIMIT ?`,
     )
     .all(candidate.event_id, input.repo, input.github, input.pr, cap);

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -692,6 +692,26 @@ function durableFixRoundReason(db, candidate, input, policy) {
   // re-emits every tick), REFUSED execute-time refusals (pr moved, ticket
   // state) and CANCELLED stale-pinned runs do not consume the budget
   // (2026-08-18: counting them exhausted max_fix_rounds before any fix ran).
+  // Do not decode every historical merge-fix envelope on each approval tick.
+  // The indexed event type/source predicate and payload prefilter leave JS to
+  // parse only entries for this exact PR, and the cap means a full history
+  // cannot make this lookup unbounded.
+  const malformed = db
+    .query(
+      `SELECT e.event_id FROM events e
+       WHERE e.source = 'chain'
+         AND e.type = 'factory.merge-fix.requested'
+         AND e.event_id != ?
+         AND json_valid(e.envelope_json) = 0
+       LIMIT ?`,
+    )
+    .all(candidate.event_id, cap);
+  for (const row of malformed) {
+    console.warn(
+      `Skipping malformed merge-fix history envelope for event ${row.event_id}`,
+    );
+  }
+
   const rows = db
     .query(
       `SELECT e.event_id, e.envelope_json, r.state FROM events e
@@ -701,16 +721,29 @@ function durableFixRoundReason(db, candidate, input, policy) {
          AND e.type = 'factory.merge-fix.requested'
          AND p.decision = 'run'
          AND r.state IN ('QUEUED','LEASED','RUNNING','VERIFYING','COMPLETED','FAILED')
-         AND e.event_id != ?`,
+         AND e.event_id != ?
+         AND CASE WHEN json_valid(e.envelope_json)
+                  THEN json_extract(e.envelope_json, '$.payload.repo') END = ?
+         AND CASE WHEN json_valid(e.envelope_json)
+                  THEN json_extract(e.envelope_json, '$.payload.github') END = ?
+         AND CASE WHEN json_valid(e.envelope_json)
+                  THEN json_extract(e.envelope_json, '$.payload.pr') END = ?
+       LIMIT ?`,
     )
-    .all(candidate.event_id);
+    .all(candidate.event_id, input.repo, input.github, input.pr, cap);
   let executed = 0;
   for (const row of rows) {
     let payload;
     try {
       payload = JSON.parse(row.envelope_json)?.payload;
     } catch {
-      return "merge_fix_history_unparseable";
+      // json_valid above makes this defensive path exceptional (for example,
+      // a driver decode failure), but one corrupt history row must not block
+      // every later merge-fix candidate.
+      console.warn(
+        `Skipping unreadable merge-fix history envelope for event ${row.event_id}`,
+      );
+      continue;
     }
     if (
       payload?.repo === input.repo &&

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1415,6 +1415,84 @@ describe("chain auto approval (WM-357)", () => {
     }
   });
 
+  test("a malformed merge-fix history envelope is warned about but does not poison another PR", async () => {
+    const db = openDb(":memory:");
+    const fixInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 430,
+      headSha: "a".repeat(40),
+      baseSha: "b".repeat(40),
+      headRef: "feat/WM-430",
+      ticket: "WM-430",
+      finding: "mechanical in-scope fix",
+      findingHash: "c".repeat(64),
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: ["event-runtime/lib/auto-approval.mjs"],
+    };
+    const predecessorArtifact = {
+      recommendation: "FIX",
+      repo: fixInput.repo,
+      github: fixInput.github,
+      base: fixInput.base,
+      plan: [],
+      fix: [fixInput],
+      escalate: [],
+      summary: "selected mechanical fix",
+    };
+    const malformed = seed(db, {
+      id: "malformed-fix-history",
+      type: "factory.merge-fix.requested",
+      input: { ...fixInput, pr: 429, ticket: "WM-429" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: {
+        ...predecessorArtifact,
+        fix: [{ ...fixInput, pr: 429, ticket: "WM-429" }],
+      },
+      predecessorInput: { repo: "factory" },
+    });
+    db.query(
+      `UPDATE events SET envelope_json = '{not-json' WHERE event_id = ?`,
+    ).run(`event-${malformed.id}`);
+    const candidate = seed(db, {
+      id: "candidate-after-malformed-history",
+      type: "factory.merge-fix.requested",
+      input: fixInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact,
+      predecessorInput: { repo: "factory" },
+    });
+
+    const warnings = [];
+    const warn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    try {
+      const result = await auto(db, {
+        policy: {
+          ...policy,
+          maxFixRounds: 2,
+          autoMergeBase: new Set(["develop"]),
+          autoMergeOwners: new Set(["watt-mind"]),
+        },
+        runtimeGuard: () => null,
+      });
+      expect(result.approved).toContainEqual({
+        proposalId: candidate.id,
+        runId: candidate.runId,
+      });
+    } finally {
+      console.warn = warn;
+    }
+
+    expect(runState(db, candidate.runId)).toBe("QUEUED");
+    expect(warnings).toContain(
+      "Skipping malformed merge-fix history envelope for event event-malformed-fix-history",
+    );
+  });
+
   test("an independent recommendation edge with an empty selector remains watched", async () => {
     const db = openDb(":memory:");
     const escalation = seed(db, {

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -1493,6 +1493,105 @@ describe("chain auto approval (WM-357)", () => {
     );
   });
 
+  test("a malformed merge-fix history envelope is warned about once per event, not on every tick", async () => {
+    const db = openDb(":memory:");
+    const fixInput = {
+      repo: "factory",
+      github: "watt-mind/factory",
+      base: "develop",
+      pr: 430,
+      headSha: "a".repeat(40),
+      baseSha: "b".repeat(40),
+      headRef: "feat/WM-430",
+      ticket: "WM-430",
+      finding: "mechanical in-scope fix",
+      findingHash: "c".repeat(64),
+      round: 1,
+      mechanical: true,
+      withinOwnedPaths: true,
+      ownedPaths: ["event-runtime/lib/auto-approval.mjs"],
+    };
+    const artifactFor = (input) => ({
+      recommendation: "FIX",
+      repo: input.repo,
+      github: input.github,
+      base: input.base,
+      plan: [],
+      fix: [input],
+      escalate: [],
+      summary: "selected mechanical fix",
+    });
+    const malformed = seed(db, {
+      id: "malformed-fix-history-once",
+      type: "factory.merge-fix.requested",
+      input: { ...fixInput, pr: 429, ticket: "WM-429" },
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: artifactFor({
+        ...fixInput,
+        pr: 429,
+        ticket: "WM-429",
+      }),
+      predecessorInput: { repo: "factory" },
+    });
+    db.query(
+      `UPDATE events SET envelope_json = '{not-json' WHERE event_id = ?`,
+    ).run(`event-${malformed.id}`);
+    const first = seed(db, {
+      id: "candidate-warn-once-first",
+      type: "factory.merge-fix.requested",
+      input: fixInput,
+      predecessorAgent: "merge-scan@2",
+      predecessorArtifact: artifactFor(fixInput),
+      predecessorInput: { repo: "factory" },
+    });
+
+    const warnings = [];
+    const warn = console.warn;
+    console.warn = (...args) => warnings.push(args.join(" "));
+    const chainPolicy = {
+      ...policy,
+      maxFixRounds: 2,
+      autoMergeBase: new Set(["develop"]),
+      autoMergeOwners: new Set(["watt-mind"]),
+    };
+    try {
+      const result = await auto(db, {
+        policy: chainPolicy,
+        runtimeGuard: () => null,
+      });
+      expect(result.approved).toContainEqual({
+        proposalId: first.id,
+        runId: first.runId,
+      });
+
+      // A later tick with a fresh candidate scans the same malformed history
+      // row but must not repeat the warning.
+      const laterInput = { ...fixInput, pr: 431, ticket: "WM-431" };
+      const second = seed(db, {
+        id: "candidate-warn-once-second",
+        type: "factory.merge-fix.requested",
+        input: laterInput,
+        predecessorAgent: "merge-scan@2",
+        predecessorArtifact: artifactFor(laterInput),
+        predecessorInput: { repo: "factory" },
+      });
+      const again = await auto(db, {
+        policy: chainPolicy,
+        runtimeGuard: () => null,
+      });
+      expect(again.approved).toContainEqual({
+        proposalId: second.id,
+        runId: second.runId,
+      });
+    } finally {
+      console.warn = warn;
+    }
+
+    const message =
+      "Skipping malformed merge-fix history envelope for event event-malformed-fix-history-once";
+    expect(warnings.filter((line) => line === message)).toHaveLength(1);
+  });
+
   test("an independent recommendation edge with an empty selector remains watched", async () => {
     const db = openDb(":memory:");
     const escalation = seed(db, {

--- a/event-runtime/lib/db.mjs
+++ b/event-runtime/lib/db.mjs
@@ -618,6 +618,16 @@ export const MIGRATIONS = [
       `);
     },
   },
+  {
+    version: 23,
+    name: "merge_eligibility_event_type_index",
+    up(db) {
+      db.exec(`
+        CREATE INDEX IF NOT EXISTS idx_events_type_source
+          ON events (type, source);
+      `);
+    },
+  },
 ];
 
 export const CURRENT_SCHEMA_VERSION =

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -284,10 +284,10 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrated.close();
   });
 
-  test("tier escalation handoffs and lookup indexes reach schema 22 from a fresh and from a v14 database", () => {
-    expect(CURRENT_SCHEMA_VERSION).toBe(22);
+  test("tier escalation handoffs and lookup indexes reach the current schema from a fresh and from a v14 database", () => {
+    expect(CURRENT_SCHEMA_VERSION).toBe(23);
     const fresh = openDb(freshFile());
-    expect(getSchemaVersion(fresh)).toBe(22);
+    expect(getSchemaVersion(fresh)).toBe(23);
     expect(
       fresh
         .query(`PRAGMA table_info(outbox)`)
@@ -317,7 +317,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     migrateDb(at14, { targetVersion: 13 });
     at14.exec("PRAGMA user_version = 14;");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(22);
+    expect(getSchemaVersion(at14)).toBe(23);
     expect(
       at14
         .query(`PRAGMA table_info(outbox)`)
@@ -331,7 +331,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
         .map((row) => row.name),
     ).toContain("subject");
     migrateDb(at14);
-    expect(getSchemaVersion(at14)).toBe(22);
+    expect(getSchemaVersion(at14)).toBe(23);
     expect(
       at14
         .query(
@@ -361,7 +361,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     legacy.close();
 
     const upgraded = openDb(file);
-    expect(getSchemaVersion(upgraded)).toBe(22);
+    expect(getSchemaVersion(upgraded)).toBe(23);
     expect(
       upgraded
         .query(`PRAGMA table_info(workers)`)
@@ -393,7 +393,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     legacy.close();
 
     const upgraded = openDb(file);
-    expect(getSchemaVersion(upgraded)).toBe(22);
+    expect(getSchemaVersion(upgraded)).toBe(23);
     expect(
       upgraded
         .query(
@@ -427,8 +427,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     migrateDb(db);
 
-    expect(CURRENT_SCHEMA_VERSION).toBe(22);
-    expect(getSchemaVersion(db)).toBe(22);
+    expect(CURRENT_SCHEMA_VERSION).toBe(23);
+    expect(getSchemaVersion(db)).toBe(23);
     expect(
       db
         .query(
@@ -516,7 +516,7 @@ describe("schema migration runner and assertions (OPS-415)", () => {
 
     migrateDb(db);
 
-    expect(getSchemaVersion(db)).toBe(22);
+    expect(getSchemaVersion(db)).toBe(23);
     expect(
       db.query(`SELECT run_id, subject FROM runs ORDER BY run_id`).all(),
     ).toEqual([
@@ -541,8 +541,8 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     expect(getSchemaVersion(db)).toBe(19);
 
     migrateDb(db);
-    expect(CURRENT_SCHEMA_VERSION).toBe(22);
-    expect(getSchemaVersion(db)).toBe(22);
+    expect(CURRENT_SCHEMA_VERSION).toBe(23);
+    expect(getSchemaVersion(db)).toBe(23);
     expect(
       db
         .query(
@@ -595,9 +595,9 @@ describe("schema migration runner and assertions (OPS-415)", () => {
     db.close();
 
     const migrated = openDb(file);
-    expect(getSchemaVersion(migrated)).toBe(22);
+    expect(getSchemaVersion(migrated)).toBe(23);
     migrateDb(migrated);
-    expect(getSchemaVersion(migrated)).toBe(22);
+    expect(getSchemaVersion(migrated)).toBe(23);
     const plans = [
       [
         "metrics latest proposal",
@@ -641,6 +641,51 @@ describe("schema migration runner and assertions (OPS-415)", () => {
       expect(detail, name).not.toMatch(/SCAN (?:p2|p|e)\b/);
     }
     migrated.close();
+  });
+
+  test("merge eligibility event type index migrates v22 databases idempotently", () => {
+    const db = new Database(freshFile());
+    migrateDb(db, { targetVersion: 22 });
+    expect(getSchemaVersion(db)).toBe(22);
+    expect(
+      db
+        .query(
+          `SELECT name FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_type_source'`,
+        )
+        .get(),
+    ).toBeNull();
+
+    migrateDb(db);
+    expect(getSchemaVersion(db)).toBe(CURRENT_SCHEMA_VERSION);
+    expect(
+      db
+        .query(
+          `SELECT sql FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_type_source'`,
+        )
+        .get()?.sql,
+    ).toContain("events (type, source)");
+
+    const detail = db
+      .query(
+        `EXPLAIN QUERY PLAN
+         SELECT event_id FROM events
+         WHERE type = 'factory.merge-landed'`,
+      )
+      .all()
+      .map((row) => row.detail)
+      .join("\n");
+    expect(detail).toMatch(/USING (?:COVERING )?INDEX idx_events_type_source/);
+    expect(detail).not.toMatch(/SCAN events\b/);
+
+    MIGRATIONS.find((entry) => entry.version === 23).up(db);
+    expect(
+      db
+        .query(
+          `SELECT COUNT(*) AS n FROM sqlite_master WHERE type = 'index' AND name = 'idx_events_type_source'`,
+        )
+        .get().n,
+    ).toBe(1);
+    db.close();
   });
 
   test("metrics indexes migrate onto an existing v2 database (WM-281)", () => {


### PR DESCRIPTION
Fixes #1900

Add indexed, bounded merge-eligibility history lookups that tolerate corrupt historical envelopes.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                                 |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------- |
| Verification Command | `bun test event-runtime/lib/auto-approval.test.mjs`                                                         | pass    | 48 tests, 0 failures                  |
| Verification Command | `bun test event-runtime/lib/db.test.mjs`                                                                    | pass    | 41 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | exit 0; lint reported warnings only   |
| UX critique          | `factory-ux-critic`                                                                                         | not run | no user-facing surface                |

UX critique: skipped

run:run_369dbfe0-024c-4fae-b7c6-c98f6857365f


## Post-review

- Reviewer fixes applied (6dc58291): the per-tick `json_valid(envelope_json) = 0` warn-scan in `durableFixRoundReason` is gated behind a cheap indexed EXISTS probe, each malformed event_id is warned about once per process via an in-memory Set, and both history scans use `ORDER BY rowid DESC` so `LIMIT` keeps the most recent rows deterministically; warn-once behavior covered by a new test.
