### PR TITLE
fix(worker): ready verified dispatch PRs

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -989,12 +989,12 @@ export function composeHandoffVerification(handoff) {
     const draftState =
       typeof handoff.pr?.draft === "boolean"
         ? handoff.pr.draft
-          ? "draft"
-          : "ready"
+          ? "yes"
+          : "no"
         : typeof handoff.prDraft === "boolean"
           ? handoff.prDraft
-            ? "draft"
-            : "ready"
+            ? "yes"
+            : "no"
           : "draft state unknown";
     const fixes =
       typeof handoff.pr?.hasFixesLine === "boolean"
@@ -1009,7 +1009,7 @@ export function composeHandoffVerification(handoff) {
           : "no"
         : "unknown";
     lines.push(
-      `- PR: #${prNumber} (${draftState}) · Fixes: ${fixes} · run trailer: ${runTrailer}`,
+      `- PR: #${prNumber} (${draftState === "draft state unknown" ? draftState : `draft: ${draftState}`}) · Fixes: ${fixes} · run trailer: ${runTrailer}`,
     );
   }
   const primary = handoff.verification;

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2859,10 +2859,10 @@ describe("handoff verification helpers (WM-718)", () => {
     const base = { verification: null, repoVerify: null, webBuild: null };
     expect(
       composeHandoffVerification({ ...base, prNumber: 7, prDraft: true }),
-    ).toContain("- PR: #7 (draft)");
+    ).toContain("- PR: #7 (draft: yes)");
     expect(
       composeHandoffVerification({ ...base, prNumber: 7, prDraft: false }),
-    ).toContain("- PR: #7 (ready)");
+    ).toContain("- PR: #7 (draft: no)");
     // pr_base_unreadable never sets prDraft; the worker drafts the PR after
     // this comment is composed, so "ready" would be a lie.
     expect(composeHandoffVerification({ ...base, prNumber: 7 })).toContain(
@@ -2908,7 +2908,7 @@ describe("handoff verification helpers (WM-718)", () => {
     const lines = body.split("\n");
     expect(lines[0]).toBe("## Handoff verification (worker-observed)");
     expect(lines[1]).toBe(
-      "- PR: #42 (draft) · Fixes: unknown · run trailer: unknown",
+      "- PR: #42 (draft: yes) · Fixes: unknown · run trailer: unknown",
     );
     expect(lines[2]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
     expect(body).toContain("(fail) x > y");
@@ -3012,6 +3012,8 @@ describe("handoff verification helpers (WM-718)", () => {
         hasRunTrailer: false,
       },
     });
-    expect(body).toContain("- PR: #77 (ready) · Fixes: yes · run trailer: no");
+    expect(body).toContain(
+      "- PR: #77 (draft: no) · Fixes: yes · run trailer: no",
+    );
   });
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3370,6 +3370,41 @@ export function assertHandoffPullRequestBase({
   }
 }
 
+/**
+ * Promote a successfully verified dispatch PR out of draft so GitHub routes
+ * its full CI lane. The handoff's state is updated only after `gh pr ready`
+ * succeeds, making the worker-authored handoff comment an observation of the
+ * final PR state rather than the draft state it had during local verification.
+ */
+export function defaultMarkHandoffPullRequestReady({ handoff, forge = null }) {
+  if (handoff?.pr?.draft !== true) return false;
+  const prNumber = handoffPrNumber(handoff);
+  if (!handoff.github || !prNumber) {
+    throw new ContractViolation(
+      [
+        "pr_ready_unverifiable: handoff requires GitHub repository and numeric PR number",
+      ],
+      { reasonCode: "handoff_verification_failed", handoff },
+    );
+  }
+  forge ??= loadForge();
+  try {
+    forge.prSetDraft(handoff.github, prNumber, false, {
+      timeout: workerSubprocessTimeoutMs(),
+    });
+  } catch (err) {
+    throw new ContractViolation(
+      [
+        `pr_ready_failed: could not mark PR #${prNumber} ready for review: ${String(err?.message ?? err)}`,
+      ],
+      { reasonCode: "handoff_verification_failed", handoff },
+    );
+  }
+  handoff.pr.draft = false;
+  handoff.prDraft = false;
+  return true;
+}
+
 const BASELINE_COMMENT_MARKER = "wm:baseline:red:";
 
 function baselineFailureSignature({ why, log = null, baseline = null }) {
@@ -3561,6 +3596,7 @@ export async function executeClaimed(
       returnHandoffTicket: () => true,
       reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
+      markHandoffPullRequestReady: () => false,
       findWorkspacePullRequest: () => null,
     };
   } else if (dispatchStubSelected) {
@@ -3575,6 +3611,7 @@ export async function executeClaimed(
       returnHandoffTicket: () => true,
       reconcileVerifiedHandoffTicket: () => false,
       holdPullRequest: () => false,
+      markHandoffPullRequestReady: () => false,
       findWorkspacePullRequest: () => null,
       ...dispatchOpts,
     };
@@ -3625,6 +3662,9 @@ export async function executeClaimed(
     dispatchOpts?.holdPullRequest ?? defaultHoldPullRequest;
   const fetchHandoffPullRequestFn =
     dispatchOpts?.fetchHandoffPullRequest ?? defaultFetchHandoffPullRequest;
+  const markHandoffPullRequestReadyFn =
+    dispatchOpts?.markHandoffPullRequestReady ??
+    defaultMarkHandoffPullRequestReady;
   const projectTierEscalationFn =
     dispatchOpts?.projectTierEscalation ?? defaultProjectTierEscalation;
   let handoffContext = null;
@@ -5057,6 +5097,7 @@ export async function executeClaimed(
           base: worktreeRecord?.base,
           fetchPullRequest: fetchHandoffPullRequestFn,
         });
+        markHandoffPullRequestReadyFn({ handoff: verified.handoff });
       }
     } catch (err) {
       if (!(err instanceof ContractViolation)) {
@@ -5100,6 +5141,7 @@ export async function executeClaimed(
               base: worktreeRecord?.base,
               fetchPullRequest: fetchHandoffPullRequestFn,
             });
+            markHandoffPullRequestReadyFn({ handoff: verified.handoff });
           }
           verified.result.reasonCode = RECOVERED_RESULT_REASON;
           break verificationAttempt;

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3375,30 +3375,26 @@ export function assertHandoffPullRequestBase({
  * its full CI lane. The handoff's state is updated only after `gh pr ready`
  * succeeds, making the worker-authored handoff comment an observation of the
  * final PR state rather than the draft state it had during local verification.
+ *
+ * Best effort, like the handoff comment itself: the run is already verified by
+ * the time this is called, so a transient forge error must not fail it, redraft
+ * anything, or bounce the ticket. On failure the handoff keeps `draft: true`,
+ * the comment truthfully records `draft: yes`, and this returns false.
  */
 export function defaultMarkHandoffPullRequestReady({ handoff, forge = null }) {
   if (handoff?.pr?.draft !== true) return false;
   const prNumber = handoffPrNumber(handoff);
-  if (!handoff.github || !prNumber) {
-    throw new ContractViolation(
-      [
-        "pr_ready_unverifiable: handoff requires GitHub repository and numeric PR number",
-      ],
-      { reasonCode: "handoff_verification_failed", handoff },
-    );
-  }
-  forge ??= loadForge();
+  if (!handoff.github || !prNumber) return false;
   try {
+    forge ??= loadForge();
     forge.prSetDraft(handoff.github, prNumber, false, {
       timeout: workerSubprocessTimeoutMs(),
     });
   } catch (err) {
-    throw new ContractViolation(
-      [
-        `pr_ready_failed: could not mark PR #${prNumber} ready for review: ${String(err?.message ?? err)}`,
-      ],
-      { reasonCode: "handoff_verification_failed", handoff },
+    console.error(
+      `[worker] could not mark PR #${prNumber} ready for review: ${String(err?.message ?? err)}`,
     );
+    return false;
   }
   handoff.pr.draft = false;
   handoff.prDraft = false;
@@ -5097,7 +5093,6 @@ export async function executeClaimed(
           base: worktreeRecord?.base,
           fetchPullRequest: fetchHandoffPullRequestFn,
         });
-        markHandoffPullRequestReadyFn({ handoff: verified.handoff });
       }
     } catch (err) {
       if (!(err instanceof ContractViolation)) {
@@ -5141,7 +5136,6 @@ export async function executeClaimed(
               base: worktreeRecord?.base,
               fetchPullRequest: fetchHandoffPullRequestFn,
             });
-            markHandoffPullRequestReadyFn({ handoff: verified.handoff });
           }
           verified.result.reasonCode = RECOVERED_RESULT_REASON;
           break verificationAttempt;
@@ -5482,6 +5476,14 @@ export async function executeClaimed(
         reasonCode: verified.reasonCode,
         receipt: res.receipt,
       };
+    }
+
+    // The run is accepted: neither failed nor refused. Only now may the PR
+    // leave draft — a refused handoff must not be promoted — and promoting it
+    // before the handoff comment is composed keeps that comment an observation
+    // of the PR's final state.
+    if (verified.handoff && handoffPrNumber(verified.handoff)) {
+      markHandoffPullRequestReadyFn({ handoff: verified.handoff });
     }
 
     // WM-718: the Handoff's Verification line is worker-authored. Post what

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5910,7 +5910,7 @@ sh -c 'sleep 5 & wait'
     expect(calls).toHaveLength(1);
   });
 
