### PR TITLE
test(worktree): exclude delayed-health fixture bands

### DIFF
--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -40,6 +40,8 @@ const DELAYED_HEALTH_OFFSETS = Array.from(
   { length: DELAYED_HEALTH_PORT_SPAN * 2 },
   (_, offset) => offset,
 );
+const DELAYED_HEALTH_BAND_WIDTH = DELAYED_HEALTH_OFFSETS.length;
+const delayedHealthFixtureRanges = [];
 
 function offsetsBindable(base, offsets) {
   for (const offset of offsets) {
@@ -80,6 +82,13 @@ function pickFreeBase(offsets, excludedRanges = []) {
   throw new Error("could not find a free port band for worktree-common tests");
 }
 
+function delayedHealthPortBand(portBase) {
+  return {
+    start: portBase,
+    end: portBase + DELAYED_HEALTH_BAND_WIDTH - 1,
+  };
+}
+
 const PORT_BASE = pickFreeBase(FIXTURE_OFFSETS);
 const PORT_RESERVATION_ROOT = mkdtempSync(
   path.join(tmpdir(), "factory-port-reservations-"),
@@ -100,6 +109,28 @@ const BAND_ENV = {
   FACTORY_PORT_SPAN: String(PORT_SPAN),
   FACTORY_PORT_RESERVATION_ROOT: PORT_RESERVATION_ROOT,
 };
+
+function delayedHealthExcludedRanges(
+  issuedRanges = delayedHealthFixtureRanges,
+) {
+  return [
+    { start: PORT_BASE, end: PORT_BASE + 2 * PORT_SPAN - 1 },
+    ...issuedRanges,
+  ];
+}
+
+test("delayed-health exclusions retain every issued fixture port band", () => {
+  const issuedRanges = [
+    delayedHealthPortBand(12000),
+    delayedHealthPortBand(14000),
+  ];
+
+  expect(delayedHealthExcludedRanges(issuedRanges)).toEqual([
+    { start: PORT_BASE, end: PORT_BASE + 2 * PORT_SPAN - 1 },
+    { start: 12000, end: 12005 },
+    { start: 14000, end: 14005 },
+  ]);
+});
 
 afterAll(() => {
   rmSync(PORT_RESERVATION_ROOT, { recursive: true, force: true });
@@ -231,10 +262,13 @@ function delayedHealthFixture({
 } = {}) {
   const fixture = worktreeUpFixture();
   // Reserve enough adjacent pairs for allocate_api_port to recover if the
-  // preferred pair is claimed after this probe, and never overlap BAND_ENV.
-  const portBase = pickFreeBase(DELAYED_HEALTH_OFFSETS, [
-    { start: PORT_BASE, end: PORT_BASE + 2 * PORT_SPAN - 1 },
-  ]);
+  // preferred pair is claimed after this probe. Exclude BAND_ENV and every
+  // delayed-health band already issued in this test-file run.
+  const portBase = pickFreeBase(
+    DELAYED_HEALTH_OFFSETS,
+    delayedHealthExcludedRanges(),
+  );
+  delayedHealthFixtureRanges.push(delayedHealthPortBand(portBase));
   const fakeBun = path.join(fixture.mockBin, "bun");
   mkdirSync(path.join(fixture.root, "event-runtime", "web"), {
     recursive: true,

--- a/bin/worktree-common.test.mjs
+++ b/bin/worktree-common.test.mjs
@@ -40,6 +40,9 @@ const DELAYED_HEALTH_OFFSETS = Array.from(
   { length: DELAYED_HEALTH_PORT_SPAN * 2 },
   (_, offset) => offset,
 );
+// Offsets are contiguous from 0, so the count doubles as the band width
+// (last offset + 1). If DELAYED_HEALTH_OFFSETS ever grows sparse, use
+// Math.max(...DELAYED_HEALTH_OFFSETS) + 1 instead.
 const DELAYED_HEALTH_BAND_WIDTH = DELAYED_HEALTH_OFFSETS.length;
 const delayedHealthFixtureRanges = [];
 
@@ -130,6 +133,26 @@ test("delayed-health exclusions retain every issued fixture port band", () => {
     { start: 12000, end: 12005 },
     { start: 14000, end: 14005 },
   ]);
+});
+
+test("delayed-health exclusions default arg accumulates fixture bands pushed at runtime", () => {
+  const saved = delayedHealthFixtureRanges.slice();
+  try {
+    delayedHealthFixtureRanges.length = 0;
+    const bandA = delayedHealthPortBand(16000);
+    const bandB = delayedHealthPortBand(18000);
+    delayedHealthFixtureRanges.push(bandA);
+    delayedHealthFixtureRanges.push(bandB);
+
+    expect(delayedHealthExcludedRanges()).toEqual([
+      { start: PORT_BASE, end: PORT_BASE + 2 * PORT_SPAN - 1 },
+      bandA,
+      bandB,
+    ]);
+  } finally {
+    delayedHealthFixtureRanges.length = 0;
+    delayedHealthFixtureRanges.push(...saved);
+  }
 });
 
 afterAll(() => {


### PR DESCRIPTION
Fixes watt-mind/factory#1987

Review the retained fixture-band exclusions and direct regression coverage.

## Validation

| Check                | Command                                                                                     | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test bin/worktree-common.test.mjs && bun run lint`                                    | pass    | 55 tests, 0 failures; lint exit 0          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2305 pass, 10 skipped; emit/format/lint clean |
| UX critique          | factory-ux-critic                                                                           | not run | no user-facing surface; test-only fixture  |

UX critique: skipped — no user-facing surface

run:run_278cb27b-3f49-41da-894c-a760c36e177d