### PR TITLE
test(adapters): use shared load-adjusted polling waits

### DIFF
--- a/event-runtime/lib/adapters/acp.test.mjs
+++ b/event-runtime/lib/adapters/acp.test.mjs
@@ -40,6 +40,7 @@ import {
   registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+import { until } from "../test-helpers-timing.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -970,31 +971,32 @@ describe("execute against a fake ACP agent", () => {
         ACP_FAKE_ERROR_FILE: fixtureErrorFile,
       },
     });
-    let pid = null;
-    for (let i = 0; i < 200; i += 1) {
-      if (existsSync(pidFile)) {
-        const candidate = Number(readFileSync(pidFile, "utf8"));
-        if (Number.isInteger(candidate) && candidate > 0) {
-          pid = candidate;
-          trackProcessGroupForPid(pid);
-          break;
-        }
-      }
-      await new Promise((r) => setTimeout(r, 10));
-    }
-    if (pid === null) {
-      let outcomeError = null;
+    let pid;
+    try {
+      pid = await until(
+        "ACP grandchild PID file",
+        () => {
+          if (!existsSync(pidFile)) return null;
+          const candidate = Number(readFileSync(pidFile, "utf8"));
+          return Number.isInteger(candidate) && candidate > 0
+            ? candidate
+            : null;
+        },
+        { timeoutMs: 2_000, everyMs: 10 },
+      );
+      trackProcessGroupForPid(pid);
+    } catch (error) {
       try {
         await pending;
-      } catch (error) {
-        outcomeError = error;
+      } catch {
+        // The polling error below identifies the missing fixture signal.
       }
       const fixtureError = existsSync(fixtureErrorFile)
         ? readFileSync(fixtureErrorFile, "utf8")
         : "fixture wrote no diagnostic";
       throw new Error(
         `ACP grandchild fixture did not write ${pidFile}: ${fixtureError}`,
-        { cause: outcomeError },
+        { cause: error },
       );
     }
     expect(pid).toBeGreaterThan(0);

--- a/event-runtime/lib/adapters/claude.test.mjs
+++ b/event-runtime/lib/adapters/claude.test.mjs
@@ -34,6 +34,7 @@ import {
   registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+import { until } from "../test-helpers-timing.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -742,17 +743,17 @@ if (behavior === "emit_denial_then_recovery") {
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
 
   async function waitForGrandchildPid(pidFile) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) {
-        const pid = Number(readFileSync(pidFile, "utf8"));
-        if (Number.isInteger(pid) && pid > 0) {
-          trackProcessGroupForPid(pid);
-          return pid;
-        }
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    throw new Error("stub did not report its grandchild PID");
+    const pid = await until(
+      "stub did not report its grandchild PID",
+      () => {
+        if (!existsSync(pidFile)) return null;
+        const candidate = Number(readFileSync(pidFile, "utf8"));
+        return Number.isInteger(candidate) && candidate > 0 ? candidate : null;
+      },
+      { timeoutMs: 5_000, everyMs: 10 },
+    );
+    trackProcessGroupForPid(pid);
+    return pid;
   }
 
   function processExists(pid) {
@@ -765,11 +766,10 @@ if (behavior === "emit_denial_then_recovery") {
   }
 
   async function expectProcessExit(pid) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (!processExists(pid)) return;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    expect(processExists(pid)).toBe(false);
+    await until(`pid ${pid} to exit`, () => !processExists(pid), {
+      timeoutMs: 5_000,
+      everyMs: 10,
+    });
   }
 
   function killIfRunning(pid) {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -38,6 +38,7 @@ import {
   registerTestProcessCleanup,
   trackProcessGroupForPid,
 } from "../test-helpers-process.mjs";
+import { until } from "../test-helpers-timing.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -659,17 +660,17 @@ process.stdin.on("end", () => {
   const testProcessGroup = process.platform === "win32" ? test.skip : test;
 
   async function waitForGrandchildPid(pidFile) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (existsSync(pidFile)) {
-        const pid = Number(readFileSync(pidFile, "utf8"));
-        if (Number.isInteger(pid) && pid > 0) {
-          trackProcessGroupForPid(pid);
-          return pid;
-        }
-      }
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    throw new Error("stub did not report its grandchild PID");
+    const pid = await until(
+      "stub did not report its grandchild PID",
+      () => {
+        if (!existsSync(pidFile)) return null;
+        const candidate = Number(readFileSync(pidFile, "utf8"));
+        return Number.isInteger(candidate) && candidate > 0 ? candidate : null;
+      },
+      { timeoutMs: 5_000, everyMs: 10 },
+    );
+    trackProcessGroupForPid(pid);
+    return pid;
   }
 
   function processExists(pid) {
@@ -682,11 +683,10 @@ process.stdin.on("end", () => {
   }
 
   async function expectProcessExit(pid) {
-    for (let attempt = 0; attempt < 500; attempt += 1) {
-      if (!processExists(pid)) return;
-      await new Promise((resolve) => setTimeout(resolve, 10));
-    }
-    expect(processExists(pid)).toBe(false);
+    await until(`pid ${pid} to exit`, () => !processExists(pid), {
+      timeoutMs: 5_000,
+      everyMs: 10,
+    });
   }
 
   function killIfRunning(pid) {


### PR DESCRIPTION
Fixes watt-mind/factory#1983

Replace fixed adapter polling loops with load-adjusted shared waits.

## Validation

| Check                | Command                                                                                                                | Result  | Notes                   |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/claude.test.mjs event-runtime/lib/adapters/pi.test.mjs event-runtime/lib/adapters/acp.test.mjs event-runtime/lib/adapters/cursor.test.mjs && bun run lint` | pass | 162 pass, 3 skip |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (615 warnings) |
| UX critique          | `factory-ux-critic`                                                                                                    | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_5b5444fe-fd10-4ae0-9feb-974eaf9cc236