### PR TITLE
fix(ticket): retry GraphQL timeouts

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -879,12 +879,10 @@ export function githubControlPlane(options = {}) {
   let projectItemsCache = null; // { at: number, promise: Promise<{project, items}> }
 
   async function call(method, pathName, opts) {
+    const isGraphql =
+      pathName === "graphql" || pathName === "/graphql" || method === "GRAPHQL";
     try {
       const result = await Promise.resolve(api(method, pathName, opts));
-      const isGraphql =
-        pathName === "graphql" ||
-        pathName === "/graphql" ||
-        method === "GRAPHQL";
       if (isGraphql) {
         if (result?.errors?.length) {
           const failure = new ControlPlaneError(
@@ -897,6 +895,14 @@ export function githubControlPlane(options = {}) {
       }
       return result;
     } catch (cause) {
+      const timeout = /\bgh timed out after (\d+)ms\b/.exec(
+        String(cause?.message ?? ""),
+      );
+      if (isGraphql && timeout)
+        throw new ControlPlaneError(
+          `github graphql timed out after ${timeout[1]}ms`,
+          { status: cause?.status ?? null, cause },
+        );
       if (cause instanceof ControlPlaneError) throw cause;
       throw new ControlPlaneError(
         cause?.message ? String(cause.message) : "github api failed",

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -38,7 +38,11 @@ import {
   provisionGithubRepo,
   writeGithubControlPlanePolicy,
 } from "./github.mjs";
-import { retryControlPlaneMutation } from "../../tools/ticket.mjs";
+import {
+  retryControlPlaneMutation,
+  setLabelsWithRetry,
+  transitionThenComment,
+} from "../../tools/ticket.mjs";
 import { SOURCE_LABELS, TYPE_LABELS } from "./labels.mjs";
 
 const TEAM = "WM";
@@ -3660,40 +3664,57 @@ describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () =>
   });
 
   test("retries one state or label timeout with the active control-plane endpoint", async () => {
-    const pauses = [];
     const calls = [];
     const github = {
       kind: "github",
-      async setLabels() {
-        calls.push("github");
+      async setLabels(...args) {
+        calls.push(args);
         if (calls.length === 1)
           throw new ControlPlaneError("github graphql timed out after 15000ms");
       },
     };
 
     await expect(
-      retryControlPlaneMutation(github, () => github.setLabels(), {
-        backoff: async (ms) => pauses.push(ms),
+      setLabelsWithRetry(github, `${REPO}#1`, {
+        add: [IN_PROGRESS_LABEL],
+        remove: [AGENT_READY_LABEL],
       }),
     ).resolves.toBeUndefined();
-    expect(calls).toEqual(["github", "github"]);
-    expect(pauses).toEqual([250]);
+    expect(calls).toEqual([
+      [`${REPO}#1`, { add: [IN_PROGRESS_LABEL], remove: [AGENT_READY_LABEL] }],
+      [`${REPO}#1`, { add: [IN_PROGRESS_LABEL], remove: [AGENT_READY_LABEL] }],
+    ]);
 
     const linearCalls = [];
     const linear = {
       kind: "linear",
-      async transition() {
-        linearCalls.push("linear");
+      async transition(...args) {
+        linearCalls.push(args);
         if (linearCalls.length === 1)
           throw new ControlPlaneError("linear graphql timed out after 15000ms");
       },
     };
     await expect(
-      retryControlPlaneMutation(linear, () => linear.transition(), {
-        backoff: async () => {},
-      }),
+      transitionThenComment(
+        linear,
+        "CLNT-123",
+        "In Review",
+        { add: ["ai:needs-review"], remove: [IN_PROGRESS_LABEL] },
+        "",
+      ),
     ).resolves.toBeUndefined();
-    expect(linearCalls).toEqual(["linear", "linear"]);
+    expect(linearCalls).toEqual([
+      [
+        "CLNT-123",
+        "In Review",
+        { add: ["ai:needs-review"], remove: [IN_PROGRESS_LABEL] },
+      ],
+      [
+        "CLNT-123",
+        "In Review",
+        { add: ["ai:needs-review"], remove: [IN_PROGRESS_LABEL] },
+      ],
+    ]);
   });
 
   test("reports a second timeout with the active control-plane endpoint", async () => {
@@ -3710,19 +3731,21 @@ describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () =>
       },
     ]) {
       let caught;
+      const pauses = [];
       try {
         await retryControlPlaneMutation(
           controlPlane,
           async () => {
             throw new ControlPlaneError(timeout);
           },
-          { backoff: async () => {} },
+          { backoff: async (ms) => pauses.push(ms) },
         );
       } catch (error) {
         caught = error;
       }
       expect(caught).toBeInstanceOf(ControlPlaneError);
       expect(caught.message).toBe(expected);
+      expect(pauses).toEqual([250]);
     }
   });
 

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -38,6 +38,7 @@ import {
   provisionGithubRepo,
   writeGithubControlPlanePolicy,
 } from "./github.mjs";
+import { retryControlPlaneMutation } from "../../tools/ticket.mjs";
 import { SOURCE_LABELS, TYPE_LABELS } from "./labels.mjs";
 
 const TEAM = "WM";
@@ -3641,6 +3642,75 @@ describe("makeGhApi async spawn is non-blocking (WM-1166)", () => {
 });
 
 describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () => {
+  test("names a timed-out GraphQL call as GitHub GraphQL", async () => {
+    const cp = githubControlPlane({
+      repo: REPO,
+      teams: { WM: REPO },
+      exec: async () => ({
+        status: null,
+        stdout: "",
+        stderr: "",
+        error: new Error("gh timed out after 15000ms"),
+      }),
+    });
+
+    await expect(cp.raw("query { ping }")).rejects.toThrow(
+      "github graphql timed out after 15000ms",
+    );
+  });
+
+  test("retries one state or label timeout with the active control-plane endpoint", async () => {
+    const pauses = [];
+    const calls = [];
+    const github = {
+      kind: "github",
+      async setLabels() {
+        calls.push("github");
+        if (calls.length === 1)
+          throw new ControlPlaneError("github graphql timed out after 15000ms");
+      },
+    };
+
+    await expect(
+      retryControlPlaneMutation(github, () => github.setLabels(), {
+        backoff: async (ms) => pauses.push(ms),
+      }),
+    ).resolves.toBeUndefined();
+    expect(calls).toEqual(["github", "github"]);
+    expect(pauses).toEqual([250]);
+
+    const linearCalls = [];
+    const linear = {
+      kind: "linear",
+      async transition() {
+        linearCalls.push("linear");
+        if (linearCalls.length === 1)
+          throw new ControlPlaneError("linear graphql timed out after 15000ms");
+      },
+    };
+    await expect(
+      retryControlPlaneMutation(linear, () => linear.transition(), {
+        backoff: async () => {},
+      }),
+    ).resolves.toBeUndefined();
+    expect(linearCalls).toEqual(["linear", "linear"]);
+  });
+
+  test("reports a second GitHub timeout as GitHub Projects GraphQL", async () => {
+    const github = {
+      kind: "github",
+      async transition() {
+        throw new ControlPlaneError("github graphql timed out after 15000ms");
+      },
+    };
+
+    await expect(
+      retryControlPlaneMutation(github, () => github.transition(), {
+        backoff: async () => {},
+      }),
+    ).rejects.toThrow("github projects graphql timed out after 15000ms");
+  });
+
   test("a gh process that never closes is terminated after its configured timeout", async () => {
     const child = new EventEmitter();
     child.stdout = new EventEmitter();

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -3696,19 +3696,34 @@ describe("GitHub CLI timeout and secondary-rate-limit recovery (GH-1352)", () =>
     expect(linearCalls).toEqual(["linear", "linear"]);
   });
 
-  test("reports a second GitHub timeout as GitHub Projects GraphQL", async () => {
-    const github = {
-      kind: "github",
-      async transition() {
-        throw new ControlPlaneError("github graphql timed out after 15000ms");
+  test("reports a second timeout with the active control-plane endpoint", async () => {
+    for (const { controlPlane, timeout, expected } of [
+      {
+        controlPlane: { kind: "github" },
+        timeout: "github graphql timed out after 15000ms",
+        expected: "github projects graphql timed out after 15000ms",
       },
-    };
-
-    await expect(
-      retryControlPlaneMutation(github, () => github.transition(), {
-        backoff: async () => {},
-      }),
-    ).rejects.toThrow("github projects graphql timed out after 15000ms");
+      {
+        controlPlane: { kind: "linear" },
+        timeout: "linear graphql timed out after 15000ms",
+        expected: "linear graphql timed out after 15000ms",
+      },
+    ]) {
+      let caught;
+      try {
+        await retryControlPlaneMutation(
+          controlPlane,
+          async () => {
+            throw new ControlPlaneError(timeout);
+          },
+          { backoff: async () => {} },
+        );
+      } catch (error) {
+        caught = error;
+      }
+      expect(caught).toBeInstanceOf(ControlPlaneError);
+      expect(caught.message).toBe(expected);
+    }
   });
 
   test("a gh process that never closes is terminated after its configured timeout", async () => {

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -148,6 +148,11 @@ export async function transitionThenComment(cp, key, state, options, comment) {
   if (comment?.trim()) await cp.comment(key, comment);
 }
 
+/** Apply a complete label delta through the same retry policy as state writes. */
+export async function setLabelsWithRetry(cp, key, options) {
+  await retryControlPlaneMutation(cp, () => cp.setLabels(key, options));
+}
+
 /**
  * File one ticket through the control plane and report the outcome.
  *
@@ -965,9 +970,7 @@ const VERBS = {
       out(current, current.join(" ") || "(none)");
       return;
     }
-    await retryControlPlaneMutation(cp, () =>
-      cp.setLabels(key, { add, remove }),
-    );
+    await setLabelsWithRetry(cp, key, { add, remove });
     out(
       { ok: true, identifier: key, added: add, removed: remove },
       `${key} labels updated`,

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -65,6 +65,7 @@ import path from "node:path";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
 import {
   loadControlPlane,
+  ControlPlaneError,
   TYPE_LABELS,
   SOURCE_LABELS,
   validateLabels,
@@ -91,9 +92,59 @@ export {
   appendIssueDetail,
 };
 
+const CONTROL_PLANE_MUTATION_RETRY_BACKOFF_MS = 250;
+
+const controlPlaneMutationBackoff = (ms) =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
+function graphqlTimeoutMessage(controlPlane, error) {
+  const message = String(error?.message ?? "");
+  const endpoint =
+    controlPlane?.kind === "github"
+      ? "github projects graphql"
+      : controlPlane?.kind === "linear"
+        ? "linear graphql"
+        : null;
+  const match = endpoint
+    ? new RegExp(
+        `^${
+          controlPlane.kind === "github" ? "github(?: projects)?" : "linear"
+        } graphql timed out after (\\d+)ms$`,
+      ).exec(message)
+    : null;
+  return match ? `${endpoint} timed out after ${match[1]}ms` : null;
+}
+
+/**
+ * State and label writes are idempotent, so one timed-out GraphQL attempt can
+ * be retried without replaying comments or ticket creation. Keep this at the
+ * CLI boundary: it covers both configured control planes while their adapters
+ * retain ownership of their respective transports.
+ */
+export async function retryControlPlaneMutation(
+  controlPlane,
+  mutation,
+  { backoff = controlPlaneMutationBackoff } = {},
+) {
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    try {
+      return await mutation();
+    } catch (cause) {
+      const timeout = graphqlTimeoutMessage(controlPlane, cause);
+      if (!timeout) throw cause;
+      if (attempt === 1)
+        throw new ControlPlaneError(timeout, {
+          status: cause?.status ?? null,
+          cause,
+        });
+      await backoff(CONTROL_PLANE_MUTATION_RETRY_BACKOFF_MS);
+    }
+  }
+}
+
 /** Transition first, so a promotion rationale is never posted for a failed move. */
 export async function transitionThenComment(cp, key, state, options, comment) {
-  await cp.transition(key, state, options);
+  await retryControlPlaneMutation(cp, () => cp.transition(key, state, options));
   if (comment?.trim()) await cp.comment(key, comment);
 }
 
@@ -914,7 +965,9 @@ const VERBS = {
       out(current, current.join(" ") || "(none)");
       return;
     }
-    await cp.setLabels(key, { add, remove });
+    await retryControlPlaneMutation(cp, () =>
+      cp.setLabels(key, { add, remove }),
+    );
     out(
       { ok: true, identifier: key, added: add, removed: remove },
       `${key} labels updated`,


### PR DESCRIPTION
Fixes watt-mind/factory#2018

State and label mutations retry one GraphQL timeout and report the correct control-plane endpoint.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test lib/control-plane/github.test.mjs && bun run lint` | pass | 132 tests; 0 lint errors |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,344 tests; emit/format clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_1e92eab2-d9a7-4a77-af4e-af57d00eb59b
