### PR TITLE
refactor(adapters): share child-env kill grace constant

### DIFF
--- a/event-runtime/lib/adapters/agy.mjs
+++ b/event-runtime/lib/adapters/agy.mjs
@@ -21,6 +21,7 @@ import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import { FACTORY_ROOT } from "../config.mjs";
 import {
   BASE_INHERITED_ENV,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
@@ -30,6 +31,7 @@ import { refuseSandbox } from "./sandboxed.mjs";
 
 export {
   BASE_INHERITED_ENV,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV,
@@ -69,7 +71,6 @@ export const HARNESS_LAYOUT = Object.freeze({
 
 export { killProcessGroup };
 
-export const KILL_GRACE_MS = 30_000;
 const TEXT_PREVIEW_CHARS = 4000;
 const STDERR_FILE_CHARS = 16_384;
 

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -24,9 +24,25 @@ import {
   verifiedPrompt as claudeVerifiedPrompt,
 } from "./claude.mjs";
 import { safeChildEnvironment as commandEnvironment } from "./command.mjs";
-import { safeChildEnvironment as agyEnvironment } from "./agy.mjs";
-import { safeChildEnvironment as cursorEnvironment } from "./cursor.mjs";
-import { safeChildEnvironment as piEnvironment } from "./pi.mjs";
+import {
+  HARNESS_LAYOUT as agyHarnessLayout,
+  KILL_GRACE_MS as agyKillGraceMs,
+  safeChildEnvironment as agyEnvironment,
+} from "./agy.mjs";
+import {
+  HARNESS_LAYOUT as cursorHarnessLayout,
+  KILL_GRACE_MS as cursorKillGraceMs,
+  safeChildEnvironment as cursorEnvironment,
+} from "./cursor.mjs";
+import {
+  HARNESS_LAYOUT as hermesHarnessLayout,
+  KILL_GRACE_MS as hermesKillGraceMs,
+} from "./hermes.mjs";
+import {
+  HARNESS_LAYOUT as piHarnessLayout,
+  KILL_GRACE_MS as piKillGraceMs,
+  safeChildEnvironment as piEnvironment,
+} from "./pi.mjs";
 
 const keySet = (env) => Object.keys(env).sort();
 
@@ -46,6 +62,35 @@ describe("shared child environment", () => {
     expect(claudePromptSuffix).toBe(PROMPT_SUFFIX);
     expect(acpVerifiedPrompt).toBe(verifiedPrompt);
     expect(claudeVerifiedPrompt).toBe(verifiedPrompt);
+  });
+
+  test("exports the shared kill grace period from every standard adapter", () => {
+    for (const adapterKillGraceMs of [
+      acpKillGraceMs,
+      agyKillGraceMs,
+      claudeKillGraceMs,
+      cursorKillGraceMs,
+      hermesKillGraceMs,
+      piKillGraceMs,
+    ]) {
+      expect(adapterKillGraceMs).toBe(KILL_GRACE_MS);
+    }
+  });
+
+  test("keeps every private harness layout leaf on the shared contract shape", () => {
+    for (const layout of [
+      agyHarnessLayout,
+      cursorHarnessLayout,
+      hermesHarnessLayout,
+      piHarnessLayout,
+    ]) {
+      for (const entry of Object.values(layout)) {
+        expect(Object.keys(entry).sort()).toEqual(["dest", "source", "type"]);
+        expect(typeof entry.source).toBe("function");
+        expect(typeof entry.dest).toBe("function");
+        expect(typeof entry.type).toBe("string");
+      }
+    }
   });
 
   test("keeps adapter differences explicit while stripping all credentials", () => {

--- a/event-runtime/lib/adapters/cursor.mjs
+++ b/event-runtime/lib/adapters/cursor.mjs
@@ -33,6 +33,7 @@ import { FACTORY_ROOT, transcriptMaxBytes } from "../config.mjs";
 import { DEFAULT_MODEL } from "../registry.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import {
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
@@ -46,6 +47,7 @@ import {
 import { refuseSandbox } from "./sandboxed.mjs";
 
 export {
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV,
@@ -77,8 +79,6 @@ export const HARNESS_LAYOUT = Object.freeze({
     type: "file",
   }),
 });
-
-export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
 export { killProcessGroup };

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -58,6 +58,7 @@ import { normalizePolicy } from "../sandbox/gondolin.mjs";
 import { PROMPT_SUFFIX, verifiedPrompt } from "./claude.mjs";
 import {
   BASE_INHERITED_ENV,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PUSH_CREDENTIAL_ENV,
   RUNTIME_IDENTITY_ENV,
@@ -79,6 +80,7 @@ import {
 // list shared by both LLM adapters (WM-223), so it cannot drift between them.
 export {
   BASE_INHERITED_ENV,
+  KILL_GRACE_MS,
   PROVIDER_CREDENTIAL_ENV,
   PROMPT_SUFFIX,
   PUSH_CREDENTIAL_ENV,
@@ -117,8 +119,6 @@ export const HARNESS_LAYOUT = Object.freeze({
  * host path pipes, and it lives beside input.json under the workspace mount.
  */
 export const SANDBOX_PROMPT_FILE = ".prompt.md";
-
-export const KILL_GRACE_MS = 30_000;
 
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
 export { killProcessGroup };


### PR DESCRIPTION
Fixes watt-mind/factory#1985

Centralize pi, Cursor, and agy kill grace exports and pin adapter layout contracts.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/pi.test.mjs event-runtime/lib/adapters/cursor.test.mjs event-runtime/lib/adapters/agy.test.mjs event-runtime/lib/adapters/hermes.test.mjs event-runtime/lib/adapters/child-env.test.mjs && bun run lint` | pass | adapter tests and lint clean |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | lib suite, emit, format, lint clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped

run:run_14a354f5-1ac4-42f7-bd65-f301bc1a9d5c
