### PR TITLE
test(worker): isolate local notification fetch stub (#1995)

### DIFF
--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -279,12 +279,17 @@ describe("worker", () => {
     );
     const expectedError =
       "FACTORY_EVENT_PORT must be a positive integer between 1 and 65535";
-    const fetchFn = spyOn(globalThis, "fetch");
+    let fetchCalls = 0;
+    const fetchFn = async () => {
+      fetchCalls += 1;
+      throw new Error("invalid ports must not attempt notification delivery");
+    };
     try {
       const result = await drainLocalNotifyOutbox({
         home,
         runId,
         port: "not-a-port",
+        fetchFn,
       });
       expect(result.delivered).toEqual([]);
       expect(result.undelivered).toEqual([
@@ -298,13 +303,35 @@ describe("worker", () => {
         },
         { title: "invalid local notification record", error: expectedError },
       ]);
-      expect(fetchFn).not.toHaveBeenCalled();
+      expect(fetchCalls).toBe(0);
       // The outbox stays put as the recovery source.
       expect(existsSync(outbox)).toBe(true);
     } finally {
-      fetchFn.mockRestore();
       rmSync(home, { recursive: true, force: true });
     }
+  });
+
+  test("forbids global fetch spies in lib tests", () => {
+    // Worker code accepts injected fetchFn dependencies. Keeping spies local to
+    // that seam prevents a global patch from leaking into interleaved tests.
+    const libDir = import.meta.dir;
+    const testFiles = [];
+    const visit = (dir) => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const file = path.join(dir, entry.name);
+        if (entry.isDirectory()) visit(file);
+        else if (entry.isFile() && entry.name.endsWith(".test.mjs")) {
+          testFiles.push(file);
+        }
+      }
+    };
+    visit(libDir);
+
+    const globalFetchSpy = /spyOn\s*\(\s*globalThis\s*,\s*["']fetch["']/;
+    const violations = testFiles.filter((file) =>
+      globalFetchSpy.test(readFileSync(file, "utf8")),
+    );
+    expect(violations).toEqual([]);
   });
 
   test("drains a worktree adapter's local notifications and reports an undelivered one after the adapter throws", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1995

Replaces the invalid-port global fetch spy with an injected stub and guards lib tests against reintroducing it.

## Validation

| Check                | Command                                                                                               | Result  | Notes                                  |
| -------------------- | ----------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs && bun run lint`                                         | pass    | 150 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2320 tests; emit and format clean      |
| UX critique          | factory-ux-critic                                                                                     | not run | backend test-only change; no user flow |

UX critique: skipped

run:run_017b6223-e14d-43f9-8c44-b679151103d3
