### PR TITLE
fix(chain): report malformed whenPath rules (#1926)

### DIFF
--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -245,14 +245,17 @@ export function resolveChains(
                 }
                 return [key, candidate];
               })
-              .filter(([, candidate]) => {
+              .filter(([key, candidate]) => {
                 if (candidate.whenPath === undefined) return true;
                 try {
                   return (
                     resolvePath(candidate.whenPath, selectionContext) !== null
                   );
-                } catch {
-                  return false;
+                } catch (err) {
+                  throw new ChainTerminalError(
+                    `chain edge "${key}" whenPath "${candidate.whenPath}" failed: ${err.message}`,
+                    err.reason,
+                  );
                 }
               });
           })();

--- a/event-runtime/lib/chain.mjs
+++ b/event-runtime/lib/chain.mjs
@@ -46,6 +46,20 @@ export class ChainTerminalError extends Error {
   }
 }
 
+/**
+ * A well-formed path whose value is simply absent. Distinct from a structural
+ * defect (unknown root, malformed expression): for a `whenPath` this is how a
+ * rule says "condition not met", so the edge is skipped rather than the chain
+ * terminated. It stays a ChainTerminalError so input mappings — which require
+ * every mapped path to resolve — keep terminating as before.
+ */
+export class ChainPathAbsentError extends ChainTerminalError {
+  constructor(message) {
+    super(message);
+    this.name = "ChainPathAbsentError";
+  }
+}
+
 function isTerminalError(err) {
   return err instanceof ChainTerminalError || err instanceof SyntaxError;
 }
