### PR TITLE
test(workspace): injectable worktree materializer seam

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3477,6 +3477,7 @@ export async function executeClaimed(
     policyRoot = FACTORY_ROOT,
     sandboxAvailability,
     materializeWorktree,
+    localNotifyFetch,
     verifyResult: verifyResultFn = verifyResult,
   } = {},
 ) {
@@ -4795,6 +4796,7 @@ export async function executeClaimed(
               home: workerEventHome,
               port: workerEventPort,
               token: workerControlToken,
+              fetchFn: localNotifyFetch,
             })
           : { delivered: [], undelivered: [] };
         if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3476,6 +3476,7 @@ export async function executeClaimed(
     resolveLinearKey = resolveLinearApiKey,
     policyRoot = FACTORY_ROOT,
     sandboxAvailability,
+    materializeWorktree,
     verifyResult: verifyResultFn = verifyResult,
   } = {},
 ) {
@@ -4540,6 +4541,7 @@ export async function executeClaimed(
         ticketLeaseOwner,
         workerLeasesDir: leasesDir,
         worktreeHandoff,
+        materializeWorktree,
       });
     } catch (err) {
       // Missing declared inputs are permanent: re-queuing cannot repopulate an

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -324,12 +324,10 @@ describe("worker", () => {
     const materializeCalls = [];
     const posted = [];
     const comments = [];
-    const fetchFn = spyOn(globalThis, "fetch").mockImplementation(
-      async (url, init) => {
-        posted.push({ url, init });
-        return new Response("{}", { status: posted.length === 1 ? 201 : 503 });
-      },
-    );
+    const localNotifyFetch = async (url, init) => {
+      posted.push({ url, init });
+      return new Response("{}", { status: posted.length === 1 ? 201 : 503 });
+    };
     const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
     const dispatch = {
       locksDir: tmpDir("evrt-local-notify-throw-locks-"),
@@ -387,6 +385,7 @@ describe("worker", () => {
             materializeCalls.push(args);
             return { injected: true };
           },
+          localNotifyFetch,
         }),
       );
 
@@ -411,7 +410,6 @@ describe("worker", () => {
         readFileSync(path.join(home, "outbox", `${runId}.jsonl`), "utf8"),
       ).toContain("BLOCKED watt-mind/factory#1973: retained notification");
     } finally {
-      fetchFn.mockRestore();
       rmSync(home, { recursive: true, force: true });
     }
   });

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -307,40 +307,113 @@ describe("worker", () => {
     }
   });
 
