### PR TITLE
feat(ci): add sandboxed verify smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -408,6 +408,86 @@ jobs:
         run: |
           find /tmp -maxdepth 1 -mindepth 1 \( -name 'evrt-*' -o -name 'wm334-real-*' -o -name 'pi-chrome-devtools-*' -o -name 'puppeteer_dev_chrome_profile-*' -o -name 'factory-wt-*' \) -mmin +30 -exec rm -rf {} + || true
 
+  sandboxed-verify-smoke:
+    name: Sandboxed verify smoke
+    # This is the production handoff boundary exercised against the PR head,
+    # not an approximation of it. Unlike the non-blocking Timing-bound tests,
+    # a red sandbox smoke is merge-blocking through required-verify below:
+    # host/CI green plus this lane red is a hermeticity regression. A future
+    # flaky quarantine must be explicit in this workflow and leave a visible,
+    # non-green signal; it must never silently make the smoke advisory.
+    if: >-
+      ${{
+        !cancelled() &&
+        needs.route.result == 'success' &&
+        (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
+        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
+      }}
+    needs: [route, shadow-runner-health]
+    runs-on: ${{ fromJSON(needs.route.outputs.verify_labels) }}
+    timeout-minutes: 20
+    steps:
+      - name: Checkout (no action download)
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          REPO: ${{ github.repository }}
+          SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+          rm -rf "${GITHUB_WORKSPACE:?}"/* "${GITHUB_WORKSPACE:?}"/.[!.]* 2>/dev/null || true
+          git init -q "$GITHUB_WORKSPACE"
+          cd "$GITHUB_WORKSPACE"
+          git remote add origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
+          git fetch -q --depth 1 origin "$SHA"
+          git checkout -q FETCH_HEAD
+          git log -1 --oneline
+
+      - name: Setup bun (no action download)
+        shell: bash
+        run: |
+          set -euo pipefail
+          .github/scripts/install-pinned-tools.sh bun
+          if [ -x "$HOME/.bun/bin/bun" ]; then
+            echo "$HOME/.bun/bin" >> "$GITHUB_PATH"
+            "$HOME/.bun/bin/bun" --version
+          else
+            bun --version
+          fi
+
+      - name: Install root dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run configured factory verify in the production handoff sandbox
+        # Keep this command synchronized with factory's host-owned verify:
+        # config/repos.yaml. `runHandoffVerifySmoke` delegates to
+        # `runHandoffCommand`, so unshare, env scrubbing, the worktree-only
+        # mount, chroot, and HOME=/tmp/home all stay owned by production code.
+        env:
+          FACTORY_HANDOFF_SMOKE_COMMAND: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint
+        shell: bash
+        run: |
+          set -euo pipefail
+          bun -e '
+            import { mkdtempSync } from "node:fs";
+            import { tmpdir } from "node:os";
+            import path from "node:path";
+            import { runHandoffVerifySmoke } from "./event-runtime/lib/verify.mjs";
+
+            const root = process.cwd();
+            const logDir = mkdtempSync(path.join(tmpdir(), "factory-handoff-smoke-"));
+            const observation = runHandoffVerifySmoke({
+              command: process.env.FACTORY_HANDOFF_SMOKE_COMMAND,
+              cwd: root,
+              worktreePath: root,
+              logPath: path.join(logDir, "verify.log"),
+              timeoutMs: 600_000,
+            });
+            console.log(observation.sandboxFacts);
+            process.stdout.write(observation.output);
+            if (!observation.passed) process.exitCode = 1;
+          '
+
   verify:
     name: Full verification
     # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
@@ -705,7 +785,14 @@ jobs:
   required-verify:
     name: Verify
     if: always()
-    needs: [route, shadow-runner-health, fast-unit-tests, verify]
+    needs:
+      [
+        route,
+        shadow-runner-health,
+        fast-unit-tests,
+        verify,
+        sandboxed-verify-smoke,
+      ]
     # Runs on cloud runner so required verification is decoupled from host fleet
     # health when executing cloud PR runs (WM-950).
     runs-on: ubuntu-latest
@@ -718,6 +805,7 @@ jobs:
       HEALTH_RESULT: ${{ needs.shadow-runner-health.result }}
       FAST_RESULT: ${{ needs.fast-unit-tests.result }}
       FULL_RESULT: ${{ needs.verify.result }}
+      SANDBOX_SMOKE_RESULT: ${{ needs.sandboxed-verify-smoke.result }}
     steps:
       - name: Report required verification result
         shell: bash
@@ -756,6 +844,7 @@ jobs:
           fi
           require_success "Fast unit tests" "$FAST_RESULT"
           require_success "Full verification" "$FULL_RESULT"
+          require_success "Sandboxed verify smoke" "$SANDBOX_SMOKE_RESULT"
 
           if [ "$failed" -ne 0 ]; then
             echo "::error::One or more required verification jobs did not succeed; Verify cannot be green."

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -244,6 +244,24 @@ well (the root `bun run check` runs it too, once `event-runtime/web` has had
 ticket commands. Never advance state, open a PR, or report success on
 failing output. Never weaken a test to get green.
 
+### Sandboxed verify smoke
+
+CI's **Sandboxed verify smoke** job runs the factory `verify:` command through
+`runHandoffVerifySmoke` → `runHandoffCommand`, the same production seam the
+worker uses before accepting a dispatch handoff. It is merge-blocking via
+`Verify`, unlike the explicitly non-blocking **Timing-bound tests** quarantine
+lane. The job prints the sandbox facts — scrubbed environment, `HOME=/tmp/home`,
+worktree mounted at `/workspace`, and namespaces — before the command output.
+
+Therefore **host/CI green + sandbox red is a hermeticity bug, not a branch
+bug**. First inspect tests that read ambient homes or an operator checkout.
+Use `event-runtime/lib/worker-test-helpers.mjs` helpers such as
+`dispatchConfigSnapshot()` to point registry-dependent tests at the checkout
+under test, and use the repository's test-home helpers instead of inheriting
+`FACTORY_EVENT_HOME`. Do not add an unsandboxed fallback or weaken the smoke;
+if a timing-only flake needs quarantine, document its visible non-blocking
+policy in `.github/workflows/ci.yml`.
+
 **Mandatory `## Handoff` comment** before moving to `In Review`:
 
 ```

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -697,6 +697,45 @@ export function runHandoffCommand({
 }
 
 /**
+ * The stable, at-a-glance facts CI prints beside a sandboxed verification.
+ * Keep this derived from the observation returned by `runHandoffCommand` so
+ * the CI smoke lane does not grow a second sandbox implementation or drift
+ * from the worker's production handoff boundary.
+ */
+export function handoffSandboxFacts(observation) {
+  const namespaces = Array.isArray(observation?.sandbox?.namespaces)
+    ? observation.sandbox.namespaces.join(",")
+    : HANDOFF_SANDBOX_NAMESPACES.join(",");
+  const tmpfs = Number.isSafeInteger(observation?.sandbox?.tmpfsMb)
+    ? `${observation.sandbox.tmpfsMb}MiB`
+    : "unknown";
+  return `Handoff sandbox facts: env scrubbed; HOME=/tmp/home; workspace=/workspace; namespaces=${namespaces}; tmpfs=${tmpfs}.`;
+}
+
+/**
+ * Execute a configured repository verify command through the worker's actual
+ * handoff seam. CI calls this for its smoke lane; the injected runner exists
+ * solely to keep the seam testable without creating a real namespace.
+ */
+export function runHandoffVerifySmoke({
+  command,
+  cwd,
+  worktreePath = cwd,
+  logPath,
+  timeoutMs,
+  runHandoffCommandFn = runHandoffCommand,
+}) {
+  const observation = runHandoffCommandFn({
+    command,
+    cwd,
+    worktreePath,
+    logPath,
+    timeoutMs,
+  });
+  return { ...observation, sandboxFacts: handoffSandboxFacts(observation) };
+}
+
+/**
  * `bun test` flags that consume the following word. Their values must never
  * widen the covering set (`--preload ./setup.mjs`, `-t verify`, ...).
  */

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -19,6 +19,7 @@ import {
   HANDOFF_DEPENDENCIES_MISSING,
   HANDOFF_FAILURE_OUTPUT_MAX_CHARS,
   HANDOFF_REASON_CODES,
+  HANDOFF_SANDBOX_NAMESPACES,
   handoffFailureReasonCode,
   handoffFailureOutput,
   missingModuleSpecifiers,
@@ -41,10 +42,12 @@ import {
   clampHandoffSandboxTmpfsMb,
   isBunTestFile,
   insideHandoffSandbox,
+  handoffSandboxFacts,
   policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
   repoVerifyFailingTests,
   runHandoffCommand,
+  runHandoffVerifySmoke,
   ticketVerifyCoveredByRepoVerify,
   verifyResult,
 } from "./verify.mjs";
@@ -2219,6 +2222,46 @@ describe("handoff failure diagnostics (#1529)", () => {
 });
 
 describe("handoff verification helpers (WM-718)", () => {
+  test("sandboxed verify smoke delegates to the production handoff seam and names its facts", () => {
+    const worktree = tmpDir("evrt-handoff-smoke-");
+    const calls = [];
+    const observation = runHandoffVerifySmoke({
+      command: "bun test event-runtime/lib --timeout 20000",
+      cwd: worktree,
+      worktreePath: worktree,
+      logPath: path.join(worktree, "handoff.log"),
+      timeoutMs: 600_000,
+      runHandoffCommandFn: (options) => {
+        calls.push(options);
+        return {
+          passed: true,
+          exitCode: 0,
+          output: "2333 pass\n0 fail\n",
+          sandbox: {
+            tmpfsMb: 1024,
+            namespaces: HANDOFF_SANDBOX_NAMESPACES,
+          },
+        };
+      },
+    });
+
+    expect(calls).toEqual([
+      {
+        command: "bun test event-runtime/lib --timeout 20000",
+        cwd: worktree,
+        worktreePath: worktree,
+        logPath: path.join(worktree, "handoff.log"),
+        timeoutMs: 600_000,
+      },
+    ]);
+    expect(observation.sandboxFacts).toBe(
+      "Handoff sandbox facts: env scrubbed; HOME=/tmp/home; workspace=/workspace; namespaces=user,mount,pid,network; tmpfs=1024MiB.",
+    );
+    expect(handoffSandboxFacts({ sandbox: {} })).toContain(
+      "env scrubbed; HOME=/tmp/home; workspace=/workspace",
+    );
+  });
+
   test("ticket commands get a credential-free environment and namespace/chroot confinement", () => {
     const worktree = tmpDir("evrt-handoff-confined-");
     const logPath = path.join(worktree, "handoff.log");


### PR DESCRIPTION
Fixes watt-mind/factory#2029

Adds a merge-blocking CI smoke lane that runs factory verify through the production handoff sandbox.

## Validation
| Check                | Command                                                                                                  | Result  | Notes                                |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/verify.test.mjs && bun run lint` | pass    | 98 tests, 0 failures; lint 0 errors |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | all stages passed; lint 0 errors    |
| UX critique          | `factory-ux-critic`                                                                                     | not run | no user-facing surface               |
UX critique: skipped

run:run_531cf495-4013-49b7-a10d-0522a5a91f8d