@@ -75,14 +89,14 @@ function resolvePath(expr, context) {
   let value = context[root];
   for (const segment of segments) {
     if (value === null || typeof value !== "object" || !(segment in value)) {
-      throw new ChainTerminalError(
+      throw new ChainPathAbsentError(
         `chain input path "${expr}" resolves to nothing`,
       );
     }
     value = value[segment];
   }
   if (value === undefined)
-    throw new ChainTerminalError(
+    throw new ChainPathAbsentError(
       `chain input path "${expr}" resolves to nothing`,
     );
   return value;
@@ -252,6 +266,10 @@ export function resolveChains(
                     resolvePath(candidate.whenPath, selectionContext) !== null
                   );
                 } catch (err) {
+                  // A well-formed path with no value is the rule's own way of
+                  // saying "condition not met" — skip the edge. Only a
+                  // structural defect terminates the chain.
+                  if (err instanceof ChainPathAbsentError) return false;
                   throw new ChainTerminalError(
                     `chain edge "${key}" whenPath "${candidate.whenPath}" failed: ${err.message}`,
                     err.reason,

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -764,23 +764,25 @@ describe("multi-emit chain resolution (WM-119)", () => {
     });
   });
 
-  test("a malformed whenPath records the failing edge instead of silently skipping", () => {
-    const db = openDb(":memory:");
-    const whenPathRegistry = {
-      ...registry,
-      edges: {
-        "when-path-edge@1": {
-          recommendationField: "recommendation",
-          edges: {
-            NEXT: {
-              eventType: "factory.work.requested",
-              input: {},
-              whenPath: "$.artifact.missing",
-            },
+  const whenPathRegistryFor = (whenPath) => ({
+    ...registry,
+    edges: {
+      "when-path-edge@1": {
+        recommendationField: "recommendation",
+        edges: {
+          NEXT: {
+            eventType: "factory.work.requested",
+            input: {},
+            whenPath,
           },
         },
       },
-    };
+    },
+  });
+
+  test("a malformed whenPath records the failing edge instead of silently skipping", () => {
+    const db = openDb(":memory:");
+    const whenPathRegistry = whenPathRegistryFor("$.nope.x");
     seedCompletedRun(db, {
       runId: "run-malformed-when-path",
       agent: "when-path-edge@1",
@@ -793,7 +795,7 @@ describe("multi-emit chain resolution (WM-119)", () => {
     expect(outcome.skipped).toBe(0);
     expect(outcome.errors).toEqual([
       expect.stringMatching(
-        /chain edge "NEXT" whenPath "\$\.artifact\.missing" failed: .*resolves to nothing/,
+        /chain edge "NEXT" whenPath "\$\.nope\.x" failed: .*unknown root "nope"/,
       ),
     ]);
     expect(resolvedAtOf(db, "run-malformed-when-path")).not.toBeNull();
@@ -801,13 +803,35 @@ describe("multi-emit chain resolution (WM-119)", () => {
       note: "chain_resolved",
       reason: "invalid_chain_data",
       error: expect.stringMatching(
-        /chain edge "NEXT" whenPath "\$\.artifact\.missing" failed: .*resolves to nothing/,
+        /chain edge "NEXT" whenPath "\$\.nope\.x" failed: .*unknown root "nope"/,
       ),
     });
     expect(resolveChains(db, whenPathRegistry)).toEqual({
       emitted: 0,
       skipped: 0,
       errors: [],
+    });
+  });
+
+  test("a well-formed whenPath with no value skips the edge without erroring", () => {
+    const db = openDb(":memory:");
+    const whenPathRegistry = whenPathRegistryFor("$.artifact.missing");
+    seedCompletedRun(db, {
+      runId: "run-absent-when-path",
+      agent: "when-path-edge@1",
+      input: { repo: "wm/when-path" },
+      artifact: { recommendation: "NEXT" },
+    });
+
+    // "condition not met" is how a rule declines an edge — not a defect.
+    expect(resolveChains(db, whenPathRegistry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
+    expect(chainResolution(db, "run-absent-when-path")).toMatchObject({
+      note: "chain_resolved",
+      reason: "no_edge_selected",
     });
   });
 

--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -764,6 +764,53 @@ describe("multi-emit chain resolution (WM-119)", () => {
     });
   });
 
+  test("a malformed whenPath records the failing edge instead of silently skipping", () => {
+    const db = openDb(":memory:");
+    const whenPathRegistry = {
+      ...registry,
+      edges: {
+        "when-path-edge@1": {
+          recommendationField: "recommendation",
+          edges: {
+            NEXT: {
+              eventType: "factory.work.requested",
+              input: {},
+              whenPath: "$.artifact.missing",
+            },
+          },
+        },
+      },
+    };
+    seedCompletedRun(db, {
+      runId: "run-malformed-when-path",
+      agent: "when-path-edge@1",
+      input: { repo: "wm/when-path" },
+      artifact: { recommendation: "NEXT" },
+    });
+
+    const outcome = resolveChains(db, whenPathRegistry);
+    expect(outcome.emitted).toBe(0);
+    expect(outcome.skipped).toBe(0);
+    expect(outcome.errors).toEqual([
+      expect.stringMatching(
+        /chain edge "NEXT" whenPath "\$\.artifact\.missing" failed: .*resolves to nothing/,
+      ),
+    ]);
+    expect(resolvedAtOf(db, "run-malformed-when-path")).not.toBeNull();
+    expect(chainResolution(db, "run-malformed-when-path")).toMatchObject({
+      note: "chain_resolved",
+      reason: "invalid_chain_data",
+      error: expect.stringMatching(
+        /chain edge "NEXT" whenPath "\$\.artifact\.missing" failed: .*resolves to nothing/,
+      ),
+    });
+    expect(resolveChains(db, whenPathRegistry)).toEqual({
+      emitted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
   test("custom eventId templating and perItem mapping overlays", () => {
     const dir = tmpDir("evrt-chain-tmpl-");
     const db = openDb(path.join(dir, "runtime.db"));


### PR DESCRIPTION
Fixes #1926

Malformed `whenPath` rules now record a durable edge-specific chain diagnosis instead of silently ending the chain.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/chain.test.mjs` | pass    | 32 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,271 pass, 0 failures |
| UX critique          | factory-ux-critic                | not run | backend-only surface   |

UX critique: skipped

run:run_1cc64d19-b666-4583-bf87-da6f6e84d11c