### PR TITLE
test(worker): restore local notify drain invariant

### DIFF
--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -414,6 +414,38 @@ describe("worker", () => {
     }
   });
 
+  test("keeps exactly one local notify drain in the adapter finally to prevent double delivery", () => {
+    // Two drain sites could race the same outbox read/truncate cycle and
+    // deliver a BLOCKED or escalation notification twice. Keep this structural
+    // guard alongside the behavioral drain tests so a future refactor cannot
+    // silently add another call site.
+    const source = readFileSync(
+      new URL("./worker.mjs", import.meta.url),
+      "utf8",
+    );
+    const marker =
+      "    } finally {\n      stopDeadlineMonitor();\n      stopCancellationMonitor();\n";
+    const start = source.indexOf(marker);
+    expect(start).toBeGreaterThan(-1);
+    const open = source.indexOf("{", start);
+    let depth = 0;
+    let end = -1;
+    for (let i = open; i < source.length; i += 1) {
+      if (source[i] === "{") depth += 1;
+      else if (source[i] === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          end = i;
+          break;
+        }
+      }
+    }
+    expect(end).toBeGreaterThan(open);
+    const finallyBody = source.slice(open, end);
+    expect(finallyBody).toContain("await drainLocalNotifyOutbox({");
+    expect(source.split("await drainLocalNotifyOutbox({")).toHaveLength(2);
+  });
+
   test("retains an undelivered local notification for handoff recovery", async () => {
     const home = tmpDir("evrt-local-notify-retained-");
     const runId = "run_1558_retained";


### PR DESCRIPTION
Fixes watt-mind/factory#1997

Restores the single local-notify drain call-site guard against duplicate escalation delivery.

## Validation

| Check                | Command                                                                                              | Result  | Notes                   |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ----------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs && bun run lint`                                        | pass    | worker test and lint clean |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean |
| UX critique          | `factory-ux-critic`                                                                                  | not run | no user-facing surface |

UX critique: skipped

run:run_c6b13b4f-2abf-4487-ad4c-34f17770c488