### PR TITLE
feat(verify): backstop event runtime lib handoffs (#1945)

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -232,6 +232,10 @@ open) and at least every 20 minutes, saying what changed. After 45 minutes
 of silence the ticket is reclaimed.
 
 **Verification is a gate.** Run the ticket's exact Verification Command.
+When a handoff changes `event-runtime/lib/**`, the worker also runs
+`bun test event-runtime/lib --timeout 20000` unless that exact lib suite (or
+an explicit parent suite) is already covered by the ticket command. Narrow
+single-file commands are therefore still safe to use for ticket verification.
 For a ticket that changes `event-runtime/web/src/**`, run
 `cd event-runtime/web && bun x tsc --noEmit` before the ticket command as
 well (the root `bun run check` runs it too, once `event-runtime/web` has had

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -99,7 +99,8 @@ export class ContractViolation extends Error {
  * (3 of 10 PRs on 2026-08-18 failed CI on exactly the check the ticket named).
  * The repo `verify:` gate below is deliberately a subset of CI (WM-528), so
  * it let those through. This is the same check made honest: the WORKER runs
- * the ticket's own Verification Command, the web build when the diff reaches
+ * the ticket's own Verification Command, the full lib suite when the diff
+ * reaches `event-runtime/lib/**`, the web build when it reaches
  * `event-runtime/web/src/**`, and compares the diff with the ticket's Owned
  * Paths — and authors the Verification line itself.
  */
@@ -110,11 +111,15 @@ export const HANDOFF_REASON_CODES = new Set([
   "handoff_verification_unspecified",
   "handoff_owned_paths_violation",
   "handoff_pr_form_invalid",
+  "event_runtime_lib_verify_failed",
   HANDOFF_DEPENDENCIES_MISSING,
 ]);
 export const HANDOFF_TAIL_LINES = 40;
 /** reasonCode the worker stamps on a result.json it synthesized itself (#1592). */
 export const RECOVERED_RESULT_REASON = "worker_recovered_missing_result";
+export const HANDOFF_EVENT_RUNTIME_LIB_PREFIX = "event-runtime/lib/";
+export const HANDOFF_EVENT_RUNTIME_LIB_VERIFY_COMMAND =
+  "bun test event-runtime/lib --timeout 20000";
 export const HANDOFF_WEB_SRC_PREFIX = "event-runtime/web/src/";
 export const HANDOFF_WEB_BUILD_DIR = "event-runtime/web";
 export const HANDOFF_WEB_BUILD_COMMAND = "bun run build";
@@ -814,6 +819,23 @@ export function ticketVerifyCoveredByRepoVerify(
   });
 }
 
+/**
+ * A ticket's explicit `bun test` target covers the lib backstop only when it
+ * names event-runtime/lib itself or one of its parent directories. A focused
+ * test inside lib is deliberately not enough: the backstop protects the rest
+ * of the suite from narrow ticket commands.
+ */
+function ticketVerifyCoversEventRuntimeLibSuite(ticketCommand) {
+  const ticketPaths = bunTestPaths(ticketCommand);
+  return (
+    ticketPaths?.some(
+      (ticketPath) =>
+        ticketPath === HANDOFF_EVENT_RUNTIME_LIB_PREFIX.slice(0, -1) ||
+        HANDOFF_EVENT_RUNTIME_LIB_PREFIX.startsWith(`${ticketPath}/`),
+    ) ?? false
+  );
+}
+
 /** Best-effort timeout for the pre-diff `git fetch origin <base>` (F4). */
 const FETCH_BASE_TIMEOUT_MS = 10_000;
 
