### PR TITLE
refactor(adapters): share ACP and Claude harness contract

### DIFF
--- a/event-runtime/lib/adapters/acp.mjs
+++ b/event-runtime/lib/adapters/acp.mjs
@@ -21,57 +21,33 @@ import path from "node:path";
 import { createInterface } from "node:readline";
 import { Readable } from "node:stream";
 import { transcriptMaxBytes } from "../config.mjs";
-import { PUSH_CREDENTIAL_ENV, safeChildEnvironment } from "./child-env.mjs";
+import {
+  HARNESS_LAYOUT,
+  KILL_GRACE_MS,
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV,
+  safeChildEnvironment,
+  verifiedPrompt,
+} from "./child-env.mjs";
 import { boundedTranscriptStream, killProcessGroup } from "./child-process.mjs";
 import { refuseSandbox } from "./sandboxed.mjs";
 
-export { PUSH_CREDENTIAL_ENV, killProcessGroup };
+export {
+  HARNESS_LAYOUT,
+  KILL_GRACE_MS,
+  PROMPT_SUFFIX,
+  PUSH_CREDENTIAL_ENV,
+  killProcessGroup,
+  verifiedPrompt,
+};
 
 /** ACP v1 major version. Agents that answer anything else are refused. */
 export const PROTOCOL_VERSION = 1;
-
-// Keep this leaf module independent of Claude's initialization order. Importing
-// Claude's equivalent creates a cycle through its registry dependency.
-export const KILL_GRACE_MS = 30_000;
 
 export const SANDBOX_SUPPORT = "unsupported";
 
 export const SANDBOX_DEFERRAL_REASON =
   "acp wraps host-authenticated coding agents (first target: claude-code-acp) whose binary, subscription OAuth, and permission surface have no Gondolin guest translation yet (WM-313 deferral; see lib/adapters/acp.mjs)";
