### PR TITLE
fix(handoff): match bare Owned Paths filenames

### DIFF
--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2565,6 +2565,15 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(ownedPathsDeviations(null, ["src/**"])).toEqual([]);
   });
 
+  test("ownedPathsDeviations accepts a bare filename alongside full paths", () => {
+    expect(
+      ownedPathsDeviations(
+        ["event-runtime/lib/adapters/acp.test.mjs", "docs/unrelated.md"],
+        ["acp.test.mjs", "event-runtime/lib/verify.mjs"],
+      ),
+    ).toEqual(["docs/unrelated.md"]);
+  });
+
   test("changedFilesSince diffs merge-base(origin/<base>)..HEAD and reports an unusable tree instead of guessing", () => {
     const dir = tmpDir("evrt-handoff-diff-");
     const git = (...args) => execFileSync("git", args, { cwd: dir });

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -343,6 +343,12 @@ export function globToRegExp(glob) {
     throw new OwnedPathsPatternError(glob, "pattern must be a string");
   }
   let g = glob.trim().replace(/^\.\//, "");
+  // A bare filename with an extension is ambiguous in an Owned Paths list:
+  // unlike a repo-relative path, it does not identify which directory holds
+  // the file. Treat it as a basename matcher so handoff verification does not
+  // report a false deviation merely because the ticket omitted that directory.
+  const matchBasenameAtAnyDepth =
+    !g.includes("/") && !/[*?{}]/.test(g) && /\.[a-z0-9]+$/i.test(g);
   // A path with no glob metacharacters and no extension is treated as a prefix:
   // `app/services` owns everything beneath it. It also names a real, concrete
   // path in its own right (`Dockerfile`, `Makefile` — extensionless files are
@@ -358,6 +364,7 @@ export function globToRegExp(glob) {
   // The "/**" appended above compiles to a trailing literal "/.*"; make the
   // "/" + anything optional so the bare path matches itself as well.
   if (matchSelf) re = re.replace(/\/\.\*$/, "(?:/.*)?");
+  if (matchBasenameAtAnyDepth) re = `(?:.*/)?${re}`;
   return new RegExp(`^${re}$`);
 }
 

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -182,6 +182,13 @@ test("extensionless concrete files (Dockerfile, Makefile) match themselves", () 
   expectTrue(!globsOverlap("app/src/auth", "app/src/auth.ts"));
 });
 
+test("bare filenames with extensions match that basename at any repository depth", () => {
+  const matcher = globToRegExp("acp.test.mjs");
+  expectTrue(matcher.test("acp.test.mjs"));
+  expectTrue(matcher.test("event-runtime/lib/adapters/acp.test.mjs"));
+  expectTrue(!matcher.test("event-runtime/lib/adapters/acp.mjs"));
+});
+
 test("the case keyword matching gets wrong", () => {
   // Same vocabulary, unrelated files: must NOT collide.
   expectTrue(


### PR DESCRIPTION
Fixes watt-mind/factory#1984

Make bare filename Owned Paths entries match changed files at any directory depth.

## Validation

| Check                | Command                                                                              | Result  | Notes                                  |
| -------------------- | ------------------------------------------------------------------------------------ | ------- | -------------------------------------- |
| Verification Command | `bun test orchestrator/owned-paths.test.mjs event-runtime/lib/verify.test.mjs && bun run lint` | pass    | focused tests passed; lint 0 errors    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2316 tests, 0 errors; format clean     |
| UX critique          | factory-ux-critic                                                                    | not run | no user-facing surface                 |

UX critique: skipped

run:run_e9b30c81-23dd-4d46-86ca-326facad031a