@@ -979,6 +1001,21 @@ export function composeHandoffVerification(handoff) {
     if (!handoff.webBuild.passed) lines.push(fenceBlock(handoff.webBuild.tail));
   } else if (handoff.diff?.ok) {
     lines.push(`- Web build: skipped (no ${HANDOFF_WEB_SRC_PREFIX}** changes)`);
+  }
+  if (handoff.eventRuntimeLibVerify) {
+    lines.push(
+      commandLine(
+        `Event-runtime lib suite (${HANDOFF_EVENT_RUNTIME_LIB_PREFIX}** changed)`,
+        handoff.eventRuntimeLibVerify,
+      ),
+    );
+    if (!handoff.eventRuntimeLibVerify.passed)
+      lines.push(fenceBlock(handoff.eventRuntimeLibVerify.tail));
+  } else if (handoff.diff?.ok) {
+    const why = handoff.ticketVerifyCoversEventRuntimeLibSuite
+      ? "ticket command already covers it"
+      : `no ${HANDOFF_EVENT_RUNTIME_LIB_PREFIX}** changes`;
+    lines.push(`- Event-runtime lib suite: skipped (${why})`);
   }
   if (handoff.diff?.ok) {
     const n = handoff.diff.files.length;
@@ -1874,6 +1911,7 @@ function verifyCompleted({
       runId: spec.runId,
       verification: null,
       repoVerify: null,
+      eventRuntimeLibVerify: null,
       webBuild: null,
       diff: null,
       ownedPaths,
@@ -1896,6 +1934,8 @@ function verifyCompleted({
         worktreeRecord.verify,
         { root: worktreePath },
       ),
+      ticketVerifyCoversEventRuntimeLibSuite:
+        ticketVerifyCoversEventRuntimeLibSuite(ticketCommand),
       reasonCode: null,
     };
     const refuse = (reasonCode, violation) => {
@@ -1938,6 +1978,9 @@ function verifyCompleted({
       base: worktreeRecord.base ?? null,
     });
     const files = handoff.diff.files ?? [];
+    const needsEventRuntimeLibVerify = files.some((file) =>
+      file.startsWith(HANDOFF_EVENT_RUNTIME_LIB_PREFIX),
+    );
     const needsWebBuild =
       files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
       existsSync(
@@ -2012,7 +2055,31 @@ function verifyCompleted({
       handoff.verification = handoff.repoVerify;
     }
 
-    // 3. tsc + vite for anything under event-runtime/web/src/** — the check
+    // 3. The full event-runtime/lib suite for a changed lib file. A ticket
+    // command that explicitly names lib (or a parent suite) already ran it.
+    if (
+      needsEventRuntimeLibVerify &&
+      !handoff.ticketVerifyCoversEventRuntimeLibSuite
+    ) {
+      const obs = runHandoffStep({
+        command: HANDOFF_EVENT_RUNTIME_LIB_VERIFY_COMMAND,
+        cwd: worktreePath,
+        worktreePath,
+        logPath: path.join(workspaceDir, ".verify.event-runtime-lib.log"),
+        timeoutMs: verifyTimeoutMs,
+      });
+      obs.source = "event_runtime_lib";
+      handoff.eventRuntimeLibVerify = obs;
+      if (!obs.passed) {
+        refuse(
+          "event_runtime_lib_verify_failed",
+          `event_runtime_lib_verify_failed: ${handoffWhy(obs)}`,
+        );
+      }
+      handoffChecks.push("event_runtime_lib_verify_passed");
+    }
+
+    // 4. tsc + vite for anything under event-runtime/web/src/** — the check
     //    #593 failed on, regardless of what the ticket's command covers.
     if (needsWebBuild) {
       const obs = runHandoffStep({

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1013,7 +1013,7 @@ export function composeHandoffVerification(handoff) {
       lines.push(fenceBlock(handoff.eventRuntimeLibVerify.tail));
   } else if (handoff.diff?.ok) {
     const why = handoff.ticketVerifyCoversEventRuntimeLibSuite
-      ? "ticket command already covers it"
+      ? "ticket or repo verify command already covers it"
       : `no ${HANDOFF_EVENT_RUNTIME_LIB_PREFIX}** changes`;
     lines.push(`- Event-runtime lib suite: skipped (${why})`);
   }
@@ -1935,7 +1935,8 @@ function verifyCompleted({
         { root: worktreePath },
       ),
       ticketVerifyCoversEventRuntimeLibSuite:
-        ticketVerifyCoversEventRuntimeLibSuite(ticketCommand),
+        ticketVerifyCoversEventRuntimeLibSuite(ticketCommand) ||
+        ticketVerifyCoversEventRuntimeLibSuite(worktreeRecord.verify),
       reasonCode: null,
     };
     const refuse = (reasonCode, violation) => {
@@ -1978,9 +1979,9 @@ function verifyCompleted({
       base: worktreeRecord.base ?? null,
     });
     const files = handoff.diff.files ?? [];
-    const needsEventRuntimeLibVerify = files.some((file) =>
-      file.startsWith(HANDOFF_EVENT_RUNTIME_LIB_PREFIX),
-    );
+    const needsEventRuntimeLibVerify =
+      files.some((file) => file.startsWith(HANDOFF_EVENT_RUNTIME_LIB_PREFIX)) &&
+      existsSync(path.join(worktreePath, HANDOFF_EVENT_RUNTIME_LIB_PREFIX));
     const needsWebBuild =
       files.some((file) => file.startsWith(HANDOFF_WEB_SRC_PREFIX)) &&
       existsSync(
@@ -2071,8 +2072,11 @@ function verifyCompleted({
       obs.source = "event_runtime_lib";
       handoff.eventRuntimeLibVerify = obs;
       if (!obs.passed) {
+        const baselineStillRed =
+          !obs.timedOut &&
+          matchesRedBaseline(worktreeRecord.baseline, obs.output);
         refuse(
-          "event_runtime_lib_verify_failed",
+          baselineStillRed ? "baseline_red" : "event_runtime_lib_verify_failed",
           `event_runtime_lib_verify_failed: ${handoffWhy(obs)}`,
         );
       }
@@ -2100,7 +2104,7 @@ function verifyCompleted({
       handoffChecks.push("web_build_passed");
     }
 
-    // 4. Owned Paths conformance: listed always; refused under strict.
+    // 5. Owned Paths conformance: listed always; refused under strict.
     if (handoff.diff.ok && ownedPathsKnown) {
       handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths);
       if (handoff.ownedPathsDeviations.length === 0) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1445,6 +1445,136 @@ describe("worktree baseline verification (WM-334)", () => {
     ]);
   });
 
+  test("a repo verify command covering the lib suite does not duplicate the backstop", () => {
+    const { dir, record } = worktreeWorkspace(
+      "bun test event-runtime/lib --timeout 20000",
+      null,
+    );
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "event-runtime/lib/changed.mjs");
+    const calls = [];
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      runHandoffCommandFn: ({ command }) => {
+        calls.push(command);
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "ok",
+          sandbox: { tmpfsMb: 1024 },
+        };
+      },
+    });
+
+    expect(out.kind).toBe("completed");
+    // The repo `verify:` command already ran the full lib suite in step 1;
+    // step 3 must not spawn it a second time.
+    expect(calls).toEqual([
+      "bun test event-runtime/lib --timeout 20000",
+      "ticket-narrow",
+    ]);
+    expect(out.handoff.ticketVerifyCoversEventRuntimeLibSuite).toBe(true);
+    expect(out.handoff.eventRuntimeLibVerify).toBeNull();
+    const body = composeHandoffVerification(out.handoff);
+    expect(body).toContain(
+      "- Event-runtime lib suite: skipped (ticket or repo verify command already covers it)",
+    );
+  });
+
+  test("a lib suite failure matching the pre-existing red baseline is refused as baseline_red, not event_runtime_lib_verify_failed", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", {
+      status: "red",
+      check: "event_runtime_lib",
+      output: "regression outside the focused ticket test",
+    });
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "event-runtime/lib/changed.mjs");
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: ({ command }) => ({
+          passed: command !== "bun test event-runtime/lib --timeout 20000",
+          exitCode:
+            command === "bun test event-runtime/lib --timeout 20000" ? 1 : 0,
+          output:
+            command === "bun test event-runtime/lib --timeout 20000"
+              ? "regression outside the focused ticket test"
+              : "ok",
+          sandbox: { tmpfsMb: 1024 },
+        }),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("baseline_red");
+      expect(err.violations[0]).toContain("event_runtime_lib_verify_failed");
+    }
+  });
+
+  test("a missing event-runtime/lib directory never triggers the backstop", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    // Commit a diff that names a path under the lib prefix as a deleted file
+    // reference only — the directory itself does not exist in the final tree.
+    record.base = "develop";
+    const git = (...args) => execFileSync("git", args, { cwd: record.path });
+    git("init", "-q", "-b", "develop");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(path.join(record.path, "README.md"), "base\n");
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/develop", "HEAD");
+    git("checkout", "-qb", "feat/x");
+    mkdirSync(path.join(record.path, "event-runtime", "lib"), {
+      recursive: true,
+    });
+    writeFileSync(
+      path.join(record.path, "event-runtime", "lib", "gone.mjs"),
+      "x\n",
+    );
+    git("add", "-A");
+    git("commit", "-qm", "add then remove");
+    execFileSync("git", ["rm", "-q", "-r", "event-runtime/lib"], {
+      cwd: record.path,
+    });
+    git("commit", "-qm", "remove lib dir");
+
+    const calls = [];
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      runHandoffCommandFn: ({ command }) => {
+        calls.push(command);
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "ok",
+          sandbox: { tmpfsMb: 1024 },
+        };
+      },
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(calls).toEqual(["repo-verify", "ticket-narrow"]);
+    expect(out.handoff.eventRuntimeLibVerify).toBeNull();
+  });
+
   test("missing dependencies install before the injected step-1 sandbox runner", () => {
     const { dir, record } = worktreeWorkspace("step-1", null);
     writeFileSync(

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1327,6 +1327,124 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
   });
 
+  function commitHandoffDiff(record, changedPath) {
+    record.base = "develop";
+    const git = (...args) => execFileSync("git", args, { cwd: record.path });
+    git("init", "-q", "-b", "develop");
+    git("config", "user.email", "t@t");
+    git("config", "user.name", "t");
+    writeFileSync(path.join(record.path, "README.md"), "base\n");
+    git("add", "-A");
+    git("commit", "-qm", "base");
+    git("update-ref", "refs/remotes/origin/develop", "HEAD");
+    git("checkout", "-qb", "feat/x");
+    const file = path.join(record.path, changedPath);
+    mkdirSync(path.dirname(file), { recursive: true });
+    writeFileSync(file, "changed\n");
+    git("add", "-A");
+    git("commit", "-qm", "work");
+  }
+
+  test("a lib change runs the full lib suite after a narrow ticket command and refuses its failure", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "event-runtime/lib/changed.mjs");
+    const calls = [];
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: ({ command }) => {
+          calls.push(command);
+          return {
+            passed: command !== "bun test event-runtime/lib --timeout 20000",
+            exitCode:
+              command === "bun test event-runtime/lib --timeout 20000" ? 1 : 0,
+            output:
+              command === "bun test event-runtime/lib --timeout 20000"
+                ? "regression outside the focused ticket test"
+                : "ok",
+            sandbox: { tmpfsMb: 1024 },
+          };
+        },
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("event_runtime_lib_verify_failed");
+    }
+    expect(calls).toEqual([
+      "repo-verify",
+      "ticket-narrow",
+      "bun test event-runtime/lib --timeout 20000",
+    ]);
+  });
+
+  test("a non-lib change skips the event-runtime lib backstop", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "docs/note.md");
+    const calls = [];
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      runHandoffCommandFn: ({ command }) => {
+        calls.push(command);
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "ok",
+          sandbox: { tmpfsMb: 1024 },
+        };
+      },
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(calls).toEqual(["repo-verify", "ticket-narrow"]);
+  });
+
+  test("a ticket command that covers the lib suite does not duplicate the backstop", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = {
+      verificationCommand:
+        "bun test event-runtime/lib --timeout 20000 && bun run lint",
+    };
+    commitHandoffDiff(record, "event-runtime/lib/changed.mjs");
+    const calls = [];
+    const out = verifyResult({
+      spec: dispatchSpec,
+      def: dispatchDef,
+      registry,
+      workspaceDir: dir,
+      attempt: 1,
+      worktreeRecord: record,
+      runHandoffCommandFn: ({ command }) => {
+        calls.push(command);
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "ok",
+          sandbox: { tmpfsMb: 1024 },
+        };
+      },
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(calls).toEqual([
+      "repo-verify",
+      "bun test event-runtime/lib --timeout 20000 && bun run lint",
+    ]);
+  });
+
   test("missing dependencies install before the injected step-1 sandbox runner", () => {
     const { dir, record } = worktreeWorkspace("step-1", null);
     writeFileSync(


### PR DESCRIPTION
Fixes watt-mind/factory#1945

Review the new lib-diff backstop and its distinct handoff refusal.

## Validation

| Check                | Command                                                                        | Result | Notes                         |
| -------------------- | ------------------------------------------------------------------------------ | ------ | ----------------------------- |
| Verification Command | `bun test event-runtime/lib --timeout 20000 && bun run lint`                  | pass   | 2300 tests; 615 baseline warnings |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 615 baseline warnings |
| UX critique          | `factory-ux-critic`                                                           | not run | no user-facing surface        |

UX critique: skipped

run:run_97706ced-8de2-4768-b87c-f208197056ae