-
-/**
- * First target is Claude Code via ACP, so its harness packaging is preserved
- * locally rather than importing Claude during this module's initialization.
- */
-export const HARNESS_LAYOUT = Object.freeze({
-  skills: Object.freeze({
-    source: (name) => ["plugins", "core", "skills", name],
-    dest: (name) => [".claude", "skills", name],
-    type: "dir",
-  }),
-  commands: Object.freeze({
-    source: (name) => ["plugins", "core", "commands", `${name}.md`],
-    dest: (name) => [".claude", "commands", `${name}.md`],
-    type: "file",
-  }),
-  subagents: Object.freeze({
-    source: (name) => ["plugins", "core", "agents", `${name}.md`],
-    dest: (name) => [".claude", "agents", `${name}.md`],
-    type: "file",
-  }),
-});
-
-export const PROMPT_SUFFIX =
-  "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
-
-function verifiedPrompt(def, adapter) {
-  if (typeof def?.promptText !== "string") {
-    throw new Error(
-      `${adapter}: definition ${def?.ref ?? "<unknown>"} has no verified promptText (registry-loaded definitions only)`,
-    );
-  }
-  return def.promptText + PROMPT_SUFFIX;
-}
 
 /** Shipped default — the Zed `claude-code-acp` binary on PATH. */
 export const DEFAULT_ACP_CONFIG = Object.freeze({

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -59,6 +59,47 @@ export const PROVIDER_CREDENTIAL_ENV = [
 ];
 
 /**
+ * Workspace-relative packaging of RunSpec.harness. This module deliberately
+ * remains independent of adapter initialization, so adapters can share the
+ * contract without introducing a registry cycle.
+ */
+export const HARNESS_LAYOUT = Object.freeze({
+  skills: Object.freeze({
+    source: (name) => ["plugins", "core", "skills", name],
+    dest: (name) => [".claude", "skills", name],
+    type: "dir",
+  }),
+  commands: Object.freeze({
+    source: (name) => ["plugins", "core", "commands", `${name}.md`],
+    dest: (name) => [".claude", "commands", `${name}.md`],
+    type: "file",
+  }),
+  subagents: Object.freeze({
+    source: (name) => ["plugins", "core", "agents", `${name}.md`],
+    dest: (name) => [".claude", "agents", `${name}.md`],
+    type: "file",
+  }),
+});
+
+export const KILL_GRACE_MS = 30_000;
+
+export const PROMPT_SUFFIX =
+  "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
+
+/**
+ * Prompt bytes are verified by the registry before they reach an adapter.
+ * `promptPath` remains provenance only: re-reading it would bypass that pin.
+ */
+export function verifiedPrompt(def, adapter) {
+  if (typeof def?.promptText !== "string") {
+    throw new Error(
+      `${adapter}: definition ${def?.ref ?? "<unknown>"} has no verified promptText (registry-loaded definitions only)`,
+    );
+  }
+  return def.promptText + PROMPT_SUFFIX;
+}
+
+/**
  * Build an adapter child environment from the worker allowlist.
  *
  * Only an explicit boolean mutating value grants push credentials. Adapters

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -1,12 +1,28 @@
 import { afterEach, describe, expect, test } from "bun:test";
 import {
   DISPATCH_IDENTITY_ENV,
+  HARNESS_LAYOUT,
+  KILL_GRACE_MS,
+  PROMPT_SUFFIX,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment,
+  verifiedPrompt,
 } from "./child-env.mjs";
+import {
+  HARNESS_LAYOUT as acpHarnessLayout,
+  KILL_GRACE_MS as acpKillGraceMs,
+  PROMPT_SUFFIX as acpPromptSuffix,
+  verifiedPrompt as acpVerifiedPrompt,
+} from "./acp.mjs";
 import { safeChildEnvironment as claudeEnvironment } from "./claude.mjs";
+import {
+  HARNESS_LAYOUT as claudeHarnessLayout,
+  KILL_GRACE_MS as claudeKillGraceMs,
+  PROMPT_SUFFIX as claudePromptSuffix,
+  verifiedPrompt as claudeVerifiedPrompt,
+} from "./claude.mjs";
 import { safeChildEnvironment as commandEnvironment } from "./command.mjs";
 import { safeChildEnvironment as agyEnvironment } from "./agy.mjs";
 import { safeChildEnvironment as cursorEnvironment } from "./cursor.mjs";
@@ -19,6 +35,17 @@ describe("shared child environment", () => {
 
   afterEach(() => {
     process.env = { ...originalEnv };
+  });
+
+  test("shares harness packaging and prompt contracts with ACP and Claude", () => {
+    expect(acpHarnessLayout).toBe(HARNESS_LAYOUT);
+    expect(claudeHarnessLayout).toBe(HARNESS_LAYOUT);
+    expect(acpKillGraceMs).toBe(KILL_GRACE_MS);
+    expect(claudeKillGraceMs).toBe(KILL_GRACE_MS);
+    expect(acpPromptSuffix).toBe(PROMPT_SUFFIX);
+    expect(claudePromptSuffix).toBe(PROMPT_SUFFIX);
+    expect(acpVerifiedPrompt).toBe(verifiedPrompt);
+    expect(claudeVerifiedPrompt).toBe(verifiedPrompt);
   });
 
   test("keeps adapter differences explicit while stripping all credentials", () => {

--- a/event-runtime/lib/adapters/claude.mjs
+++ b/event-runtime/lib/adapters/claude.mjs
@@ -31,10 +31,14 @@ import { FACTORY_ROOT, transcriptMaxBytes } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import {
   BASE_INHERITED_ENV,
+  HARNESS_LAYOUT,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
+  PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment,
+  verifiedPrompt,
 } from "./child-env.mjs";
 import {
   boundedTranscriptStream,
@@ -43,10 +47,14 @@ import {
 } from "./child-process.mjs";
 export {
   BASE_INHERITED_ENV,
+  HARNESS_LAYOUT,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
+  PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
   safeChildEnvironment,
+  verifiedPrompt,
 };
 import { refuseSandbox } from "./sandboxed.mjs";
 
@@ -77,52 +85,11 @@ export const SANDBOX_DEFERRAL_REASON =
 /** This adapter refuses sandboxed definitions (fail closed) until the deferral above is resolved. */
 export const SANDBOX_SUPPORT = "unsupported";
 
-/**
- * Workspace-relative packaging of RunSpec.harness (WM-851). Sources are emit
- * output under FACTORY_ROOT (`plugins/core`) so the bytes match the Claude
- * plugin; dest is the project `.claude/` tree the CLI reads from cwd.
- */
-export const HARNESS_LAYOUT = Object.freeze({
-  skills: Object.freeze({
-    source: (name) => ["plugins", "core", "skills", name],
-    dest: (name) => [".claude", "skills", name],
-    type: "dir",
-  }),
-  commands: Object.freeze({
-    source: (name) => ["plugins", "core", "commands", `${name}.md`],
-    dest: (name) => [".claude", "commands", `${name}.md`],
-    type: "file",
-  }),
-  subagents: Object.freeze({
-    source: (name) => ["plugins", "core", "agents", `${name}.md`],
-    dest: (name) => [".claude", "agents", `${name}.md`],
-    type: "file",
-  }),
-});
-
-export const KILL_GRACE_MS = 30_000;
-
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
 export { killProcessGroup };
 
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
-
-export const PROMPT_SUFFIX =
-  "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
-
-/**
- * Prompt bytes are verified by the registry before they reach an adapter.
- * `promptPath` remains provenance only: re-reading it would bypass that pin.
- */
-export function verifiedPrompt(def, adapter) {
-  if (typeof def?.promptText !== "string") {
-    throw new Error(
-      `${adapter}: definition ${def?.ref ?? "<unknown>"} has no verified promptText (registry-loaded definitions only)`,
-    );
-  }
-  return def.promptText + PROMPT_SUFFIX;
-}
 
 // `mutating: false` means no durable mutation beyond the run's declared
 // workspace output; it does not mean a model cannot use the shell to inspect


### PR DESCRIPTION
Fixes watt-mind/factory#1974

Unify ACP and Claude harness contracts in a cycle-safe leaf module.

## Validation

| Check                | Command                                                                                         | Result  | Notes                           |
| -------------------- | ----------------------------------------------------------------------------------------------- | ------- | ------------------------------- |
| Verification Command | `bun test event-runtime/lib/adapters --timeout 20000 && bun run lint`                          | pass    | adapter tests and lint clean    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, lint clean |
| UX critique          | factory-ux-critic                                                                               | not run | no user-facing surface          |

UX critique: skipped

run:run_33e5fb56-fc19-45f4-9670-f4e1e318e1e6
