### PR TITLE
fix(planner): preserve Linear read classification

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -551,6 +551,13 @@ const LINEAR_READ_TIMEOUT_MS = (() => {
   return Number.isFinite(n) && n > 0 ? n : 8_000;
 })();
 
+/**
+ * The whole-tick Linear read budget is spent. `linearReadTimeout` raises this
+ * *before* spawning the child, so it surfaces from inside the same `try` that
+ * wraps the read: every such catch must rethrow it untouched. Rewrapping it as
+ * `linear_read_failed` would turn a deferrable "come back next tick" into a
+ * hard dead-letter on every read past the deadline (#1890).
+ */
 class LinearReadBudgetExceededError extends Error {
   constructor() {
     super("linear_read_budget_exhausted");
@@ -787,6 +794,8 @@ function fetchTicketDefault(ticketId, repo, { readBudget = null } = {}) {
       }),
     );
   } catch (err) {
+    // Budget exhaustion is deferrable, not a read failure (see the class).
+    if (err instanceof LinearReadBudgetExceededError) throw err;
     throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
@@ -831,6 +840,8 @@ function fetchViewerDefault(
     }
     return parsed?.viewer ?? null;
   } catch (err) {
+    // Budget exhaustion is deferrable, not a read failure (see the class).
+    if (err instanceof LinearReadBudgetExceededError) throw err;
     throwIfLinearCliRateLimited(err);
     throwIfLinearReadBudgetExhausted(err, readBudget);
     const stderr = String(err?.stderr ?? "");
@@ -986,6 +997,8 @@ function fetchInFlightDefault(repoConfig, { readBudget = null } = {}) {
     const rows = JSON.parse(out);
     return Array.isArray(rows) ? rows : [];
   } catch (err) {
+    // Budget exhaustion is deferrable, not a read failure (see the class).
+    if (err instanceof LinearReadBudgetExceededError) throw err;
     throwIfLinearCliRateLimited(err);
     throwIfLinearReadBudgetExhausted(err, readBudget);
     const stderr = String(err?.stderr ?? "");

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -573,6 +573,22 @@ function linearReadTimeout(readBudget) {
   return Math.min(LINEAR_READ_TIMEOUT_MS, remaining);
 }
 
+function linearReadTimedOut(err) {
+  return (
+    err?.code === "ETIMEDOUT" ||
+    (err?.signal === "SIGTERM" && err?.status == null)
+  );
+}
+
+function throwIfLinearReadBudgetExhausted(err, readBudget) {
+  if (
+    readBudget &&
+    linearReadTimedOut(err) &&
+    readBudget.deadline - readBudget.now() <= 0
+  )
+    throw new LinearReadBudgetExceededError();
+}
+
 function isLinearReadDeferred(err) {
   return (
     isLinearRateLimited(err) || err instanceof LinearReadBudgetExceededError
@@ -681,9 +697,26 @@ export function wrapLinearReads(
       : resolveNow() + 60_000;
   };
 
-  const fetchTicket = dispatch.fetchTicket ?? fetchTicketDefault;
-  const fetchViewer = dispatch.fetchViewer ?? fetchViewerDefault;
-  const fetchInFlight = dispatch.fetchInFlight ?? fetchInFlightDefault;
+  // Bind policy dependencies into production fetchers rather than appending
+  // them to every call. In particular, fetchViewer's second positional value
+  // is its config snapshot, so a caller that omits it must not receive the
+  // budget object in its place.
+  const fetchTicket =
+    dispatch.fetchTicket ??
+    ((ticketId, repo) =>
+      fetchTicketDefault(ticketId, repo, {
+        readBudget: cache.linearReadBudget,
+      }));
+  const fetchViewer =
+    dispatch.fetchViewer ??
+    ((repoName, snapshot = configSnapshot) =>
+      fetchViewerDefault(repoName, snapshot, {
+        readBudget: cache.linearReadBudget,
+      }));
+  const fetchInFlight =
+    dispatch.fetchInFlight ??
+    ((repo) =>
+      fetchInFlightDefault(repo, { readBudget: cache.linearReadBudget }));
 
   return {
     ...dispatch,
@@ -695,7 +728,7 @@ export function wrapLinearReads(
       if (cache.tickets.has(key)) return cache.tickets.get(key);
       throwIfReadBudgetExhausted(repo);
       try {
-        const value = fetchTicket(id, repo, cache.linearReadBudget);
+        const value = fetchTicket(id, repo);
         cache.tickets.set(key, value);
         return value;
       } catch (err) {
@@ -709,7 +742,7 @@ export function wrapLinearReads(
       if (cache.viewers.has(key)) return cache.viewers.get(key);
       throwIfReadBudgetExhausted(repo);
       try {
-        const value = fetchViewer(repo, ...args, cache.linearReadBudget);
+        const value = fetchViewer(repo, ...args);
         cache.viewers.set(key, value);
         return value;
       } catch (err) {
@@ -726,7 +759,7 @@ export function wrapLinearReads(
       throwIfReadBudgetExhausted(repo);
       try {
         cache.inFlightCalls += 1;
-        const value = fetchInFlight(repo, cache.linearReadBudget);
+        const value = fetchInFlight(repo);
         cache.inFlight.set(key, { value, at });
         return value;
       } catch (err) {
@@ -737,7 +770,7 @@ export function wrapLinearReads(
   };
 }
 
-function fetchTicketDefault(ticketId, repo, readBudget = null) {
+function fetchTicketDefault(ticketId, repo, { readBudget = null } = {}) {
   try {
     // Pass --repo so tools/ticket.mjs resolves the ticket's OWN control plane
     // (linear for CLNT repos, github for factory) instead of falling back to
@@ -754,11 +787,10 @@ function fetchTicketDefault(ticketId, repo, readBudget = null) {
       }),
     );
   } catch (err) {
-    if (readBudget && readBudget.deadline - readBudget.now() <= 0)
-      throw new LinearReadBudgetExceededError();
     throwIfLinearCliRateLimited(err);
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
+    throwIfLinearReadBudgetExhausted(err, readBudget);
     throw new Error(
       `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
       { cause: err },
@@ -769,7 +801,7 @@ function fetchTicketDefault(ticketId, repo, readBudget = null) {
 function fetchViewerDefault(
   repoName,
   configSnapshot = null,
-  readBudget = null,
+  { readBudget = null } = {},
 ) {
   try {
     const repo = repoName
@@ -799,9 +831,8 @@ function fetchViewerDefault(
     }
     return parsed?.viewer ?? null;
   } catch (err) {
-    if (readBudget && readBudget.deadline - readBudget.now() <= 0)
-      throw new LinearReadBudgetExceededError();
     throwIfLinearCliRateLimited(err);
+    throwIfLinearReadBudgetExhausted(err, readBudget);
     const stderr = String(err?.stderr ?? "");
     throw new Error(
       `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
@@ -932,7 +963,7 @@ function ownedPathsClosureDetails(repoName, repo, ticketDescription) {
   });
 }
 
-function fetchInFlightDefault(repoConfig, readBudget = null) {
+function fetchInFlightDefault(repoConfig, { readBudget = null } = {}) {
   try {
     // --repo so ticket.mjs resolves this repo's own control plane (a Linear
     // team/project query against the GitHub plane fails as a project-title
@@ -955,9 +986,8 @@ function fetchInFlightDefault(repoConfig, readBudget = null) {
     const rows = JSON.parse(out);
     return Array.isArray(rows) ? rows : [];
   } catch (err) {
-    if (readBudget && readBudget.deadline - readBudget.now() <= 0)
-      throw new LinearReadBudgetExceededError();
     throwIfLinearCliRateLimited(err);
+    throwIfLinearReadBudgetExhausted(err, readBudget);
     const stderr = String(err?.stderr ?? "");
     throw new Error(
       `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4335,6 +4335,88 @@ describe("Linear rate limit (WM-878)", () => {
     description: "## Owned Paths\n- event-runtime/lib/planner.mjs\n",
   });
 
+  function withLinearCli(source, fn) {
+    const root = tmpDir("evrt-plan-linear-cli-");
+    const cli = path.join(root, "linear.mjs");
+    writeFileSync(cli, source);
+    const previous = process.env.FACTORY_LINEAR_CLI;
+    process.env.FACTORY_LINEAR_CLI = cli;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_LINEAR_CLI;
+      else process.env.FACTORY_LINEAR_CLI = previous;
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  function deadlineBudget() {
+    let reads = 0;
+    return {
+      deadline: 10_000,
+      now: () => (reads++ < 2 ? 0 : 10_000),
+    };
+  }
+
+  test("binds the read budget without replacing an omitted viewer config snapshot", () => {
+    withLinearCli(
+      'console.log(JSON.stringify({ viewer: { id: "viewer-1" } }));',
+      () => {
+        const cache = createLinearReadCache();
+        cache.linearReadBudget = { deadline: 10_000, now: () => 0 };
+        const reads = wrapLinearReads({}, cache, NOW, {
+          repos: new Map([
+            ["gated", { name: "gated", controlPlane: "linear" }],
+          ]),
+        });
+
+        expect(reads.fetchViewer("gated")).toEqual({ id: "viewer-1" });
+      },
+    );
+  });
+
+  test("a deadline-boundary CLI 429 retains its resetAt", () => {
+    withLinearCli(
+      [
+        'console.error(JSON.stringify({ resetAt: "2026-08-19T13:00:00.000Z" }));',
+        "process.exit(3);",
+      ].join("\n"),
+      () => {
+        const cache = createLinearReadCache();
+        cache.linearReadBudget = deadlineBudget();
+        const reads = wrapLinearReads({}, cache, NOW, {
+          repos: new Map([
+            ["gated", { name: "gated", controlPlane: "linear" }],
+          ]),
+        });
+
+        let error;
+        try {
+          reads.fetchTicket("WM-429", "gated");
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error).toBeInstanceOf(LinearRateLimitError);
+        expect(error.resetAt).toBe("2026-08-19T13:00:00.000Z");
+        expect(cache.rateLimitedUntil).toBe(
+          Date.parse("2026-08-19T13:00:00.000Z"),
+        );
+      },
+    );
+  });
+
+  test("a deadline-boundary missing ticket still returns null", () => {
+    withLinearCli('console.error("no such issue"); process.exit(1);', () => {
+      const cache = createLinearReadCache();
+      cache.linearReadBudget = deadlineBudget();
+      const reads = wrapLinearReads({}, cache, NOW, {
+        repos: new Map([["gated", { name: "gated", controlPlane: "linear" }]]),
+      });
+
+      expect(reads.fetchTicket("WM-missing", "gated")).toBeNull();
+    });
+  });
+
   test("a simulated Linear 400 rate-limit refuses linear_rate_limited, leaves the event admitted, and does not dead-letter", () => {
     withReposRoot(gatedYaml, () => {
       const db = openDb(":memory:");

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4417,6 +4417,65 @@ describe("Linear rate limit (WM-878)", () => {
     });
   });
 
+  test("an exhausted budget defers every default read on a github plane (#1890)", () => {
+    // wrapLinearReads skips its own pre-check for a github control plane, so
+    // the budget throw surfaces from *inside* each default fetcher's try. It
+    // must stay deferrable rather than being rewrapped as linear_read_failed.
+    withLinearCli("throw new Error('the CLI must never be spawned');", () => {
+      const configSnapshot = {
+        repos: new Map([["gh", { name: "gh", controlPlane: "github" }]]),
+      };
+      for (const read of [
+        (reads) => reads.fetchTicket("watt-mind/factory#534", "gh"),
+        (reads) => reads.fetchViewer("gh"),
+        (reads) =>
+          reads.fetchInFlight({
+            name: "gh",
+            team: "WM",
+            project: "Factory",
+            controlPlane: "github",
+          }),
+      ]) {
+        const cache = createLinearReadCache();
+        cache.linearReadBudget = { deadline: 0, now: () => 5000 };
+        let error;
+        try {
+          read(wrapLinearReads({}, cache, NOW, configSnapshot));
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error?.name).toBe("LinearReadBudgetExceededError");
+        expect(error?.message).toBe("linear_read_budget_exhausted");
+      }
+    });
+  });
+
+  test("a child killed by the read timeout at the deadline defers", () => {
+    // The genuine linearReadTimedOut path: the budget still had room when the
+    // child was spawned, the child was SIGTERMed by that timeout, and the
+    // deadline has passed by the time the failure is classified.
+    withLinearCli("Bun.sleepSync(2000);", () => {
+      const cache = createLinearReadCache();
+      let clockReads = 0;
+      cache.linearReadBudget = {
+        deadline: 100,
+        now: () => (clockReads++ < 2 ? 0 : 100),
+      };
+      const reads = wrapLinearReads({}, cache, NOW, {
+        repos: new Map([["gated", { name: "gated", controlPlane: "linear" }]]),
+      });
+
+      let error;
+      try {
+        reads.fetchTicket("WM-slow", "gated");
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error?.name).toBe("LinearReadBudgetExceededError");
+      expect(error?.message).toBe("linear_read_budget_exhausted");
+    });
+  });
+
   test("a simulated Linear 400 rate-limit refuses linear_rate_limited, leaves the event admitted, and does not dead-letter", () => {
     withReposRoot(gatedYaml, () => {
       const db = openDb(":memory:");
@@ -4726,6 +4785,44 @@ describe("GitHub dispatch candidate parsing (GH-974)", () => {
       expect(logs).toContain(
         "planned noop (ticket_identifier_unresolvable: not a GitHub issue identifier: WM-621 (want owner/repo#N)) — operator-webhook:github-candidate-legacy",
       );
+    });
+  });
+
+  test("an exhausted read budget defers a github candidate rather than failing the plan (#1890)", () => {
+    withGithubRepo(() => {
+      const db = openDb(":memory:");
+      admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "github-budget-exhausted",
+        correlationId: "github-budget-exhausted",
+        payload: {
+          repo: "github-candidates",
+          ticket: "watt-mind/factory#534",
+        },
+      });
+
+      // Default fetchers, budget already spent: the throw comes from inside
+      // the fetcher's own try, which used to exit as a hard linear_read_failed.
+      expect(
+        planAdmittedEvents(db, registry, {
+          now: NOW,
+          policyVersion: "git:test",
+          linearReadBudget: { deadline: 0, now: () => 5000 },
+          dispatch: { countLeases: () => 0, budgetRefusal: () => null },
+        }),
+      ).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+
+      expect(
+        db
+          .query(
+            `SELECT status, plan_failures, last_plan_error FROM events WHERE event_id = ?`,
+          )
+          .get("github-budget-exhausted"),
+      ).toMatchObject({
+        status: "admitted",
+        plan_failures: 0,
+        last_plan_error: "linear_read_budget_exhausted",
+      });
     });
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1890

Keep Linear read failures classified correctly at a pass deadline.

## Validation

| Check                | Command                                                                                                                  | Result  | Notes                   |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- | ----------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs`                                                                            | pass    | 114 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`     | pass    | clean (615 known warnings) |
| UX critique          | factory-ux-critic                                                                                                        | not run | no user-facing surface  |

UX critique: skipped — planner-only backend behavior
run:run_42ba0c9a-93d5-4c08-a6b7-b8ffea3a751d
