### PR TITLE
fix(runtime): skip reviewed tier continuations

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3686,6 +3686,27 @@ export async function executeClaimed(
     return failureCount(db, runId, "agent_error") + 1 >= spec.maxAttempts;
   };
 
+  // The guard performs live tracker and forge reads. Memoize per reason code:
+  // a terminal path consults it once for the claim-release decision and again
+  // inside the escalation write, and those two answers must be the same world.
+  let escalationGuardCache = null;
+  const resolveEscalationGuard = (reasonCode) => {
+    if (escalationGuardCache?.reasonCode === reasonCode) {
+      return escalationGuardCache.guard;
+    }
+    const guard = tierEscalationDue(reasonCode)
+      ? tierEscalationContinuationGuard(spec, reasonCode, {
+          fetchTicket: fetchTicketFn,
+          findPullRequest:
+            dispatchOpts?.findWorkspacePullRequest ??
+            defaultFindWorkspacePullRequest,
+          workspacePath: worktreePath ?? checkoutPath,
+        })
+      : null;
+    escalationGuardCache = { reasonCode, guard };
+    return guard;
+  };
+
   const projectScheduledEscalation = (scheduled) =>
     scheduled
       ? reconcileTierEscalations(db, {
@@ -3741,15 +3762,7 @@ export async function executeClaimed(
 
   /** Terminal failure-shaped write: classify, finalize, and budget any retry atomically. */
   const failTerminal = (to, journalReason, reasonCode, beforeTerminal) => {
-    const escalationGuard = tierEscalationDue(reasonCode)
-      ? tierEscalationContinuationGuard(spec, reasonCode, {
-          fetchTicket: fetchTicketFn,
-          findPullRequest:
-            dispatchOpts?.findWorkspacePullRequest ??
-            defaultFindWorkspacePullRequest,
-          workspacePath: worktreePath ?? checkoutPath,
-        })
-      : null;
+    const escalationGuard = resolveEscalationGuard(reasonCode);
     const result = txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
@@ -5042,7 +5055,15 @@ export async function executeClaimed(
     if (!lateCompletion && exitCode !== 0) {
       const reasonCode = `agent_exit_${exitCode}`;
       const escalating = tierEscalationDue(reasonCode);
-      if (mayMutateClaimedTicket() && !escalating) {
+      // A skipped escalation writes no continuation, so the claim has no
+      // successor to inherit it: release it here or the ticket is stranded
+      // In Progress forever. `defaultUnclaimTicket` no-ops unless the ticket
+      // is still In Progress + ai:in-progress, so the `ticket_in_review` skip
+      // cannot drag a reviewed ticket back to Todo (#2006).
+      const escalationGuard = escalating
+        ? resolveEscalationGuard(reasonCode)
+        : null;
+      if (mayMutateClaimedTicket() && (!escalating || escalationGuard?.skip)) {
         try {
           unclaimTicketFn({
             repo: repoName,
@@ -5243,15 +5264,6 @@ export async function executeClaimed(
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${activeError.violations.join("; ")}`
         : null;
       const escalating = tierEscalationDue(reasonCode);
-      const escalationGuard = escalating
-        ? tierEscalationContinuationGuard(spec, reasonCode, {
-            fetchTicket: fetchTicketFn,
-            findPullRequest:
-              dispatchOpts?.findWorkspacePullRequest ??
-              defaultFindWorkspacePullRequest,
-            workspacePath: worktreePath ?? checkoutPath,
-          })
-        : null;
       // WM-718: the PR is the agent's, already opened; the structural hold is
       // to draft it and quote the observed failure where the reviewer looks.
       if (
@@ -5271,8 +5283,32 @@ export async function executeClaimed(
           /* intentionally ignored */
         }
       }
-      if (mayMutateClaimedTicket() && !escalating) {
-        if (isAgentHandoffFailure(reasonCode)) {
+      // Resolve the guard only AFTER the hold above: an ordinary handoff
+      // verification failure has just converted the agent's own PR to draft,
+      // and probing the forge before that would read the still-open PR as
+      // retained review ownership and suppress every escalation on the most
+      // common failure path (#2006).
+      const escalationGuard = escalating
+        ? resolveEscalationGuard(reasonCode)
+        : null;
+      if (mayMutateClaimedTicket() && (!escalating || escalationGuard?.skip)) {
+        if (escalationGuard?.skip) {
+          // No continuation was scheduled, so nothing inherits the claim.
+          // Release it through the plain unclaim, which no-ops unless the
+          // ticket is still In Progress + ai:in-progress — the
+          // `ticket_in_review` skip must never pull a reviewed ticket back to
+          // Todo the way the handoff return would.
+          try {
+            unclaimTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              why: failureReason,
+              log: null,
+            });
+          } catch {
+            /* intentionally ignored */
+          }
+        } else if (isAgentHandoffFailure(reasonCode)) {
           try {
             const returned = returnHandoffTicketFn({
               repo: repoName,
@@ -6098,8 +6134,12 @@ export function cancelRun(
   } = {},
 ) {
   const currentNow = resolveNow(now);
-  const active = ACTIVE_EXECUTIONS.get(runId);
   const outcome = txImmediate(db, () => {
+    // Read the executor registry inside the transaction: an execution can
+    // register or finish while the write waits on the lock, and the
+    // post-commit ownership handoff below must act on what was true when the
+    // cancellation actually committed.
+    const active = ACTIVE_EXECUTIONS.get(runId);
     const run = db
       .query(`SELECT state, attempts FROM runs WHERE run_id = ?`)
       .get(runId);
@@ -6146,9 +6186,20 @@ export function cancelRun(
     if (active) {
       active.abort(reason);
     }
-    return { ...result, proposalClose, escalation, escalationRefused };
+    return {
+      ...result,
+      proposalClose,
+      escalation,
+      escalationRefused,
+      hadActiveExecution: Boolean(active),
+    };
   });
-  const { escalation, escalationRefused, ...cancelledRun } = outcome;
+  const {
+    escalation,
+    escalationRefused,
+    hadActiveExecution: active,
+    ...cancelledRun
+  } = outcome;
 
   // An executing continuation owns its ticket/workspace cleanup and responds
   // to the abort above. An APPROVED/QUEUED continuation has no executor to do

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -5063,6 +5063,9 @@ export async function executeClaimed(
         attempt,
         terminalState: "FAILED",
         reasonCode,
+        ...(res?.tierEscalationSkip
+          ? { tierEscalationSkip: res.tierEscalationSkip }
+          : {}),
         ...(res?.escalation
           ? {
               escalatedRunId: res.escalation.continuation_run_id,
@@ -5394,6 +5397,9 @@ export async function executeClaimed(
         reasonCode,
         detail: failureReason,
         ...(handoff ? { handoff } : {}),
+        ...(res?.tierEscalationSkip
+          ? { tierEscalationSkip: res.tierEscalationSkip }
+          : {}),
         ...(res?.escalation
           ? {
               escalatedRunId: res.escalation.continuation_run_id,
@@ -6086,10 +6092,14 @@ export function cancelRun(
     reason = "operator_cancel",
     now = () => Date.now(),
     policyVersion,
+    unclaimTierEscalation = defaultUnclaimTicket,
+    cleanupTierEscalationWorkspace = ({ sourceWorkspacePath, repo }) =>
+      destroyWorkspace(sourceWorkspacePath, { repoName: repo }),
   } = {},
 ) {
   const currentNow = resolveNow(now);
-  return txImmediate(db, () => {
+  const active = ACTIVE_EXECUTIONS.get(runId);
+  const outcome = txImmediate(db, () => {
     const run = db
       .query(`SELECT state, attempts FROM runs WHERE run_id = ?`)
       .get(runId);
@@ -6129,12 +6139,61 @@ export function cancelRun(
       actor,
       now: currentNow,
     });
-    const active = ACTIVE_EXECUTIONS.get(runId);
+    const escalation = tierEscalationForContinuation(db, runId);
+    const escalationRefused = escalation
+      ? refuseTierEscalationClaim(db, escalation, reason)
+      : false;
     if (active) {
       active.abort(reason);
     }
-    return { ...result, proposalClose };
+    return { ...result, proposalClose, escalation, escalationRefused };
   });
+  const { escalation, escalationRefused, ...cancelledRun } = outcome;
+
+  // An executing continuation owns its ticket/workspace cleanup and responds
+  // to the abort above. An APPROVED/QUEUED continuation has no executor to do
+  // that work, so cancellation must consume the durable ownership transfer.
+  // Keep tracker/filesystem effects outside the SQLite write transaction.
+  if (!escalation || active) return cancelledRun;
+
+  let claimReleased = false;
+  let claimReleaseError = null;
+  try {
+    claimReleased =
+      unclaimTierEscalation({
+        repo: escalation.repo,
+        ticket: escalation.ticket,
+        why: reason,
+        log: null,
+      }) === true;
+  } catch (err) {
+    claimReleaseError = err?.message ?? String(err);
+  }
+
+  let workspaceCleaned = false;
+  let workspaceCleanupError = null;
+  try {
+    workspaceCleaned =
+      cleanupTierEscalationWorkspace({
+        sourceWorkspacePath: escalation.sourceWorkspacePath,
+        workspacePath: escalation.workspacePath,
+        repo: escalation.repo,
+        ticket: escalation.ticket,
+      }) === true;
+  } catch (err) {
+    workspaceCleanupError = err?.message ?? String(err);
+  }
+
+  return {
+    ...cancelledRun,
+    escalationCancellation: {
+      projectionRefused: escalationRefused,
+      claimReleased,
+      workspaceCleaned,
+      ...(claimReleaseError ? { claimReleaseError } : {}),
+      ...(workspaceCleanupError ? { workspaceCleanupError } : {}),
+    },
+  };
 }
 
 /**

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1035,6 +1035,52 @@ export function tierEscalationEligibility(spec, reasonCode) {
 }
 
 /**
+ * Decide whether an otherwise eligible tier escalation still owns work to do.
+ *
+ * The failed agent can hand a ticket to review before its worker observes a
+ * failed handoff verification. Do not let that late failure create a stronger
+ * continuation which races the retained PR's review/fix lane.
+ */
+export function tierEscalationContinuationGuard(
+  spec,
+  reasonCode,
+  {
+    fetchTicket,
+    findPullRequest = defaultFindWorkspacePullRequest,
+    workspacePath,
+  } = {},
+) {
+  const eligibility = tierEscalationEligibility(spec, reasonCode);
+  if (!eligibility.eligible) return { ...eligibility, skip: false };
+
+  let ticket;
+  try {
+    ticket = fetchTicket?.(spec.input?.ticket, spec.input?.repo);
+  } catch {
+    // Preserve the existing continuation behavior when the tracker cannot be
+    // read. The continuation's claim-time gate still performs its own
+    // fail-closed tracker proof before it can execute.
+    ticket = null;
+  }
+  if (ticket?.state?.name === "In Review") {
+    return { ...eligibility, skip: true, reason: "ticket_in_review" };
+  }
+
+  let pullRequest;
+  try {
+    pullRequest = workspacePath ? findPullRequest?.({ workspacePath }) : null;
+  } catch {
+    // PR discovery is an additional ownership signal, not a reason to drop a
+    // recoverable continuation when the forge is temporarily unavailable.
+    pullRequest = null;
+  }
+  if (pullRequest?.isDraft === false) {
+    return { ...eligibility, skip: true, reason: "retained_pr_open" };
+  }
+  return { ...eligibility, skip: false };
+}
+
+/**
  * Layer the RunSpec-derived dispatch identity onto the adapter environment.
  *
  * Any `dispatch@<version>` agent qualifies. Identity keys are only emitted when
@@ -1642,6 +1688,7 @@ export function scheduleTierEscalation(
     continuationRunId = newRunId(),
     reasonCode,
     handoffFailure = null,
+    continuationGuard = null,
   } = {},
 ) {
   const rootRunId = failedSpec.rootRunId ?? failedSpec.runId;
@@ -1650,6 +1697,7 @@ export function scheduleTierEscalation(
     .get(rootRunId);
   if (existing) return existing;
   if (!tierEscalationEligibility(failedSpec, reasonCode).eligible) return null;
+  if (continuationGuard?.skip) return null;
   if (!workspacePath || !sourceWorkspacePath)
     throw new Error("tier escalation requires the retained workspace paths");
 
@@ -1765,7 +1813,7 @@ export function defaultFindWorkspacePullRequest({ workspacePath, forge }) {
     .prList(null, {
       cwd: workspacePath,
       state: "open",
-      fields: ["number", "url", "headRefName"],
+      fields: ["number", "url", "headRefName", "isDraft"],
       timeout: workerSubprocessTimeoutMs(),
     })
     .find((pr) => pr?.headRefName === branch && pr?.url);
@@ -3648,6 +3696,23 @@ export async function executeClaimed(
         })
       : null;
 
+  const commentTierEscalationSkip = (reason) => {
+    if (!reason || !mayMutateClaimedTicket()) return;
+    const why =
+      reason === "ticket_in_review"
+        ? "ticket is already In Review"
+        : "the retained worktree already has an open non-draft PR";
+    try {
+      commentTicketFn({
+        repo: repoName,
+        ticket: ticketId,
+        body: `Tier escalation skipped: ${why}; failed run \`${runId}\` remains with the existing review handoff.`,
+      });
+    } catch {
+      /* The terminal run remains recorded even if tracker commentary fails. */
+    }
+  };
+
   const abortController = new AbortController();
   ACTIVE_EXECUTIONS.set(runId, {
     abort: (reason) => abortController.abort(reason),
@@ -3675,8 +3740,17 @@ export async function executeClaimed(
   };
 
   /** Terminal failure-shaped write: classify, finalize, and budget any retry atomically. */
-  const failTerminal = (to, journalReason, reasonCode, beforeTerminal) =>
-    txImmediate(db, () => {
+  const failTerminal = (to, journalReason, reasonCode, beforeTerminal) => {
+    const escalationGuard = tierEscalationDue(reasonCode)
+      ? tierEscalationContinuationGuard(spec, reasonCode, {
+          fetchTicket: fetchTicketFn,
+          findPullRequest:
+            dispatchOpts?.findWorkspacePullRequest ??
+            defaultFindWorkspacePullRequest,
+          workspacePath: worktreePath ?? checkoutPath,
+        })
+      : null;
+    const result = txImmediate(db, () => {
       const currentNow = nowFn();
       if (!assertCurrentToken(db, runId, fencingToken)) {
         recordFencedAttempt(db, {
@@ -3726,7 +3800,7 @@ export async function executeClaimed(
           policyVersion,
           now: nowFn(),
         });
-      } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
+      } else if (escalationGuard?.eligible && !escalationGuard.skip) {
         escalation = scheduleTierEscalation(db, registry, spec, {
           workspacePath: worktreePath ?? checkoutPath,
           sourceWorkspacePath: workspaceDir,
@@ -3734,6 +3808,7 @@ export async function executeClaimed(
           policyVersion,
           now: currentNow,
           reasonCode,
+          continuationGuard: escalationGuard,
         });
       }
       return {
@@ -3741,8 +3816,15 @@ export async function executeClaimed(
         cause: decision.cause,
         requeued: decision.retry,
         escalation,
+        tierEscalationSkip:
+          !decision.retry && escalationGuard?.skip
+            ? escalationGuard.reason
+            : null,
       };
     });
+    commentTierEscalationSkip(result?.tierEscalationSkip);
+    return result;
+  };
 
   let def = null;
   try {
@@ -5158,6 +5240,15 @@ export async function executeClaimed(
         ? `${composeHandoffVerification(handoff)}\n\n**Result:** run ${runId} FAILED \`${reasonCode}\` — ${activeError.violations.join("; ")}`
         : null;
       const escalating = tierEscalationDue(reasonCode);
+      const escalationGuard = escalating
+        ? tierEscalationContinuationGuard(spec, reasonCode, {
+            fetchTicket: fetchTicketFn,
+            findPullRequest:
+              dispatchOpts?.findWorkspacePullRequest ??
+              defaultFindWorkspacePullRequest,
+            workspacePath: worktreePath ?? checkoutPath,
+          })
+        : null;
       // WM-718: the PR is the agent's, already opened; the structural hold is
       // to draft it and quote the observed failure where the reviewer looks.
       if (
@@ -5271,7 +5362,7 @@ export async function executeClaimed(
             policyVersion,
             now: nowFn(),
           });
-        } else if (tierEscalationEligibility(spec, reasonCode).eligible) {
+        } else if (escalationGuard?.eligible && !escalationGuard.skip) {
           escalation = scheduleTierEscalation(db, registry, spec, {
             workspacePath: worktreePath ?? checkoutPath,
             sourceWorkspacePath: workspaceDir,
@@ -5280,11 +5371,20 @@ export async function executeClaimed(
             now: currentNow,
             reasonCode,
             handoffFailure: continuationFailure,
+            continuationGuard: escalationGuard,
           });
         }
-        return { ok: true, escalation };
+        return {
+          ok: true,
+          escalation,
+          tierEscalationSkip:
+            !decision.retry && escalationGuard?.skip
+              ? escalationGuard.reason
+              : null,
+        };
       });
       const projection = projectScheduledEscalation(res?.escalation);
+      commentTierEscalationSkip(res?.tierEscalationSkip);
       if (!res?.escalation) cleanupWorkspace({ retainWorkspace: retain });
       if (res?.fenced) return { fenced: true };
       return {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3843,6 +3843,109 @@ sh -c 'sleep 5 & wait'
     });
   });
 
+  test("failed dispatch skips an In Review continuation but schedules one for an active ticket", async () => {
+    const executeFailure = async (reviewed) => {
+      const db = openDb(":memory:");
+      let ticketState = "Todo";
+      const ticket = "watt-mind/factory#2006";
+      const comments = [];
+      const spec = queueRun(
+        db,
+        makeSpec({
+          runId: `run_tier_failed_${reviewed ? "reviewed" : "active"}`,
+          agent: "dispatch@1",
+          input: { repo: "factory", ticket },
+          workspace: {
+            type: "worktree",
+            checkoutDir: "repo",
+            retainOnFailure: true,
+          },
+          outputContract: "factory.dispatch-result/v1",
+          modelTier: "light",
+          maxAttempts: 1,
+        }),
+      );
+      linkEvent(db, spec.runId, { type: "factory.dispatch.requested" });
+      const o = opts({
+        dispatch: {
+          locksDir: tmpDir("tier-skip-locks-"),
+          leasesDir: tmpDir("tier-skip-leases-"),
+          fetchTicket: () => ({
+            identifier: ticket,
+            state: { name: ticketState },
+            assignee: ticketState === "Todo" ? null : { name: "hdkiller" },
+            labels: {
+              nodes: [
+                {
+                  name:
+                    ticketState === "Todo"
+                      ? "ai:agent-ready"
+                      : "ai:in-progress",
+                },
+              ],
+            },
+            description:
+              "## Owned Paths\n- event-runtime/lib/worker.mjs\n\n## Verification Command\n`bun test event-runtime/lib/worker.test.mjs`\n",
+          }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          claimTicket: () => ((ticketState = "In Progress"), { ok: true }),
+          commentTicket: (entry) => comments.push(entry),
+          projectTierEscalation: () => true,
+          findWorkspacePullRequest: () => null,
+        },
+        materializeWorktree: () => ({
+          path: tmpDir("tier-skip-checkout-"),
+        }),
+      });
+      const claim = claimNext(db, o);
+      const result = await executeClaimed(
+        db,
+        registry,
+        {
+          fake: {
+            async execute() {
+              if (reviewed) ticketState = "In Review";
+              return { exitCode: 1, timedOut: false };
+            },
+          },
+        },
+        claim,
+        o,
+      );
+      const continuations = db
+        .query(`SELECT * FROM tier_escalations ORDER BY created_at`)
+        .all();
+      db.close();
+      return { result, comments, continuations };
+    };
+
+    const reviewed = await executeFailure(true);
+    expect(reviewed.result).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "agent_exit_1",
+      tierEscalationSkip: "ticket_in_review",
+    });
+    expect(reviewed.continuations).toEqual([]);
+    expect(reviewed.comments).toContainEqual(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "Tier escalation skipped: ticket is already In Review",
+        ),
+      }),
+    );
+
+    const active = await executeFailure(false);
+    expect(active.result).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "agent_exit_1",
+      escalatedRunId: expect.any(String),
+    });
+    expect(active.result.tierEscalationSkip).toBeUndefined();
+    expect(active.continuations).toHaveLength(1);
+  });
+
   test("continuation handoff failures are matched per violation, anchored at its start", () => {
     const quoted =
       "repo_verify_failed: (fail) x\nweb_build_failed: quoted inside output";
@@ -4530,6 +4633,76 @@ sh -c 'sleep 5 & wait'
     expect(calls.at(-1)[2]).toContain(
       "https://github.com/watt-mind/factory/pull/1281",
     );
+  });
+
+  test("cancelRun releases an unstarted tier continuation claim and retained worktree ownership", () => {
+    const db = openDb(":memory:");
+    const failed = queueRun(
+      db,
+      makeSpec({
+        runId: "run_cancel_tier_failed",
+        agent: "dispatch@1",
+        input: { repo: "factory", ticket: "watt-mind/factory#2006" },
+        workspace: {
+          type: "worktree",
+          checkoutDir: "repo",
+          retainOnFailure: true,
+        },
+        modelTier: "light",
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, failed.runId);
+    const escalation = scheduleTierEscalation(db, registry, failed, {
+      workspacePath: "/retained/factory-2006",
+      sourceWorkspacePath: "/workspace/run-2006",
+      continuationRunId: "run_cancel_tier_continuation",
+      reasonCode: "agent_exit_1",
+    });
+    const unclaims = [];
+    const cleanups = [];
+
+    const result = cancelRun(db, escalation.continuation_run_id, {
+      actor: "operator",
+      policyVersion: "test",
+      now: T0,
+      unclaimTierEscalation: (entry) => (unclaims.push(entry), true),
+      cleanupTierEscalationWorkspace: (entry) => (cleanups.push(entry), true),
+    });
+
+    expect(runState(db, escalation.continuation_run_id)).toBe("CANCELLED");
+    expect(result.escalationCancellation).toEqual({
+      projectionRefused: true,
+      claimReleased: true,
+      workspaceCleaned: true,
+    });
+    expect(unclaims).toEqual([
+      {
+        repo: "factory",
+        ticket: "watt-mind/factory#2006",
+        why: "operator_cancel",
+        log: null,
+      },
+    ]);
+    expect(cleanups).toEqual([
+      {
+        sourceWorkspacePath: "/workspace/run-2006",
+        workspacePath: "/retained/factory-2006",
+        repo: "factory",
+        ticket: "watt-mind/factory#2006",
+      },
+    ]);
+    expect(
+      db
+        .query(
+          `SELECT projection_state, projection_error FROM tier_escalations WHERE continuation_run_id = ?`,
+        )
+        .get(escalation.continuation_run_id),
+    ).toEqual({
+      projection_state: "refused",
+      projection_error: "operator_cancel",
+    });
+    db.close();
   });
 
   test("adapter_error with maxAttempts 1 requeues and succeeds without consuming the agent budget", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -120,6 +120,7 @@ import {
   reconcileTierEscalations,
   scheduleTierEscalation,
   sweepOrphanedLocalNotifyOutbox,
+  tierEscalationContinuationGuard,
   tierEscalationEligibility,
   retryRun,
   runLinearCli,
@@ -3789,6 +3790,57 @@ sh -c 'sleep 5 & wait'
         "agent_exit_1",
       ).eligible,
     ).toBe(false);
+  });
+
+  test("tier escalation skips work already handed to review but keeps active claims eligible", () => {
+    const spec = makeSpec({
+      agent: "dispatch@1",
+      input: { repo: "factory", ticket: "watt-mind/factory#2006" },
+      workspace: { type: "worktree", checkoutDir: "repo" },
+      modelTier: "light",
+    });
+    const inReview = tierEscalationContinuationGuard(spec, "agent_exit_1", {
+      fetchTicket: () => ({ state: { name: "In Review" } }),
+    });
+    expect(inReview).toMatchObject({
+      eligible: true,
+      skip: true,
+      reason: "ticket_in_review",
+    });
+    const db = openDb(":memory:");
+    queueRun(db, spec);
+    linkEvent(db, spec.runId);
+    expect(
+      scheduleTierEscalation(db, registry, spec, {
+        workspacePath: "/retained/factory-2006",
+        sourceWorkspacePath: "/workspace/run-2006",
+        continuationRunId: "run_tier_in_review",
+        reasonCode: "agent_exit_1",
+        continuationGuard: inReview,
+      }),
+    ).toBeNull();
+    expect(
+      db.query(`SELECT * FROM runs WHERE run_id = 'run_tier_in_review'`).get(),
+    ).toBeNull();
+    db.close();
+    for (const state of ["Todo", "In Progress"]) {
+      expect(
+        tierEscalationContinuationGuard(spec, "agent_exit_1", {
+          fetchTicket: () => ({ state: { name: state } }),
+        }),
+      ).toMatchObject({ eligible: true, skip: false });
+    }
+    expect(
+      tierEscalationContinuationGuard(spec, "agent_exit_1", {
+        fetchTicket: () => ({ state: { name: "In Progress" } }),
+        workspacePath: "/retained/factory-2006",
+        findPullRequest: () => ({ isDraft: false }),
+      }),
+    ).toMatchObject({
+      eligible: true,
+      skip: true,
+      reason: "retained_pr_open",
+    });
   });
 
   test("continuation handoff failures are matched per violation, anchored at its start", () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -3946,6 +3946,196 @@ sh -c 'sleep 5 & wait'
     expect(active.continuations).toHaveLength(1);
   });
 
+  test("a retained open PR skips the continuation and still releases the ticket claim", async () => {
+    const db = openDb(":memory:");
+    const ticket = "watt-mind/factory#2006";
+    let ticketState = "Todo";
+    const comments = [];
+    const unclaims = [];
+    const spec = queueRun(
+      db,
+      makeSpec({
+        runId: "run_tier_retained_pr",
+        agent: "dispatch@1",
+        input: { repo: "factory", ticket },
+        workspace: {
+          type: "worktree",
+          checkoutDir: "repo",
+          retainOnFailure: true,
+        },
+        outputContract: "factory.dispatch-result/v1",
+        modelTier: "light",
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, spec.runId, { type: "factory.dispatch.requested" });
+    const o = opts({
+      dispatch: {
+        locksDir: tmpDir("tier-retained-locks-"),
+        leasesDir: tmpDir("tier-retained-leases-"),
+        fetchTicket: () => ({
+          identifier: ticket,
+          state: { name: ticketState },
+          assignee: ticketState === "Todo" ? null : { name: "hdkiller" },
+          labels: {
+            nodes: [
+              {
+                name:
+                  ticketState === "Todo" ? "ai:agent-ready" : "ai:in-progress",
+              },
+            ],
+          },
+          description:
+            "## Owned Paths\n- event-runtime/lib/worker.mjs\n\n## Verification Command\n`bun test event-runtime/lib/worker.test.mjs`\n",
+        }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        budgetRefusal: () => null,
+        claimTicket: () => ((ticketState = "In Progress"), { ok: true }),
+        commentTicket: (entry) => comments.push(entry),
+        unclaimTicket: (entry) => (unclaims.push(entry), true),
+        projectTierEscalation: () => true,
+        // The agent opened a PR and left it out of draft; the ticket never
+        // reached In Review, so only the forge carries the ownership signal.
+        findWorkspacePullRequest: () => ({ number: 4242, isDraft: false }),
+      },
+      materializeWorktree: () => ({ path: tmpDir("tier-retained-checkout-") }),
+    });
+    const claim = claimNext(db, o);
+    const result = await executeClaimed(
+      db,
+      registry,
+      {
+        fake: {
+          async execute() {
+            return { exitCode: 1, timedOut: false };
+          },
+        },
+      },
+      claim,
+      o,
+    );
+
+    expect(result).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "agent_exit_1",
+      tierEscalationSkip: "retained_pr_open",
+    });
+    expect(db.query(`SELECT * FROM tier_escalations`).all()).toEqual([]);
+    // No continuation inherits the claim, so the run must hand the ticket back
+    // itself rather than strand it In Progress with nothing scheduled.
+    expect(unclaims).toEqual([
+      { repo: "factory", ticket, why: "agent_exit_1", log: null },
+    ]);
+    expect(comments).toContainEqual(
+      expect.objectContaining({
+        body: expect.stringContaining(
+          "the retained worktree already has an open non-draft PR",
+        ),
+      }),
+    );
+    db.close();
+  });
+
+  test("the PR the failed handoff just opened is drafted before the guard reads it, so escalation still happens", async () => {
+    const db = openDb(":memory:");
+    const ticket = "watt-mind/factory#2006";
+    let ticketState = "Todo";
+    // The agent's own PR: open and NOT draft at the moment the handoff
+    // verification fails. WM-718's hold converts it; the guard must observe
+    // the converted state, not the pre-hold one.
+    let prIsDraft = false;
+    const held = [];
+    const spec = queueRun(
+      db,
+      makeSpec({
+        runId: "run_tier_handoff_pr",
+        agent: "dispatch@1",
+        input: { repo: "factory", ticket },
+        workspace: {
+          type: "worktree",
+          checkoutDir: "repo",
+          retainOnFailure: true,
+        },
+        outputContract: "factory.dispatch-result/v1",
+        modelTier: "light",
+        maxAttempts: 1,
+      }),
+    );
+    linkEvent(db, spec.runId, { type: "factory.dispatch.requested" });
+    const o = opts({
+      verifyResult: () => {
+        throw new ContractViolation(["repo_verify_failed"], {
+          reasonCode: "handoff_verification_failed",
+          handoff: {
+            prNumber: 4242,
+            prUrl: "https://github.com/watt-mind/factory/pull/4242",
+            github: "watt-mind/factory",
+            verification: [],
+          },
+        });
+      },
+      dispatch: {
+        locksDir: tmpDir("tier-handoff-locks-"),
+        leasesDir: tmpDir("tier-handoff-leases-"),
+        fetchTicket: () => ({
+          identifier: ticket,
+          state: { name: ticketState },
+          assignee: ticketState === "Todo" ? null : { name: "hdkiller" },
+          labels: {
+            nodes: [
+              {
+                name:
+                  ticketState === "Todo" ? "ai:agent-ready" : "ai:in-progress",
+              },
+            ],
+          },
+          description:
+            "## Owned Paths\n- event-runtime/lib/worker.mjs\n\n## Verification Command\n`bun test event-runtime/lib/worker.test.mjs`\n",
+        }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        budgetRefusal: () => null,
+        claimTicket: () => ((ticketState = "In Progress"), { ok: true }),
+        commentTicket: () => {},
+        holdPullRequest: (entry) => (
+          held.push(entry),
+          (prIsDraft = true),
+          true
+        ),
+        returnHandoffTicket: () => ({ agentReadyRestored: true }),
+        unclaimTicket: () => true,
+        projectTierEscalation: () => true,
+        findWorkspacePullRequest: () => ({ number: 4242, isDraft: prIsDraft }),
+      },
+      materializeWorktree: () => ({ path: tmpDir("tier-handoff-checkout-") }),
+    });
+    const claim = claimNext(db, o);
+    const result = await executeClaimed(
+      db,
+      registry,
+      {
+        fake: {
+          async execute() {
+            return { exitCode: 0, timedOut: false };
+          },
+        },
+      },
+      claim,
+      o,
+    );
+
+    expect(result).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "handoff_verification_failed",
+      escalatedRunId: expect.any(String),
+    });
+    expect(result.tierEscalationSkip).toBeUndefined();
+    expect(held).toHaveLength(1);
+    expect(db.query(`SELECT * FROM tier_escalations`).all()).toHaveLength(1);
+    db.close();
+  });
+
   test("continuation handoff failures are matched per violation, anchored at its start", () => {
     const quoted =
       "repo_verify_failed: (fail) x\nweb_build_failed: quoted inside output";


### PR DESCRIPTION
Fixes watt-mind/factory#2006

Review the tier-escalation guard and cancellation cleanup that prevent duplicate continuations from racing review-owned work.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs && bun run lint` | pass | 272 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | tests, emit, format, lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped

run:run_8c67348f-877e-43d3-bd93-f5d09e27572a