-  test("drains the local notify outbox from the adapter finally so a throw cannot strand an escalation", () => {
-    // The drain used to sit after the adapter try/finally: an adapter that
-    // threw skipped it, and the retained escalation was never delivered and
-    // never reported on the ticket. Ordering is still load-bearing — the
-    // drain has to run after the adapter has fully stopped writing — so the
-    // call must live inside that `finally`, not before it and not after the
-    // block.
-    const source = readFileSync(
-      new URL("./worker.mjs", import.meta.url),
-      "utf8",
+  test("drains a worktree adapter's local notifications and reports an undelivered one after the adapter throws", async () => {
+    const db = openDb(":memory:");
+    const home = tmpDir("evrt-local-notify-throw-");
+    const runId = "run_local_notify_adapter_throw";
+    const ticket = "watt-mind/factory#1973";
+    queueRun(
+      db,
+      makeSpec({
+        runId,
+        input: { repo: "factory", ticket },
+        workspace: { type: "worktree" },
+      }),
     );
-    const marker =
-      "    } finally {\n      stopDeadlineMonitor();\n      stopCancellationMonitor();\n";
-    const start = source.indexOf(marker);
-    expect(start).toBeGreaterThan(-1);
-    const open = source.indexOf("{", start);
-    let depth = 0;
-    let end = -1;
-    for (let i = open; i < source.length; i += 1) {
-      if (source[i] === "{") depth += 1;
-      else if (source[i] === "}") {
-        depth -= 1;
-        if (depth === 0) {
-          end = i;
-          break;
-        }
-      }
+    const claim = claimNext(db, opts());
+    const materializeCalls = [];
+    const posted = [];
+    const comments = [];
+    const fetchFn = spyOn(globalThis, "fetch").mockImplementation(
+      async (url, init) => {
+        posted.push({ url, init });
+        return new Response("{}", { status: posted.length === 1 ? 201 : 503 });
+      },
+    );
+    const description = "## Owned Paths\n- event-runtime/lib/worker.mjs\n";
+    const dispatch = {
+      locksDir: tmpDir("evrt-local-notify-throw-locks-"),
+      leasesDir: tmpDir("evrt-local-notify-throw-leases-"),
+      fetchTicket: () => ({
+        identifier: ticket,
+        state: { name: "Todo" },
+        assignee: null,
+        labels: { nodes: [{ name: "ai:agent-ready" }] },
+        description,
+      }),
+      fetchInFlight: () => [],
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      claimTicket: () => ({ ok: true }),
+      commentTicket: (args) => comments.push(args),
+    };
+    const throwingAdapter = {
+      async execute() {
+        const outbox = path.join(home, "outbox", `${runId}.jsonl`);
+        mkdirSync(path.dirname(outbox), { recursive: true });
+        writeFileSync(
+          outbox,
+          ["delivered notification", "retained notification"]
+            .map((title) =>
+              JSON.stringify({
+                schemaVersion: "factory.local-notify-outbox/v1",
+                runId,
+                kind: "BLOCKED",
+                title: `BLOCKED watt-mind/factory#1973: ${title}`,
+                refs: { issue: ticket, repo: "factory" },
+                source: `agent:${runId}`,
+              }),
+            )
+            .join("\n") + "\n",
+        );
+        throw new Error("adapter threw");
+      },
+    };
+
+    try {
+      const summary = await executeClaimed(
+        db,
+        registry,
+        { fake: throwingAdapter },
+        claim,
+        opts({
+          dispatch,
+          env: {
+            FACTORY_EVENT_HOME: home,
+            FACTORY_EVENT_PORT: "7499",
+            FACTORY_CONTROL_API_TOKEN: "worker-token",
+          },
+          materializeWorktree: (args) => {
+            materializeCalls.push(args);
+            return { injected: true };
+          },
+        }),
+      );
+
+      expect(summary).toMatchObject({ terminalState: "FAILED" });
+      expect(materializeCalls).toHaveLength(1);
+      expect(posted).toHaveLength(2);
+      expect(posted[0].url).toBe("http://127.0.0.1:7499/inbox");
+      expect(JSON.parse(posted[0].init.body)).toMatchObject({
+        title: "BLOCKED watt-mind/factory#1973: delivered notification",
+        refs: { issue: ticket, repo: "factory" },
+      });
+      expect(comments).toEqual([
+        expect.objectContaining({
+          repo: "factory",
+          ticket,
+          body: expect.stringContaining(
+            "BLOCKED watt-mind/factory#1973: retained notification",
+          ),
+        }),
+      ]);
+      expect(
+        readFileSync(path.join(home, "outbox", `${runId}.jsonl`), "utf8"),
+      ).toContain("BLOCKED watt-mind/factory#1973: retained notification");
+    } finally {
+      fetchFn.mockRestore();
+      rmSync(home, { recursive: true, force: true });
     }
-    expect(end).toBeGreaterThan(open);
-    const finallyBody = source.slice(open, end);
-    expect(finallyBody).toContain("await drainLocalNotifyOutbox({");
-    expect(finallyBody).toContain("commentTicketFn({");
-    // Exactly one drain call site, and it is the one inside the finally.
-    expect(source.split("await drainLocalNotifyOutbox({")).toHaveLength(2);
   });
 
   test("retains an undelivered local notification for handoff recovery", async () => {

--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -776,6 +776,7 @@ export function createWorkspace({
   adapter = null,
   ticketLeaseOwner = null,
   workerLeasesDir,
+  materializeWorktree: materializeWorktreeFn = materializeWorktree,
   worktreeOwnershipConflict = detectWorktreeOwnershipConflict,
   worktreePreservationComment = commentOnPreservedWorktree,
   worktreeHandoff = null,
@@ -838,7 +839,7 @@ export function createWorkspace({
   let worktree = null;
   if (workspace.type === "worktree") {
     try {
-      worktree = materializeWorktree({
+      worktree = materializeWorktreeFn({
         workspaceDir: dir,
         input,
         checkoutDir: workspace.checkoutDir ?? "repo",

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -446,6 +446,26 @@ describe("worktree workspaces (WM-108)", () => {
     expect(destroyWorkspace(dir)).toBe(true);
   });
 
+  test("uses an injected materializeWorktree seam when provided", () => {
+    const calls = [];
+    const created = make("wtrepo", "WM-seam", "run_wt_seam", {
+      materializeWorktree: (args) => {
+        calls.push(args);
+        return { injected: true };
+      },
+    });
+
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      input: { repo: "wtrepo", ticket: "WM-seam" },
+      checkoutDir: "repo",
+      runId: "run_wt_seam",
+      attempt: 1,
+    });
+    expect(created.worktree).toEqual({ injected: true });
+    expect(destroyWorkspace(created.dir)).toBe(true);
+  });
+
   test("a sandboxed definition is refused when the workspace carries a worktree marker", () => {
     const { dir } = make("wtrepo", "WM-1-SANDBOX", "run_wt1_sandbox");
     expect(() =>


### PR DESCRIPTION
Fixes watt-mind/factory#1973

Review the injected worktree and notification-fetch seams plus the behavioral adapter-failure coverage.

## Validation

| Check                | Command                                                                                                              | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/workspace.test.mjs event-runtime/lib/worker.test.mjs --timeout 20000 && bun run lint` | pass    | 187 tests, 0 failures; lint 0 errors   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2314 tests, 0 failures; checks clean   |
| UX critique          | factory-ux-critic                                                                                                    | not run | backend test seam; no user-facing flow |

UX critique: skipped

run:run_84b6f0f4-152d-4bb2-b4b7-3f3ae61c2b6c
