### PR TITLE
test(doctor): clarify import-safe fixture

### DIFF
--- a/orchestrator/doctor.test.mjs
+++ b/orchestrator/doctor.test.mjs
@@ -64,6 +64,10 @@ const fakeChrome = (dir, body) => {
 test("imports exported helpers without materialized instance config", () => {
   const root = scratch();
   mkdirSync(path.join(root, "tools"), { recursive: true });
+  // `doctor.mjs` calls `factoryRoot()`, which recognizes FACTORY_ROOT only
+  // when its `tools/linear.mjs` marker resolves. This empty marker lets the
+  // import use this deliberately config-less root; no Linear exports execute
+  // while importing doctor, so fixture content is unnecessary.
   writeFileSync(path.join(root, "tools", "linear.mjs"), "");
 
   const result = Bun.spawnSync({
@@ -79,7 +83,9 @@ test("imports exported helpers without materialized instance config", () => {
   });
 
   expect(result.exitCode).toBe(0);
-  expect(new TextDecoder().decode(result.stderr)).toBe("");
+  expect(new TextDecoder().decode(result.stderr)).not.toContain(
+    "instance_config_missing",
+  );
 });
 
 describe("base branch CI diagnostics (#1928)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1986

Review the clarified import-safe fixture and regression-focused stderr assertion.

## Validation

| Check                | Command                                                                                               | Result  | Notes                         |
| -------------------- | ----------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/doctor.test.mjs && bun run lint`                                               | pass    | 56 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2305 pass, 10 skipped         |
| UX critique          | `factory-ux-critic`                                                                                   | not run | no user-facing surface        |

UX critique: skipped

run:run_f6da488a-b29a-4eaa-857b-1b56df7ba046
