### PR TITLE
fix(api): route promotion endpoints through dispatcher

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -782,6 +782,28 @@ describe("overlay promotion routes (gh-860)", () => {
     db.close();
   });
 
+  test("API dispatcher routes promotion preview and apply to the registry handler", async () => {
+    const db = openDb(":memory:");
+    seed(db);
+    const { server, request, close } = await makeServer({ db, repos: reposFn });
+    try {
+      const preview = await request("/promotion/preview");
+      expect(preview.status).toBe(200);
+      const { digest } = await preview.json();
+
+      const apply = await request("/promotion/apply", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ repo: "factory", digest, keys: [] }),
+      });
+      expect(apply.status).toBe(200);
+      expect(await apply.json()).toMatchObject({ status: "noop" });
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
   test("POST /promotion/apply drives injected seams and returns the PR", async () => {
     const db = openDb(":memory:");
     seed(db);

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -482,6 +482,8 @@ export function createApi({
         url.pathname === "/agents" ||
         url.pathname === "/overrides" ||
         url.pathname.startsWith("/overrides/") ||
+        url.pathname === "/promotion/preview" ||
+        url.pathname === "/promotion/apply" ||
         url.pathname === "/repos" ||
         url.pathname.startsWith("/repos/")
       ) {


### PR DESCRIPTION
Fixes watt-mind/factory#1935

Routes promotion preview and apply requests through the API dispatcher instead of returning 404.

## Validation

| Check                | Command                                                                                                     | Result  | Notes                                |
| -------------------- | ----------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
| Verification Command | `bun test event-runtime/lib/api-registry.test.mjs event-runtime/lib/api.test.mjs`                           | pass    | 46 tests, 0 failures                 |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | lib suite, emit, format, lint passed |
| UX critique          | factory-ux-critic                                                                                            | skipped | backend API dispatcher only          |

UX critique: skipped — no user-facing surface

run:run_3c35ba17-f8ef-452b-8e23-ee26893ca324