### PR TITLE
fix(dispatch): clarify Fixes line handoff grammar (#1925)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:74c8bcad35d975b55aa9f48efc3d869e1618afbc222f491d401c22d76a8f98f4",
+    "agents/dispatch.md": "sha256:5c73ac1b9d839b22b9c08164daf564b035c983ba0c021599d82edc37897b797a",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -157,6 +157,13 @@ shell` means the spawn prompt was defective: correct its path/launch details
    run:<concrete run id, e.g. run_0e2d13da-…>
    ```
 
+   The first line is strict: it must be exactly `Fixes <ticket-ref>` by
+   itself — no colon after `Fixes`, no surrounding sentence, and nothing after
+   the ref except at most one trailing `.`, `,`, `;`, or `:`. Use the exact
+   ticket reference: `owner/repo#N` is always accepted; bare `#N` is accepted
+   only when the PR targets that same repository. A malformed Fixes-like line
+   fails handoff validation, so correct it rather than adding another line.
+
    `Fixes <TICKET>` and the trailing concrete `run:<run-id>` line are unchanged
    required lines — the `## Validation` section is added between them, never
    in place of either. Append the trailer with

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3195,7 +3195,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:b629b32521d6f81e9ba798403eeb8db6c7703745e42fd2ffe949d8a52a9d467d","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:c9c95b3482cd08600d034c5524a7dade9330010ef711edfbca35ca161e607628","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -409,8 +409,10 @@ describe("registry", () => {
     // the literal environment-variable form during handoff verification.
     // Regenerated (#1843): merge-scan skips rebase churn for ai:landing and
     // in-flight/fresh Full verification; merge-fix re-checks that CI guard.
+    // Regenerated (#1925): dispatch spells out the exact first-line Fixes
+    // grammar and its prompt pin changes; the registry digest follows it.
     const expected =
-      "sha256:564641dee5b94b51d650f63233c467c12bed227e4a19b34c5f2a3c6dafd90c2c";
+      "sha256:dde1373788b1ecea1e8c11d130c42b0a0fa93ff0df2c9616a50beba6e556c10a";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -703,8 +705,10 @@ describe("registry", () => {
     // prompt pin only, `pack` remains non-enumerable.
     // Regenerated (#1829): dispatch emits the concrete run trailer with printf,
     // so quoted PR-body files cannot leave the environment variable literal.
+    // Regenerated (#1925): dispatch specifies the exact Fixes-line grammar;
+    // its prompt pin legitimately changes while `pack` remains non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:b629b32521d6f81e9ba798403eeb8db6c7703745e42fd2ffe949d8a52a9d467d",
+      "sha256:c9c95b3482cd08600d034c5524a7dade9330010ef711edfbca35ca161e607628",
     );
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3000,16 +3000,17 @@ function escapeRegExp(value) {
 }
 
 /**
- * True when some body line is a `Fixes <ticket>` line (case-insensitive,
- * tolerant of surrounding whitespace and one trailing punctuation mark).
- * Accepts the full `owner/repo#n` form, the short `#n` form when the PR
- * lives in that repository, and Linear ids verbatim. Returns null when the
- * handoff carries no usable ticket, so the caller reports "unknown" rather
- * than probing the body for `Fixes null`.
+ * Finds a valid `Fixes <ticket>` first line (case-insensitive, tolerant of
+ * surrounding whitespace and one trailing punctuation mark), and otherwise
+ * preserves the first Fixes-like line for a corrective violation. Accepts the
+ * full `owner/repo#n` form, the short `#n` form when the PR lives in that
+ * repository, and Linear ids verbatim. Returns null when the handoff carries
+ * no usable ticket, so the caller reports "unknown" rather than probing the
+ * body for `Fixes null`.
  */
-function handoffFixesLinePresent({ lines, ticket, github }) {
+function handoffFixesLine({ lines, ticket, github }) {
   const ref = typeof ticket === "string" ? ticket.trim() : "";
-  if (!ref) return null;
+  if (!ref) return { present: null, malformedLine: null };
   const alternatives = [escapeRegExp(ref)];
   const repoMatch = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([0-9]+)$/.exec(ref);
   if (
@@ -3023,7 +3024,12 @@ function handoffFixesLinePresent({ lines, ticket, github }) {
     `^\\s*fixes\\s+(?:${alternatives.join("|")})\\s*[.,;:]?\\s*$`,
     "i",
   );
-  return lines.some((line) => pattern.test(line));
+  const firstLine = lines[0] ?? "";
+  if (pattern.test(firstLine)) return { present: true, malformedLine: null };
+  return {
+    present: false,
+    malformedLine: lines.find((line) => /^\s*fixes\b/i.test(line)) ?? null,
+  };
 }
 
 /**
@@ -3072,11 +3078,12 @@ export function assertHandoffPullRequestBase({
   const bodyLines = (typeof pr?.body === "string" ? pr.body : "").split(
     /\r?\n/,
   );
-  const hasFixesLine = handoffFixesLinePresent({
+  const fixesLine = handoffFixesLine({
     lines: bodyLines,
     ticket: handoff.ticket,
     github: handoff.github,
   });
+  const hasFixesLine = fixesLine.present;
   const hasRunTrailer =
     typeof handoff.runId === "string" && handoff.runId.trim()
       ? bodyLines.some((line) => line.trim() === `run:${handoff.runId.trim()}`)
@@ -3114,10 +3121,11 @@ export function assertHandoffPullRequestBase({
     );
   }
   if (hasFixesLine === false) {
+    const malformedDetail = fixesLine.malformedLine
+      ? ` has malformed Fixes line ${JSON.stringify(fixesLine.malformedLine)}; expected exactly Fixes ${handoff.ticket}`
+      : ` has no Fixes line for ${handoff.ticket}`;
     throw new ContractViolation(
-      [
-        `handoff_pr_form_invalid: PR #${prNumber} is missing Fixes ${handoff.ticket}`,
-      ],
+      [`handoff_pr_form_invalid: PR #${prNumber}${malformedDetail}`],
       { reasonCode: "handoff_pr_form_invalid", handoff },
     );
   }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3001,16 +3001,19 @@ function escapeRegExp(value) {
 
 /**
  * Finds a valid `Fixes <ticket>` first line (case-insensitive, tolerant of
- * surrounding whitespace and one trailing punctuation mark), and otherwise
- * preserves the first Fixes-like line for a corrective violation. Accepts the
- * full `owner/repo#n` form, the short `#n` form when the PR lives in that
- * repository, and Linear ids verbatim. Returns null when the handoff carries
- * no usable ticket, so the caller reports "unknown" rather than probing the
- * body for `Fixes null`.
+ * surrounding whitespace and one trailing punctuation mark). A body may open
+ * with blank lines, so "first" means the first non-empty line. When no such
+ * line is found the result distinguishes the two correctable shapes: a
+ * well-formed Fixes line that sits somewhere further down (`misplacedLine` —
+ * move it to the top) from a Fixes-like line that is malformed
+ * (`malformedLine` — rewrite it). Accepts the full `owner/repo#n` form, the
+ * short `#n` form when the PR lives in that repository, and Linear ids
+ * verbatim. Returns null when the handoff carries no usable ticket, so the
+ * caller reports "unknown" rather than probing the body for `Fixes null`.
  */
 function handoffFixesLine({ lines, ticket, github }) {
   const ref = typeof ticket === "string" ? ticket.trim() : "";
-  if (!ref) return { present: null, malformedLine: null };
+  if (!ref) return { present: null, malformedLine: null, misplacedLine: null };
   const alternatives = [escapeRegExp(ref)];
   const repoMatch = /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#([0-9]+)$/.exec(ref);
   if (
@@ -3024,11 +3027,16 @@ function handoffFixesLine({ lines, ticket, github }) {
     `^\\s*fixes\\s+(?:${alternatives.join("|")})\\s*[.,;:]?\\s*$`,
     "i",
   );
-  const firstLine = lines[0] ?? "";
-  if (pattern.test(firstLine)) return { present: true, malformedLine: null };
+  const firstLine = lines.find((line) => line.trim() !== "") ?? "";
+  if (pattern.test(firstLine))
+    return { present: true, malformedLine: null, misplacedLine: null };
+  const misplacedLine = lines.find((line) => pattern.test(line)) ?? null;
+  if (misplacedLine !== null)
+    return { present: false, malformedLine: null, misplacedLine };
   return {
     present: false,
     malformedLine: lines.find((line) => /^\s*fixes\b/i.test(line)) ?? null,
+    misplacedLine: null,
   };
 }
 
@@ -3121,11 +3129,18 @@ export function assertHandoffPullRequestBase({
     );
   }
   if (hasFixesLine === false) {
-    const malformedDetail = fixesLine.malformedLine
-      ? ` has malformed Fixes line ${JSON.stringify(fixesLine.malformedLine)}; expected exactly Fixes ${handoff.ticket}`
-      : ` has no Fixes line for ${handoff.ticket}`;
+    let formDetail;
+    if (fixesLine.misplacedLine !== null) {
+      // The line is correct — only its position is wrong. Saying "malformed"
+      // here would quote the expectation back as the offence.
+      formDetail = ` has ${JSON.stringify(fixesLine.misplacedLine.trim())} but it must be the first line of the PR body`;
+    } else if (fixesLine.malformedLine) {
+      formDetail = ` has malformed Fixes line ${JSON.stringify(fixesLine.malformedLine)}; expected exactly Fixes ${handoff.ticket}`;
+    } else {
+      formDetail = ` has no Fixes line for ${handoff.ticket}`;
+    }
     throw new ContractViolation(
-      [`handoff_pr_form_invalid: PR #${prNumber}${malformedDetail}`],
+      [`handoff_pr_form_invalid: PR #${prNumber}${formDetail}`],
       { reasonCode: "handoff_pr_form_invalid", handoff },
     );
   }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5495,7 +5495,9 @@ sh -c 'sleep 5 & wait'
           body: "run:run-1504",
         }),
       }),
-    ).toThrow("handoff_pr_form_invalid");
+    ).toThrow(
+      "handoff_pr_form_invalid: PR #77 has no Fixes line for watt-mind/factory#1504",
+    );
     expect(missingFixes.pr).toMatchObject({
       hasFixesLine: false,
       hasRunTrailer: true,
@@ -5593,6 +5595,40 @@ sh -c 'sleep 5 & wait'
       }),
     });
     expect(linear.pr.hasFixesLine).toBe(true);
