### PR TITLE
test(adapters): de-flake grandchild pidfile race

### DIFF
--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -950,6 +950,12 @@ describe("execute against a fake ACP agent", () => {
     },
   );
 
+  test("rejects an incomplete grandchild PID before process-group lookup", () => {
+    expect(() => trackProcessGroupForPid(0)).toThrow(
+      "invalid or incomplete test pid 0",
+    );
+  });
+
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
   testProcessGroup("timeout kills a long-lived grandchild", async () => {
     const workspaceDir = ws();
@@ -967,9 +973,12 @@ describe("execute against a fake ACP agent", () => {
     let pid = null;
     for (let i = 0; i < 200; i += 1) {
       if (existsSync(pidFile)) {
-        pid = Number(readFileSync(pidFile, "utf8"));
-        trackProcessGroupForPid(pid);
-        break;
+        const candidate = Number(readFileSync(pidFile, "utf8"));
+        if (Number.isInteger(candidate) && candidate > 0) {
+          pid = candidate;
+          trackProcessGroupForPid(pid);
+          break;
+        }
       }
       await new Promise((r) => setTimeout(r, 10));
     }

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -745,8 +745,10 @@ if (behavior === "emit_denial_then_recovery") {
     for (let attempt = 0; attempt < 500; attempt += 1) {
       if (existsSync(pidFile)) {
         const pid = Number(readFileSync(pidFile, "utf8"));
-        trackProcessGroupForPid(pid);
-        return pid;
+        if (Number.isInteger(pid) && pid > 0) {
+          trackProcessGroupForPid(pid);
+          return pid;
+        }
       }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }

--- a/event-runtime/lib/adapters/cursor.test.mjs
+++ b/event-runtime/lib/adapters/cursor.test.mjs
@@ -472,11 +472,18 @@ if (behavior === "emit_error_tool_result") {
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
 
   async function waitForGrandchildPid(pidFile) {
-    await until("stub grandchild PID file", () => existsSync(pidFile), {
-      timeoutMs: 15_000,
-      everyMs: 10,
-    });
-    const pid = Number(readFileSync(pidFile, "utf8"));
+    const pid = await until(
+      "stub grandchild PID file",
+      () => {
+        if (!existsSync(pidFile)) return null;
+        const candidate = Number(readFileSync(pidFile, "utf8"));
+        return Number.isInteger(candidate) && candidate > 0 ? candidate : null;
+      },
+      {
+        timeoutMs: 15_000,
+        everyMs: 10,
+      },
+    );
     trackProcessGroupForPid(pid);
     return pid;
   }

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -662,8 +662,10 @@ process.stdin.on("end", () => {
     for (let attempt = 0; attempt < 500; attempt += 1) {
       if (existsSync(pidFile)) {
         const pid = Number(readFileSync(pidFile, "utf8"));
-        trackProcessGroupForPid(pid);
-        return pid;
+        if (Number.isInteger(pid) && pid > 0) {
+          trackProcessGroupForPid(pid);
+          return pid;
+        }
       }
       await new Promise((resolve) => setTimeout(resolve, 10));
     }

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -106,6 +106,12 @@ export function trackProcessGroupForPid(pid, options = {}) {
       `cannot track process group for invalid or incomplete test pid ${pid}`,
     );
   }
+  // In a PID namespace `ps` can fail to resolve the runner during module
+  // initialization. Refuse the runner by PID as well as by its resolved PGID
+  // so cleanup can never register (and later signal) its own process group.
+  if (Number(pid) === process.pid) {
+    throw new Error("refusing to track the test runner process group");
+  }
   if (process.platform === "win32")
     return trackProcess(pid, { ...options, group: false });
   const pgid = processGroupForPid(pid);

--- a/event-runtime/lib/test-helpers-process.mjs
+++ b/event-runtime/lib/test-helpers-process.mjs
@@ -101,6 +101,11 @@ export function trackProcess(
 
 /** Find and register the detached process group containing pid. */
 export function trackProcessGroupForPid(pid, options = {}) {
+  if (!Number.isInteger(Number(pid)) || Number(pid) <= 0) {
+    throw new Error(
+      `cannot track process group for invalid or incomplete test pid ${pid}`,
+    );
+  }
   if (process.platform === "win32")
     return trackProcess(pid, { ...options, group: false });
   const pgid = processGroupForPid(pid);


### PR DESCRIPTION
Fixes watt-mind/factory#1971

Review the positive-PID retry and namespace-safe runner guard.

## Validation

| Check                | Command | Result | Notes |
| -------------------- | ------- | ------ | ----- |
| Verification Command | `bun test event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/cursor.test.mjs event-runtime/lib/adapters/pi.test.mjs event-runtime/lib/adapters/acp.test.mjs event-runtime/cli/process-cleanup.test.mjs evals/lib/grader.test.mjs --timeout 20000 && bun run lint` | pass | 173 pass, 3 skip; lint 0 errors |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | tests, emit, format, lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped

run:run_0cca3e18-a6a2-442f-8b92-bf8e4f1a45a7
