### PR TITLE
fix(doctor): warn on missing factory command links

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -64,6 +64,42 @@ const defaultWorkflowRunList = (repo, options) =>
   readWorkflowRuns({ repo, ...options });
 
 /**
+ * Report whether every emitted factory command is available in a repository.
+ * Command links are intentionally untracked and can be restored with one
+ * `factory emit`, so missing and dangling links are actionable warnings.
+ */
+export function factoryCommandLinkDiagnostic({
+  commandsDir,
+  expectedCommands = [],
+} = {}) {
+  const missing = [];
+  const broken = [];
+  for (const name of expectedCommands) {
+    const target = path.join(commandsDir, `${name}.md`);
+    let st = null;
+    try {
+      st = lstatSync(target);
+    } catch {
+      /* intentionally ignored */
+    }
+    if (!st) {
+      missing.push(name);
+      continue;
+    }
+    if (st.isSymbolicLink() && !existsSync(target)) broken.push(name);
+  }
+  const problems = [...missing, ...broken];
+  return {
+    ok: problems.length === 0 ? true : "warn",
+    label: "/factory-* commands linked",
+    detail: problems.length
+      ? `${problems.length}/${expectedCommands.length} missing or broken: ${problems.join(", ")}`
+      : `${expectedCommands.length} commands`,
+    fix: problems.length ? "factory emit" : null,
+  };
+}
+
+/**
  * Report whether a repository's base branch has a healthy completed Actions
  * run. The reader is injectable so doctor tests never need GitHub access.
  */
@@ -1128,31 +1164,15 @@ if (import.meta.main) {
       }
     }
 
-    const commandsDir = path.join(p, ".claude", "commands");
-    const missing = [];
-    const broken = [];
-    for (const name of expectedCommands) {
-      const target = path.join(commandsDir, `${name}.md`);
-      let st = null;
-      try {
-        st = lstatSync(target);
-      } catch {
-        /* intentionally ignored */
-      }
-      if (!st) {
-        missing.push(name);
-        continue;
-      }
-      if (st.isSymbolicLink() && !existsSync(target)) broken.push(name); // dangling symlink
-    }
-    const problems = [...missing, ...broken];
+    const commandLinks = factoryCommandLinkDiagnostic({
+      commandsDir: path.join(p, ".claude", "commands"),
+      expectedCommands,
+    });
     check(
-      problems.length === 0,
-      "/factory-* commands linked",
-      problems.length
-        ? `${problems.length}/${expectedCommands.length} missing or broken: ${problems.join(", ")}`
-        : `${expectedCommands.length} commands`,
-      problems.length ? "factory emit" : null,
+      commandLinks.ok,
+      commandLinks.label,
+      commandLinks.detail,
+      commandLinks.fix,
     );
 
     const gitignorePath = path.join(p, ".gitignore");

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -14,11 +14,14 @@ import { test, expect, describe } from "bun:test";
 import {
   mkdtempSync,
   mkdirSync,
+  readdirSync,
   writeFileSync,
   chmodSync,
   existsSync,
   readFileSync,
   rmSync,
+  symlinkSync,
+  unlinkSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -41,6 +44,7 @@ import {
   parseCliVersion,
   repoToolchainDiagnostics,
   stackDaemonDiagnostics,
+  factoryCommandLinkDiagnostic,
 } from "./doctor.mjs";
 
 const HERE = path.dirname(new URL(import.meta.url).pathname);
@@ -128,6 +132,82 @@ describe("base branch CI diagnostics (#1928)", () => {
         detail: "develop — skipped, no completed Actions history",
       }),
     ]);
+  });
+});
+
+describe("factory command link diagnostic (#1950)", () => {
+  const expectedCommands = () =>
+    readdirSync(path.join(HERE, "..", "shared", "commands"))
+      .filter((file) => file.endsWith(".md"))
+      .map((file) => path.basename(file, ".md"));
+
+  const setupLinkedCommands = (dir, names) => {
+    const commandsDir = path.join(dir, ".claude", "commands");
+    mkdirSync(commandsDir, { recursive: true });
+    for (const name of names) {
+      symlinkSync(
+        path.join(HERE, "..", "shared", "commands", `${name}.md`),
+        path.join(commandsDir, `${name}.md`),
+      );
+    }
+    return commandsDir;
+  };
+
+  test("passes when every expected command is linked", () => {
+    const dir = scratch();
+    const names = expectedCommands();
+    const commandsDir = setupLinkedCommands(dir, names);
+
+    expect(
+      factoryCommandLinkDiagnostic({ commandsDir, expectedCommands: names }),
+    ).toEqual({
+      ok: true,
+      label: "/factory-* commands linked",
+      detail: `${names.length} commands`,
+      fix: null,
+    });
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("warns with the existing emit hint when a command link is missing", () => {
+    const dir = scratch();
+    const names = expectedCommands();
+    const commandsDir = setupLinkedCommands(dir, names);
+    const missing = names[0];
+    unlinkSync(path.join(commandsDir, `${missing}.md`));
+
+    expect(
+      factoryCommandLinkDiagnostic({ commandsDir, expectedCommands: names }),
+    ).toEqual({
+      ok: "warn",
+      label: "/factory-* commands linked",
+      detail: `1/${names.length} missing or broken: ${missing}`,
+      fix: "factory emit",
+    });
+
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("warns with the existing emit hint when a command link is dangling", () => {
+    const dir = scratch();
+    const names = expectedCommands();
+    const commandsDir = setupLinkedCommands(dir, names);
+    const broken = names[0];
+    const target = path.join(commandsDir, `${broken}.md`);
+    unlinkSync(target);
+    symlinkSync(path.join(dir, "missing-target.md"), target);
+
+    expect(
+      factoryCommandLinkDiagnostic({ commandsDir, expectedCommands: names }),
+    ).toEqual({
+      ok: "warn",
+      label: "/factory-* commands linked",
+      detail: `1/${names.length} missing or broken: ${broken}`,
+      fix: "factory emit",
+    });
+
+    rmSync(dir, { recursive: true, force: true });
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#1950

Treat untracked factory command links as actionable doctor warnings; restore them with `factory emit`.

## Validation

| Check                | Command                                                                                              | Result  | Notes                                           |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------- |
| Verification Command | `bun test orchestrator/doctor.test.mjs && bun run lint`                                             | pass    | 50 tests; lint completed with 0 errors          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2297 tests; emit and format checks clean        |
| UX critique          | factory-ux-critic                                                                                    | not run | no user-facing surface                          |

UX critique: skipped
run:run_e046c37f-408c-4864-b419-d19de257e6f3