-  test("a failed ready-for-review transition leaves the handoff draft", () => {
+  test("a failed ready-for-review transition is best effort: the run keeps its verified handoff, recorded draft: yes", () => {
     const handoff = {
       github: "watt-mind/factory",
       prNumber: 77,
@@ -5923,13 +5923,189 @@ sh -c 'sleep 5 & wait'
       },
     };
 
-    expect(() =>
-      defaultMarkHandoffPullRequestReady({ handoff, forge }),
-    ).toThrow(
-      "pr_ready_failed: could not mark PR #77 ready for review: GitHub rejected the transition",
-    );
+    const err = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Promotion happens after the run is already verified; a transient forge
+      // error must never throw here, or a green run is failed and its PR is
+      // re-drafted by the failure path it lands in.
+      expect(defaultMarkHandoffPullRequestReady({ handoff, forge })).toBe(
+        false,
+      );
+      expect(
+        err.mock.calls.some((c) =>
+          String(c[0]).includes(
+            "could not mark PR #77 ready for review: GitHub rejected the transition",
+          ),
+        ),
+      ).toBe(true);
+    } finally {
+      err.mockRestore();
+    }
     expect(handoff.pr.draft).toBe(true);
     expect(handoff.prDraft).toBe(true);
+    // The comment stays truthful about the state the PR is actually left in.
+    expect(
+      composeHandoffVerification({
+        ...handoff,
+        verification: null,
+        repoVerify: null,
+        webBuild: null,
+      }),
+    ).toContain("- PR: #77 (draft: yes)");
+  });
+
+  test("a handoff with no usable PR coordinates is left alone rather than promoted", () => {
+    const forge = {
+      prSetDraft: () => {
+        throw new Error("prSetDraft must not be called");
+      },
+    };
+    for (const handoff of [
+      { github: "watt-mind/factory", prNumber: null, pr: { draft: true } },
+      { github: null, prNumber: 77, pr: { number: 77, draft: true } },
+      { github: "watt-mind/factory", prNumber: 77, pr: { draft: false } },
+      { github: "watt-mind/factory", prNumber: 77 },
+    ]) {
+      expect(defaultMarkHandoffPullRequestReady({ handoff, forge })).toBe(
+        false,
+      );
+    }
+  });
+
+  test("executeClaimed promotes a verified handoff PR, and never a refused one (#2005)", async () => {
+    const TICKET = "watt-mind/factory#2005";
+    // The gate reads the live PR; this is the form it must accept, and it is
+    // what makes the handoff record say `draft: true` before promotion.
+    const livePullRequest = {
+      baseRefName: "develop",
+      isDraft: true,
+      body: `Fixes ${TICKET}`,
+    };
+    const handoffFixture = () => ({
+      github: "watt-mind/factory",
+      ticket: TICKET,
+      prNumber: 77,
+      verification: null,
+      repoVerify: null,
+      webBuild: null,
+    });
+    const runResult = (spec, overrides = {}) => {
+      const artifact = { repos: [], recommendedAction: "wait" };
+      return {
+        schemaVersion: "factory.run-result/v1",
+        runId: spec.runId,
+        attempt: 1,
+        terminalState: "completed",
+        reasonCode: "ok",
+        outputContract: spec.outputContract,
+        artifact,
+        artifactHash: hashJson(artifact),
+        evidenceSetHash: null,
+        verification: { status: "passed", checks: [] },
+        artifacts: [],
+        ...overrides,
+      };
+    };
+    const dispatchSeams = (calls) => ({
+      locksDir: tmpDir("evrt-pr-ready-locks-"),
+      leasesDir: tmpDir("evrt-pr-ready-leases-"),
+      fetchTicket: () => ({
+        identifier: TICKET,
+        state: { name: "Todo" },
+        assignee: null,
+        labels: { nodes: [{ name: "ai:agent-ready" }] },
+        description: "## Owned Paths\n- event-runtime/lib/worker.mjs\n",
+      }),
+      fetchInFlight: () => [],
+      countLeases: () => 0,
+      budgetRefusal: () => null,
+      claimTicket: () => ({ ok: true }),
+      unclaimTicket: () => true,
+      commentTicket: (args) => (calls.comments.push(args), true),
+      fetchHandoffPullRequest: () => livePullRequest,
+      markHandoffPullRequestReady: ({ handoff }) => {
+        calls.promoted.push(handoff);
+        handoff.pr.draft = false;
+        handoff.prDraft = false;
+        return true;
+      },
+    });
+    const workerOpts = (calls, verified) =>
+      opts({
+        artifactStore: freshRoot(),
+        dispatch: dispatchSeams(calls),
+        materializeWorktree: () => ({
+          github: "watt-mind/factory",
+          base: "develop",
+        }),
+        verifyResult: verified,
+      });
+
+    const acceptedDb = openDb(":memory:");
+    const acceptedSpec = makeSpec({
+      input: { repo: "factory", ticket: TICKET },
+      workspace: { type: "worktree" },
+    });
+    queueRun(acceptedDb, acceptedSpec);
+    const acceptedCalls = { comments: [], promoted: [] };
+    const acceptedHandoff = handoffFixture();
+    const accepted = await executeClaimed(
+      acceptedDb,
+      registry,
+      adapters,
+      claimNext(acceptedDb, opts()),
+      workerOpts(acceptedCalls, () => ({
+        kind: "completed",
+        result: runResult(acceptedSpec),
+        receipt: {},
+        handoff: acceptedHandoff,
+      })),
+    );
+
+    expect(accepted).toMatchObject({ terminalState: "COMPLETED" });
+    expect(acceptedCalls.promoted).toEqual([acceptedHandoff]);
+    // Promotion runs before the handoff comment is composed, so the comment
+    // reports the state the PR is actually left in.
+    expect(acceptedCalls.comments).toEqual([
+      expect.objectContaining({
+        body: expect.stringContaining("- PR: #77 (draft: no)"),
+      }),
+    ]);
+    acceptedDb.close();
+
+    // A refused run must leave its PR in draft: the merge stage skips drafts,
+    // which is exactly what keeps an unaccepted handoff from landing.
+    const refusedDb = openDb(":memory:");
+    const refusedSpec = makeSpec({
+      input: { repo: "factory", ticket: TICKET },
+      workspace: { type: "worktree" },
+    });
+    queueRun(refusedDb, refusedSpec);
+    const refusedCalls = { comments: [], promoted: [] };
+    const refusedHandoff = handoffFixture();
+    const refused = await executeClaimed(
+      refusedDb,
+      registry,
+      adapters,
+      claimNext(refusedDb, opts()),
+      workerOpts(refusedCalls, () => ({
+        kind: "refused",
+        reasonCode: "ticket_not_ready",
+        result: runResult(refusedSpec, {
+          terminalState: "refused",
+          reasonCode: "ticket_not_ready",
+        }),
+        handoff: refusedHandoff,
+      })),
+    );
+
+    expect(refused).toMatchObject({
+      terminalState: "REFUSED",
+      reasonCode: "ticket_not_ready",
+    });
+    expect(refusedCalls.promoted).toEqual([]);
+    expect(refusedHandoff.pr.draft).toBe(true);
+    refusedDb.close();
   });
 
   test("handoff PR form rejects literal run trailers when a run ID is set", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -5910,6 +5910,28 @@ sh -c 'sleep 5 & wait'
     expect(calls).toHaveLength(1);
   });
 