+  });
+
+  test("handoff PR form identifies malformed Fixes-like lines", () => {
+    for (const [body, offendingLine] of [
+      ["Fixes: #1504\n\nrun:run-1504", "Fixes: #1504"],
+      [
+        "Fixes watt-mind/factory#1504 (follow-up)\n\nrun:run-1504",
+        "Fixes watt-mind/factory#1504 (follow-up)",
+      ],
+      [
+        "Implementation details\n\nFixes watt-mind/factory#1504\n\nrun:run-1504",
+        "Fixes watt-mind/factory#1504",
+      ],
+    ]) {
+      const handoff = {
+        github: "watt-mind/factory",
+        prNumber: 77,
+        ticket: "watt-mind/factory#1504",
+        runId: "run-1504",
+      };
+      expect(() =>
+        assertHandoffPullRequestBase({
+          handoff,
+          base: "develop",
+          fetchPullRequest: () => ({
+            baseRefName: "develop",
+            isDraft: false,
+            body,
+          }),
+        }),
+      ).toThrow(
+        `handoff_pr_form_invalid: PR #77 has malformed Fixes line ${JSON.stringify(offendingLine)}`,
+      );
+    }
   });
 
   test("handoff PR form refuses a null body and reports unknown for a missing ticket or run id", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5597,6 +5597,26 @@ sh -c 'sleep 5 & wait'
     expect(linear.pr.hasFixesLine).toBe(true);
   });
 
