### PR TITLE
test(planner): loosen rate-limit skip assertions

### DIFF
--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4417,18 +4417,18 @@ describe("Linear rate limit (WM-878)", () => {
 
       expect(counts).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
       expect(ticketReads).toBe(0);
-      expect(logs).toEqual([
-        `planner: Linear rate-limited until ${resetAt} — skipping Linear reads`,
-      ]);
-      expect(
-        db
-          .query(
-            `SELECT status, last_plan_error FROM events WHERE event_id = ?`,
-          )
-          .get(ref.eventId),
-      ).toMatchObject({
+      expect(logs).toHaveLength(1);
+      expect(logs[0]).toMatch(/rate-limited/);
+      expect(logs[0]).toContain(resetAt);
+      const escapedResetAt = resetAt.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+      const event = db
+        .query(`SELECT status, last_plan_error FROM events WHERE event_id = ?`)
+        .get(ref.eventId);
+      expect(event).toMatchObject({
         status: "admitted",
-        last_plan_error: `linear_rate_limited: resetAt=${resetAt}`,
+        last_plan_error: expect.stringMatching(
+          new RegExp(`^linear_rate_limited:.*${escapedResetAt}`),
+        ),
       });
     });
   });


### PR DESCRIPTION
Fixes watt-mind/factory#1924

Makes planner rate-limit tests tolerant of harmless operator wording changes.

## Validation

| Check                | Command                                                                          | Result  | Notes                          |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs`                                 | pass    | 111 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 pre-existing warnings |
| UX critique          | factory-ux-critic                                                                | not run | skipped: test-only assertion change |

UX critique: skipped — no user-facing surface (test-only assertion change)

run:run_93e4c83c-a020-4437-a123-9d9337d0c695
