### PR TITLE
fix(notify): retain dispatch API failures locally

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -189,7 +189,11 @@ case "$cmd" in
     # serve-side push after a successful durable record (12) fall back to the
     # original direct transport so the human is reached on at least one leg
     # (WM-759). A successful durable+push does not fall through (no double-send).
-    # HTTP rejection (10) is still terminal.
+    # An agent never receives the worker's control bearer. During a dispatch
+    # without one, HTTP rejection (10) is retained in a run-scoped local
+    # outbox for the worker to submit with its own bearer after handoff
+    # (WM-1558). A configured bearer may be stale, so its explicit rejection
+    # gets a distinct status and preserves the normal direct fallback.
     _notify_stdin=0
     if [[ "${1:-}" == "-" ]]; then
       _notify_stdin=1
@@ -248,7 +252,10 @@ case "$cmd" in
             console.error(token
               ? "notify: control API rejected FACTORY_CONTROL_API_TOKEN"
               : "notify: control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env");
-            process.exit(10);
+            // The shell needs to distinguish a bad supplied bearer (fall
+            // through to direct transport) from an absent bearer (queue it
+            // for the worker). Other HTTP errors remain terminal status 10.
+            process.exit(token ? 13 : 10);
           }
           if (!response.ok) {
             const rawDetail = typeof responseBody?.error === "string" ? responseBody.error : responseText;
@@ -280,7 +287,16 @@ case "$cmd" in
       _notify_status=$?
       set -e
       if [[ "$_notify_status" -eq 0 ]]; then exit 0; fi
-      if [[ "$_notify_status" -ne 11 && "$_notify_status" -ne 12 ]]; then exit "$_notify_status"; fi
+      if [[ "${FACTORY_DISPATCH:-}" == 1 && ( "$_notify_status" -eq 10 || "$_notify_status" -eq 11 ) && -z "${FACTORY_CONTROL_API_TOKEN:-}" && -n "${FACTORY_RUN_ID:-}" && -n "${FACTORY_EVENT_HOME:-}" ]]; then
+        if bun "$ROOT/lib/notify.mjs" --queue-local >/dev/null; then
+          echo "notify: control API rejected request; queued_local for worker handoff" >&2
+          exit 0
+        fi
+        echo "notify: control API rejected request and local outbox could not be written" >&2
+      fi
+      if [[ "$_notify_status" -ne 11 && "$_notify_status" -ne 12 && "$_notify_status" -ne 13 ]]; then
+        exit "$_notify_status"
+      fi
     fi
 
     # Unreachable runtime (or an unstructured legacy message): preserve the

--- a/bin/factory
+++ b/bin/factory
@@ -287,7 +287,10 @@ case "$cmd" in
       _notify_status=$?
       set -e
       if [[ "$_notify_status" -eq 0 ]]; then exit 0; fi
-      if [[ "${FACTORY_DISPATCH:-}" == 1 && ( "$_notify_status" -eq 10 || "$_notify_status" -eq 11 ) && -z "${FACTORY_CONTROL_API_TOKEN:-}" && -n "${FACTORY_RUN_ID:-}" && -n "${FACTORY_EVENT_HOME:-}" ]]; then
+      # Only a terminal HTTP rejection (10) is queued. Status 11 means the
+      # runtime was unreachable, which WM-759 routes to the direct transport
+      # below so a human is paged now rather than after the worker drains.
+      if [[ "${FACTORY_DISPATCH:-}" == 1 && "$_notify_status" -eq 10 && -z "${FACTORY_CONTROL_API_TOKEN:-}" && -n "${FACTORY_RUN_ID:-}" && -n "${FACTORY_EVENT_HOME:-}" ]]; then
         if bun "$ROOT/lib/notify.mjs" --queue-local >/dev/null; then
           echo "notify: control API rejected request; queued_local for worker handoff" >&2
           exit 0

--- a/docs/event-runtime-dispatch.md
+++ b/docs/event-runtime-dispatch.md
@@ -387,6 +387,19 @@ sandbox step. It otherwise preserves the independent ticket command check;
 unparseable shell commands, missing files, non-test modules and flag values
 (`--preload x`) never qualify for skipping.
 
+### Run-scoped notification fallback
+
+Dispatch adapters mark the child with `FACTORY_DISPATCH=1` and pass the
+isolated `FACTORY_EVENT_HOME` and port to the agent, but never
+`FACTORY_CONTROL_API_TOKEN`. If `factory notify` cannot create a durable
+control-API record during a run, it appends the structured notification to
+`$FACTORY_EVENT_HOME/outbox/<run-id>.jsonl` and reports `queued_local` instead
+of losing the message. After the agent exits, the worker submits each entry to
+`POST /inbox` with its own bearer. Delivered entries are removed; a failed or
+malformed entry remains in the outbox and its intended text is recorded on the
+ticket during handoff. This keeps the bearer out of the agent environment while
+making a missing or rejected agent-side token observable and recoverable.
+
 ---
 
 ## 6. Execution form: the `claude` adapter, `mutating: true`

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -25,6 +25,7 @@ import {
 } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
+import { localNotifyOutboxPath } from "../../lib/notify.mjs";
 import {
   LEASE_HEARTBEAT_MS,
   leaseDir,
@@ -1048,13 +1049,116 @@ export function dispatchIdentityEnv({
   repoName = null,
 }) {
   if (!String(spec?.agent ?? "").startsWith("dispatch@")) return env;
-  const identity = {};
+  // A dispatched agent must never inherit the worker's control bearer. It can
+  // retain a notification locally and the worker will submit it after exit.
+  const agentEnv = { ...env };
+  delete agentEnv.FACTORY_CONTROL_API_TOKEN;
+  const identity = { FACTORY_DISPATCH: "1" };
   if (runId != null && runId !== "") identity.FACTORY_RUN_ID = String(runId);
   if (ticketId != null && ticketId !== "")
     identity.FACTORY_TICKET = String(ticketId);
   if (repoName != null && repoName !== "")
     identity.FACTORY_REPO = String(repoName);
-  return { ...env, ...identity };
+  // A dispatched agent needs the location of its isolated runtime to retain
+  // notifications, but never the worker's control bearer. The caller supplies
+  // these two non-secret values explicitly rather than copying process.env.
+  for (const key of ["FACTORY_EVENT_HOME", "FACTORY_EVENT_PORT"]) {
+    const value = env[key];
+    if (value != null && value !== "") identity[key] = String(value);
+  }
+  return { ...agentEnv, ...identity };
+}
+
+const LOCAL_NOTIFY_OUTBOX_SCHEMA = "factory.local-notify-outbox/v1";
+
+function localOutboxEntry(value, runId) {
+  if (
+    !value ||
+    typeof value !== "object" ||
+    Array.isArray(value) ||
+    value.schemaVersion !== LOCAL_NOTIFY_OUTBOX_SCHEMA ||
+    value.runId !== runId ||
+    value.source !== `agent:${runId}` ||
+    typeof value.kind !== "string" ||
+    value.kind.trim() === "" ||
+    typeof value.title !== "string" ||
+    value.title.trim() === "" ||
+    !value.refs ||
+    typeof value.refs !== "object" ||
+    Array.isArray(value.refs)
+  ) {
+    return null;
+  }
+  return value;
+}
+
+/**
+ * Submit agent-retained notifications with the worker's bearer. Failed lines
+ * stay in the append-only run outbox so the worker can report their exact text
+ * in the ticket handoff instead of silently losing an escalation.
+ */
+export async function drainLocalNotifyOutbox({
+  home = process.env.FACTORY_EVENT_HOME,
+  runId,
+  port = process.env.FACTORY_EVENT_PORT || "7381",
+  token = process.env.FACTORY_CONTROL_API_TOKEN,
+  fetchFn = fetch,
+}) {
+  let outboxPath;
+  try {
+    outboxPath = localNotifyOutboxPath({ home, runId });
+  } catch (error) {
+    return { delivered: [], undelivered: [], error: error.message };
+  }
+  if (!existsSync(outboxPath)) return { delivered: [], undelivered: [] };
+
+  const lines = readFileSync(outboxPath, "utf8").split("\n").filter(Boolean);
+  const retained = [];
+  const delivered = [];
+  const undelivered = [];
+  for (const line of lines) {
+    let entry;
+    try {
+      entry = localOutboxEntry(JSON.parse(line), runId);
+    } catch {
+      entry = null;
+    }
+    if (!entry) {
+      retained.push(line);
+      undelivered.push({
+        title: "invalid local notification record",
+        error: "invalid outbox entry",
+      });
+      continue;
+    }
+    try {
+      const response = await fetchFn(`http://127.0.0.1:${port}/inbox`, {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+          ...(token ? { authorization: `Bearer ${token}` } : {}),
+        },
+        body: JSON.stringify({
+          kind: entry.kind,
+          title: entry.title,
+          refs: entry.refs,
+          source: entry.source,
+        }),
+      });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      delivered.push(entry);
+    } catch (error) {
+      retained.push(line);
+      undelivered.push({
+        title: entry.title,
+        error: String(error?.message ?? error),
+      });
+    }
+  }
+  if (retained.length)
+    writeFileSync(outboxPath, `${retained.join("\n")}\n`, "utf8");
+  else unlinkSync(outboxPath);
+  return { delivered, undelivered };
 }
 
 function maxEnvironmentRetries(spec) {
@@ -4519,14 +4623,25 @@ export async function executeClaimed(
       deadlinePoll = null;
     };
 
+    const workerEventHome =
+      env.FACTORY_EVENT_HOME ?? process.env.FACTORY_EVENT_HOME;
+    const workerEventPort =
+      env.FACTORY_EVENT_PORT ?? process.env.FACTORY_EVENT_PORT;
+    const workerControlToken =
+      env.FACTORY_CONTROL_API_TOKEN ?? process.env.FACTORY_CONTROL_API_TOKEN;
     let outcome;
     try {
       // Dispatch identity comes from the immutable RunSpec, never the ambient
       // worker environment. The adapter's child-environment builder preserves
       // these values while continuing to strip credentials it does not need.
+      const dispatchEnv = { ...env };
+      for (const key of ["FACTORY_EVENT_HOME", "FACTORY_EVENT_PORT"]) {
+        if (dispatchEnv[key] === undefined && process.env[key] !== undefined)
+          dispatchEnv[key] = process.env[key];
+      }
       const adapterEnv = dispatchIdentityEnv({
         spec,
-        env,
+        env: dispatchEnv,
         runId,
         ticketId,
         repoName,
@@ -4553,6 +4668,36 @@ export async function executeClaimed(
     } finally {
       stopDeadlineMonitor();
       stopCancellationMonitor();
+    }
+
+    // The agent may have retained a notification because it deliberately lacks
+    // the control bearer. Drain only after its process has exited, so no writer
+    // can race the read/truncate cycle. A delivery failure is recorded on the
+    // ticket but never replaces the agent's primary terminal outcome.
+    const notificationDrain = isWorktree
+      ? await drainLocalNotifyOutbox({
+          runId,
+          home: workerEventHome,
+          port: workerEventPort,
+          token: workerControlToken,
+        })
+      : { delivered: [], undelivered: [] };
+    if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {
+      try {
+        const messages = notificationDrain.undelivered
+          .slice(0, 10)
+          .map(({ title, error }) => `- ${JSON.stringify(title)} — ${error}`)
+          .join("\n");
+        commentTicketFn({
+          repo: repoName,
+          ticket: ticketId,
+          body:
+            `## Notification outbox\n` +
+            `Worker could not deliver ${notificationDrain.undelivered.length} retained notification(s); intended text:\n${messages}`,
+        });
+      } catch {
+        // The retained outbox remains the recovery source if the tracker is down.
+      }
     }
 
     if (outcome?.usage)

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4668,35 +4668,43 @@ export async function executeClaimed(
     } finally {
       stopDeadlineMonitor();
       stopCancellationMonitor();
-    }
-
-    // The agent may have retained a notification because it deliberately lacks
-    // the control bearer. Drain only after its process has exited, so no writer
-    // can race the read/truncate cycle. A delivery failure is recorded on the
-    // ticket but never replaces the agent's primary terminal outcome.
-    const notificationDrain = isWorktree
-      ? await drainLocalNotifyOutbox({
-          runId,
-          home: workerEventHome,
-          port: workerEventPort,
-          token: workerControlToken,
-        })
-      : { delivered: [], undelivered: [] };
-    if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {
+      // The agent may have retained a notification because it deliberately
+      // lacks the control bearer. Drain in `finally` so an adapter throw can
+      // never strand a retained escalation, and only after the adapter has
+      // fully stopped, so no writer races the read/truncate cycle. Neither the
+      // drain nor its ticket comment may throw: the agent's primary terminal
+      // outcome (or error) always wins.
       try {
-        const messages = notificationDrain.undelivered
-          .slice(0, 10)
-          .map(({ title, error }) => `- ${JSON.stringify(title)} — ${error}`)
-          .join("\n");
-        commentTicketFn({
-          repo: repoName,
-          ticket: ticketId,
-          body:
-            `## Notification outbox\n` +
-            `Worker could not deliver ${notificationDrain.undelivered.length} retained notification(s); intended text:\n${messages}`,
-        });
-      } catch {
-        // The retained outbox remains the recovery source if the tracker is down.
+        const notificationDrain = isWorktree
+          ? await drainLocalNotifyOutbox({
+              runId,
+              home: workerEventHome,
+              port: workerEventPort,
+              token: workerControlToken,
+            })
+          : { delivered: [], undelivered: [] };
+        if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {
+          try {
+            const messages = notificationDrain.undelivered
+              .slice(0, 10)
+              .map(
+                ({ title, error }) => `- ${JSON.stringify(title)} — ${error}`,
+              )
+              .join("\n");
+            commentTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              body:
+                `## Notification outbox\n` +
+                `Worker could not deliver ${notificationDrain.undelivered.length} retained notification(s); intended text:\n${messages}`,
+            });
+          } catch {
+            // The retained outbox remains the recovery source if the tracker
+            // is down.
+          }
+        }
+      } catch (err) {
+        recordTerminalError("drainLocalNotifyOutbox", err);
       }
     }
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -93,6 +93,7 @@ import {
   defaultProjectTierEscalation,
   defaultReturnHandoffTicket,
   defaultUnclaimTicket,
+  drainLocalNotifyOutbox,
   dispatchLockPath,
   DYNAMIC_DEADLINE_ADAPTERS,
   executeClaimed,
@@ -155,6 +156,85 @@ registerTestProcessCleanup(import.meta.url);
 let seq = 0;
 
 describe("worker", () => {
+  test("drains an agent local notification outbox with the worker bearer", async () => {
+    const home = tmpDir("evrt-local-notify-outbox-");
+    const runId = "run_1558";
+    const outbox = path.join(home, "outbox", `${runId}.jsonl`);
+    mkdirSync(path.dirname(outbox), { recursive: true });
+    writeFileSync(
+      outbox,
+      `${JSON.stringify({
+        schemaVersion: "factory.local-notify-outbox/v1",
+        runId,
+        kind: "BLOCKED",
+        title: "BLOCKED watt-mind/factory#1558: token unavailable",
+        refs: { issue: "watt-mind/factory#1558", repo: "factory" },
+        source: `agent:${runId}`,
+      })}\n`,
+    );
+    const calls = [];
+    const result = await drainLocalNotifyOutbox({
+      home,
+      runId,
+      port: "7499",
+      token: "worker-only-token",
+      fetchFn: async (url, init) => {
+        calls.push({ url, init });
+        return new Response("{}", { status: 201 });
+      },
+    });
+
+    expect(result).toEqual({
+      delivered: [
+        expect.objectContaining({
+          title: "BLOCKED watt-mind/factory#1558: token unavailable",
+        }),
+      ],
+      undelivered: [],
+    });
+    expect(calls).toHaveLength(1);
+    expect(calls[0].init.headers.authorization).toBe(
+      "Bearer worker-only-token",
+    );
+    expect(existsSync(outbox)).toBe(false);
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("retains an undelivered local notification for handoff recovery", async () => {
+    const home = tmpDir("evrt-local-notify-retained-");
+    const runId = "run_1558_retained";
+    const outbox = path.join(home, "outbox", `${runId}.jsonl`);
+    mkdirSync(path.dirname(outbox), { recursive: true });
+    writeFileSync(
+      outbox,
+      `${JSON.stringify({
+        schemaVersion: "factory.local-notify-outbox/v1",
+        runId,
+        kind: "ESCALATED",
+        title: "ESCALATED watt-mind/factory#1558: worker delivery failed",
+        refs: { issue: "watt-mind/factory#1558", repo: "factory" },
+        source: `agent:${runId}`,
+      })}\n`,
+    );
+    const result = await drainLocalNotifyOutbox({
+      home,
+      runId,
+      fetchFn: async () => {
+        throw new Error("runtime unavailable");
+      },
+    });
+
+    expect(result.delivered).toEqual([]);
+    expect(result.undelivered).toEqual([
+      {
+        title: "ESCALATED watt-mind/factory#1558: worker delivery failed",
+        error: "runtime unavailable",
+      },
+    ]);
+    expect(readFileSync(outbox, "utf8")).toContain("worker delivery failed");
+    rmSync(home, { recursive: true, force: true });
+  });
+
   test("canonical authorisation hash is verified before dispatch execution", () => {
     const description =
       "## Owned Paths\n- event-runtime/lib/worker.mjs\n- docs/event-runtime-inbox.md\n";
@@ -5400,7 +5480,12 @@ sh -c 'sleep 5 & wait'
   });
 
   test("dispatchIdentityEnv omits unset identity keys and gates on the dispatch@ prefix (#1497)", () => {
-    const env = { PATH: "/bin" };
+    const env = {
+      PATH: "/bin",
+      FACTORY_CONTROL_API_TOKEN: "worker-only-token",
+      FACTORY_EVENT_HOME: "/tmp/factory-events",
+      FACTORY_EVENT_PORT: "7381",
+    };
     const full = dispatchIdentityEnv({
       spec: { agent: "dispatch@2" },
       env,
@@ -5410,10 +5495,14 @@ sh -c 'sleep 5 & wait'
     });
     expect(full).toEqual({
       PATH: "/bin",
+      FACTORY_EVENT_HOME: "/tmp/factory-events",
+      FACTORY_EVENT_PORT: "7381",
+      FACTORY_DISPATCH: "1",
       FACTORY_RUN_ID: "run-1",
       FACTORY_TICKET: "1497",
       FACTORY_REPO: "factory",
     });
+    expect(full.FACTORY_CONTROL_API_TOKEN).toBeUndefined();
 
     const partial = dispatchIdentityEnv({
       spec: { agent: "dispatch@1" },
@@ -5422,7 +5511,14 @@ sh -c 'sleep 5 & wait'
       ticketId: null,
       repoName: undefined,
     });
-    expect(partial).toEqual({ PATH: "/bin", FACTORY_RUN_ID: "run-2" });
+    expect(partial).toEqual({
+      PATH: "/bin",
+      FACTORY_EVENT_HOME: "/tmp/factory-events",
+      FACTORY_EVENT_PORT: "7381",
+      FACTORY_DISPATCH: "1",
+      FACTORY_RUN_ID: "run-2",
+    });
+    expect(partial.FACTORY_CONTROL_API_TOKEN).toBeUndefined();
     expect("FACTORY_TICKET" in partial).toBe(false);
     expect("FACTORY_REPO" in partial).toBe(false);
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -200,6 +200,42 @@ describe("worker", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
+  test("drains the local notify outbox from the adapter finally so a throw cannot strand an escalation", () => {
+    // The drain used to sit after the adapter try/finally: an adapter that
+    // threw skipped it, and the retained escalation was never delivered and
+    // never reported on the ticket. Ordering is still load-bearing — the
+    // drain has to run after the adapter has fully stopped writing — so the
+    // call must live inside that `finally`, not before it and not after the
+    // block.
+    const source = readFileSync(
+      new URL("./worker.mjs", import.meta.url),
+      "utf8",
+    );
+    const marker =
+      "    } finally {\n      stopDeadlineMonitor();\n      stopCancellationMonitor();\n";
+    const start = source.indexOf(marker);
+    expect(start).toBeGreaterThan(-1);
+    const open = source.indexOf("{", start);
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < source.length; i += 1) {
+      if (source[i] === "{") depth += 1;
+      else if (source[i] === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    expect(end).toBeGreaterThan(open);
+    const finallyBody = source.slice(open, end);
+    expect(finallyBody).toContain("await drainLocalNotifyOutbox({");
+    expect(finallyBody).toContain("commentTicketFn({");
+    // Exactly one drain call site, and it is the one inside the finally.
+    expect(source.split("await drainLocalNotifyOutbox({")).toHaveLength(2);
+  });
+
   test("retains an undelivered local notification for handoff recovery", async () => {
     const home = tmpDir("evrt-local-notify-retained-");
     const runId = "run_1558_retained";

--- a/lib/notify.mjs
+++ b/lib/notify.mjs
@@ -16,7 +16,7 @@
  *   bun lib/notify.mjs --script   # python script path, if the command is python3 <path>
  *   bun lib/notify.mjs --export-env  # shell exports for FACTORY_NOTIFY_{CMD,SCRIPT}
  */
-import { existsSync, readFileSync } from "node:fs";
+import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { factoryRoot } from "./factory-root.mjs";
@@ -95,6 +95,52 @@ export function notifyScript(options) {
   return argv ? pythonScriptPath(argv) : null;
 }
 
+const LOCAL_OUTBOX_SCHEMA = "factory.local-notify-outbox/v1";
+
+/**
+ * The agent never receives the worker's control bearer. When it cannot create
+ * a durable inbox record, it writes here for the worker to submit after the
+ * agent exits. Keep the run id path-safe: this is an agent-controlled value.
+ */
+export function localNotifyOutboxPath({ home, runId }) {
+  if (typeof home !== "string" || home.trim() === "")
+    throw new Error("FACTORY_EVENT_HOME is required for local notify outbox");
+  if (typeof runId !== "string" || !/^[A-Za-z0-9._-]+$/.test(runId))
+    throw new Error("FACTORY_RUN_ID is invalid for local notify outbox");
+  return path.join(home, "outbox", `${runId}.jsonl`);
+}
+
+export function queueLocalNotification({
+  home = process.env.FACTORY_EVENT_HOME,
+  runId = process.env.FACTORY_RUN_ID,
+  kind,
+  title,
+  refs = {},
+  source = `agent:${runId}`,
+}) {
+  if (typeof kind !== "string" || kind.trim() === "")
+    throw new Error("local notify outbox requires kind");
+  if (typeof title !== "string" || title.trim() === "")
+    throw new Error("local notify outbox requires title");
+  if (!refs || typeof refs !== "object" || Array.isArray(refs))
+    throw new Error("local notify outbox refs must be an object");
+  const outboxPath = localNotifyOutboxPath({ home, runId });
+  mkdirSync(path.dirname(outboxPath), { recursive: true, mode: 0o700 });
+  appendFileSync(
+    outboxPath,
+    `${JSON.stringify({
+      schemaVersion: LOCAL_OUTBOX_SCHEMA,
+      runId,
+      kind: kind.trim(),
+      title,
+      refs,
+      source,
+    })}\n`,
+    { encoding: "utf8", mode: 0o600 },
+  );
+  return outboxPath;
+}
+
 function exportEnv(options) {
   const command = notifyCommand(options);
   if (!command) return "";
@@ -106,7 +152,25 @@ function exportEnv(options) {
 
 if (import.meta.main) {
   const flag = process.argv[2];
-  if (flag === "--export-env") {
+  if (flag === "--queue-local") {
+    const message = process.env.FACTORY_INBOX_MESSAGE;
+    const kind = process.env.FACTORY_INBOX_KIND;
+    if (!message || !kind) {
+      console.error(
+        "notify: local outbox requires FACTORY_INBOX_KIND and FACTORY_INBOX_MESSAGE",
+      );
+      process.exit(2);
+    }
+    const prefix = message
+      .slice(kind.length)
+      .trimStart()
+      .split(":", 1)[0]
+      .trim();
+    const { parseNotifyRefs } = await import("./notify-refs.mjs");
+    process.stdout.write(
+      `${queueLocalNotification({ kind, title: message, refs: parseNotifyRefs(prefix) })}\n`,
+    );
+  } else if (flag === "--export-env") {
     process.stdout.write(exportEnv());
   } else if (flag === "--script") {
     const script = notifyScript();

--- a/lib/notify.test.mjs
+++ b/lib/notify.test.mjs
@@ -1,5 +1,11 @@
 import { test, expect } from "bun:test";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import {
@@ -7,6 +13,7 @@ import {
   notifyArgv,
   notifyCommand,
   notifyScript,
+  queueLocalNotification,
 } from "./notify.mjs";
 
 function tmpRoot(policy) {
@@ -27,6 +34,26 @@ test("expandHome resolves a leading tilde", () => {
   );
   expect(expandHome("~", "/home/op")).toBe("/home/op");
   expect(expandHome("/abs/n.py", "/home/op")).toBe("/abs/n.py");
+});
+
+test("missing control bearer queues a run-scoped local notification", () => {
+  const home = mkdtempSync(path.join(tmpdir(), "factory-notify-outbox-"));
+  try {
+    const outbox = queueLocalNotification({
+      home,
+      runId: "run_1558",
+      kind: "BLOCKED",
+      title: "BLOCKED watt-mind/factory#1558: control API unavailable",
+      refs: { issue: "watt-mind/factory#1558", repo: "factory" },
+    });
+    expect(outbox).toBe(path.join(home, "outbox", "run_1558.jsonl"));
+    expect(readFileSync(outbox, "utf8")).toContain(
+      '"schemaVersion":"factory.local-notify-outbox/v1"',
+    );
+    expect(readFileSync(outbox, "utf8")).toContain('"source":"agent:run_1558"');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
 });
 
 test("no env and no policy yields null, never a private-repo default", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1558

## Summary
- retain dispatch notifications in a run-scoped local outbox when no control bearer can create an inbox record
- strip the worker bearer from dispatch agent environments and drain retained records with worker authority after agent exit
- document the fallback and cover delivery, retention, and bearer isolation

## Verification
- `FACTORY_EVENT_HOME=$(mktemp -d) bun test lib/notify.test.mjs event-runtime/lib/worker.test.mjs`
- `bun test bin/factory.test.mjs`
- `bun test event-runtime/lib --timeout 20000`
- `bun run lint` (passes with existing repository warnings)
- `bun run emit`
- `bun run format:check`

run:run_81bc0ca7-854d-4a22-9913-656abb3b2541