+  const assertHandoffFormThrows = (body, message) => {
+    const handoff = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    expect(() =>
+      assertHandoffPullRequestBase({
+        handoff,
+        base: "develop",
+        fetchPullRequest: () => ({
+          baseRefName: "develop",
+          isDraft: false,
+          body,
+        }),
+      }),
+    ).toThrow(message);
+  };
+
   test("handoff PR form identifies malformed Fixes-like lines", () => {
     for (const [body, offendingLine] of [
       ["Fixes: #1504\n\nrun:run-1504", "Fixes: #1504"],
@@ -5604,31 +5624,40 @@ sh -c 'sleep 5 & wait'
         "Fixes watt-mind/factory#1504 (follow-up)\n\nrun:run-1504",
         "Fixes watt-mind/factory#1504 (follow-up)",
       ],
-      [
-        "Implementation details\n\nFixes watt-mind/factory#1504\n\nrun:run-1504",
-        "Fixes watt-mind/factory#1504",
-      ],
     ]) {
-      const handoff = {
-        github: "watt-mind/factory",
-        prNumber: 77,
-        ticket: "watt-mind/factory#1504",
-        runId: "run-1504",
-      };
-      expect(() =>
-        assertHandoffPullRequestBase({
-          handoff,
-          base: "develop",
-          fetchPullRequest: () => ({
-            baseRefName: "develop",
-            isDraft: false,
-            body,
-          }),
-        }),
-      ).toThrow(
+      assertHandoffFormThrows(
+        body,
         `handoff_pr_form_invalid: PR #77 has malformed Fixes line ${JSON.stringify(offendingLine)}`,
       );
     }
+  });
+
+  test("handoff PR form reports a well-formed Fixes line that is not first", () => {
+    // The line itself is exactly right — quoting it as "malformed" against an
+    // identical expectation would leave the author nothing to act on.
+    assertHandoffFormThrows(
+      "Implementation details\n\nFixes watt-mind/factory#1504\n\nrun:run-1504",
+      'handoff_pr_form_invalid: PR #77 has "Fixes watt-mind/factory#1504" but it must be the first line of the PR body',
+    );
+  });
+
+  test("handoff PR form accepts a Fixes line after leading blank lines", () => {
+    const handoff = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      ticket: "watt-mind/factory#1504",
+      runId: "run-1504",
+    };
+    assertHandoffPullRequestBase({
+      handoff,
+      base: "develop",
+      fetchPullRequest: () => ({
+        baseRefName: "develop",
+        isDraft: false,
+        body: "\n  \nFixes watt-mind/factory#1504\n\nrun:run-1504",
+      }),
+    });
+    expect(handoff.pr.hasFixesLine).toBe(true);
   });
 
   test("handoff PR form refuses a null body and reports unknown for a missing ticket or run id", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1925

Dispatch agents receive exact Fixes-line grammar and actionable malformed-line errors.

## Validation

| Check                | Command                          | Result  | Notes                              |
| -------------------- | -------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs` | pass | 312 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,271 pass, 10 skipped; clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_db145357-6eac-4d31-9ad8-69f6d0dea7f3