### PR TITLE
fix(owned-paths): root-anchor the handoff deviation gate only

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -905,7 +905,13 @@ function pinManifestFreshness(repo) {
   const patterns = Array.isArray(policy.pinManifests)
     ? policy.pinManifests
     : [];
-  const matchers = patterns.map(globToRegExp);
+  // This planner path does have the configured checkout on disk, so preserve
+  // root-file semantics for legacy bare manifest names. Other plan-time
+  // ownership routing works only from ticket/config text and intentionally
+  // remains any-depth rather than consulting an ambient CWD.
+  const matchers = patterns.map((pattern) =>
+    globToRegExp(pattern, { repoRoot: repoPath }),
+  );
   const manifests = [];
 
   // Match the owned-paths reader's file-only traversal. Directory mtime alone
@@ -1911,6 +1917,9 @@ function ownedPathContains(ownerValue, candidateValue) {
   if (isMatchEverythingGlob(owner) || owner === candidate) return true;
 
   const candidateHasGlob = /[*?{]/.test(candidate);
+  // Merge-fix eligibility is evaluated from the ticket payload before a
+  // checkout is guaranteed to exist, so bare Owned Paths intentionally retain
+  // their conservative any-depth semantics here.
   if (!candidateHasGlob) return globToRegExp(owner).test(candidate);
 
   // A directory (bare or /**) owns narrower globs rooted below it. Other

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -905,13 +905,11 @@ function pinManifestFreshness(repo) {
   const patterns = Array.isArray(policy.pinManifests)
     ? policy.pinManifests
     : [];
-  // This planner path does have the configured checkout on disk, so preserve
-  // root-file semantics for legacy bare manifest names. Other plan-time
-  // ownership routing works only from ticket/config text and intentionally
-  // remains any-depth rather than consulting an ambient CWD.
-  const matchers = patterns.map((pattern) =>
-    globToRegExp(pattern, { repoRoot: repoPath }),
-  );
+  // Compiled root-free, matching `matchingManifestPaths`. Both matchers must
+  // agree on which manifests a pattern covers: anchoring only one of them
+  // would let a closure cache be keyed off a manifest set the other never
+  // scanned, and serve a stale closure.
+  const matchers = patterns.map(globToRegExp);
   const manifests = [];
 
   // Match the owned-paths reader's file-only traversal. Directory mtime alone
@@ -1918,8 +1916,8 @@ function ownedPathContains(ownerValue, candidateValue) {
 
   const candidateHasGlob = /[*?{]/.test(candidate);
   // Merge-fix eligibility is evaluated from the ticket payload before a
-  // checkout is guaranteed to exist, so bare Owned Paths intentionally retain
-  // their conservative any-depth semantics here.
+  // checkout is guaranteed to exist, so bare Owned Paths keep their broad
+  // any-depth semantics here; nothing on this path stats the filesystem.
   if (!candidateHasGlob) return globToRegExp(owner).test(candidate);
 
   // A directory (bare or /**) owns narrower globs rooted below it. Other

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -931,11 +931,15 @@ export function changedFilesSince({
 }
 
 /** Files outside every Owned Paths glob (`**` owns everything). */
-export function ownedPathsDeviations(files = [], ownedPaths = []) {
+export function ownedPathsDeviations(
+  files = [],
+  ownedPaths = [],
+  { repoRoot } = {},
+) {
   if (!Array.isArray(files)) return [];
   const globs = (ownedPaths ?? []).map((g) => String(g).trim()).filter(Boolean);
   if (globs.length === 0 || globs.includes("**")) return [];
-  const matchers = globs.map((g) => globToRegExp(g));
+  const matchers = globs.map((g) => globToRegExp(g, { repoRoot }));
   return files.filter((file) => !matchers.some((re) => re.test(file)));
 }
 
@@ -2140,7 +2144,9 @@ function verifyCompleted({
 
     // 5. Owned Paths conformance: listed always; refused under strict.
     if (handoff.diff.ok && ownedPathsKnown) {
-      handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths);
+      handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths, {
+        repoRoot: worktreePath,
+      });
       if (handoff.ownedPathsDeviations.length === 0) {
         handoffChecks.push("owned_paths_conformant");
       } else if (conformance === "strict") {

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -2144,8 +2144,12 @@ function verifyCompleted({
 
     // 5. Owned Paths conformance: listed always; refused under strict.
     if (handoff.diff.ok && ownedPathsKnown) {
+      // The handoff deviation gate is the one place root-anchoring applies:
+      // narrowing here only ever removes a false deviation report, and the
+      // worktree root is known on disk. Resolve it so the matcher can never
+      // fall back to the process CWD.
       handoff.ownedPathsDeviations = ownedPathsDeviations(files, ownedPaths, {
-        repoRoot: worktreePath,
+        repoRoot: path.resolve(worktreePath),
       });
       if (handoff.ownedPathsDeviations.length === 0) {
         handoffChecks.push("owned_paths_conformant");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2574,14 +2574,19 @@ describe("handoff verification helpers (WM-718)", () => {
     ).toEqual(["docs/unrelated.md"]);
   });
 
-  test("ownedPathsDeviations lets a bare filename own that basename at any depth", () => {
-    // `ownedPathsDeviations` compiles globs without a repository root, so a
-    // bare `package.json` stays an any-depth basename matcher — the ticket did
-    // not say which directory it meant, and over-claiming here only costs a
-    // missing deviation report, while under-claiming would block real work.
-    // Anchoring a bare entry to the root file is opt-in via
-    // `globToRegExp(g, { repoRoot })`; threading a repo root through this
-    // helper is follow-up work (see watt-mind/factory#1996).
+  test("ownedPathsDeviations anchors a root-resolving bare filename", () => {
+    const root = tmpDir("owned-paths-deviations-");
+    writeFileSync(path.join(root, "package.json"), "{}\n");
+    expect(
+      ownedPathsDeviations(
+        ["package.json", "fixtures/nested/package.json", "docs/unrelated.md"],
+        ["package.json"],
+        { repoRoot: root },
+      ),
+    ).toEqual(["fixtures/nested/package.json", "docs/unrelated.md"]);
+  });
+
+  test("ownedPathsDeviations keeps a bare filename any-depth without a root", () => {
     expect(
       ownedPathsDeviations(
         ["package.json", "fixtures/nested/package.json", "docs/unrelated.md"],

--- a/orchestrator/escalate.mjs
+++ b/orchestrator/escalate.mjs
@@ -44,11 +44,20 @@ import { loadForge } from "../lib/forge/index.mjs";
 
 export const EXIT = { CLEAN: 0, ESCALATE: 2, CANNOT_EVALUATE: 3 };
 
-/** Which changed files hit which escalate globs? Pure, for tests. */
-export function matchEscalations(files, globs, { repoRoot } = {}) {
+/**
+ * Which changed files hit which escalate globs? Pure, for tests.
+ *
+ * Root-anchoring (`globToRegExp(..., { repoRoot })`) is deliberately NOT
+ * applied here: the escalation gate errs broad. A bare `schema.prisma` keeps
+ * its any-depth basename semantics even when a file by that name also sits at
+ * the checkout root. A false escalation costs one human review; a missed one
+ * ships an unreviewed security-sensitive change. Matching is therefore pure
+ * text — it never stats the filesystem and never consults `process.cwd()`.
+ */
+export function matchEscalations(files, globs) {
   const hits = [];
   for (const f of files) {
-    const matched = globs.filter((g) => globsOverlap(f, g, { repoRoot }));
+    const matched = globs.filter((g) => globsOverlap(f, g));
     if (matched.length) hits.push({ file: f, globs: matched });
   }
   return hits;
@@ -220,15 +229,12 @@ if (import.meta.main) {
 
   // Non-empty is the whole test for an injection: an exported-but-empty seam is
   // an absent answer, not a diff with no files in it.
-  // The config names the target repository's checkout. Use it for both the
-  // forge read and bare-filename matching; never let the orchestrator CWD
-  // decide whether an escalation pattern anchors at a repository root.
-  const repoPath = String(repo.path).replace(/^~/, homedir());
   const injected = process.env.FACTORY_ESCALATE_DIFF_FILES;
   let raw;
   if (injected?.trim()) {
     raw = injected;
   } else {
+    const repoPath = String(repo.path).replace(/^~/, homedir());
     try {
       raw = loadForge().prDiffFiles(null, pr, { cwd: repoPath }).join("\n");
     } catch (err) {
@@ -253,7 +259,7 @@ if (import.meta.main) {
   }
   const files = changed.files;
 
-  const hits = matchEscalations(files, globs, { repoRoot: repoPath });
+  const hits = matchEscalations(files, globs);
   if (hits.length) {
     console.log(
       `ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`,

--- a/orchestrator/escalate.mjs
+++ b/orchestrator/escalate.mjs
@@ -45,10 +45,10 @@ import { loadForge } from "../lib/forge/index.mjs";
 export const EXIT = { CLEAN: 0, ESCALATE: 2, CANNOT_EVALUATE: 3 };
 
 /** Which changed files hit which escalate globs? Pure, for tests. */
-export function matchEscalations(files, globs) {
+export function matchEscalations(files, globs, { repoRoot } = {}) {
   const hits = [];
   for (const f of files) {
-    const matched = globs.filter((g) => globsOverlap(f, g));
+    const matched = globs.filter((g) => globsOverlap(f, g, { repoRoot }));
     if (matched.length) hits.push({ file: f, globs: matched });
   }
   return hits;
@@ -220,12 +220,15 @@ if (import.meta.main) {
 
   // Non-empty is the whole test for an injection: an exported-but-empty seam is
   // an absent answer, not a diff with no files in it.
+  // The config names the target repository's checkout. Use it for both the
+  // forge read and bare-filename matching; never let the orchestrator CWD
+  // decide whether an escalation pattern anchors at a repository root.
+  const repoPath = String(repo.path).replace(/^~/, homedir());
   const injected = process.env.FACTORY_ESCALATE_DIFF_FILES;
   let raw;
   if (injected?.trim()) {
     raw = injected;
   } else {
-    const repoPath = String(repo.path).replace(/^~/, homedir());
     try {
       raw = loadForge().prDiffFiles(null, pr, { cwd: repoPath }).join("\n");
     } catch (err) {
@@ -250,7 +253,7 @@ if (import.meta.main) {
   }
   const files = changed.files;
 
-  const hits = matchEscalations(files, globs);
+  const hits = matchEscalations(files, globs, { repoRoot: repoPath });
   if (hits.length) {
     console.log(
       `ESCALATE — PR #${pr} touches ${hits.length} protected file(s) in ${repo.name}:`,

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -329,29 +329,56 @@ test("Prisma/SaaS app config leaves ordinary dashboard, analytics, and docs chan
   ).toEqual([]);
 });
 
-test("bare escalation globs use the target repo root, not the process CWD", () => {
-  const rootWithFile = mkdtempSync(path.join(tmpdir(), "escalate-root-with-"));
-  const rootWithoutFile = mkdtempSync(
-    path.join(tmpdir(), "escalate-root-without-"),
-  );
+test("escalation stays any-depth for a bare name that also exists at the root", () => {
+  // The ESCALATE gate deliberately does NOT root-anchor bare escalate_paths
+  // entries. A client repo whose checkout root really holds `schema.prisma`
+  // must still escalate a nested `prisma/schema.prisma`: a false escalation
+  // costs one review, a missed one ships an unreviewed security change.
+  const root = mkdtempSync(path.join(tmpdir(), "escalate-root-"));
   try {
-    writeFileSync(path.join(rootWithFile, "package.json"), "{}\n");
-    const files = ["package.json", "fixtures/nested/package.json"];
-
-    expect(
-      matchEscalations(files, ["package.json"], { repoRoot: rootWithFile }),
-    ).toEqual([{ file: "package.json", globs: ["package.json"] }]);
-    // An absent root file must retain any-depth matching rather than narrowing
-    // based on whichever directory runs the escalation process.
-    expect(
-      matchEscalations(files, ["package.json"], { repoRoot: rootWithoutFile }),
-    ).toEqual([
-      { file: "package.json", globs: ["package.json"] },
-      { file: "fixtures/nested/package.json", globs: ["package.json"] },
+    writeFileSync(path.join(root, "schema.prisma"), "// root\n");
+    const files = ["schema.prisma", "prisma/schema.prisma", "docs/readme.md"];
+    expect(matchEscalations(files, ["schema.prisma"])).toEqual([
+      { file: "schema.prisma", globs: ["schema.prisma"] },
+      { file: "prisma/schema.prisma", globs: ["schema.prisma"] },
     ]);
   } finally {
-    rmSync(rootWithFile, { recursive: true, force: true });
-    rmSync(rootWithoutFile, { recursive: true, force: true });
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("escalation matching never consults the process CWD", () => {
+  // Run the same match from a directory that does hold a root `schema.prisma`
+  // and from one that does not. Identical output proves the gate is pure text
+  // and cannot be narrowed by wherever the orchestrator happens to run.
+  const withFile = mkdtempSync(path.join(tmpdir(), "escalate-cwd-with-"));
+  const withoutFile = mkdtempSync(path.join(tmpdir(), "escalate-cwd-without-"));
+  try {
+    writeFileSync(path.join(withFile, "schema.prisma"), "// root\n");
+    const script = [
+      `const { matchEscalations } = await import(${JSON.stringify(
+        path.resolve(import.meta.dir, "escalate.mjs"),
+      )});`,
+      `console.log(JSON.stringify(matchEscalations(["schema.prisma", "prisma/schema.prisma"], ["schema.prisma"])));`,
+    ].join("\n");
+    const run = (cwd) =>
+      Bun.spawnSync({
+        cmd: [process.execPath, "-e", script],
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+        .stdout.toString()
+        .trim();
+    const expected = JSON.stringify([
+      { file: "schema.prisma", globs: ["schema.prisma"] },
+      { file: "prisma/schema.prisma", globs: ["schema.prisma"] },
+    ]);
+    expect(run(withFile)).toBe(expected);
+    expect(run(withoutFile)).toBe(expected);
+  } finally {
+    rmSync(withFile, { recursive: true, force: true });
+    rmSync(withoutFile, { recursive: true, force: true });
   }
 });
 

--- a/orchestrator/escalate.test.mjs
+++ b/orchestrator/escalate.test.mjs
@@ -329,6 +329,32 @@ test("Prisma/SaaS app config leaves ordinary dashboard, analytics, and docs chan
   ).toEqual([]);
 });
 
+test("bare escalation globs use the target repo root, not the process CWD", () => {
+  const rootWithFile = mkdtempSync(path.join(tmpdir(), "escalate-root-with-"));
+  const rootWithoutFile = mkdtempSync(
+    path.join(tmpdir(), "escalate-root-without-"),
+  );
+  try {
+    writeFileSync(path.join(rootWithFile, "package.json"), "{}\n");
+    const files = ["package.json", "fixtures/nested/package.json"];
+
+    expect(
+      matchEscalations(files, ["package.json"], { repoRoot: rootWithFile }),
+    ).toEqual([{ file: "package.json", globs: ["package.json"] }]);
+    // An absent root file must retain any-depth matching rather than narrowing
+    // based on whichever directory runs the escalation process.
+    expect(
+      matchEscalations(files, ["package.json"], { repoRoot: rootWithoutFile }),
+    ).toEqual([
+      { file: "package.json", globs: ["package.json"] },
+      { file: "fixtures/nested/package.json", globs: ["package.json"] },
+    ]);
+  } finally {
+    rmSync(rootWithFile, { recursive: true, force: true });
+    rmSync(rootWithoutFile, { recursive: true, force: true });
+  }
+});
+
 test("flags a file under an escalate glob", () => {
   const hits = matchEscalations(["app/src/payment/stripe.ts"], globs);
   expect(hits.length).toBe(1);

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -405,11 +405,11 @@ export function globToRegExp(glob, { repoRoot } = {}) {
  * pair of tickets; false negatives cost two agents editing one file. Bias to
  * the former, always.
  */
-export function globsOverlap(a, b) {
+export function globsOverlap(a, b, { repoRoot } = {}) {
   if (a === b) return true;
   try {
-    const ra = globToRegExp(a);
-    const rb = globToRegExp(b);
+    const ra = globToRegExp(a, { repoRoot });
+    const rb = globToRegExp(b, { repoRoot });
     const isConcrete = (g) => !/[*?{]/.test(g);
 
     // At least one side names an actual path: decide by matching, which is exact.

--- a/orchestrator/owned-paths.mjs
+++ b/orchestrator/owned-paths.mjs
@@ -365,9 +365,13 @@ export function globToRegExp(glob, { repoRoot } = {}) {
   // as `package.json` means the root file and nothing nested. This resolution
   // only ever narrows the matcher, so it is opt-in — never inferred from the
   // process CWD, which the compiler does not read.
+  // Only an absolute root may narrow the matcher. A relative `repoRoot` would
+  // be joined against `process.cwd()`, letting whichever directory the caller
+  // happens to run from decide the semantics; that is exactly what this
+  // resolution must never do, so such a root is ignored rather than resolved.
   const resolvesToRootFile =
     typeof repoRoot === "string" &&
-    repoRoot !== "" &&
+    path.isAbsolute(repoRoot) &&
     !g.includes("/") &&
     statSync(path.join(repoRoot, g), { throwIfNoEntry: false })?.isFile() ===
       true;

--- a/orchestrator/owned-paths.test.mjs
+++ b/orchestrator/owned-paths.test.mjs
@@ -189,20 +189,95 @@ test("bare filenames with extensions match that basename at any repository depth
   expectTrue(!matcher.test("event-runtime/lib/adapters/acp.mjs"));
 });
 
-test("compiling a glob never reads the filesystem or the process CWD", () => {
+test("compiling a glob never consults the process CWD", () => {
   // `globToRegExp` is shared with the escalate gate, which compiles globs with
   // no repository in hand. If compilation consulted an ambient directory, a
   // stray root file would silently narrow an escalate_paths matcher and drop
-  // escalations. Whatever sits next to the test process must not matter: with
-  // no `repoRoot`, a bare filename stays an any-depth basename matcher.
-  const root = mkdtempSync(path.join(tmpdir(), "owned-paths-root-"));
+  // escalations. Prove it by compiling the same glob from two working
+  // directories — one that does hold a root `package.json`, one that does not
+  // — in a child process, and requiring identical results.
+  const withFile = mkdtempSync(path.join(tmpdir(), "owned-paths-cwd-with-"));
+  const withoutFile = mkdtempSync(path.join(tmpdir(), "owned-paths-cwd-out-"));
   try {
-    writeFileSync(path.join(root, "package.json"), "{}\n");
-    const ambient = globToRegExp("package.json");
-    expectTrue(ambient.test("package.json"));
-    expectTrue(ambient.test("fixtures/nested/package.json"));
+    writeFileSync(path.join(withFile, "package.json"), "{}\n");
+    const script = [
+      `const { globToRegExp } = await import(${JSON.stringify(
+        path.resolve(import.meta.dir, "owned-paths.mjs"),
+      )});`,
+      `const m = globToRegExp("package.json");`,
+      `console.log(JSON.stringify([m.source, m.test("package.json"), m.test("fixtures/nested/package.json")]));`,
+    ].join("\n");
+    const run = (cwd) =>
+      Bun.spawnSync({
+        cmd: [process.execPath, "-e", script],
+        cwd,
+        stdout: "pipe",
+        stderr: "pipe",
+      })
+        .stdout.toString()
+        .trim();
+    const inWith = run(withFile);
+    expectTrue(inWith.length > 0, "child process produced no output");
+    expectEqual(JSON.parse(inWith).slice(1), [true, true]);
+    expectEqual(run(withoutFile), inWith);
     // Explicitly passing no root, and passing an empty options bag, agree.
     expectTrue(globToRegExp("package.json", {}).test("nested/package.json"));
+  } finally {
+    rmSync(withFile, { recursive: true, force: true });
+    rmSync(withoutFile, { recursive: true, force: true });
+  }
+});
+
+test("a relative repoRoot is ignored rather than resolved against the CWD", () => {
+  // A relative root would be joined onto `process.cwd()`, reintroducing exactly
+  // the ambient dependency the option exists to avoid. Such a root must leave
+  // the matcher at its broad any-depth default.
+  for (const repoRoot of ["", ".", "orchestrator", "./orchestrator"]) {
+    const matcher = globToRegExp("package.json", { repoRoot });
+    expectTrue(matcher.test("package.json"), repoRoot);
+    expectTrue(matcher.test("fixtures/nested/package.json"), repoRoot);
+  }
+});
+
+test("globsOverlap threads repoRoot through to both sides", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "owned-paths-overlap-"));
+  try {
+    writeFileSync(path.join(root, "package.json"), "{}\n");
+    // Root-free (the default everywhere but the handoff deviation gate): the
+    // bare name is an any-depth basename and overlaps the nested file.
+    expectTrue(globsOverlap("package.json", "fixtures/nested/package.json"));
+    expectTrue(globsOverlap("fixtures/nested/package.json", "package.json"));
+    // With the root named and a real file there, the bare entry means that one
+    // file, so the nested path no longer overlaps -- in either argument order.
+    expectTrue(
+      !globsOverlap("package.json", "fixtures/nested/package.json", {
+        repoRoot: root,
+      }),
+    );
+    expectTrue(
+      !globsOverlap("fixtures/nested/package.json", "package.json", {
+        repoRoot: root,
+      }),
+    );
+    // The root file itself still overlaps, and a wildcarded counterpart is
+    // still compiled with the same root.
+    expectTrue(
+      globsOverlap("package.json", "package.json", { repoRoot: root }),
+    );
+    expectTrue(globsOverlap("*.json", "package.json", { repoRoot: root }));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("globsOverlap with an unresolvable repoRoot keeps any-depth overlap", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "owned-paths-overlap-none-"));
+  try {
+    expectTrue(
+      globsOverlap("package.json", "fixtures/nested/package.json", {
+        repoRoot: root,
+      }),
+    );
   } finally {
     rmSync(root, { recursive: true, force: true });
   }


### PR DESCRIPTION
Fixes watt-mind/factory#2003

Root-anchor bare Owned Paths entries **in the handoff deviation gate only**. Every other consumer keeps its existing root-free, any-depth matching.

## Final semantics

| Gate | Matching | Why |
| --- | --- | --- |
| `verify.mjs` `ownedPathsDeviations` (handoff conformance) | Root-anchored via `{ repoRoot: worktreePath }` | The worktree root is known on disk. Anchoring only ever *removes* a false deviation report, so it is direction-safe. |
| `escalate.mjs` `matchEscalations` (ESCALATE gate) | **Unchanged from develop** — root-free, any-depth | Deliberate. The escalation gate errs broad: a false escalation costs one human review, a missed one ships an unreviewed security-sensitive change. |
| `planner.mjs` `pinManifestFreshness` | Root-free | Must agree with `matchingManifestPaths`; anchoring only one of the pair could key a closure cache off a manifest set the other never scanned. |
| `planner.mjs` `ownedPathContains` (merge-fix eligibility) | Root-free | Evaluated from ticket payload before a checkout is guaranteed to exist. |

Ticket AC bullet 2 (anchor the escalate gate too) was **overridden by the operator** after review: the escalation gate keeps its documented err-broad bias.

## Hardening

- `globToRegExp` ignores a non-absolute `repoRoot` instead of joining it onto `process.cwd()` — the option can never reintroduce an ambient-directory dependency.
- `verify.mjs` resolves the worktree path before passing it.

## Tests

- `escalate.test.mjs`: a bare name that *does* resolve to a root file still matches nested files; matching is proven CWD-independent by compiling in a child process from two different working directories.
- `owned-paths.test.mjs`: direct `globsOverlap(..., { repoRoot })` coverage (both argument orders, resolvable and unresolvable roots), a relative-`repoRoot`-is-ignored test, and the previously misnamed CWD test now actually chdirs (child process) rather than merely creating a temp dir.
- `verify.test.mjs`: anchored and unanchored `ownedPathsDeviations` behaviour.

## Validation

| Check | Command | Result |
| --- | --- | --- |
| Focused | `bun test orchestrator/escalate.test.mjs orchestrator/owned-paths.test.mjs event-runtime/lib/verify.test.mjs event-runtime/lib/planner.test.mjs` | pass (293) |
| Repo verify | `bun test event-runtime/lib --timeout 20000` | pass (2317, 10 skip) |
| Orchestrator | `bun test orchestrator` | pass (517) |
| Lint / format | `bun run lint && bun run format:check` | pass (0 errors, 615 pre-existing warnings) |

UX critique: skipped — backend ownership-routing and handoff-gate change.

run:run_34b27f43-0083-4e8f-b52d-4c1a3701e8a2
