### PR TITLE
fix(event-runtime): match /promotion/ routes by prefix

### DIFF
--- a/event-runtime/lib/api-registry.test.mjs
+++ b/event-runtime/lib/api-registry.test.mjs
@@ -804,6 +804,24 @@ describe("overlay promotion routes (gh-860)", () => {
     }
   });
 
+  test("API dispatcher sends nested promotion paths to the registry handler", async () => {
+    const seen = [];
+    const { server, request, close } = await makeServer({
+      registryApi: ({ url, send }) => {
+        seen.push(url.pathname);
+        return send(204);
+      },
+    });
+    try {
+      const response = await request("/promotion/preview/extra");
+      expect(response.status).toBe(204);
+      expect(seen).toEqual(["/promotion/preview/extra"]);
+    } finally {
+      close();
+      server.close();
+    }
+  });
+
   test("POST /promotion/apply drives injected seams and returns the PR", async () => {
     const db = openDb(":memory:");
     seed(db);

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -158,6 +158,8 @@ export function createApi({
   buildArtifactInventory = artifactInventory,
   getTickStats = null,
   getLinearBudget = loadLinearBudget,
+  // Injectable so dispatcher tests can prove a route group receives a path.
+  registryApi = handleRegistryApiRoute,
 } = {}) {
   const actor = "operator";
   const staticRegistryLoadedAt = new Date(now()).toISOString();
@@ -482,12 +484,11 @@ export function createApi({
         url.pathname === "/agents" ||
         url.pathname === "/overrides" ||
         url.pathname.startsWith("/overrides/") ||
-        url.pathname === "/promotion/preview" ||
-        url.pathname === "/promotion/apply" ||
+        url.pathname.startsWith("/promotion/") ||
         url.pathname === "/repos" ||
         url.pathname.startsWith("/repos/")
       ) {
-        const result = await handleRegistryApiRoute({ ...common, janitor });
+        const result = await registryApi({ ...common, janitor });
         if (result !== false) return result;
       }
       if (


### PR DESCRIPTION
Fixes watt-mind/factory#1960

Nested promotion URLs now reach the registry dispatcher.

## Validation

| Check                | Command                                                                          | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-registry.test.mjs && bun run lint` | pass    | API tests and lint clean      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2298 pass, 0 failures         |
| UX critique          | `factory-ux-critic`                                                            | not run | no user-facing surface        |

UX critique: skipped — no user-facing surface

run:run_067d32da-bbb3-4056-b837-1641b8692f14