### PR TITLE
feat(inbox): synthesize operator-friendly notifications

### DIFF
--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -219,9 +219,13 @@ export async function runNotifierDeliveryCase({
   const saved = {
     N: process.env.FACTORY_EVENT_NOTIFY,
     C: process.env.FACTORY_EVENT_NOTIFY_CMD,
+    W: process.env.FACTORY_WEB_URL,
   };
   process.env.FACTORY_EVENT_NOTIFY = "1";
   process.env.FACTORY_EVENT_NOTIFY_CMD = stub;
+  // The push appends a deep link to the item's random id when a web URL is
+  // configured. This box exports one; the fixture asserts an exact message.
+  delete process.env.FACTORY_WEB_URL;
   const logs = [];
   let deliveryStarted = false;
   let deliverySettled = false;
@@ -244,10 +248,16 @@ export async function runNotifierDeliveryCase({
     writeFileSync(releaseFile, "release\n");
     const delivery = await awaitNotifierDelivery(db, "test/evt-tick");
     deliverySettled = true;
-    // The parked-event projection carries its decision question and options
-    // (WM-390), so one delivery is a four-line message.
+    // The push is the synthesized item: its human title and body, then the
+    // decision question and its options once (WM-390, the body's restatement
+    // of the ask is stripped so the operator does not read it twice).
     const expectedMessage = [
       "BLOCKED linear.ticket.agent_ready evt-tick: no_worktree_scripts",
+      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-tick.",
+      "",
+      "Why it matters: The runtime reported “no worktree scripts” and needs an operator to decide what happens next.",
+      "",
+      "Reason code: no_worktree_scripts.",
       "Should this parked event be requeued?",
       "1. Requeue the event",
       "2. Not now",
@@ -276,6 +286,8 @@ export async function runNotifierDeliveryCase({
     else process.env.FACTORY_EVENT_NOTIFY = saved.N;
     if (saved.C === undefined) delete process.env.FACTORY_EVENT_NOTIFY_CMD;
     else process.env.FACTORY_EVENT_NOTIFY_CMD = saved.C;
+    if (saved.W === undefined) delete process.env.FACTORY_WEB_URL;
+    else process.env.FACTORY_WEB_URL = saved.W;
     db.close();
   }
 }

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -149,11 +149,14 @@ const DECISION_EFFECTS = Object.freeze({
   dismiss: "keeps the item resolved without changing the referenced work",
 });
 
-function readableSubject(refs) {
+function readableSubject(refs, ticketTitle) {
   if (refs.issue) {
     const match = /(?:^|\/)([^/\s#]+)#(\d+)$/.exec(refs.issue);
-    if (match) return `${match[1]}#${match[2]}`;
-    return refs.issue;
+    if (match) {
+      const ticket = `${match[1]}#${match[2]}`;
+      return ticketTitle ? `${ticket} "${ticketTitle}"` : ticket;
+    }
+    return ticketTitle ? `${refs.issue} "${ticketTitle}"` : refs.issue;
   }
   if (refs.pr) return `PR ${refs.pr.replace(/^PR\s*/i, "")}`;
   if (refs.proposalId) return `proposal ${refs.proposalId}`;
@@ -200,13 +203,24 @@ function linksFor(refs) {
   return links;
 }
 
-function proposalAgent(decision) {
+function proposalSubject(decision) {
   const question = decision?.question;
   const match =
     typeof question === "string"
-      ? /^Run\s+([^\s]+)\s+for\s+/i.exec(question)
+      ? /^Run\s+([^\s]+)(?:\s+for\s+(.+?))?\?$/i.exec(question.trim())
       : null;
-  return match?.[1] ?? null;
+  if (!match) return null;
+  return {
+    agent: match[1].replace(/@\d+$/, ""),
+    subject: match[2]?.trim() ?? null,
+  };
+}
+
+function optionEffect(option) {
+  return (
+    DECISION_EFFECTS[option.effect] ??
+    `asks the runtime to ${String(option.effect ?? "continue").replaceAll("_", " ")}`
+  );
 }
 
 /**
@@ -220,21 +234,22 @@ export function synthesizeInboxItem(input) {
   const kind = input?.kind ?? "human_needed";
   const reason = reasonCodeFor(input);
   const label = INBOX_KIND_LABELS[kind] ?? String(kind).replaceAll("_", " ");
-  const subject = readableSubject(refs);
+  const ticketTitle =
+    typeof input?.ticketTitle === "string" && input.ticketTitle.trim()
+      ? input.ticketTitle.trim()
+      : null;
+  const subject = readableSubject(refs, ticketTitle);
   const why = humanReason(reason);
   const originalBody =
     typeof input?.body === "string" && input.body.trim()
       ? input.body.trim()
       : null;
   const decision = input?.decision;
-  const agent = proposalAgent(decision);
+  const proposal = proposalSubject(decision);
   const effects = Array.isArray(decision?.options)
-    ? decision.options
-        .map((option) => {
-          const effect = DECISION_EFFECTS[option.effect];
-          return effect ? `${option.label} — ${effect}.` : null;
-        })
-        .filter(Boolean)
+    ? decision.options.map(
+        (option) => `${option.label} — ${optionEffect(option)}.`,
+      )
     : [];
   // Keep the serialized request untouched. It is hashed by decision responses,
   // so rewriting its context after a producer has handed it off would make a
@@ -263,8 +278,8 @@ export function synthesizeInboxItem(input) {
   return {
     ...input,
     title:
-      agent && (kind === "decision_needed" || kind === "proposal_expired")
-        ? `Approve ${agent} run (${subject})?`
+      proposal && (kind === "decision_needed" || kind === "proposal_expired")
+        ? `Approve ${proposal.agent} run (${ticketTitle ? subject : (proposal.subject ?? subject)})?`
         : `${label}: ${subject} — ${titleReason(reason)}`,
     body,
   };

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -112,6 +112,164 @@ function parseWaiters(value) {
   }
 }
 
+const INBOX_REASON_GLOSSARY = Object.freeze({
+  owned_paths_not_closed:
+    "The ticket's allowed paths do not cover every required file, so the change cannot be safely completed as scoped.",
+  needs_human:
+    "The runtime stopped because an operator decision is required before it can proceed.",
+  ticket_untrusted_author:
+    "The ticket author is not trusted by this repository's dispatch policy.",
+  proposal_expired:
+    "The proposal expired before an operator approved or rejected it.",
+  proposal_terminal:
+    "The proposal is no longer open, so the requested decision would have no effect.",
+  stale_ref:
+    "The referenced ticket, run, or proposal is already terminal, so this item no longer needs action.",
+});
+
+const INBOX_KIND_LABELS = Object.freeze({
+  BLOCKED: "Blocked",
+  ESCALATED: "Escalated",
+  "CI RED": "CI failed",
+  "SMOKE RED": "Smoke check failed",
+  "CIRCUIT BREAKER": "Circuit breaker",
+  "RC READY": "Release candidate ready",
+  human_needed: "Human action needed",
+  decision_needed: "Decision needed",
+  proposal_expired: "Proposal expired",
+});
+
+const DECISION_EFFECTS = Object.freeze({
+  authorise: "authorizes the scoped work and dispatches a new run",
+  send_to_triage: "removes ai:agent-ready so a human can re-scope the ticket",
+  answer: "records the operator's reply for the agent",
+  requeue: "puts the parked event back into planning",
+  approve_proposal: "approves the proposal and allows its run to proceed",
+  reject_proposal: "rejects the proposal and stops that requested run",
+  dismiss: "keeps the item resolved without changing the referenced work",
+});
+
+function readableSubject(refs) {
+  if (refs.issue) {
+    const match = /(?:^|\/)([^/\s#]+)#(\d+)$/.exec(refs.issue);
+    if (match) return `${match[1]}#${match[2]}`;
+    return refs.issue;
+  }
+  if (refs.pr) return `PR ${refs.pr.replace(/^PR\s*/i, "")}`;
+  if (refs.proposalId) return `proposal ${refs.proposalId}`;
+  if (refs.runId) return `run ${refs.runId}`;
+  if (refs.repo) return refs.repo;
+  return "this item";
+}
+
+function reasonCodeFor(input) {
+  if (typeof input?.reasonCode === "string" && input.reasonCode.trim())
+    return input.reasonCode.trim();
+  if (input?.kind === "proposal_expired") return "proposal_expired";
+  const title = typeof input?.title === "string" ? input.title : "";
+  const known = Object.keys(INBOX_REASON_GLOSSARY).find((code) =>
+    new RegExp(`(?:^|[^a-z0-9_])${code}(?:$|[^a-z0-9_])`, "i").test(title),
+  );
+  if (known) return known;
+  const candidate = title.match(/:\s*([a-z][a-z0-9_]+)(?:\s|$)/i)?.[1];
+  return candidate?.toLowerCase() ?? null;
+}
+
+function humanReason(reason) {
+  if (!reason) return "The runtime needs an operator to review what happened.";
+  return (
+    INBOX_REASON_GLOSSARY[reason] ??
+    `The runtime reported “${reason.replaceAll("_", " ")}” and needs an operator to decide what happens next.`
+  );
+}
+
+function titleReason(reason) {
+  if (reason === "owned_paths_not_closed")
+    return "its allowed paths do not cover every required file";
+  return humanReason(reason)
+    .replace(/^The runtime /, "")
+    .replace(/\.$/, "");
+}
+
+function linksFor(refs) {
+  const links = [];
+  if (refs.issue) links.push(`Ticket: ${refs.issue}`);
+  if (refs.runId) links.push(`Run: ${refs.runId}`);
+  if (refs.pr) links.push(`PR: ${refs.pr}`);
+  if (refs.proposalId) links.push(`Proposal: ${refs.proposalId}`);
+  return links;
+}
+
+function proposalAgent(decision) {
+  const question = decision?.question;
+  const match =
+    typeof question === "string"
+      ? /^Run\s+([^\s]+)\s+for\s+/i.exec(question)
+      : null;
+  return match?.[1] ?? null;
+}
+
+/**
+ * Convert producer-oriented inbox data into an operator-readable message.
+ * Producers retain their concise machine title as an input signal, while the
+ * persisted title/body explain what happened, why it matters, and where the
+ * operator can inspect the referenced work.
+ */
+export function synthesizeInboxItem(input) {
+  const refs = input?.refs ?? {};
+  const kind = input?.kind ?? "human_needed";
+  const reason = reasonCodeFor(input);
+  const label = INBOX_KIND_LABELS[kind] ?? String(kind).replaceAll("_", " ");
+  const subject = readableSubject(refs);
+  const why = humanReason(reason);
+  const originalBody =
+    typeof input?.body === "string" && input.body.trim()
+      ? input.body.trim()
+      : null;
+  const decision = input?.decision;
+  const agent = proposalAgent(decision);
+  const effects = Array.isArray(decision?.options)
+    ? decision.options
+        .map((option) => {
+          const effect = DECISION_EFFECTS[option.effect];
+          return effect ? `${option.label} — ${effect}.` : null;
+        })
+        .filter(Boolean)
+    : [];
+  // Keep the serialized request untouched. It is hashed by decision responses,
+  // so rewriting its context after a producer has handed it off would make a
+  // valid response look stale. The durable body carries the same information.
+  const decisionDetails = [
+    typeof decision?.question === "string" && decision.question.trim()
+      ? `Question: ${decision.question.trim()}`
+      : null,
+    typeof decision?.context === "string" && decision.context.trim()
+      ? `Context: ${decision.context.trim()}`
+      : null,
+    effects.length ? `Option effects:\n${effects.join("\n")}` : null,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  const body = [
+    `What happened: A ${label.toLowerCase()} item needs attention for ${subject}.`,
+    `Why it matters: ${why}`,
+    reason ? `Reason code: ${reason}.` : null,
+    linksFor(refs).length ? `Links:\n${linksFor(refs).join("\n")}` : null,
+    decisionDetails,
+    originalBody,
+  ]
+    .filter(Boolean)
+    .join("\n\n");
+  return {
+    ...input,
+    title:
+      agent && (kind === "decision_needed" || kind === "proposal_expired")
+        ? `Approve ${agent} run (${subject})?`
+        : `${label}: ${subject} — ${titleReason(reason)}`,
+    body,
+  };
+}
+
 /** Option id+effect (+ authorise paths); free text is not part of "same question". */
 function decisionShape(decision) {
   if (!decision || !Array.isArray(decision.options)) return null;
@@ -402,8 +560,6 @@ export function createInboxItem(
 ) {
   const kind = requiredString(input?.kind, "kind");
   if (!KIND_SET.has(kind)) throw new Error(`unknown inbox kind: ${kind}`);
-  const title = requiredString(input?.title, "title");
-  const body = optionalString(input?.body, "body");
   const severity = optionalString(input?.severity, "severity") ?? "normal";
   const source = optionalString(input?.source, "source") ?? "cli";
   if (
@@ -414,7 +570,17 @@ export function createInboxItem(
     throw new Error(`unknown inbox source: ${source}`);
   }
   const refs = normalizeRefs(input?.refs);
-  const decision = input?.decision ?? null;
+  // Runtime notifications are the high-volume producer that previously wrote
+  // machine-oriented titles and almost always a null body. Keep API/agent
+  // callers backward-compatible while making the durable notification ledger
+  // self-explanatory before it is projected to the operator.
+  const presentation =
+    source === "serve:notify"
+      ? synthesizeInboxItem({ ...input, kind, refs, source })
+      : input;
+  const title = requiredString(presentation?.title, "title");
+  const body = optionalString(presentation?.body, "body");
+  const decision = presentation?.decision ?? null;
   if (decision !== null) {
     const checked = validateDecisionRequest(decision, { refs });
     if (!checked.valid) {
@@ -1319,6 +1485,13 @@ export async function deliverInboxItem(
 
 const LINEAR_POLL_INTERVAL_MS = 60_000;
 const linearPollAt = new WeakMap();
+const TERMINAL_RUN_STATES = new Set([
+  "COMPLETED",
+  "FAILED",
+  "REFUSED",
+  "TIMED_OUT",
+  "CANCELLED",
+]);
 
 function prNumber(ref) {
   if (typeof ref !== "string") return null;
@@ -1399,6 +1572,48 @@ export async function fetchLinearInboxIssues(
     .filter(Boolean);
 }
 
+/**
+ * GitHub Issues cannot answer Linear's batched `issue(id:)` query. Resolve
+ * those rows through their repository-selected adapter, while preserving one
+ * bounded batch for the Linear rows and the injectable test seam.
+ */
+async function fetchReferencedInboxIssues(rows, fallback) {
+  const linearIds = [];
+  const githubRows = [];
+  for (const entry of rows) {
+    const repoName = entry.refs.repo;
+    if (!repoName) {
+      linearIds.push(entry.refs.issue);
+      continue;
+    }
+    try {
+      const plane = loadControlPlane({ repoName });
+      if (plane.kind === "github") {
+        githubRows.push({ entry, plane });
+        continue;
+      }
+    } catch {
+      // The existing poll is fail-open. A stale/missing repo config should not
+      // make unrelated Linear inbox rows stop reconciling.
+    }
+    linearIds.push(entry.refs.issue);
+  }
+  const githubIssues = await Promise.all(
+    githubRows.map(async ({ entry, plane }) => {
+      const ticket = await plane.getTicket(entry.refs.issue);
+      return {
+        identifier: entry.refs.issue,
+        state: ticket.state,
+        labels: ticket.labels,
+        title: ticket.title,
+      };
+    }),
+  );
+  const linearIssues =
+    linearIds.length > 0 ? await fallback([...new Set(linearIds)]) : [];
+  return [...githubIssues, ...linearIssues];
+}
+
 function linearIssueResolved(row, issue, db) {
   const state = issue?.state?.name;
   if (typeof state !== "string" || state === "") return false;
@@ -1425,6 +1640,10 @@ function linearIssueResolved(row, issue, db) {
     );
   }
   return false;
+}
+
+function issueIsClosed(issue) {
+  return issue?.state?.type === "completed";
 }
 
 /** Resolve asks when their runtime-owned or externally polled referent moves on. */
@@ -1478,6 +1697,20 @@ export function reconcileInbox(
     // ask is moot and resolveInboxItem records it as superseded (auto:*).
     const refs = parseObject(row.refs_json);
     let resolvedBy = null;
+    if (refs.runId) {
+      const run = db
+        .query("SELECT state FROM runs WHERE run_id = ?")
+        .get(refs.runId);
+      if (run && TERMINAL_RUN_STATES.has(run.state)) {
+        resolveInboxItem(db, row.id, {
+          now,
+          resolvedBy: "auto:stale_ref",
+          reason: "stale_ref",
+        });
+        resolved.push({ id: row.id, resolvedBy: "auto:stale_ref" });
+        continue;
+      }
+    }
     if (row.kind === "decision_needed" || row.kind === "proposal_expired") {
       if (!refs.proposalId) continue;
       const proposal = db
@@ -1504,33 +1737,49 @@ export function reconcileInbox(
         .get(refs.eventSource, refs.eventId);
       if (event && event.status !== "human_needed")
         resolvedBy = "auto:event_requeued";
-    } else if (
-      (row.kind === "BLOCKED" || row.kind === "ESCALATED") &&
-      refs.issue
-    ) {
-      linearRows.push({ row, refs });
     }
     if (!resolvedBy) continue;
     resolveInboxItem(db, row.id, { now, resolvedBy });
     resolved.push({ id: row.id, resolvedBy });
   }
 
+  // A ticket can be referenced by any inbox kind. The kind-specific branches
+  // above handle local proposal/event state first; a closed external ticket is
+  // stale regardless of whether the item was BLOCKED, RC READY, or a decision.
+  for (const row of rows) {
+    const refs = parseObject(row.refs_json);
+    if (
+      refs.issue &&
+      !resolved.some((entry) => entry.id === row.id) &&
+      !linearRows.some((entry) => entry.row.id === row.id)
+    ) {
+      linearRows.push({ row, refs });
+    }
+  }
+
   if (linearRows.length === 0) return resolved;
   const lastPoll = linearPollAt.get(db) ?? -Infinity;
   if (now - lastPoll < LINEAR_POLL_INTERVAL_MS) return resolved;
   linearPollAt.set(db, now);
-  const issueIds = [...new Set(linearRows.map(({ refs }) => refs.issue))];
-  return Promise.resolve(linearIssues(issueIds))
+  return Promise.resolve(fetchReferencedInboxIssues(linearRows, linearIssues))
     .then((issues) => {
       const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
       for (const { row, refs } of linearRows) {
         const issue = byId.get(refs.issue);
-        if (!issue || !linearIssueResolved(row, issue, db)) continue;
+        if (!issue) continue;
+        const stale = issueIsClosed(issue);
+        if (!stale && !linearIssueResolved(row, issue, db)) continue;
         const resolvedBy =
-          row.kind === "BLOCKED"
-            ? "auto:linear_unblocked"
-            : "auto:linear_escalation_cleared";
-        resolveInboxItem(db, row.id, { now, resolvedBy });
+          stale || (row.kind !== "BLOCKED" && row.kind !== "ESCALATED")
+            ? "auto:stale_ref"
+            : row.kind === "BLOCKED"
+              ? "auto:linear_unblocked"
+              : "auto:linear_escalation_cleared";
+        resolveInboxItem(db, row.id, {
+          now,
+          resolvedBy,
+          ...(resolvedBy === "auto:stale_ref" ? { reason: "stale_ref" } : {}),
+        });
         resolved.push({ id: row.id, resolvedBy });
       }
       return resolved;

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -149,7 +149,7 @@ const DECISION_EFFECTS = Object.freeze({
   dismiss: "keeps the item resolved without changing the referenced work",
 });
 
-function readableSubject(refs, ticketTitle) {
+function readableSubject(refs, ticketTitle, eventType) {
   if (refs.issue) {
     const match = /(?:^|\/)([^/\s#]+)#(\d+)$/.exec(refs.issue);
     if (match) {
@@ -161,21 +161,29 @@ function readableSubject(refs, ticketTitle) {
   if (refs.pr) return `PR ${refs.pr.replace(/^PR\s*/i, "")}`;
   if (refs.proposalId) return `proposal ${refs.proposalId}`;
   if (refs.runId) return `run ${refs.runId}`;
+  // Parked-event notices carry only their event coordinates. Name the event
+  // rather than degrading to "this item"; the repo qualifies it when known.
+  if (refs.eventId) {
+    const named = eventType
+      ? `${eventType} ${refs.eventId}`
+      : `event ${refs.eventId}`;
+    return refs.repo ? `${named} (${refs.repo})` : named;
+  }
   if (refs.repo) return refs.repo;
   return "this item";
 }
 
+/**
+ * Reason codes are structured input, never scraped out of a producer's title:
+ * a machine title is prose, and guessing a code from it invents facts (an
+ * English word or a ticket slug rendered as if it were a runtime reason).
+ * Producers that know their reason pass `reasonCode`; the rest render none.
+ */
 function reasonCodeFor(input) {
   if (typeof input?.reasonCode === "string" && input.reasonCode.trim())
     return input.reasonCode.trim();
   if (input?.kind === "proposal_expired") return "proposal_expired";
-  const title = typeof input?.title === "string" ? input.title : "";
-  const known = Object.keys(INBOX_REASON_GLOSSARY).find((code) =>
-    new RegExp(`(?:^|[^a-z0-9_])${code}(?:$|[^a-z0-9_])`, "i").test(title),
-  );
-  if (known) return known;
-  const candidate = title.match(/:\s*([a-z][a-z0-9_]+)(?:\s|$)/i)?.[1];
-  return candidate?.toLowerCase() ?? null;
+  return null;
 }
 
 function humanReason(reason) {
@@ -224,6 +232,28 @@ function optionEffect(option) {
 }
 
 /**
+ * The durable body restates the ask and what each option does. The Telegram
+ * push renders that request itself (question plus numbered options), so it
+ * strips exactly these paragraphs back out and the operator reads it once.
+ */
+function decisionParagraphs(decision) {
+  const effects = Array.isArray(decision?.options)
+    ? decision.options.map(
+        (option) => `${option.label} — ${optionEffect(option)}.`,
+      )
+    : [];
+  return [
+    typeof decision?.question === "string" && decision.question.trim()
+      ? `Question: ${decision.question.trim()}`
+      : null,
+    typeof decision?.context === "string" && decision.context.trim()
+      ? `Context: ${decision.context.trim()}`
+      : null,
+    effects.length ? `Option effects:\n${effects.join("\n")}` : null,
+  ].filter(Boolean);
+}
+
+/**
  * Convert producer-oriented inbox data into an operator-readable message.
  * Producers retain their concise machine title as an input signal, while the
  * persisted title/body explain what happened, why it matters, and where the
@@ -238,7 +268,11 @@ export function synthesizeInboxItem(input) {
     typeof input?.ticketTitle === "string" && input.ticketTitle.trim()
       ? input.ticketTitle.trim()
       : null;
-  const subject = readableSubject(refs, ticketTitle);
+  const eventType =
+    typeof input?.eventType === "string" && input.eventType.trim()
+      ? input.eventType.trim()
+      : null;
+  const subject = readableSubject(refs, ticketTitle, eventType);
   const why = humanReason(reason);
   const originalBody =
     typeof input?.body === "string" && input.body.trim()
@@ -246,31 +280,15 @@ export function synthesizeInboxItem(input) {
       : null;
   const decision = input?.decision;
   const proposal = proposalSubject(decision);
-  const effects = Array.isArray(decision?.options)
-    ? decision.options.map(
-        (option) => `${option.label} — ${optionEffect(option)}.`,
-      )
-    : [];
   // Keep the serialized request untouched. It is hashed by decision responses,
   // so rewriting its context after a producer has handed it off would make a
   // valid response look stale. The durable body carries the same information.
-  const decisionDetails = [
-    typeof decision?.question === "string" && decision.question.trim()
-      ? `Question: ${decision.question.trim()}`
-      : null,
-    typeof decision?.context === "string" && decision.context.trim()
-      ? `Context: ${decision.context.trim()}`
-      : null,
-    effects.length ? `Option effects:\n${effects.join("\n")}` : null,
-  ]
-    .filter(Boolean)
-    .join("\n\n");
   const body = [
     `What happened: A ${label.toLowerCase()} item needs attention for ${subject}.`,
     `Why it matters: ${why}`,
     reason ? `Reason code: ${reason}.` : null,
     linksFor(refs).length ? `Links:\n${linksFor(refs).join("\n")}` : null,
-    decisionDetails,
+    ...decisionParagraphs(decision),
     originalBody,
   ]
     .filter(Boolean)
@@ -280,7 +298,9 @@ export function synthesizeInboxItem(input) {
     title:
       proposal && (kind === "decision_needed" || kind === "proposal_expired")
         ? `Approve ${proposal.agent} run (${ticketTitle ? subject : (proposal.subject ?? subject)})?`
-        : `${label}: ${subject} — ${titleReason(reason)}`,
+        : reason
+          ? `${label}: ${subject} — ${titleReason(reason)}`
+          : `${label}: ${subject}`,
     body,
   };
 }
@@ -1425,7 +1445,15 @@ function correlatedProposal(db, inboxItemId) {
 
 function telegramMessage(item, webUrl) {
   const lines = [item.title];
-  if (item.body) lines.push(item.body);
+  if (item.body) {
+    // The push renders the ask below; drop the body's restatement of it.
+    const duplicated = new Set(decisionParagraphs(item.decision));
+    const kept = item.body
+      .split("\n\n")
+      .filter((paragraph) => !duplicated.has(paragraph))
+      .join("\n\n");
+    if (kept) lines.push(kept);
+  }
   if (item.decision) {
     lines.push(item.decision.question);
     item.decision.options.forEach((option, index) => {
@@ -1507,6 +1535,16 @@ const TERMINAL_RUN_STATES = new Set([
   "TIMED_OUT",
   "CANCELLED",
 ]);
+// Notices that only report how a run went. Their referent is the run itself,
+// so a terminal run makes them stale. Asks are deliberately excluded: an
+// ESCALATED item is *born* on a REFUSED run, and a decision the operator has
+// not answered stays open no matter what the run it names went on to do.
+const RUN_PROGRESS_KINDS = new Set(["CI RED", "SMOKE RED", "CIRCUIT BREAKER"]);
+
+/** An ask the operator has been handed and has not answered yet. */
+function hasPendingDecision(row) {
+  return row.decision_json != null && row.response_json == null;
+}
 
 function prNumber(ref) {
   if (typeof ref !== "string") return null;
@@ -1592,9 +1630,12 @@ export async function fetchLinearInboxIssues(
  * those rows through their repository-selected adapter, while preserving one
  * bounded batch for the Linear rows and the injectable test seam.
  */
-async function fetchReferencedInboxIssues(rows, fallback) {
+async function fetchReferencedInboxIssues(rows, fallback, controlPlane) {
   const linearIds = [];
-  const githubRows = [];
+  // One lookup per distinct ticket, not per open item: several inbox rows
+  // routinely name the same ticket, and each GitHub lookup is its own
+  // un-batched API call against a shared token budget.
+  const githubRows = new Map();
   for (const entry of rows) {
     const repoName = entry.refs.repo;
     if (!repoName) {
@@ -1602,9 +1643,10 @@ async function fetchReferencedInboxIssues(rows, fallback) {
       continue;
     }
     try {
-      const plane = loadControlPlane({ repoName });
+      const plane = controlPlane({ repoName });
       if (plane.kind === "github") {
-        githubRows.push({ entry, plane });
+        if (!githubRows.has(entry.refs.issue))
+          githubRows.set(entry.refs.issue, plane);
         continue;
       }
     } catch {
@@ -1614,19 +1656,25 @@ async function fetchReferencedInboxIssues(rows, fallback) {
     linearIds.push(entry.refs.issue);
   }
   const githubIssues = await Promise.all(
-    githubRows.map(async ({ entry, plane }) => {
-      const ticket = await plane.getTicket(entry.refs.issue);
-      return {
-        identifier: entry.refs.issue,
-        state: ticket.state,
-        labels: ticket.labels,
-        title: ticket.title,
-      };
+    [...githubRows].map(async ([issue, plane]) => {
+      // Per-row fail-open: one deleted ticket or one rate-limited read must
+      // not reject the whole batch and stall every other row's reconcile.
+      try {
+        const ticket = await plane.getTicket(issue);
+        return {
+          identifier: issue,
+          state: ticket.state,
+          labels: ticket.labels,
+          title: ticket.title,
+        };
+      } catch {
+        return null;
+      }
     }),
   );
   const linearIssues =
     linearIds.length > 0 ? await fallback([...new Set(linearIds)]) : [];
-  return [...githubIssues, ...linearIssues];
+  return [...githubIssues.filter(Boolean), ...linearIssues];
 }
 
 function linearIssueResolved(row, issue, db) {
@@ -1664,7 +1712,11 @@ function issueIsClosed(issue) {
 /** Resolve asks when their runtime-owned or externally polled referent moves on. */
 export function reconcileInbox(
   db,
-  { now = Date.now(), linearIssues = fetchLinearInboxIssues } = {},
+  {
+    now = Date.now(),
+    linearIssues = fetchLinearInboxIssues,
+    controlPlane = loadControlPlane,
+  } = {},
 ) {
   const resolved = [];
   const rows = db
@@ -1712,20 +1764,7 @@ export function reconcileInbox(
     // ask is moot and resolveInboxItem records it as superseded (auto:*).
     const refs = parseObject(row.refs_json);
     let resolvedBy = null;
-    if (refs.runId) {
-      const run = db
-        .query("SELECT state FROM runs WHERE run_id = ?")
-        .get(refs.runId);
-      if (run && TERMINAL_RUN_STATES.has(run.state)) {
-        resolveInboxItem(db, row.id, {
-          now,
-          resolvedBy: "auto:stale_ref",
-          reason: "stale_ref",
-        });
-        resolved.push({ id: row.id, resolvedBy: "auto:stale_ref" });
-        continue;
-      }
-    }
+    let resolvedReason = null;
     if (row.kind === "decision_needed" || row.kind === "proposal_expired") {
       if (!refs.proposalId) continue;
       const proposal = db
@@ -1753,8 +1792,28 @@ export function reconcileInbox(
       if (event && event.status !== "human_needed")
         resolvedBy = "auto:event_requeued";
     }
+    // A run-progress notice about a run that has already finished is stale.
+    // This never applies to an open ask: the operator still owes an answer.
+    if (
+      !resolvedBy &&
+      refs.runId &&
+      RUN_PROGRESS_KINDS.has(row.kind) &&
+      !hasPendingDecision(row)
+    ) {
+      const run = db
+        .query("SELECT state FROM runs WHERE run_id = ?")
+        .get(refs.runId);
+      if (run && TERMINAL_RUN_STATES.has(run.state)) {
+        resolvedBy = "auto:stale_ref";
+        resolvedReason = "stale_ref";
+      }
+    }
     if (!resolvedBy) continue;
-    resolveInboxItem(db, row.id, { now, resolvedBy });
+    resolveInboxItem(db, row.id, {
+      now,
+      resolvedBy,
+      ...(resolvedReason ? { reason: resolvedReason } : {}),
+    });
     resolved.push({ id: row.id, resolvedBy });
   }
 
@@ -1776,7 +1835,9 @@ export function reconcileInbox(
   const lastPoll = linearPollAt.get(db) ?? -Infinity;
   if (now - lastPoll < LINEAR_POLL_INTERVAL_MS) return resolved;
   linearPollAt.set(db, now);
-  return Promise.resolve(fetchReferencedInboxIssues(linearRows, linearIssues))
+  return Promise.resolve(
+    fetchReferencedInboxIssues(linearRows, linearIssues, controlPlane),
+  )
     .then((issues) => {
       const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
       for (const { row, refs } of linearRows) {

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -137,6 +137,7 @@ describe("human inbox ledger (WM-285)", () => {
       kind: "BLOCKED",
       title:
         "BLOCKED factory.dispatch.requested run_123-watt-mind/factory#1158: owned_paths_not_closed",
+      reasonCode: "owned_paths_not_closed",
       refs: {
         repo: "factory",
         issue: "watt-mind/factory#1158",
@@ -169,6 +170,7 @@ describe("human inbox ledger (WM-285)", () => {
       const item = synthesizeInboxItem({
         kind,
         title: `machine ${kind}: ${reason}`,
+        reasonCode: reason,
         refs: { issue: "watt-mind/factory#1158", runId: "run_1", pr: "42" },
       });
       expect(item.title).toMatch(/^[A-Z]|^Blocked:|^Escalated:|^CI failed:/);
@@ -181,10 +183,44 @@ describe("human inbox ledger (WM-285)", () => {
     }
   });
 
+  test("never invents a reason code out of a producer's free-text title", () => {
+    const item = synthesizeInboxItem({
+      kind: "BLOCKED",
+      // Reads like a reason code, but nothing structured says it is one.
+      title: "BLOCKED factory#1158: owned_paths_not_closed",
+      refs: { issue: "watt-mind/factory#1158" },
+    });
+    expect(item.title).toBe("Blocked: factory#1158");
+    expect(item.body).not.toContain("Reason code:");
+    expect(item.body).not.toContain("allowed paths");
+  });
+
+  test('names the event a parked notice refers to instead of "this item"', () => {
+    const item = synthesizeInboxItem({
+      kind: "BLOCKED",
+      title: "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
+      reasonCode: "repo_report_only",
+      eventType: "linear.ticket.agent_ready",
+      refs: { eventSource: "linear", eventId: "evt-park" },
+    });
+    expect(item.body).toContain(
+      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-park.",
+    );
+    expect(item.body).toContain("Reason code: repo_report_only.");
+    expect(
+      synthesizeInboxItem({
+        kind: "BLOCKED",
+        title: "BLOCKED evt-park",
+        refs: { eventSource: "linear", eventId: "evt-park", repo: "factory" },
+      }).body,
+    ).toContain("for event evt-park (factory).");
+  });
+
   test("uses cached ticket titles and proposal subjects in human titles", () => {
     const ticket = synthesizeInboxItem({
       kind: "BLOCKED",
       title: "BLOCKED factory#1158: owned_paths_not_closed",
+      reasonCode: "owned_paths_not_closed",
       ticketTitle: "select Opus only for Claude parent runs",
       refs: { issue: "watt-mind/factory#1158" },
     });
@@ -1304,7 +1340,7 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
-  test("terminal run and closed ticket references auto-resolve as stale", async () => {
+  test("a run-progress notice for a finished run and a closed ticket auto-resolve as stale", async () => {
     const db = openDb(":memory:");
     const now = new Date(1000).toISOString();
     db.query(
@@ -1315,7 +1351,7 @@ describe("human inbox ledger (WM-285)", () => {
     createInboxItem(
       db,
       {
-        kind: "human_needed",
+        kind: "CI RED",
         title: "terminal run",
         refs: { runId: "run-terminal" },
         source: "serve:notify",
@@ -1353,6 +1389,100 @@ describe("human inbox ledger (WM-285)", () => {
     expect(getInboxItem(db, "closed-ticket")).toMatchObject({
       resolvedReason: "stale_ref",
     });
+  });
+
+  test("GitHub ticket lookups are deduped per ticket and fail open per row", async () => {
+    const db = openDb(":memory:");
+    // Two distinct items naming the same ticket — the shape that used to cost
+    // one un-batched GitHub read per open item, every poll.
+    for (const [id, kind, issue] of [
+      ["gh-a", "BLOCKED", "watt-mind/factory#1"],
+      ["gh-b", "RC READY", "watt-mind/factory#1"],
+      ["gh-c", "BLOCKED", "watt-mind/factory#2"],
+    ]) {
+      createInboxItem(
+        db,
+        { kind, title: id, refs: { issue, repo: "factory" } },
+        { id, now: 1000 },
+      );
+    }
+    const looked = [];
+    const resolved = await reconcileInbox(db, {
+      now: 60_000,
+      linearIssues: async () => {
+        throw new Error("GitHub rows must not reach the Linear batch");
+      },
+      controlPlane: () => ({
+        kind: "github",
+        getTicket: async (issue) => {
+          looked.push(issue);
+          // One unreadable ticket must not sink the whole poll.
+          if (issue === "watt-mind/factory#2") throw new Error("rate limited");
+          return { state: { name: "Closed", type: "completed" }, labels: [] };
+        },
+      }),
+    });
+
+    // Two rows share one ticket: one lookup, not one per open item.
+    expect(looked).toEqual(["watt-mind/factory#1", "watt-mind/factory#2"]);
+    expect(resolved).toEqual([
+      { id: "gh-a", resolvedBy: "auto:stale_ref" },
+      { id: "gh-b", resolvedBy: "auto:stale_ref" },
+    ]);
+    expect(getInboxItem(db, "gh-c").resolvedAt).toBeNull();
+  });
+
+  test("an escalation on a REFUSED run survives reconcile — it is born terminal", async () => {
+    const db = openDb(":memory:");
+    const at = new Date(1000).toISOString();
+    db.query(
+      `INSERT INTO runs
+         (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES ('run-refused', 'refused-key', '{}', 'sha256:test', 'REFUSED', 1, ?, ?)`,
+    ).run(at, at);
+    const refs = { runId: "run-refused", issue: "WM-901", repo: "factory" };
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "How should the factory proceed with WM-901?",
+        refs,
+        source: "agent:run-refused",
+        decision: templateFor("ESCALATED", { producer: "escalation", refs }),
+      },
+      { id: "live-escalation", now: 1000 },
+    );
+    // A parked ask whose event is still parked must survive the same sweep.
+    db.query(
+      `INSERT INTO runs
+         (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES ('run-done', 'done-key', '{}', 'sha256:test', 'COMPLETED', 1, ?, ?)`,
+    ).run(at, at);
+    createInboxItem(
+      db,
+      {
+        kind: "human_needed",
+        title: "an unanswered ask about a finished run",
+        refs: { runId: "run-done" },
+        source: "serve:notify",
+      },
+      { id: "live-ask", now: 1000 },
+    );
+
+    expect(
+      await reconcileInbox(db, {
+        now: 60_000,
+        linearIssues: async () => [
+          {
+            identifier: "WM-901",
+            state: { name: "In Progress", type: "started" },
+            labels: { nodes: [{ name: "ai:agent-ready" }] },
+          },
+        ],
+      }),
+    ).toEqual([]);
+    expect(getInboxItem(db, "live-escalation").resolvedAt).toBeNull();
+    expect(getInboxItem(db, "live-ask").resolvedAt).toBeNull();
   });
 
   test("a pending decision becomes moot when its event leaves human_needed", async () => {

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -162,6 +162,51 @@ describe("human inbox ledger (WM-285)", () => {
     );
   });
 
+  test("synthesizes titles and bodies for every inbox kind, including unknown reasons", () => {
+    for (const kind of INBOX_KINDS) {
+      const reason =
+        kind === "proposal_expired" ? "proposal_expired" : "novel_reason";
+      const item = synthesizeInboxItem({
+        kind,
+        title: `machine ${kind}: ${reason}`,
+        refs: { issue: "watt-mind/factory#1158", runId: "run_1", pr: "42" },
+      });
+      expect(item.title).toMatch(/^[A-Z]|^Blocked:|^Escalated:|^CI failed:/);
+      expect(item.body).toContain("What happened:");
+      expect(item.body).toContain("Why it matters:");
+      expect(item.body).toContain(`Reason code: ${reason}.`);
+      expect(item.body).toContain("Ticket: watt-mind/factory#1158");
+      expect(item.body).toContain("Run: run_1");
+      expect(item.body).toContain("PR: 42");
+    }
+  });
+
+  test("uses cached ticket titles and proposal subjects in human titles", () => {
+    const ticket = synthesizeInboxItem({
+      kind: "BLOCKED",
+      title: "BLOCKED factory#1158: owned_paths_not_closed",
+      ticketTitle: "select Opus only for Claude parent runs",
+      refs: { issue: "watt-mind/factory#1158" },
+    });
+    expect(ticket.title).toBe(
+      'Blocked: factory#1158 "select Opus only for Claude parent runs" — its allowed paths do not cover every required file',
+    );
+
+    const proposal = synthesizeInboxItem({
+      kind: "decision_needed",
+      title: "Reaper",
+      refs: { proposalId: "proposal-1" },
+      decision: {
+        question: "Run reaper@1 for hourly sweep?",
+        options: [{ label: "Approve", effect: "approve_proposal" }],
+      },
+    });
+    expect(proposal.title).toBe("Approve reaper run (hourly sweep)?");
+    expect(proposal.body).toContain(
+      "Approve — approves the proposal and allows its run to proceed.",
+    );
+  });
+
   test("decision requests are validated and exposed with decision metadata", () => {
     const db = openDb(":memory:");
     expect(() =>
@@ -256,6 +301,7 @@ describe("human inbox ledger (WM-285)", () => {
       {
         kind: "decision_needed",
         title: "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+        ticketTitle: "select Opus only for Claude parent runs",
         refs,
         source: "serve:notify",
         decision: templateFor("decision_needed", {
@@ -268,7 +314,9 @@ describe("human inbox ledger (WM-285)", () => {
       },
       { id: "inbox_dispatch" },
     );
-    expect(created.title).toBe("Approve dispatch@1 run (WM-862)?");
+    expect(created.title).toBe(
+      'Approve dispatch run (WM-862 "select Opus only for Claude parent runs")?',
+    );
     expect(created.body).toContain("Question: Run dispatch@1 for WM-862");
     expect(created.body).toContain("Approve proposal — approves the proposal");
     expect(created.decision.question).toBe(

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -20,6 +20,7 @@ import {
   resolveInboxItem,
   fetchLinearInboxIssues,
   linearGql,
+  synthesizeInboxItem,
 } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";
 import { templateFor } from "./decision-templates.mjs";
@@ -118,6 +119,49 @@ test("the documented decision API errors match decide and retry", () => {
 });
 
 describe("human inbox ledger (WM-285)", () => {
+  test("synthesizes an operator-readable inbox message and explains decision effects", () => {
+    const request = {
+      schemaVersion: "factory.decision-request/v1",
+      question: "How should the factory proceed with watt-mind/factory#1158?",
+      context: "The dispatch run stopped before opening a pull request.",
+      options: [
+        {
+          id: "triage",
+          label: "Send back to Triage",
+          effect: "send_to_triage",
+        },
+        { id: "answer", label: "Answer the agent", effect: "answer" },
+      ],
+    };
+    const item = synthesizeInboxItem({
+      kind: "BLOCKED",
+      title:
+        "BLOCKED factory.dispatch.requested run_123-watt-mind/factory#1158: owned_paths_not_closed",
+      refs: {
+        repo: "factory",
+        issue: "watt-mind/factory#1158",
+        runId: "run_123",
+        pr: "42",
+      },
+      decision: request,
+    });
+
+    expect(item.title).toBe(
+      "Blocked: factory#1158 — its allowed paths do not cover every required file",
+    );
+    expect(item.body).toContain(
+      "What happened: A blocked item needs attention",
+    );
+    expect(item.body).toContain("Why it matters: The ticket's allowed paths");
+    expect(item.body).toContain("Ticket: watt-mind/factory#1158");
+    expect(item.body).toContain("Run: run_123");
+    expect(item.body).toContain("PR: 42");
+    expect(item.body).toContain("Send back to Triage — removes ai:agent-ready");
+    expect(item.body).toContain(
+      "Answer the agent — records the operator's reply",
+    );
+  });
+
   test("decision requests are validated and exposed with decision metadata", () => {
     const db = openDb(":memory:");
     expect(() =>
@@ -193,7 +237,7 @@ describe("human inbox ledger (WM-285)", () => {
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(3);
   });
 
-  test("a dispatch proposal item stores the action-first title and why-line (WM-896)", () => {
+  test("a dispatch proposal item stores a human-readable title and decision details", () => {
     const db = openDb(":memory:");
     const refs = {
       proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
@@ -224,9 +268,9 @@ describe("human inbox ledger (WM-285)", () => {
       },
       { id: "inbox_dispatch" },
     );
-    expect(created.title).toBe(
-      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
-    );
+    expect(created.title).toBe("Approve dispatch@1 run (WM-862)?");
+    expect(created.body).toContain("Question: Run dispatch@1 for WM-862");
+    expect(created.body).toContain("Approve proposal — approves the proposal");
     expect(created.decision.question).toBe(
       "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
     );
@@ -1212,6 +1256,57 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
+  test("terminal run and closed ticket references auto-resolve as stale", async () => {
+    const db = openDb(":memory:");
+    const now = new Date(1000).toISOString();
+    db.query(
+      `INSERT INTO runs
+         (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES ('run-terminal', 'terminal-key', '{}', 'sha256:test', 'COMPLETED', 1, ?, ?)`,
+    ).run(now, now);
+    createInboxItem(
+      db,
+      {
+        kind: "human_needed",
+        title: "terminal run",
+        refs: { runId: "run-terminal" },
+        source: "serve:notify",
+      },
+      { id: "terminal-run", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "RC READY",
+        title: "closed ticket",
+        refs: { issue: "WM-closed" },
+      },
+      { id: "closed-ticket", now: 1000 },
+    );
+
+    expect(
+      await reconcileInbox(db, {
+        now: 60_000,
+        linearIssues: async () => [
+          {
+            identifier: "WM-closed",
+            state: { name: "Done", type: "completed" },
+            labels: { nodes: [] },
+          },
+        ],
+      }),
+    ).toEqual([
+      { id: "terminal-run", resolvedBy: "auto:stale_ref" },
+      { id: "closed-ticket", resolvedBy: "auto:stale_ref" },
+    ]);
+    expect(getInboxItem(db, "terminal-run")).toMatchObject({
+      resolvedReason: "stale_ref",
+    });
+    expect(getInboxItem(db, "closed-ticket")).toMatchObject({
+      resolvedReason: "stale_ref",
+    });
+  });
+
   test("a pending decision becomes moot when its event leaves human_needed", async () => {
     const db = openDb(":memory:");
     insertEvent(db, { eventId: "evt-2" });
@@ -1726,10 +1821,10 @@ describe("approving an expired proposal retargets its item (WM-714)", () => {
     });
     expect(again.id).toBe(id);
     expect(again.title).toBe(
-      `DECISION NEEDED proposal ${FRESH}: expired undecided`,
+      `Proposal expired: proposal ${FRESH} — The proposal expired before an operator approved or rejected it`,
     );
     expect(listInboxItems(db).map((item) => item.title)).toEqual([
-      `DECISION NEEDED proposal ${FRESH}: expired undecided`,
+      `Proposal expired: proposal ${FRESH} — The proposal expired before an operator approved or rejected it`,
     ]);
     expect(db.query("SELECT COUNT(*) AS n FROM inbox_items").get().n).toBe(1);
     // Supersession does not lose the retarget the operator already paid for.

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -161,13 +161,33 @@ function alreadyNotified(db, kind, target) {
  *
  * @returns {Array<{ kind: string, dedupKind?: string, target: string, title: string, message?: string, refs: object, source: string }>}
  */
+/** Ticket/repo the parked event's own envelope already names, if any. */
+function eventRefs(row) {
+  let payload;
+  try {
+    payload = JSON.parse(row.envelopeJson ?? "{}")?.payload;
+  } catch {
+    return {};
+  }
+  if (!payload || typeof payload !== "object") return {};
+  return {
+    ...(typeof payload.ticket === "string" && payload.ticket
+      ? { issue: payload.ticket }
+      : {}),
+    ...(typeof payload.repo === "string" && payload.repo
+      ? { repo: payload.repo }
+      : {}),
+  };
+}
+
 export function pendingNotifications(db, { now = Date.now() } = {}) {
   ensureNotifyLog(db);
   const pending = [];
 
   const parked = db
     .query(
-      `SELECT e.source, e.event_id AS eventId, e.type, e.last_plan_error AS lastPlanError,
+      `SELECT e.source, e.event_id AS eventId, e.type, e.envelope_json AS envelopeJson,
+              e.last_plan_error AS lastPlanError,
               (SELECT p.reason FROM proposals p
                 WHERE p.event_source = e.source AND p.event_id = e.event_id
                   AND p.decision = 'human_needed'
@@ -180,17 +200,26 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
   for (const e of parked) {
     const target = `${e.source}/${e.eventId}`;
     if (alreadyNotified(db, KIND_HUMAN_NEEDED, target)) continue;
+    const reason = e.reason ?? e.lastPlanError ?? "human_needed";
+    // A parked event knows only its own coordinates. Lift whatever the
+    // envelope already names so the operator's item can say which repo and
+    // ticket stalled instead of "this item".
+    const refs = { eventSource: e.source, eventId: e.eventId, ...eventRefs(e) };
     pending.push({
       kind: "BLOCKED",
       dedupKind: KIND_HUMAN_NEEDED,
       target,
-      title: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
-      message: `BLOCKED ${e.type} ${e.eventId}: ${e.reason ?? e.lastPlanError ?? "human_needed"}`,
-      refs: { eventSource: e.source, eventId: e.eventId },
+      title: `BLOCKED ${e.type} ${e.eventId}: ${reason}`,
+      message: `BLOCKED ${e.type} ${e.eventId}: ${reason}`,
+      refs,
+      // Structured presentation inputs: the reason is a code, not scraped
+      // back out of the title above.
+      reasonCode: reason,
+      eventType: e.type,
       source: "serve:notify",
       decision: templateFor("BLOCKED", {
         producer: "parked",
-        refs: { eventSource: e.source, eventId: e.eventId },
+        refs,
       }),
       dedupeKey: `BLOCKED:${target}`,
     });

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -208,6 +208,10 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
     const spec = p.spec_json ? JSON.parse(p.spec_json) : null;
     const agent = spec?.agent ?? "?";
     const title = proposalSubject(spec);
+    const ticketTitle =
+      typeof spec?.approvalPolicy?.dispatchEvidence?.ticket?.title === "string"
+        ? spec.approvalPolicy.dispatchEvidence.ticket.title
+        : null;
     const issue =
       typeof spec?.input?.ticket === "string" ? spec.input.ticket : null;
     const repo = typeof spec?.input?.repo === "string" ? spec.input.repo : null;
@@ -233,6 +237,7 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
           kind: KIND_PROPOSAL_EXPIRED,
           target: p.id,
           title,
+          ...(ticketTitle ? { ticketTitle } : {}),
           message: `DECISION NEEDED proposal ${p.id} (${agent}): expired undecided`,
           refs,
           source: "serve:notify",
@@ -247,6 +252,7 @@ export function pendingNotifications(db, { now = Date.now() } = {}) {
         dedupKind: DEDUP_PROPOSAL_TTL,
         target: p.id,
         title,
+        ...(ticketTitle ? { ticketTitle } : {}),
         message: `DECISION NEEDED proposal ${p.id} (${agent}): expires in ${minutesLeft}m`,
         refs,
         source: "serve:notify",

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -83,6 +83,7 @@ function insertProposal(
     agent = "worktree-ticket@1",
     input,
     model,
+    approvalPolicy,
     createdAt,
     ttlSeconds = 1800,
   },
@@ -93,6 +94,7 @@ function insertProposal(
           agent,
           ...(input ? { input } : {}),
           ...(model ? { model } : {}),
+          ...(approvalPolicy ? { approvalPolicy } : {}),
         }
       : null;
   db.query(
@@ -216,6 +218,17 @@ describe("notify (WM-65)", () => {
     await first.deliveries;
     expect(stub.pushes()).toEqual([
       "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
+      "What happened: A blocked item needs attention for this item.",
+      "",
+      "Why it matters: The runtime reported “repo report only” and needs an operator to decide what happens next.",
+      "",
+      "Reason code: repo_report_only.",
+      "",
+      "Question: Should this parked event be requeued?",
+      "",
+      "Option effects:",
+      "Requeue the event — puts the parked event back into planning.",
+      "Not now — keeps the item resolved without changing the referenced work.",
       "Should this parked event be requeued?",
       "1. Requeue the event",
       "2. Not now",
@@ -248,7 +261,7 @@ describe("notify (WM-65)", () => {
     });
     expect(afterRestart.sent).toEqual([]);
     await afterRestart.deliveries;
-    expect(stub.pushes()).toHaveLength(5);
+    expect(stub.pushes()).toHaveLength(16);
     db.close();
   });
 
@@ -292,7 +305,9 @@ describe("notify (WM-65)", () => {
         "SELECT title, decision_json, dedupe_key FROM inbox_items WHERE kind = 'decision_needed'",
       )
       .get();
-    expect(proposalItem.title).toBe("Ci-Doctor");
+    expect(proposalItem.title).toBe(
+      "Approve ci-doctor run (proposal prop-aging)?",
+    );
     expect(
       JSON.parse(proposalItem.decision_json).options.map(
         (option) => option.effect,
@@ -331,6 +346,11 @@ describe("notify (WM-65)", () => {
       agent: "dispatch@1",
       model: "cursor-grok-4.6-high",
       input: { ticket: "WM-862", repo: "factory" },
+      approvalPolicy: {
+        dispatchEvidence: {
+          ticket: { title: "select Opus only for Claude parent runs" },
+        },
+      },
       reason: "auto_approval_ineligible:dispatch_recheck_failed",
       createdAt: new Date(now - 16 * 60_000).toISOString(),
       ttlSeconds: 1800,
@@ -344,7 +364,7 @@ describe("notify (WM-65)", () => {
     });
     expect(out.sent).toHaveLength(1);
     expect(out.sent[0].title).toBe(
-      "Dispatch WM-862 · factory · cursor-grok-4.6-high",
+      "Dispatch WM-862 · factory · cursor-grok-4.6-high — select Opus only for Claude parent runs",
     );
     expect(out.sent[0].message).toBe(
       "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 14m",
@@ -354,7 +374,9 @@ describe("notify (WM-65)", () => {
         "SELECT title, refs_json, decision_json FROM inbox_items WHERE kind = 'decision_needed'",
       )
       .get();
-    expect(item.title).toBe("Dispatch WM-862 · factory · cursor-grok-4.6-high");
+    expect(item.title).toBe(
+      'Approve dispatch run (WM-862 "select Opus only for Claude parent runs")?',
+    );
     expect(JSON.parse(item.refs_json)).toMatchObject({
       proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",
       issue: "WM-862",
@@ -372,7 +394,10 @@ describe("notify (WM-65)", () => {
     expect(stub.pushes()[0]).toBe(
       "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 14m",
     );
-    expect(stub.pushes()[1]).toBe(
+    expect(stub.pushes()).toContain(
+      'What happened: A decision needed item needs attention for WM-862 "select Opus only for Claude parent runs".',
+    );
+    expect(stub.pushes()).toContain(
       "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",
     );
   });

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -218,17 +218,13 @@ describe("notify (WM-65)", () => {
     await first.deliveries;
     expect(stub.pushes()).toEqual([
       "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
-      "What happened: A blocked item needs attention for this item.",
+      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-park.",
       "",
       "Why it matters: The runtime reported “repo report only” and needs an operator to decide what happens next.",
       "",
       "Reason code: repo_report_only.",
-      "",
-      "Question: Should this parked event be requeued?",
-      "",
-      "Option effects:",
-      "Requeue the event — puts the parked event back into planning.",
-      "Not now — keeps the item resolved without changing the referenced work.",
+      // The push renders the ask once: the body's restatement is stripped and
+      // only the question plus its numbered options follow.
       "Should this parked event be requeued?",
       "1. Requeue the event",
       "2. Not now",
@@ -261,7 +257,7 @@ describe("notify (WM-65)", () => {
     });
     expect(afterRestart.sent).toEqual([]);
     await afterRestart.deliveries;
-    expect(stub.pushes()).toHaveLength(16);
+    expect(stub.pushes()).toHaveLength(10);
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2024

Inbox notification cards now show cached ticket titles, proposal subjects, decision effects, and synthesized context; worker-created escalations are tracked in #2032.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/api.test.mjs event-runtime/lib/notify.test.mjs lib/notify.test.mjs && bun run lint` | pass | 91 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,348 tests; emit, format, lint clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped
run:run_2e0ab5bc-96f8-4d92-ac21-7cc8c46355b7
