### PR TITLE
fix(web): retarget promotions on repo context switch

### DIFF
--- a/event-runtime/web/src/views/Agents.test.tsx
+++ b/event-runtime/web/src/views/Agents.test.tsx
@@ -665,4 +665,46 @@ describe("PromotionPanel (gh-860)", () => {
       );
     });
   });
+
+  test("retargets a promotion after its repo context changes", async () => {
+    await withPromotionStubs(async () => {
+      const applied: { repo: string; digest: string; keys: string[] }[] = [];
+      api.promotionApply = async (body) => {
+        applied.push(body);
+        return {
+          status: "opened",
+          repo: body.repo,
+          ticket: "gh-1927-x",
+          branch: "promo/x",
+          pr: { url: "https://example/pr/10", number: 10 },
+        };
+      };
+
+      const client = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+      });
+      const r = render(
+        <QueryClientProvider client={client}>
+          <PromotionPanel defaultRepo="factory" />
+        </QueryClientProvider>,
+      );
+      fireEvent.click(
+        r.getByRole("button", { name: "Promote overrides to Git…" }),
+      );
+      const good = await waitFor(() =>
+        r.getByLabelText("eventType:factory.demo/v1:adapter"),
+      );
+
+      r.rerender(
+        <QueryClientProvider client={client}>
+          <PromotionPanel defaultRepo="other" />
+        </QueryClientProvider>,
+      );
+      fireEvent.click(good);
+      fireEvent.click(r.getByRole("button", { name: "Promote 1 selected" }));
+
+      await waitFor(() => expect(applied).toHaveLength(1));
+      expect(applied[0]?.repo).toBe("other");
+    });
+  });
 });

--- a/event-runtime/web/src/views/Agents.tsx
+++ b/event-runtime/web/src/views/Agents.tsx
@@ -277,6 +277,11 @@ export function PromotionPanel({
   const [repo, setRepo] = useState(defaultRepo);
   const [selected, setSelected] = useState<Set<string>>(new Set());
 
+  useEffect(() => {
+    setRepo(defaultRepo);
+    setSelected(new Set());
+  }, [defaultRepo]);
+
   const preview = useQuery({
     queryKey: ["promotion-preview"],
     queryFn: api.promotionPreview,


### PR DESCRIPTION
Fixes watt-mind/factory#1927

Review the repo-context synchronization and regression test; the separate baseline promotion-route 404 is tracked in #1935.

## Validation

| Check                | Command                                                                                                                | Result | Notes                                      |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------ | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web/src/views/Agents.test.tsx`                                                                 | pass   | 20 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`      | pass   | exit 0; lint has 0 errors                  |
| Web typecheck        | `cd event-runtime/web && bun x tsc --noEmit`                                                                            | pass   | clean                                      |
| UX critique          | `factory-ux-critic`                                                                                                     | pass   | SHIP; context and target aligned at bj29   |

UX critique: required — SHIP

run:run_33626aed-70c3-4123-bb4d-5dab632cfc50
