### PR TITLE
fix: sweep orphaned local notify outboxes

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1070,6 +1070,64 @@ export function dispatchIdentityEnv({
 }
 
 const LOCAL_NOTIFY_OUTBOX_SCHEMA = "factory.local-notify-outbox/v1";
+const LOCAL_NOTIFY_ACTIVE_RUN_STATES = Object.freeze([
+  "QUEUED",
+  "LEASED",
+  "RUNNING",
+  "VERIFYING",
+]);
+
+function localNotifyPort(port) {
+  const value = typeof port === "string" ? port.trim() : String(port);
+  if (!/^[1-9]\d*$/.test(value)) return null;
+  const numeric = Number(value);
+  return Number.isSafeInteger(numeric) && numeric <= 65_535 ? numeric : null;
+}
+
+/**
+ * Remove retained local notification files for runs that can no longer be
+ * executed. This is deliberately separate from the per-run drain in
+ * executeClaimed's finally block: a crashed or unclaimed run never reaches
+ * that block. Queued runs remain protected because a retry can still drain
+ * their prior attempt's retained escalation.
+ */
+export function sweepOrphanedLocalNotifyOutbox({
+  db,
+  home = process.env.FACTORY_EVENT_HOME,
+} = {}) {
+  if (!db || typeof home !== "string" || home.trim() === "") return [];
+  const outboxDir = path.join(home, "outbox");
+  if (!existsSync(outboxDir)) return [];
+
+  let entries;
+  try {
+    entries = readdirSync(outboxDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const activeRunIds = new Set(
+    db
+      .query(
+        `SELECT run_id FROM runs WHERE state IN (${LOCAL_NOTIFY_ACTIVE_RUN_STATES.map(() => "?").join(", ")})`,
+      )
+      .all(...LOCAL_NOTIFY_ACTIVE_RUN_STATES)
+      .map(({ run_id: runId }) => runId),
+  );
+  const swept = [];
+  for (const entry of entries) {
+    const match = /^([A-Za-z0-9._-]+)\.jsonl$/.exec(entry.name);
+    if (!match || activeRunIds.has(match[1])) continue;
+    try {
+      unlinkSync(path.join(outboxDir, entry.name));
+      swept.push(match[1]);
+    } catch {
+      // A concurrent writer or permissions change must not stop a worker from
+      // claiming the next run; the next startup will retry this hygiene pass.
+    }
+  }
+  return swept;
+}
 
 function localOutboxEntry(value, runId) {
   if (
@@ -1112,6 +1170,16 @@ export async function drainLocalNotifyOutbox({
   }
   if (!existsSync(outboxPath)) return { delivered: [], undelivered: [] };
 
+  const validatedPort = localNotifyPort(port);
+  if (validatedPort === null) {
+    return {
+      delivered: [],
+      undelivered: [],
+      error:
+        "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535",
+    };
+  }
+
   const lines = readFileSync(outboxPath, "utf8").split("\n").filter(Boolean);
   const retained = [];
   const delivered = [];
@@ -1132,19 +1200,22 @@ export async function drainLocalNotifyOutbox({
       continue;
     }
     try {
-      const response = await fetchFn(`http://127.0.0.1:${port}/inbox`, {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-          ...(token ? { authorization: `Bearer ${token}` } : {}),
+      const response = await fetchFn(
+        `http://127.0.0.1:${validatedPort}/inbox`,
+        {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...(token ? { authorization: `Bearer ${token}` } : {}),
+          },
+          body: JSON.stringify({
+            kind: entry.kind,
+            title: entry.title,
+            refs: entry.refs,
+            source: entry.source,
+          }),
         },
-        body: JSON.stringify({
-          kind: entry.kind,
-          title: entry.title,
-          refs: entry.refs,
-          source: entry.source,
-        }),
-      });
+      );
       if (!response.ok) throw new Error(`HTTP ${response.status}`);
       delivered.push(entry);
     } catch (error) {
@@ -5837,6 +5908,10 @@ export function reapExpiredLeases(
 
 /** Claim and execute one run, or return a typed refusal/null without execution. */
 export async function runOnce(db, registry, adapters, opts = {}) {
+  sweepOrphanedLocalNotifyOutbox({
+    db,
+    home: opts.env?.FACTORY_EVENT_HOME ?? opts.eventHome,
+  });
   // claimNext already reconciles pending escalation projections and logs a
   // failed one without abandoning the claim: a tracker outage on one
   // escalation must never stall claiming of every other queued run. Forward

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1076,6 +1076,12 @@ const LOCAL_NOTIFY_ACTIVE_RUN_STATES = Object.freeze([
   "RUNNING",
   "VERIFYING",
 ]);
+/**
+ * How long a retained outbox file must sit untouched before the sweep may
+ * delete it. Long enough that no live drain can lose its recovery source,
+ * short enough that a crashed worker's leftovers do not accumulate.
+ */
+const LOCAL_NOTIFY_OUTBOX_GRACE_MS = 60 * 60 * 1000;
 
 function localNotifyPort(port) {
   const value = typeof port === "string" ? port.trim() : String(port);
@@ -1090,10 +1096,19 @@ function localNotifyPort(port) {
  * executeClaimed's finally block: a crashed or unclaimed run never reaches
  * that block. Queued runs remain protected because a retry can still drain
  * their prior attempt's retained escalation.
+ *
+ * Active-state protection alone is not enough. A file is written by the agent
+ * before the run reaches any of those states in this worker's view (and a
+ * concurrent worker's run is invisible to a different event home's snapshot),
+ * so a run-state check on its own would delete the very file the drain treats
+ * as its recovery source. A file must therefore also be older than
+ * LOCAL_NOTIFY_OUTBOX_GRACE_MS before it is eligible.
  */
 export function sweepOrphanedLocalNotifyOutbox({
   db,
   home = process.env.FACTORY_EVENT_HOME,
+  now = Date.now(),
+  graceMs = LOCAL_NOTIFY_OUTBOX_GRACE_MS,
 } = {}) {
   if (!db || typeof home !== "string" || home.trim() === "") return [];
   const outboxDir = path.join(home, "outbox");
@@ -1118,8 +1133,16 @@ export function sweepOrphanedLocalNotifyOutbox({
   for (const entry of entries) {
     const match = /^([A-Za-z0-9._-]+)\.jsonl$/.exec(entry.name);
     if (!match || activeRunIds.has(match[1])) continue;
+    const filePath = path.join(outboxDir, entry.name);
+    let mtimeMs;
     try {
-      unlinkSync(path.join(outboxDir, entry.name));
+      mtimeMs = statSync(filePath).mtimeMs;
+    } catch {
+      continue;
+    }
+    if (!(now - mtimeMs >= graceMs)) continue;
+    try {
+      unlinkSync(filePath);
       swept.push(match[1]);
     } catch {
       // A concurrent writer or permissions change must not stop a worker from
@@ -1170,17 +1193,35 @@ export async function drainLocalNotifyOutbox({
   }
   if (!existsSync(outboxPath)) return { delivered: [], undelivered: [] };
 
+  const lines = readFileSync(outboxPath, "utf8").split("\n").filter(Boolean);
+
   const validatedPort = localNotifyPort(port);
   if (validatedPort === null) {
+    // Report one undelivered entry per retained line rather than a bare
+    // `error` field: the caller only reads `undelivered`, and a misconfigured
+    // port must surface as the same ticket comment as any other delivery
+    // failure instead of failing silently. The file stays put as the
+    // recovery source.
+    const error =
+      "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535";
     return {
       delivered: [],
-      undelivered: [],
-      error:
-        "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535",
+      undelivered: lines.map((line) => {
+        let entry;
+        try {
+          entry = localOutboxEntry(JSON.parse(line), runId);
+        } catch {
+          entry = null;
+        }
+        return {
+          title: entry ? entry.title : "invalid local notification record",
+          error,
+        };
+      }),
+      error,
     };
   }
 
-  const lines = readFileSync(outboxPath, "utf8").split("\n").filter(Boolean);
   const retained = [];
   const delivered = [];
   const undelivered = [];

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -119,6 +119,7 @@ import {
   resolveLinearApiKey,
   reconcileTierEscalations,
   scheduleTierEscalation,
+  sweepOrphanedLocalNotifyOutbox,
   tierEscalationEligibility,
   retryRun,
   runLinearCli,
@@ -156,6 +157,28 @@ registerTestProcessCleanup(import.meta.url);
 let seq = 0;
 
 describe("worker", () => {
+  test("sweeps orphaned local notify outboxes while preserving active runs", () => {
+    const home = tmpDir("evrt-local-notify-sweep-");
+    const outboxDir = path.join(home, "outbox");
+    const db = openDb(":memory:");
+    const active = queueRun(db, makeSpec({ runId: "run_active_outbox" }));
+    claimNext(db, opts());
+    mkdirSync(outboxDir, { recursive: true });
+    writeFileSync(path.join(outboxDir, `${active.runId}.jsonl`), "active\n");
+    writeFileSync(path.join(outboxDir, "run_orphan_outbox.jsonl"), "orphan\n");
+
+    expect(sweepOrphanedLocalNotifyOutbox({ db, home })).toEqual([
+      "run_orphan_outbox",
+    ]);
+    expect(existsSync(path.join(outboxDir, `${active.runId}.jsonl`))).toBe(
+      true,
+    );
+    expect(existsSync(path.join(outboxDir, "run_orphan_outbox.jsonl"))).toBe(
+      false,
+    );
+    rmSync(home, { recursive: true, force: true });
+  });
+
   test("drains an agent local notification outbox with the worker bearer", async () => {
     const home = tmpDir("evrt-local-notify-outbox-");
     const runId = "run_1558";
@@ -198,6 +221,40 @@ describe("worker", () => {
     );
     expect(existsSync(outbox)).toBe(false);
     rmSync(home, { recursive: true, force: true });
+  });
+
+  test("retains an outbox entry with an attributable error for an invalid port", async () => {
+    const home = tmpDir("evrt-local-notify-invalid-port-");
+    const runId = "run_invalid_port";
+    const outbox = path.join(home, "outbox", `${runId}.jsonl`);
+    mkdirSync(path.dirname(outbox), { recursive: true });
+    writeFileSync(
+      outbox,
+      `${JSON.stringify({
+        schemaVersion: "factory.local-notify-outbox/v1",
+        runId,
+        kind: "BLOCKED",
+        title: "BLOCKED watt-mind/factory#1964: invalid port",
+        refs: {},
+        source: `agent:${runId}`,
+      })}\n`,
+    );
+    const fetchFn = spyOn(globalThis, "fetch");
+    try {
+      expect(
+        await drainLocalNotifyOutbox({ home, runId, port: "not-a-port" }),
+      ).toEqual({
+        delivered: [],
+        undelivered: [],
+        error:
+          "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535",
+      });
+      expect(fetchFn).not.toHaveBeenCalled();
+      expect(existsSync(outbox)).toBe(true);
+    } finally {
+      fetchFn.mockRestore();
+      rmSync(home, { recursive: true, force: true });
+    }
   });
 
   test("drains the local notify outbox from the adapter finally so a throw cannot strand an escalation", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -167,15 +167,47 @@ describe("worker", () => {
     writeFileSync(path.join(outboxDir, `${active.runId}.jsonl`), "active\n");
     writeFileSync(path.join(outboxDir, "run_orphan_outbox.jsonl"), "orphan\n");
 
-    expect(sweepOrphanedLocalNotifyOutbox({ db, home })).toEqual([
-      "run_orphan_outbox",
-    ]);
+    // Past the grace window: the inactive run's file is eligible, the active
+    // run's file is still protected by its state.
+    expect(
+      sweepOrphanedLocalNotifyOutbox({
+        db,
+        home,
+        now: Date.now() + 2 * 60 * 60 * 1000,
+      }),
+    ).toEqual(["run_orphan_outbox"]);
     expect(existsSync(path.join(outboxDir, `${active.runId}.jsonl`))).toBe(
       true,
     );
     expect(existsSync(path.join(outboxDir, "run_orphan_outbox.jsonl"))).toBe(
       false,
     );
+    rmSync(home, { recursive: true, force: true });
+  });
+
+  test("leaves an outbox file inside the mtime grace window alone", () => {
+    // Without an age grace the sweep deletes the very file a live drain
+    // retains as its recovery source: the agent writes the outbox before the
+    // worker's run is visible in any active state to this sweep's snapshot.
+    const home = tmpDir("evrt-local-notify-grace-");
+    const outboxDir = path.join(home, "outbox");
+    const db = openDb(":memory:");
+    mkdirSync(outboxDir, { recursive: true });
+    const fresh = path.join(outboxDir, "run_fresh_outbox.jsonl");
+    writeFileSync(fresh, "fresh\n");
+
+    expect(sweepOrphanedLocalNotifyOutbox({ db, home })).toEqual([]);
+    expect(existsSync(fresh)).toBe(true);
+
+    // Only once the file has aged past the window does it become eligible.
+    expect(
+      sweepOrphanedLocalNotifyOutbox({
+        db,
+        home,
+        now: Date.now() + 61 * 60 * 1000,
+      }),
+    ).toEqual(["run_fresh_outbox"]);
+    expect(existsSync(fresh)).toBe(false);
     rmSync(home, { recursive: true, force: true });
   });
 
@@ -223,33 +255,51 @@ describe("worker", () => {
     rmSync(home, { recursive: true, force: true });
   });
 
-  test("retains an outbox entry with an attributable error for an invalid port", async () => {
+  test("reports one undelivered entry per line for an invalid port", async () => {
+    // The caller only reads `undelivered`; an `error` field alone made a
+    // misconfigured port invisible and the retained lines were then swept.
     const home = tmpDir("evrt-local-notify-invalid-port-");
     const runId = "run_invalid_port";
     const outbox = path.join(home, "outbox", `${runId}.jsonl`);
     mkdirSync(path.dirname(outbox), { recursive: true });
-    writeFileSync(
-      outbox,
-      `${JSON.stringify({
+    const line = (title) =>
+      JSON.stringify({
         schemaVersion: "factory.local-notify-outbox/v1",
         runId,
         kind: "BLOCKED",
-        title: "BLOCKED watt-mind/factory#1964: invalid port",
+        title,
         refs: {},
         source: `agent:${runId}`,
-      })}\n`,
+      });
+    writeFileSync(
+      outbox,
+      `${line("BLOCKED watt-mind/factory#1964: invalid port")}\n${line(
+        "BLOCKED watt-mind/factory#1964: second escalation",
+      )}\nnot-json\n`,
     );
+    const expectedError =
+      "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535";
     const fetchFn = spyOn(globalThis, "fetch");
     try {
-      expect(
-        await drainLocalNotifyOutbox({ home, runId, port: "not-a-port" }),
-      ).toEqual({
-        delivered: [],
-        undelivered: [],
-        error:
-          "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535",
+      const result = await drainLocalNotifyOutbox({
+        home,
+        runId,
+        port: "not-a-port",
       });
+      expect(result.delivered).toEqual([]);
+      expect(result.undelivered).toEqual([
+        {
+          title: "BLOCKED watt-mind/factory#1964: invalid port",
+          error: expectedError,
+        },
+        {
+          title: "BLOCKED watt-mind/factory#1964: second escalation",
+          error: expectedError,
+        },
+        { title: "invalid local notification record", error: expectedError },
+      ]);
       expect(fetchFn).not.toHaveBeenCalled();
+      // The outbox stays put as the recovery source.
       expect(existsSync(outbox)).toBe(true);
     } finally {
       fetchFn.mockRestore();

--- a/lib/notify.mjs
+++ b/lib/notify.mjs
@@ -15,6 +15,7 @@
  *   bun lib/notify.mjs            # print the resolved command (empty if none)
  *   bun lib/notify.mjs --script   # python script path, if the command is python3 <path>
  *   bun lib/notify.mjs --export-env  # shell exports for FACTORY_NOTIFY_{CMD,SCRIPT}
+ *   bun lib/notify.mjs --queue-local # append a notification to this run's local outbox
  */
 import { appendFileSync, existsSync, mkdirSync, readFileSync } from "node:fs";
 import { homedir } from "node:os";
@@ -177,7 +178,7 @@ if (import.meta.main) {
     if (script) process.stdout.write(script + "\n");
   } else if (flag && flag !== "--command") {
     console.error(
-      "usage: bun lib/notify.mjs [--command|--script|--export-env]",
+      "usage: bun lib/notify.mjs [--command|--script|--export-env|--queue-local]",
     );
     process.exit(2);
   } else {

--- a/lib/notify.test.mjs
+++ b/lib/notify.test.mjs
@@ -174,3 +174,13 @@ test("CLI --export-env prints shell exports for the resolved command", () => {
   expect(out).toContain('export FACTORY_NOTIFY_CMD="python3 /opt/notify.py"');
   expect(out).toContain('export FACTORY_NOTIFY_SCRIPT="/opt/notify.py"');
 });
+
+test("CLI usage lists --queue-local", () => {
+  const result = Bun.spawnSync({
+    cmd: ["bun", path.resolve(import.meta.dir, "notify.mjs"), "--bogus-flag"],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(2);
+  expect(result.stderr.toString()).toContain("--queue-local");
+});


### PR DESCRIPTION
Fixes watt-mind/factory#1964

Sweep stale local notification files and reject malformed inbox ports before delivery.

## Validation
| Check                | Command                                                                                                 | Result  | Notes                       |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `bun test lib/notify.test.mjs event-runtime/lib/worker.test.mjs && bun run lint`                       | pass    | 171 tests, 0 failures       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2299 pass, 0 failures |
| UX critique          | `factory-ux-critic`                                                                                    | not run | no user-facing surface       |

UX critique: skipped — no user-facing surface

run:run_1ec6240b-1bb7-4a57-84a6-90785eb286e4
