### PR TITLE
test(timing): make timing bounds load-aware

### DIFF
--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -29,6 +29,7 @@ import {
   spawnTracked,
   spawnSupervisor,
   spawnWorker,
+  until,
   waitFor,
   registerCliTmpCleanup,
   registerTestProcessCleanup,
@@ -161,14 +162,19 @@ describe("work command", () => {
           "--poll-ms",
           "25",
           "--skip-report-ms",
-          "1000",
+          "100",
         ],
         { FACTORY_EVENT_HOME: home },
       );
       try {
         await waitFor(box, '"runId":"run_placement_skip"');
-        await Bun.sleep(100); // at least three more 25ms polls
-        expect(box.out.match(/"runId":"run_placement_skip"/g)).toHaveLength(1);
+        await until(
+          "the next placement skip-report interval",
+          () =>
+            (box.out.match(/"runId":"run_placement_skip"/g) ?? []).length >= 2,
+          { timeoutMs: 5_000, everyMs: 10 },
+        );
+        expect(box.out.match(/"runId":"run_placement_skip"/g)).toHaveLength(2);
         expect(box.out).toContain('"definition":"factory-status-report@1"');
         expect(box.out).toContain("placement_unsatisfied:node=gpu");
       } finally {
@@ -195,14 +201,19 @@ describe("work command", () => {
           "--poll-ms",
           "25",
           "--skip-report-ms",
-          "1000",
+          "100",
         ],
         { FACTORY_EVENT_HOME: home },
       );
       try {
         await waitFor(box, '"runId":"run_registry_skip"');
-        await Bun.sleep(100); // at least three more 25ms polls
-        expect(box.out.match(/"runId":"run_registry_skip"/g)).toHaveLength(1);
+        await until(
+          "the next registry skip-report interval",
+          () =>
+            (box.out.match(/"runId":"run_registry_skip"/g) ?? []).length >= 2,
+          { timeoutMs: 5_000, everyMs: 10 },
+        );
+        expect(box.out.match(/"runId":"run_registry_skip"/g)).toHaveLength(2);
         expect(box.out).toMatch(
           /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
         );

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1791,7 +1791,7 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     // The lock is held for 75 ms; a lower bound proves the approval actually
     // waited on it instead of racing past a lock that was never taken.
     expect(elapsedMs).toBeGreaterThanOrEqual(50);
-    expect(elapsedMs).toBeLessThan(2_000);
+    expect(elapsedMs).toBeLessThan(loadAdjustedTimeout(2_000));
     expect(await lock.exited).toBe(0);
     expect(await s.client.cancel(waiting.runId, "test cleanup")).toEqual({
       cancelled: true,
@@ -1825,7 +1825,9 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
       const healthStartedAt = Date.now();
       const health = await fetch(s.url("/health"));
       expect(health.status).toBe(200);
-      expect(Date.now() - healthStartedAt).toBeLessThan(500);
+      expect(Date.now() - healthStartedAt).toBeLessThan(
+        loadAdjustedTimeout(500),
+      );
       expect(await approval).toEqual({
         approved: true,
         runId: approvedProposal.runId,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -46,6 +46,7 @@ import {
   registerTestProcessCleanup,
   spawnTracked,
 } from "./test-helpers-process.mjs";
+import { until } from "./test-helpers-timing.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -999,10 +1000,15 @@ describe("serve PID lock (OPS-458)", () => {
       out1 += b;
     });
 
-    const deadline = Date.now() + 8000;
-    while (Date.now() < deadline && !out1.includes("control API on")) {
-      await Bun.sleep(100);
-    }
+    await until(
+      "the first control API startup",
+      () => out1.includes("control API on"),
+      {
+        // `until` applies loadAdjustedTimeout to this ceiling.
+        timeoutMs: 8_000,
+        everyMs: 100,
+      },
+    );
     expect(out1).toContain("control API on");
 
     // Second serve targeting same home should fail immediately
@@ -1040,11 +1046,12 @@ describe("serve PID lock (OPS-458)", () => {
       out3 += b;
     });
 
-    const deadline3 = Date.now() + 8000;
-    while (Date.now() < deadline3 && !out3.includes("control API on")) {
-      await Bun.sleep(100);
-    }
     try {
+      await until(
+        "the replacement control API startup",
+        () => out3.includes("control API on"),
+        { timeoutMs: 8_000, everyMs: 100 },
+      );
       expect(out3).toContain("control API on");
     } finally {
       serve3.kill("SIGTERM");

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -21,6 +21,7 @@ import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry, RegistryError } from "./registry.mjs";
 import { runOnce } from "./worker.mjs";
 import { tick } from "../cli/serve.mjs";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 // Importing test-helpers pins FACTORY_EVENT_HOME/FACTORY_HOME to an isolated
 // temp home for this whole file, so default-home lookups (artifactsRoot(),
 // dbPath()) never reach the operator's real ~/.factory (OPS-425).
@@ -722,9 +723,9 @@ describe("multi-emit chain resolution (WM-119)", () => {
         `chain benchmark: tick=${tickMs.toFixed(1)}ms health_p95=${healthP95.toFixed(1)}ms child_event_lookups=${childEventLookups}`,
       );
       expect(childEventLookups).toBe(1); // one bulk lookup, never 2,000
-      expect(tickMs).toBeLessThan(200);
+      expect(tickMs).toBeLessThan(loadAdjustedTimeout(200));
       // /health p95 is measured against the stub Bun.serve above: it proves the tick does not block the event loop, not real API latency.
-      expect(healthP95).toBeLessThan(500);
+      expect(healthP95).toBeLessThan(loadAdjustedTimeout(500));
       // The production-shaped benchmark must never touch the operator's real
       // ~/.factory/event-runtime/runtime.db (no default-home openDb/migration).
       expect(realFactorySnapshot().dbMtime).toBe(realHomeBefore.dbMtime);

--- a/event-runtime/lib/db.test.mjs
+++ b/event-runtime/lib/db.test.mjs
@@ -32,6 +32,7 @@ import {
 } from "./db.mjs";
 import { dbPath, isTestOrCiProcess, runtimeHome } from "./config.mjs";
 import { createIsolatedHome, realFactorySnapshot } from "../test-helpers.mjs";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
 const freshFile = () => path.join(tmpDir("evrt-db-"), "runtime.db");
 
@@ -114,7 +115,7 @@ describe("retryBusy (#1349)", () => {
     ).rejects.toBe(busy);
     // The lowered timeout bounds the whole budget, not just one attempt.
     expect(attempts).toBe(1);
-    expect(Date.now() - startedAt).toBeLessThan(1_000);
+    expect(Date.now() - startedAt).toBeLessThan(loadAdjustedTimeout(1_000));
     expect(db.query("PRAGMA busy_timeout").get().timeout).toBe(10);
     db.close();
   });

--- a/event-runtime/lib/hooks.test.mjs
+++ b/event-runtime/lib/hooks.test.mjs
@@ -15,6 +15,7 @@ import {
   hookDecisionsFor,
   validateHookModule,
 } from "./hooks.mjs";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
 const FIXTURE_HOOKS = path.join(
   RUNTIME_ROOT,
@@ -245,7 +246,7 @@ describe("hook registry (WM-842)", () => {
       now,
       timeoutMs: 30,
     });
-    expect(performance.now() - started).toBeLessThan(1500);
+    expect(performance.now() - started).toBeLessThan(loadAdjustedTimeout(1500));
     expect(out).toMatchObject({
       decision: "deny",
       reason: "hook_error:factory/sample:hangs",

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -24,6 +24,7 @@ import {
 import { decisionRequestHash } from "./decision.mjs";
 import { templateFor } from "./decision-templates.mjs";
 import { listMemos, MEMO_SCHEMA_VERSION, memoDigest } from "./memos.mjs";
+import { loadAdjustedTimeout } from "./test-helpers-timing.mjs";
 
 const inboxDocPath = path.resolve(
   import.meta.dir,
@@ -573,8 +574,13 @@ describe("human inbox ledger (WM-285)", () => {
     const started = new Promise((resolve) => {
       effectStarted = resolve;
     });
+    let releaseEffect;
+    const effectFinished = new Promise((resolve) => {
+      releaseEffect = resolve;
+    });
+    let deciding;
     try {
-      const deciding = decideInboxItem(
+      deciding = decideInboxItem(
         db,
         "slow_effect",
         {
@@ -586,18 +592,16 @@ describe("human inbox ledger (WM-285)", () => {
         {
           applyEffect: async () => {
             effectStarted();
-            await new Promise((resolve) => setTimeout(resolve, 250));
+            await effectFinished;
             return { outcome: "applied" };
           },
         },
       );
       await started;
 
-      const writeStarted = performance.now();
       expect(() =>
         createInboxItem(other, { kind: "BLOCKED", title: "other writer" }),
       ).not.toThrow();
-      expect(performance.now() - writeStarted).toBeLessThan(200);
       await expect(
         decideInboxItem(db, "slow_effect", {
           schemaVersion: "factory.decision-response/v1",
@@ -616,12 +620,15 @@ describe("human inbox ledger (WM-285)", () => {
         claimedAt: expect.any(String),
       });
 
+      releaseEffect();
       await deciding;
       expect(getInboxItem(db, "slow_effect").response.effect).toEqual({
         kind: "send_to_triage",
         outcome: "applied",
       });
     } finally {
+      releaseEffect?.();
+      await deciding;
       other.close();
       db.close();
     }
@@ -1162,7 +1169,7 @@ describe("human inbox ledger (WM-285)", () => {
 
     const started = performance.now();
     expect(inboxCounts(db).open).toBe(10_000);
-    expect(performance.now() - started).toBeLessThan(200);
+    expect(performance.now() - started).toBeLessThan(loadAdjustedTimeout(200));
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1923

Make timing-sensitive tests wait on observable state or load-adjusted ceilings.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli/work.test.mjs event-runtime/lib/inbox.test.mjs event-runtime/lib/chain.test.mjs event-runtime/lib/api-runs.test.mjs event-runtime/lib/db.test.mjs event-runtime/lib/hooks.test.mjs event-runtime/lib/api.test.mjs event-runtime/lib/test-helpers-timing.test.mjs` | pass | 220 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2270 pass, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — test-only change; no user-facing surface

run:run_e3e5fadc-8f3d-481e-bea7-fb230e196089