### PR TITLE
fix(verify): record repo verify failure diagnostics

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1030,6 +1030,15 @@ export function composeHandoffVerification(handoff) {
   }
   if (handoff.repoVerify && handoff.repoVerify !== primary)
     lines.push(commandLine("Repo verify", handoff.repoVerify));
+  if (handoff.repoVerify?.executionContext) {
+    lines.push(`- Repo verify context: ${handoff.repoVerify.executionContext}`);
+    const failingTests = handoff.repoVerify.failingTests ?? [];
+    lines.push(
+      failingTests.length > 0
+        ? `- Repo verify failing tests: ${failingTests.map((name) => `\`${name}\``).join(", ")}`
+        : "- Repo verify failing tests: none parseable",
+    );
+  }
   lines.push(
     ...optionalStepLines({
       label: "Web build",
@@ -1143,6 +1152,24 @@ export const HANDOFF_FAILURE_OUTPUT_MAX_CHARS = 2 * 1024;
 // as the failure (WM-918's own registry test says "reads bun (fail) and ✗").
 const REPO_VERIFY_TEST_FAILURE_LINE = /^\s*(?:\(fail\)|✗)/i;
 const REPO_VERIFY_ERROR_LINE = /\berror\b/i;
+
+/**
+ * Extract runner-reported failing test names for the handoff record. Keeping
+ * this separate from the diagnostic excerpt makes the original observation
+ * useful to triage without asking it to parse a truncated failure message.
+ */
+export function repoVerifyFailingTests(output) {
+  return [
+    ...new Set(
+      stripAnsi(output)
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => REPO_VERIFY_TEST_FAILURE_LINE.test(line))
+        .map((line) => line.replace(REPO_VERIFY_TEST_FAILURE_LINE, "").trim())
+        .filter(Boolean),
+    ),
+  ];
+}
 
 function boundedDiagnostic(lines) {
   const excerpt = [];
@@ -2047,6 +2074,12 @@ function verifyCompleted({
       obs.source = "repo_verify";
       handoff.repoVerify = obs;
       if (!obs.passed) {
+        // This is deliberately failure-only: successful repo verification
+        // retains its existing pass path and emits only repo_verify_passed.
+        // The marker lets triage distinguish this observation from a later
+        // clean-checkout reproduction at the same commit.
+        obs.executionContext = "dispatch_worktree";
+        obs.failingTests = repoVerifyFailingTests(obs.output);
         const baselineStillRed =
           !obs.timedOut &&
           matchesRedBaseline(worktreeRecord.baseline, obs.output);

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1035,7 +1035,13 @@ export function composeHandoffVerification(handoff) {
     const failingTests = handoff.repoVerify.failingTests ?? [];
     lines.push(
       failingTests.length > 0
-        ? `- Repo verify failing tests: ${failingTests.map((name) => `\`${name}\``).join(", ")}`
+        ? `- Repo verify failing tests: ${failingTests
+            .map((name) =>
+              name.startsWith("…and ")
+                ? name
+                : `\`${name.replaceAll("`", "'")}\``,
+            )
+            .join(", ")}`
         : "- Repo verify failing tests: none parseable",
     );
   }
@@ -1152,6 +1158,13 @@ export const HANDOFF_FAILURE_OUTPUT_MAX_CHARS = 2 * 1024;
 // as the failure (WM-918's own registry test says "reads bun (fail) and ✗").
 const REPO_VERIFY_TEST_FAILURE_LINE = /^\s*(?:\(fail\)|✗)/i;
 const REPO_VERIFY_ERROR_LINE = /\berror\b/i;
+// bun appends a per-test wall-clock suffix (e.g. "[12.34ms]", "[1.2s]") after
+// the marker is stripped; it varies run to run and defeats the Set dedup.
+const REPO_VERIFY_TIMING_SUFFIX = /\s*\[[\d.]+m?s\]$/;
+// Bound the handoff record itself, independent of how the comment renders
+// it: an unbounded name list can blow GitHub's 64KB comment limit on broad
+// failures (a single suite regression can list hundreds of test names).
+const REPO_VERIFY_FAILING_TESTS_MAX = 20;
 
 /**
  * Extract runner-reported failing test names for the handoff record. Keeping
@@ -1159,16 +1172,25 @@ const REPO_VERIFY_ERROR_LINE = /\berror\b/i;
  * useful to triage without asking it to parse a truncated failure message.
  */
 export function repoVerifyFailingTests(output) {
-  return [
+  const names = [
     ...new Set(
       stripAnsi(output)
         .split("\n")
         .map((line) => line.trim())
         .filter((line) => REPO_VERIFY_TEST_FAILURE_LINE.test(line))
-        .map((line) => line.replace(REPO_VERIFY_TEST_FAILURE_LINE, "").trim())
+        .map((line) =>
+          line
+            .replace(REPO_VERIFY_TEST_FAILURE_LINE, "")
+            .replace(REPO_VERIFY_TIMING_SUFFIX, "")
+            .trim(),
+        )
         .filter(Boolean),
     ),
   ];
+  if (names.length <= REPO_VERIFY_FAILING_TESTS_MAX) return names;
+  const shown = names.slice(0, REPO_VERIFY_FAILING_TESTS_MAX);
+  shown.push(`…and ${names.length - REPO_VERIFY_FAILING_TESTS_MAX} more`);
+  return shown;
 }
 
 function boundedDiagnostic(lines) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -43,6 +43,7 @@ import {
   insideHandoffSandbox,
   policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
+  repoVerifyFailingTests,
   runHandoffCommand,
   ticketVerifyCoveredByRepoVerify,
   verifyResult,
@@ -1941,6 +1942,43 @@ describe("worktree baseline verification (WM-334)", () => {
   });
 });
 
+describe("repoVerifyFailingTests", () => {
+  test("strips bun's trailing timing suffix so repeated names dedup", () => {
+    const output = [
+      "(fail) totals > rejects an invalid total [12.34ms]",
+      "(fail) totals > rejects an invalid total [1.2s]",
+      "✗ widgets > renders without a crash [0.9ms]",
+    ].join("\n");
+    expect(repoVerifyFailingTests(output)).toEqual([
+      "totals > rejects an invalid total",
+      "widgets > renders without a crash",
+    ]);
+  });
+
+  test("caps the name list so a broad regression cannot blow the comment budget", () => {
+    const lines = Array.from(
+      { length: 45 },
+      (_, i) => `(fail) suite > case ${i}`,
+    );
+    const result = repoVerifyFailingTests(lines.join("\n"));
+    expect(result).toHaveLength(21);
+    expect(result.slice(0, 20)).toEqual(
+      Array.from({ length: 20 }, (_, i) => `suite > case ${i}`),
+    );
+    expect(result.at(-1)).toBe("…and 25 more");
+  });
+
+  test("does not truncate a list at exactly the cap", () => {
+    const lines = Array.from(
+      { length: 20 },
+      (_, i) => `(fail) suite > case ${i}`,
+    );
+    const result = repoVerifyFailingTests(lines.join("\n"));
+    expect(result).toHaveLength(20);
+    expect(result.at(-1)).toBe("suite > case 19");
+  });
+});
+
 test("handoff sandbox exposes bunx through the Bun executable", () => {
   const binaries = handoffRuntimeBinaries((name) =>
     name === "bun" ? Bun.which("bun") : null,
@@ -2891,6 +2929,25 @@ describe("handoff verification helpers (WM-718)", () => {
 
     expect(body).toContain("- Repo verify context: dispatch_worktree");
     expect(body).toContain("- Repo verify failing tests: `x > y`");
+  });
+
+  test("composeHandoffVerification escapes backticks in a test name and leaves the overflow marker unquoted", () => {
+    const body = composeHandoffVerification({
+      repoVerify: {
+        source: "repo_verify",
+        command: "bun test event-runtime/lib",
+        exitCode: 1,
+        passed: false,
+        tail: "(fail) x > y",
+        executionContext: "dispatch_worktree",
+        failingTests: ["uses `backtick` in the name", "…and 5 more"],
+      },
+      diff: { ok: false, error: "base unresolved" },
+    });
+
+    expect(body).toContain(
+      "- Repo verify failing tests: `uses 'backtick' in the name`, …and 5 more",
+    );
   });
 
   test("composeHandoffVerification reports optional steps as unknown when the diff is unavailable", () => {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1080,6 +1080,10 @@ describe("worktree baseline verification (WM-334)", () => {
       expect(err.violations[0]).toContain("error: expected 400, received 200");
       // A passing test whose name contains "(fail)" is not a failure marker.
       expect(err.violations[0]).not.toContain("(pass) timing-test registry");
+      expect(err.handoff.repoVerify.executionContext).toBe("dispatch_worktree");
+      expect(err.handoff.repoVerify.failingTests).toEqual([
+        "totals > rejects an invalid total",
+      ]);
     }
 
     const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");
@@ -1923,6 +1927,10 @@ describe("worktree baseline verification (WM-334)", () => {
         expect(err.violations).toEqual([
           "repo_verify_failed: timed out after 25ms",
         ]);
+        expect(err.handoff.repoVerify.executionContext).toBe(
+          "dispatch_worktree",
+        );
+        expect(err.handoff.repoVerify.failingTests).toEqual([]);
         expect(Date.now() - started).toBeLessThan(1_000);
       }
     } finally {
@@ -2865,6 +2873,24 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(lines.filter((l) => l.startsWith("- Verification:"))).toHaveLength(
       1,
     );
+  });
+
+  test("composeHandoffVerification identifies a failed repo verify's worktree and tests", () => {
+    const body = composeHandoffVerification({
+      repoVerify: {
+        source: "repo_verify",
+        command: "bun test event-runtime/lib",
+        exitCode: 1,
+        passed: false,
+        tail: "(fail) x > y",
+        executionContext: "dispatch_worktree",
+        failingTests: ["x > y"],
+      },
+      diff: { ok: false, error: "base unresolved" },
+    });
+
+    expect(body).toContain("- Repo verify context: dispatch_worktree");
+    expect(body).toContain("- Repo verify failing tests: `x > y`");
   });
 
   test("composeHandoffVerification reports optional steps as unknown when the diff is unavailable", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1998

Adds repo-verify failure test names and dispatch-worktree context for faster triage.

## Validation

| Check                | Command                                                                                     | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs && bun run lint`                                | pass    | verify tests and lint completed cleanly    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | unit slice, emit, format, and lint clean   |
| UX critique          | factory-ux-critic                                                                           | not run | no user-facing surface                     |

UX critique: skipped

run:run_6e42fccd-fc81-40fc-81fa-e8dfc270c10a