+  test("a failed ready-for-review transition leaves the handoff draft", () => {
+    const handoff = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      pr: { number: 77, draft: true },
+      prDraft: true,
+    };
+    const forge = {
+      prSetDraft: () => {
+        throw new Error("GitHub rejected the transition");
+      },
+    };
+
+    expect(() =>
+      defaultMarkHandoffPullRequestReady({ handoff, forge }),
+    ).toThrow(
+      "pr_ready_failed: could not mark PR #77 ready for review: GitHub rejected the transition",
+    );
+    expect(handoff.pr.draft).toBe(true);
+    expect(handoff.prDraft).toBe(true);
+  });
+
   test("handoff PR form rejects literal run trailers when a run ID is set", () => {
     const base = {
       github: "watt-mind/factory",

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -88,6 +88,7 @@ import {
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
   defaultFindWorkspacePullRequest,
   defaultLocksDir,
+  defaultMarkHandoffPullRequestReady,
   defaultReconcileVerifiedHandoffTicket,
   defaultHoldPullRequest,
   defaultProjectTierEscalation,
@@ -5872,6 +5873,41 @@ sh -c 'sleep 5 & wait'
       hasRunTrailer: true,
       hasUnexpandedRunTrailer: false,
     });
+  });
+
+  test("verified draft handoffs are marked ready and record draft: no", () => {
+    const handoff = {
+      github: "watt-mind/factory",
+      prNumber: 77,
+      pr: { number: 77, draft: true },
+      prDraft: true,
+    };
+    const calls = [];
+    const forge = {
+      prSetDraft: (...args) => calls.push(args),
+    };
+
+    expect(defaultMarkHandoffPullRequestReady({ handoff, forge })).toBe(true);
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toEqual([
+      "watt-mind/factory",
+      77,
+      false,
+      expect.objectContaining({ timeout: expect.any(Number) }),
+    ]);
+    expect(handoff.pr.draft).toBe(false);
+    expect(handoff.prDraft).toBe(false);
+    expect(
+      composeHandoffVerification({
+        ...handoff,
+        verification: null,
+        repoVerify: null,
+        webBuild: null,
+      }),
+    ).toContain("- PR: #77 (draft: no)");
+
+    expect(defaultMarkHandoffPullRequestReady({ handoff, forge })).toBe(false);
+    expect(calls).toHaveLength(1);
   });
 
   test("handoff PR form rejects literal run trailers when a run ID is set", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2005

Review the worker handoff ordering and draft-state observation; documentation follow-up is tracked in #2013.

## Validation

| Check                | Command                                                                                                                  | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs event-runtime/lib/verify.test.mjs && bun run lint` | pass    | 250 tests, 0 failures; lint clean  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`         | pass    | all four stages exited 0           |
| UX critique          | `factory-ux-critic`                                                                                                      | not run | backend worker; no user-facing UI  |

UX critique: skipped

run:run_d37f05d5-67e0-4b2b-9491-64d45ccc56ca
