### PR TITLE
fix(adapters): break ACP/Claude initialization cycle

### DIFF
--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -21,24 +21,18 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { Readable } from "node:stream";
 import { transcriptMaxBytes } from "../config.mjs";
-import {
-  HARNESS_LAYOUT as CLAUDE_HARNESS_LAYOUT,
-  KILL_GRACE_MS as CLAUDE_KILL_GRACE_MS,
-  PROMPT_SUFFIX,
-  PUSH_CREDENTIAL_ENV,
-  killProcessGroup,
-  safeChildEnvironment,
-  verifiedPrompt,
-} from "./claude.mjs";
-import { boundedTranscriptStream } from "./child-process.mjs";
+import { PUSH_CREDENTIAL_ENV, safeChildEnvironment } from "./child-env.mjs";
+import { boundedTranscriptStream, killProcessGroup } from "./child-process.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
-export { PROMPT_SUFFIX, PUSH_CREDENTIAL_ENV, killProcessGroup };
+export { PUSH_CREDENTIAL_ENV, killProcessGroup };
 
 /** ACP v1 major version. Agents that answer anything else are refused. */
 export const PROTOCOL_VERSION = 1;
 
-export const KILL_GRACE_MS = CLAUDE_KILL_GRACE_MS;
+// Keep this leaf module independent of Claude's initialization order. Importing
+// Claude's equivalent creates a cycle through its registry dependency.
+export const KILL_GRACE_MS = 30_000;
 
 export const SANDBOX_SUPPORT = "unsupported";
 
@@ -46,10 +40,38 @@ export const SANDBOX_DEFERRAL_REASON =
   "acp wraps host-authenticated coding agents (first target: claude-code-acp) whose binary, subscription OAuth, and permission surface have no Gondolin guest translation yet (WM-313 deferral; see lib/adapters/acp.mjs)";
 
 /**
- * First target is Claude Code via ACP, so harness packaging matches claude.
- * Not part of the WM-837 contract.
+ * First target is Claude Code via ACP, so its harness packaging is preserved
+ * locally rather than importing Claude during this module's initialization.
  */
-export const HARNESS_LAYOUT = CLAUDE_HARNESS_LAYOUT;
+export const HARNESS_LAYOUT = Object.freeze({
+  skills: Object.freeze({
+    source: (name) => ["plugins", "core", "skills", name],
+    dest: (name) => [".claude", "skills", name],
+    type: "dir",
+  }),
+  commands: Object.freeze({
+    source: (name) => ["plugins", "core", "commands", `${name}.md`],
+    dest: (name) => [".claude", "commands", `${name}.md`],
+    type: "file",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["plugins", "core", "agents", `${name}.md`],
+    dest: (name) => [".claude", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
+export const PROMPT_SUFFIX =
+  "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
+
+function verifiedPrompt(def, adapter) {
+  if (typeof def?.promptText !== "string") {
+    throw new Error(
+      `${adapter}: definition ${def?.ref ?? "<unknown>"} has no verified promptText (registry-loaded definitions only)`,
+    );
+  }
+  return def.promptText + PROMPT_SUFFIX;
+}
 
 /** Shipped default — the Zed `claude-code-acp` binary on PATH. */
 export const DEFAULT_ACP_CONFIG = Object.freeze({

--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -1,5 +1,6 @@
 import { tmpDir } from "../../test-support/tmp.mjs?file=event-runtime-lib-adapters-acp-test-mjs";
 import { afterAll, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
 import { EventEmitter } from "node:events";
 import {
   existsSync,
@@ -998,5 +999,33 @@ describe("execute against a fake ACP agent", () => {
       alive = false;
     }
     expect(alive).toBe(false);
+  });
+});
+
+describe("acp.mjs standalone import (GH-1939)", () => {
+  test("loads and initializes with no prior claude.mjs import in the module graph", () => {
+    const acpPath = path.resolve(import.meta.dir, "acp.mjs");
+    const home = tmpDir("evrt-acp-standalone-home-");
+    const env = { ...process.env, FACTORY_EVENT_HOME: home };
+    delete env.FACTORY_ROOT;
+    delete env.FACTORY_REPOS_ROOT;
+    delete env.FACTORY_CONTROL_API_TOKEN;
+
+    // Import acp.mjs first and alone: no prior claude.mjs load anywhere in
+    // this process's module graph. Before GH-1939 this deadlocked/threw
+    // because acp.mjs pulled KILL_GRACE_MS (and friends) from claude.mjs,
+    // which in turn depends back on the adapter registry during its own
+    // initialization — a cycle. acp.mjs must be a self-contained leaf.
+    const result = spawnSync(
+      "bun",
+      [
+        "-e",
+        `const m = await import(${JSON.stringify(acpPath)}); if (m.KILL_GRACE_MS !== 30_000) { console.error("KILL_GRACE_MS=" + m.KILL_GRACE_MS); process.exit(1); } console.log("ok");`,
+      ],
+      { encoding: "utf8", env },
+    );
+
+    expect(result.status).toBe(0);
+    expect(result.stdout.trim()).toBe("ok");
   });
 });


### PR DESCRIPTION
Fixes watt-mind/factory#1939

ACP adapter initialization no longer depends on Claude's cyclic export bindings.

## Validation

| Check                | Command                                                                                               | Result  | Notes                                      |
| -------------------- | ----------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) bun test event-runtime/lib/adapters/acp.test.mjs event-runtime/lib/worker.test.mjs` | pass    | 170 pass, 0 fail                           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,278 pass, 10 skipped; lint warnings only |
| UX critique          | factory-ux-critic                                                                                     | not run | backend adapter; no user-facing surface    |

UX critique: skipped — backend adapter change with no user-facing surface

run:run_ac13675d-c55b-4a1d-8067-686c95cfac82
