### PR TITLE
fix(doctor): make config loading import-safe

### DIFF
--- a/orchestrator/doctor.mjs
+++ b/orchestrator/doctor.mjs
@@ -940,59 +940,55 @@ export function stackDaemonDiagnostics({
   return diagnostics;
 }
 
-const ROOT = factoryRoot();
-installLinearBudgetCapture();
-const argv = process.argv.slice(2);
-const val = (f) => {
-  const i = argv.indexOf(f);
-  return i === -1 ? null : argv[i + 1];
-};
-const only = (val("--repo") || "")
-  .split(",")
-  .map((s) => s.trim())
-  .filter(Boolean);
-
-const expand = (p) => String(p ?? "").replace(/^~/, homedir());
-const cfg = Bun.YAML.parse(
-  readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
-);
-const repos = (cfg.repos ?? []).filter(
-  (r) => !only.length || only.includes(r.name),
-);
-
-// Commits behind origin/<base> before the main checkout is worth flagging.
-const BEHIND_WARN = 10;
-
-const c = {
-  dim: (s) => `\x1b[2m${s}\x1b[0m`,
-  bold: (s) => `\x1b[1m${s}\x1b[0m`,
-  green: (s) => `\x1b[32m${s}\x1b[0m`,
-  red: (s) => `\x1b[31m${s}\x1b[0m`,
-  yellow: (s) => `\x1b[33m${s}\x1b[0m`,
-};
-
-let failures = 0;
-const check = (ok, label, detail, fix) => {
-  if (ok === "warn" || ok === "info") {
-    console.log(
-      `  ${ok === "warn" ? c.yellow("!") : c.dim("-")} ${label}${detail ? c.dim("  " + detail) : ""}`,
-    );
-    if (fix) console.log(`      ${c.dim(fix)}`);
-    return;
-  }
-  console.log(
-    `  ${ok ? c.green("✓") : c.red("✗")} ${label}${detail ? c.dim("  " + detail) : ""}`,
-  );
-  if (!ok) {
-    failures++;
-    if (fix) console.log(`      ${c.bold("fix:")} ${fix}`);
-  }
-};
-
-const sh = (cmd, cwd) =>
-  spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
-
 if (import.meta.main) {
+  const ROOT = factoryRoot();
+  installLinearBudgetCapture();
+  const argv = process.argv.slice(2);
+  const val = (f) => {
+    const i = argv.indexOf(f);
+    return i === -1 ? null : argv[i + 1];
+  };
+  const only = (val("--repo") || "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  const expand = (p) => String(p ?? "").replace(/^~/, homedir());
+  const cfg = Bun.YAML.parse(
+    readFileSync(path.join(ROOT, "config/repos.yaml"), "utf8"),
+  );
+  const repos = (cfg.repos ?? []).filter(
+    (r) => !only.length || only.includes(r.name),
+  );
+
+  // Commits behind origin/<base> before the main checkout is worth flagging.
+  const BEHIND_WARN = 10;
+  const c = {
+    dim: (s) => `\x1b[2m${s}\x1b[0m`,
+    bold: (s) => `\x1b[1m${s}\x1b[0m`,
+    green: (s) => `\x1b[32m${s}\x1b[0m`,
+    red: (s) => `\x1b[31m${s}\x1b[0m`,
+    yellow: (s) => `\x1b[33m${s}\x1b[0m`,
+  };
+  let failures = 0;
+  const check = (ok, label, detail, fix) => {
+    if (ok === "warn" || ok === "info") {
+      console.log(
+        `  ${ok === "warn" ? c.yellow("!") : c.dim("-")} ${label}${detail ? c.dim("  " + detail) : ""}`,
+      );
+      if (fix) console.log(`      ${c.dim(fix)}`);
+      return;
+    }
+    console.log(
+      `  ${ok ? c.green("✓") : c.red("✗")} ${label}${detail ? c.dim("  " + detail) : ""}`,
+    );
+    if (!ok) {
+      failures++;
+      if (fix) console.log(`      ${c.bold("fix:")} ${fix}`);
+    }
+  };
+  const sh = (cmd, cwd) =>
+    spawnSync("/bin/bash", ["-lc", cmd], { cwd, encoding: "utf8" });
+
   // ------------------------------------------------------------------ machine ---
   console.log(c.bold("\nmachine"));
   const controlPlaneKind = controlPlaneKindFromPolicy(ROOT);

--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -61,6 +61,27 @@ const fakeChrome = (dir, body) => {
   return p;
 };
 
+test("imports exported helpers without materialized instance config", () => {
+  const root = scratch();
+  mkdirSync(path.join(root, "tools"), { recursive: true });
+  writeFileSync(path.join(root, "tools", "linear.mjs"), "");
+
+  const result = Bun.spawnSync({
+    cmd: [
+      process.execPath,
+      "--eval",
+      `import(${JSON.stringify(new URL("./doctor.mjs", import.meta.url).href)})`,
+    ],
+    cwd: root,
+    env: { ...process.env, FACTORY_ROOT: root },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(result.exitCode).toBe(0);
+  expect(new TextDecoder().decode(result.stderr)).toBe("");
+});
+
 describe("base branch CI diagnostics (#1928)", () => {
   const repo = {
     name: "factory",


### PR DESCRIPTION
Fixes watt-mind/factory#1975

Makes doctor helper imports work without deployed instance configuration.

## Validation

| Check                | Command                                                                                                          | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/doctor.test.mjs && bun run lint`                                                        | pass    | 56 tests; lint 0 errors       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; lint 0 errors          |
| UX critique          | factory-ux-critic                                                                                               | not run | no user-facing surface        |

UX critique: skipped

run:run_50927927-73ea-4800-b8b3-ed1ba6a3f329
