### PR TITLE
chore(docs): replace removed linear CLI references

### DIFF
--- a/event-runtime/README.md
+++ b/event-runtime/README.md
@@ -241,7 +241,7 @@ First consumer: `factory.triage.requested` → `triage-scan@1` reads the pinned
 tree plus Linear and emits a typed plan (`TRIAGE` with per-issue actions from
 a closed set, or `NOOP`) → the chain proposes `triage-apply@1` → the operator
 approves the **concrete per-issue action list** → the actions adapter's
-item-list mode resolves each action id to one fixed `tools/linear.mjs`
+item-list mode resolves each action id to one fixed `tools/ticket.mjs`
 invocation. An unregistered action id refuses before applying anything,
 including the valid items beside it.
 

--- a/runners/run-agent.sh
+++ b/runners/run-agent.sh
@@ -141,9 +141,9 @@ fi
 # runs draw on subscription allowances instead of API per-token billing.
 UNSET_KEYS=("-u" "ANTHROPIC_API_KEY" "-u" "GEMINI_API_KEY" "-u" "GOOGLE_API_KEY" "-u" "GOOGLE_GENAI_API_KEY" "-u" "OPENAI_API_KEY" "-u" "MISTRAL_API_KEY" "-u" "DEEPSEEK_API_KEY" "-u" "GROQ_API_KEY")
 
-# Stages run inside a repo, not inside this checkout, so `bun tools/linear.mjs`
+# Stages run inside a repo, not inside this checkout, so `bun tools/ticket.mjs`
 # does not resolve for them. The floor tells agents to use
-# "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that path real. Without
+# "$FACTORY_ROOT/tools/ticket.mjs"; this is what makes that path real. Without
 # it, --strict-mcp-config removes the Linear MCP and leaves no replacement.
 export FACTORY_ROOT="$ROOT"
 
@@ -198,7 +198,7 @@ LOG="$LOG_DIR/${REPO}-${COMMAND}-$(date +%Y%m%d-%H%M%S).jsonl"
 
 # The run id IS the transcript basename — the rollup (metrics/runs.jsonl) is
 # already keyed by it, so a `run:<id>` stamp in a Linear comment or PR body
-# joins straight back to the transcript and its metrics row. tools/linear.mjs
+# joins straight back to the transcript and its metrics row. tools/ticket.mjs
 # stamps comments/issues mechanically when this is set; PR bodies rely on the
 # floor's rule. Complementary to OPS-40, not a replacement for a real assignee
 # lock (OPS-76).
@@ -294,7 +294,7 @@ if [[ "$HARNESS" == "claude" ]]; then
   # servers: no user scope, no project .mcp.json, no claude.ai connectors. What
   # an unattended agent can reach is now declared in git and moves by PR.
   #
-  # That deliberately drops the Linear MCP too — tools/linear.mjs replaces it,
+  # That deliberately drops the Linear MCP too — tools/ticket.mjs replaces it,
   # which is why FACTORY_ROOT above is load-bearing rather than a convenience.
   # It also drops what nobody chose to grant: sessions were loading a client law
   # firm's connector (51 tools) and Gmail (16) into agents running unattended


### PR DESCRIPTION
Fixes watt-mind/factory#2022

Update active runner and runtime documentation references to tools/ticket.mjs; #2035 tracks the remaining out-of-scope audit items.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun run lint` | pass | 0 errors; 615 existing warnings |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,343 tests; emit and format clean |
| UX critique | factory-ux-critic | not run | docs and runner comments; no user-facing surface |

UX critique: skipped

run:run_0355bd9b-fabf-4c5c-b4c0-12b54f11bc48