### PR TITLE
fix(planner): use ticket CLI for reads

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -614,7 +614,24 @@ function linearCli() {
   // Test seam: point the planner's ticket reads at a stand-in CLI.
   return (
     process.env.FACTORY_LINEAR_CLI ||
-    path.join(FACTORY_ROOT, "tools", "linear.mjs")
+    path.join(FACTORY_ROOT, "tools", "ticket.mjs")
+  );
+}
+
+const DEPRECATED_LINEAR_SHIM_NOTICE =
+  "tools/linear.mjs is deprecated — use tools/ticket.mjs (or `factory ticket`)";
+
+function linearReadFailureReason(err) {
+  const stderr = String(err?.stderr ?? "");
+  const underlyingStderr = stderr
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line && line !== DEPRECATED_LINEAR_SHIM_NOTICE)
+    .pop();
+  return (
+    underlyingStderr ||
+    (linearReadTimedOut(err) ? "linear read timed out" : err.message)
   );
 }
 
@@ -802,10 +819,9 @@ function fetchTicketDefault(ticketId, repo, { readBudget = null } = {}) {
     const stderr = String(err?.stderr ?? "");
     if (stderr.includes("no such issue")) return null;
     throwIfLinearReadBudgetExhausted(err, readBudget);
-    throw new Error(
-      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
-      { cause: err },
-    );
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
   }
 }
 
@@ -846,11 +862,9 @@ function fetchViewerDefault(
     if (err instanceof LinearReadBudgetExceededError) throw err;
     throwIfLinearCliRateLimited(err);
     throwIfLinearReadBudgetExhausted(err, readBudget);
-    const stderr = String(err?.stderr ?? "");
-    throw new Error(
-      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
-      { cause: err },
-    );
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
   }
 }
 
@@ -1007,11 +1021,9 @@ function fetchInFlightDefault(repoConfig, { readBudget = null } = {}) {
     if (err instanceof LinearReadBudgetExceededError) throw err;
     throwIfLinearCliRateLimited(err);
     throwIfLinearReadBudgetExhausted(err, readBudget);
-    const stderr = String(err?.stderr ?? "");
-    throw new Error(
-      `linear_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
-      { cause: err },
-    );
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
   }
 }
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -4477,6 +4477,37 @@ describe("Linear rate limit (WM-878)", () => {
     });
   });
 
+  test("a timeout-killed child cannot classify the deprecated shim notice as its error", () => {
+    // The shim used to emit this before invoking ticket.mjs. A timeout can
+    // terminate the child before it emits a transport diagnostic, so retain
+    // the timeout signal instead of turning the warning into the failure.
+    withLinearCli(
+      [
+        'console.error("tools/linear.mjs is deprecated — use tools/ticket.mjs (or `factory ticket`)");',
+        'process.kill(process.pid, "SIGTERM");',
+      ].join("\n"),
+      () => {
+        const cache = createLinearReadCache();
+        const reads = wrapLinearReads({}, cache, NOW, {
+          repos: new Map([
+            ["gated", { name: "gated", controlPlane: "linear" }],
+          ]),
+        });
+
+        let error;
+        try {
+          reads.fetchTicket("WM-timeout", "gated");
+        } catch (caught) {
+          error = caught;
+        }
+        expect(error?.message).toBe(
+          "linear_read_failed: linear read timed out",
+        );
+        expect(error?.message).not.toContain("tools/linear.mjs is deprecated");
+      },
+    );
+  });
+
   test("a simulated Linear 400 rate-limit refuses linear_rate_limited, leaves the event admitted, and does not dead-letter", () => {
     withReposRoot(gatedYaml, () => {
       const db = openDb(":memory:");


### PR DESCRIPTION
Fixes watt-mind/factory#2010

Review the planner read path and timeout classification regression; both local gates are green.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs && bun run lint` | pass | 119 tests; 0 lint errors |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,335 tests; emit, format, lint clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_7a6df470-6ed0-4aef-8358-e6a071111158
