### PR TITLE
fix(doctor): preserve base branch CI diagnostics

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -58,9 +58,9 @@ import { readWorkflowRuns } from "./ci.mjs";
 export const MIN_BUN_VERSION = "1.1.0";
 export const MIN_GIT_VERSION = "2.40.0";
 export const BASE_BRANCH_CI_TIMEOUT_MS = 10_000;
-// All base-branch Actions reads share this 10s ceiling, regardless of repo
-// count, so an unavailable GitHub Actions API cannot delay node-local checks.
-export const BASE_BRANCH_CI_AGGREGATE_TIMEOUT_MS = 10_000;
+// Each repository gets at most 10s, while the wider aggregate ceiling lets a
+// slow read fail in isolation instead of starving every repository after it.
+export const BASE_BRANCH_CI_AGGREGATE_TIMEOUT_MS = 60_000;
 export const BASE_BRANCH_CI_RUN_LIMIT = 20;
 
 const defaultWorkflowRunList = (repo, options) =>

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -165,7 +165,58 @@ describe("base branch CI diagnostics (#1928)", () => {
         detail: expect.stringContaining("aggregate GitHub Actions deadline"),
       }),
     ]);
-    expect(BASE_BRANCH_CI_AGGREGATE_TIMEOUT_MS).toBe(BASE_BRANCH_CI_TIMEOUT_MS);
+  });
+
+  test("gives a later repository a CI signal after a slow earlier read", () => {
+    const laterRepo = {
+      name: "later",
+      github: "watt-mind/later",
+      base: "main",
+    };
+    let elapsedMs = 0;
+    const calls = [];
+    const rows = baseBranchCiDiagnostics({
+      repos: [repo, laterRepo],
+      deadlineMs: BASE_BRANCH_CI_AGGREGATE_TIMEOUT_MS,
+      now: () => elapsedMs,
+      runList: (name, options) => {
+        calls.push({ name, options });
+        if (name === repo.github) {
+          elapsedMs += BASE_BRANCH_CI_TIMEOUT_MS;
+          return [];
+        }
+        return [
+          {
+            status: "completed",
+            conclusion: "success",
+            workflowName: "CI",
+            databaseId: 42,
+          },
+        ];
+      },
+    });
+
+    expect(calls).toEqual([
+      expect.objectContaining({ name: repo.github }),
+      expect.objectContaining({
+        name: laterRepo.github,
+        options: expect.objectContaining({
+          timeout: BASE_BRANCH_CI_TIMEOUT_MS,
+        }),
+      }),
+    ]);
+    expect(rows[1]).toEqual(
+      expect.objectContaining({
+        ok: true,
+        detail: expect.stringContaining("CI succeeded"),
+      }),
+    );
+  });
+
+  test("keeps the aggregate budget above the per-repository cap", () => {
+    expect(BASE_BRANCH_CI_AGGREGATE_TIMEOUT_MS).toBeGreaterThan(
+      BASE_BRANCH_CI_TIMEOUT_MS,
+    );
   });
 
   test("skips without failing when Actions has no completed history", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1961

Extends the aggregate CI diagnostics budget so slow repositories do not hide later signals.

## Validation

| Check                | Command                                                                                                             | Result  | Notes                        |
| -------------------- | ------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------- |
| Verification Command | `bun test orchestrator/doctor.test.mjs && bun run lint`                                                            | pass    | 55 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2297 pass, 10 skipped        |
| UX critique          | `factory-ux-critic`                                                                                                 | not run | no user-facing surface       |

UX critique: skipped

run:run_bc043f1a-4b88-45a8-8c3e-c2740e9c000d
