### PR TITLE
fix(planner): prevent Linear read budget starvation

### DIFF
--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -38,6 +38,7 @@ import {
 } from "./api-test-helpers.mjs";
 import { createHookRegistry } from "./hooks.mjs";
 import { GITHUB_INTAKE_STALE_AFTER_MS } from "./intake.mjs";
+import { statusView } from "./status-view.mjs";
 
 const makeServer = async (...args) => {
   const result = await makeApiServer(...args);
@@ -673,6 +674,27 @@ describe("GET /status hook decisions (WM-842)", () => {
     } finally {
       s.close();
     }
+  });
+
+  test("stalled Linear read-budget anomalies are capped at 20 rows plus a count line (#1937)", () => {
+    const dir = tmpDir("evrt-status-budget-cap-");
+    const db = openDb(path.join(dir, "runtime.db"));
+    const nowMs = 100000000;
+    const staleAt = new Date(nowMs - 5 * 60_000 - 1).toISOString();
+    for (let i = 1; i <= 25; i++) {
+      db.query(
+        `INSERT INTO events (source, event_id, type, subject, status, payload_hash, occurred_at, received_at, plan_failures, last_plan_error, admitted_at, envelope_json)
+         VALUES ("test", ?, "test.type", "test", "admitted", "dummy-hash", ?, ?, 0, "linear_read_budget_exhausted", ?, "{}")`,
+      ).run(`evt-budget-cap-${i}`, staleAt, staleAt, staleAt);
+    }
+    const anomalies = statusView(db, registry, nowMs, {
+      policyVersion: "git:test",
+    }).anomalies.configuration.filter((a) => a.includes("Linear read-budget"));
+    expect(anomalies).toHaveLength(21);
+    expect(anomalies[20]).toBe(
+      "More admitted events beyond the first 20 are deferred for Linear read-budget exhaustion",
+    );
+    db.close();
   });
 
   test("hooks.decisions24h is empty before any hook ever ran (no table yet)", async () => {

--- a/event-runtime/lib/api-status-view.test.mjs
+++ b/event-runtime/lib/api-status-view.test.mjs
@@ -182,6 +182,10 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
       `INSERT INTO events (source, event_id, type, subject, status, payload_hash, occurred_at, received_at, correlation_id, plan_failures, last_plan_error, admitted_at, envelope_json)
        VALUES ("test", "evt-dead-1", "test.type", "test", "dead_lettered", "dummy-hash", ?, ?, "corr-1", 3, "failed to plan", ?, "{}")`,
     ).run(atIso, atIso, atIso);
+    db.query(
+      `INSERT INTO events (source, event_id, type, subject, status, payload_hash, occurred_at, received_at, correlation_id, plan_failures, last_plan_error, admitted_at, envelope_json)
+       VALUES ("test", "evt-budget-1", "test.type", "test", "admitted", "dummy-hash", ?, ?, "corr-2", 0, "linear_read_budget_exhausted", ?, "{}")`,
+    ).run(atIso, atIso, new Date(nowMs - 5 * 60_000 - 1).toISOString());
 
     // Proposals piling up for a scheduled loop
     for (let i = 1; i <= 4; i++) {
@@ -330,6 +334,9 @@ describe("StatusView and Worker client types pinned to API response (OPS-284)", 
 
       // Remaining anomaly primitives
       expect(Array.isArray(status.anomalies.configuration)).toBe(true);
+      expect(status.anomalies.configuration).toContain(
+        "Admitted event test:evt-budget-1 has been deferred for Linear read-budget exhaustion for over 5 minutes",
+      );
       expect(status.anomalies.expiredOpenProposals).toEqual(["prop-expired-1"]);
       expect(typeof status.anomalies.staleLeases).toBe("number");
       expect(typeof status.anomalies.unpublishedOutbox).toBe("number");

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -3242,7 +3242,7 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     }
   }
   for (const { source, event_id: eventId, type } of rows) {
-    cache.linearReadBudget = createEventReadBudget();
+    cache.linearReadBudget = opts.linearReadBudget ?? createEventReadBudget();
     try {
       const outcome = planEvent(db, registry, { source, eventId }, planOpts);
       if (

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -541,14 +541,14 @@ function resolveNow(now) {
   return typeof now === "function" ? now() : now;
 }
 
-// The web proxy gives /health 10 seconds. The planner tick runs its Linear
-// CLI reads synchronously on the serve event loop, so all Linear reads in one
-// pass share this wall-clock budget and must finish well inside it or serve
-// wedges (#1835 AC3). Each child receives only the remaining pass time. The
-// env override exists for the serve regression test, not for operators.
+// Planning runs in the planner worker, not the serve loop. Bound each event's
+// Linear CLI reads so one stalled ticket cannot delay the next event forever;
+// the default leaves room for normal control-plane reads without holding an
+// operator's planner pass hostage. Operators may set the positive millisecond
+// FACTORY_LINEAR_READ_TIMEOUT_MS environment variable to tune this deadline.
 const LINEAR_READ_TIMEOUT_MS = (() => {
   const n = Number(process.env.FACTORY_LINEAR_READ_TIMEOUT_MS);
-  return Number.isFinite(n) && n > 0 ? n : 8_000;
+  return Number.isFinite(n) && n > 0 ? n : 25_000;
 })();
 
 /**
@@ -3205,16 +3205,15 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     .all();
   const configSnapshot = opts.configSnapshot ?? policySnapshot();
   const cache = opts.linearReadCache ?? createLinearReadCache();
-  cache.linearReadBudget =
-    opts.linearReadBudget ??
+  const createEventReadBudget = () =>
     createLinearReadBudget({
       now: opts.linearReadClock ?? Date.now,
       timeoutMs: opts.linearReadTimeoutMs ?? LINEAR_READ_TIMEOUT_MS,
     });
-  // Production reads the persisted clock once per planner pass; an injected
-  // budget keeps the rate-limit regression tests deterministic. The cache
-  // path itself is scoped by FACTORY_EVENT_HOME (tools/ticket.mjs), so test
-  // processes never observe the operator's shared budget capture.
+  // Keep ticket/in-flight/rate-limit caches for the pass, but give every
+  // event its own deadline. A prior stalled event must not consume later
+  // candidates' read time and turn an otherwise healthy batch into a
+  // retry_later livelock.
   const budget = opts.linearBudget ?? loadLinearBudget();
   const limited = linearRateLimitState(budget, resolveNow(opts.now));
   if (limited) {
@@ -3243,6 +3242,7 @@ export function planAdmittedEvents(db, registry, opts = {}) {
     }
   }
   for (const { source, event_id: eventId, type } of rows) {
+    cache.linearReadBudget = createEventReadBudget();
     try {
       const outcome = planEvent(db, registry, { source, eventId }, planOpts);
       if (

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -541,12 +541,14 @@ function resolveNow(now) {
   return typeof now === "function" ? now() : now;
 }
 
-// Planning runs in the planner worker, not the serve loop. Bound each event's
-// Linear CLI reads so one stalled ticket cannot delay the next event forever;
-// the default leaves room for normal control-plane reads without holding an
-// operator's planner pass hostage. Operators may set the positive millisecond
-// FACTORY_LINEAR_READ_TIMEOUT_MS environment variable to tune this deadline.
-const LINEAR_READ_TIMEOUT_MS = (() => {
+// Planning normally runs in the planner worker, but `serve --no-planner` still
+// plans inline on the serve loop, so a stalled read can block the tick itself.
+// Bound each event's Linear CLI reads so one stalled ticket cannot delay the
+// next event forever; the default leaves room for normal control-plane reads
+// without holding an operator's planner pass hostage. Operators may set the
+// positive millisecond FACTORY_LINEAR_READ_TIMEOUT_MS environment variable to
+// tune this deadline.
+export const LINEAR_READ_TIMEOUT_MS = (() => {
   const n = Number(process.env.FACTORY_LINEAR_READ_TIMEOUT_MS);
   return Number.isFinite(n) && n > 0 ? n : 25_000;
 })();

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4574,10 +4574,25 @@ describe("Linear rate limit (WM-878)", () => {
     });
   });
 
-  test("a pass-level read budget defers later stalled Linear reads", () => {
-    withReposRoot(gatedYaml, () => {
+  test("a stalled event cannot exhaust the next event's Linear read budget", () => {
+    const checkout = tmpDir("evrt-plan-budget-repo-");
+    execFileSync("git", ["init", "-q", "-b", "develop", checkout]);
+    writeFileSync(path.join(checkout, "README.md"), "fixture\n");
+    execFileSync("git", ["-C", checkout, "add", "README.md"]);
+    execFileSync("git", [
+      "-C",
+      checkout,
+      "-c",
+      "user.name=Test",
+      "-c",
+      "user.email=test@example.com",
+      "commit",
+      "-qm",
+      "fixture",
+    ]);
+    withReposRoot(gatedYaml.replace("/tmp/nowhere", checkout), () => {
       const db = openDb(":memory:");
-      for (const ticket of ["WM-1866-1", "WM-1866-2"]) {
+      for (const ticket of ["WM-18661", "WM-18662"]) {
         admit(db, {
           type: "factory.dispatch.requested",
           eventId: `pass-budget-${ticket}`,
@@ -4606,22 +4621,27 @@ describe("Linear rate limit (WM-878)", () => {
             fetchInFlight: () => [],
           },
         }),
-      ).toEqual({ planned: 0, failed: 0, deadLettered: 0 });
+      ).toEqual({ planned: 1, failed: 0, deadLettered: 0 });
 
-      expect(ticketReads).toEqual(["WM-1866-1"]);
-      for (const ticket of ["WM-1866-1", "WM-1866-2"]) {
-        expect(
-          db
-            .query(
-              `SELECT status, plan_failures, last_plan_error FROM events WHERE event_id = ?`,
-            )
-            .get(`pass-budget-${ticket}`),
-        ).toMatchObject({
-          status: "admitted",
-          plan_failures: 0,
-          last_plan_error: "linear_read_budget_exhausted",
-        });
-      }
+      expect(ticketReads).toEqual(["WM-18661", "WM-18662"]);
+      expect(
+        db
+          .query(
+            `SELECT status, plan_failures, last_plan_error FROM events WHERE event_id = ?`,
+          )
+          .get("pass-budget-WM-18661"),
+      ).toMatchObject({
+        status: "admitted",
+        plan_failures: 0,
+        last_plan_error: "linear_read_budget_exhausted",
+      });
+      expect(
+        db
+          .query(
+            `SELECT status, last_plan_error FROM events WHERE event_id = ?`,
+          )
+          .get("pass-budget-WM-18662"),
+      ).toEqual({ status: "planned", last_plan_error: null });
     });
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -26,6 +26,7 @@ import {
   modelAdapterMismatch,
   DEFAULT_MAX_IN_FLIGHT as PLANNER_DEFAULT_MAX_IN_FLIGHT,
   idempotencyKeyFor,
+  LINEAR_READ_TIMEOUT_MS,
   pinMemos,
   planAdmittedEvents,
   planEvent,
@@ -4644,6 +4645,16 @@ describe("Linear rate limit (WM-878)", () => {
       ).toEqual({ status: "planned", last_plan_error: null });
     });
   });
+
+  // The default is what production runs on: no deployment sets
+  // FACTORY_LINEAR_READ_TIMEOUT_MS, so a silent change to this number changes
+  // how long a stalled Linear read can hold a planner pass.
+  test.skipIf(process.env.FACTORY_LINEAR_READ_TIMEOUT_MS != null)(
+    "the Linear read budget defaults to 25s when FACTORY_LINEAR_READ_TIMEOUT_MS is unset",
+    () => {
+      expect(LINEAR_READ_TIMEOUT_MS).toBe(25_000);
+    },
+  );
 
   test("one planning pass over 10 candidates makes at most 3 in-flight queries", () => {
     withReposRoot(gatedYaml, () => {

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -19,6 +19,10 @@ import {
 } from "./workers.mjs";
 
 const LINEAR_READ_BUDGET_STALLED_AFTER_MS = 5 * 60_000;
+// A whole-backlog stall would otherwise push one anomaly line per admitted
+// event and drown every other anomaly in the status view; the count line tells
+// the operator how many more are behind the cap.
+const LINEAR_READ_BUDGET_STALLED_LIMIT = 20;
 
 function eventCounts(db) {
   const counts = {
@@ -224,15 +228,22 @@ export function statusView(
       eventId: row.event_id,
       lastError: row.last_plan_error,
     }));
+  // `events` carries no last-plan-attempt timestamp, so staleness is aged from
+  // admitted_at: the row is only reported once the event has been admitted (and
+  // therefore replanned every tick) for longer than the threshold.
+  const stalledLinearReadBudgetCutoff = new Date(
+    nowMs - LINEAR_READ_BUDGET_STALLED_AFTER_MS,
+  ).toISOString();
   const stalledLinearReadBudgets = db
     .query(
       `SELECT source, event_id FROM events
        WHERE status = 'admitted'
          AND last_plan_error = 'linear_read_budget_exhausted'
          AND admitted_at < ?
-       ORDER BY admitted_at, rowid`,
+       ORDER BY admitted_at, rowid
+       LIMIT ?`,
     )
-    .all(new Date(nowMs - LINEAR_READ_BUDGET_STALLED_AFTER_MS).toISOString());
+    .all(stalledLinearReadBudgetCutoff, LINEAR_READ_BUDGET_STALLED_LIMIT + 1);
 
   const fleet = workerCapacityView(db, nowMs, {
     workerPolicy,
@@ -307,11 +318,18 @@ export function statusView(
   if (policyVersion === "unknown")
     configAnomalies.push("policyVersion is unknown");
   if (fleet.policyError) configAnomalies.push(fleet.policyError);
-  for (const row of stalledLinearReadBudgets) {
+  for (const row of stalledLinearReadBudgets.slice(
+    0,
+    LINEAR_READ_BUDGET_STALLED_LIMIT,
+  )) {
     configAnomalies.push(
       `Admitted event ${row.source}:${row.event_id} has been deferred for Linear read-budget exhaustion for over ${LINEAR_READ_BUDGET_STALLED_AFTER_MS / 60_000} minutes`,
     );
   }
+  if (stalledLinearReadBudgets.length > LINEAR_READ_BUDGET_STALLED_LIMIT)
+    configAnomalies.push(
+      `More admitted events beyond the first ${LINEAR_READ_BUDGET_STALLED_LIMIT} are deferred for Linear read-budget exhaustion`,
+    );
   // Registry-load anomalies that are deliberately not load errors — today
   // only artifact-view sidecars that do not fit their schema (WM-454).
   configAnomalies.push(...(registry?.anomalies ?? []));

--- a/event-runtime/lib/status-view.mjs
+++ b/event-runtime/lib/status-view.mjs
@@ -18,6 +18,8 @@ import {
   stalledWorkers,
 } from "./workers.mjs";
 
+const LINEAR_READ_BUDGET_STALLED_AFTER_MS = 5 * 60_000;
+
 function eventCounts(db) {
   const counts = {
     admitted: 0,
@@ -222,6 +224,15 @@ export function statusView(
       eventId: row.event_id,
       lastError: row.last_plan_error,
     }));
+  const stalledLinearReadBudgets = db
+    .query(
+      `SELECT source, event_id FROM events
+       WHERE status = 'admitted'
+         AND last_plan_error = 'linear_read_budget_exhausted'
+         AND admitted_at < ?
+       ORDER BY admitted_at, rowid`,
+    )
+    .all(new Date(nowMs - LINEAR_READ_BUDGET_STALLED_AFTER_MS).toISOString());
 
   const fleet = workerCapacityView(db, nowMs, {
     workerPolicy,
@@ -296,6 +307,11 @@ export function statusView(
   if (policyVersion === "unknown")
     configAnomalies.push("policyVersion is unknown");
   if (fleet.policyError) configAnomalies.push(fleet.policyError);
+  for (const row of stalledLinearReadBudgets) {
+    configAnomalies.push(
+      `Admitted event ${row.source}:${row.event_id} has been deferred for Linear read-budget exhaustion for over ${LINEAR_READ_BUDGET_STALLED_AFTER_MS / 60_000} minutes`,
+    );
+  }
   // Registry-load anomalies that are deliberately not load errors — today
   // only artifact-view sidecars that do not fit their schema (WM-454).
   configAnomalies.push(...(registry?.anomalies ?? []));


### PR DESCRIPTION
Fixes watt-mind/factory#1937

Review the per-event Linear deadline and stale-budget-exhaustion status anomaly.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                                |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------ |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/planner.test.mjs event-runtime/lib/api-status-view.test.mjs` | pass    | 119 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,278 pass, emit/format/lint clean   |
| UX critique          | `factory-ux-critic`                                                                                       | not run | no user-facing surface               |

UX critique: skipped — planner/status backend-only change

run:run_b656d20a-3d40-498b-8e85-a664961365ba