### PR TITLE
fix(event-runtime): point preserved-worktree comment at tools/ticket.mjs

### DIFF
--- a/event-runtime/lib/workspace.mjs
+++ b/event-runtime/lib/workspace.mjs
@@ -451,7 +451,7 @@ export function commentOnPreservedWorktree({
   const text = `Recovered an abandoned dirty worktree before re-dispatch: preserved its uncommitted changes at \`${preservation.ref}\` (commit ${preservation.commit}, ${preservation.push === "pushed" ? "pushed to origin" : "kept locally because push failed"}).`;
   const result = spawn(
     "bun",
-    [path.join(FACTORY_ROOT, "tools", "linear.mjs"), "comment", ticket, text],
+    [path.join(FACTORY_ROOT, "tools", "ticket.mjs"), "comment", ticket, text],
     {
       cwd: FACTORY_ROOT,
       encoding: "utf8",

--- a/event-runtime/lib/workspace.test.mjs
+++ b/event-runtime/lib/workspace.test.mjs
@@ -13,6 +13,7 @@ import path from "node:path";
 import { spawnSync } from "node:child_process";
 import { Database } from "bun:sqlite";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
+import { FACTORY_ROOT } from "./config.mjs";
 import { MEMO_SCHEMA_VERSION, memoDigest, withProvenance } from "./memos.mjs";
 import {
   assertSandboxWorkspaceSupported,
@@ -660,6 +661,25 @@ describe("worktree workspaces (WM-108)", () => {
         delete process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS;
       else process.env.FACTORY_WORKTREE_SCRIPT_TIMEOUT_MS = previous;
     }
+  });
+
+  test("a preservation comment spawns tools/ticket.mjs, not the deleted tools/linear.mjs", () => {
+    const calls = [];
+    const result = commentOnPreservedWorktree({
+      ticket: "WM-13-argv",
+      preservation: { ref: "wip/x", commit: "abc", push: "pushed" },
+      spawn: (...args) => {
+        calls.push(args);
+        return { error: null, status: 0, stdout: "", stderr: "" };
+      },
+    });
+    expect(result).toEqual({ status: "posted" });
+    expect(calls).toHaveLength(1);
+    const [command, argv] = calls[0];
+    expect(command).toBe("bun");
+    expect(argv[0]).toBe(path.join(FACTORY_ROOT, "tools", "ticket.mjs"));
+    expect(argv[0]).not.toMatch(/linear\.mjs$/);
+    expect(argv.slice(1, 3)).toEqual(["comment", "WM-13-argv"]);
   });
 
   test("a preservation comment that fails to spawn records the cause, not a blank error", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2038

commentOnPreservedWorktree in event-runtime/lib/workspace.mjs spawned the deleted `tools/linear.mjs`, so every preserved-worktree recovery comment has failed at runtime since PR #2027 removed that shim (WM-2017). This points it at `tools/ticket.mjs`, which keeps the same `comment <ISSUE-ID> <text>` argv contract, and adds a spawn-argv seam test so a future rename fails loudly instead of silently.

## Handoff
- PR: (this PR)
- Verification: `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/workspace.test.mjs && bun run lint && bun run format:check` — pass, 39/39 tests pass, lint 0 errors (pre-existing warnings only), format clean. Also ran the full `bun test event-runtime/lib --timeout 20000`: 2342 pass, 0 fail, 10 skip (environment-gated: QEMU-only VM tests).
- UX critique: skipped — internal recovery-comment plumbing, no user-completable flow
- Files: 2 changed, both within Owned Paths (event-runtime/lib/workspace.mjs, event-runtime/lib/workspace.test.mjs)
- Risks: none known — single-line spawn target fix plus a regression test; verified no other live code path still spawns the deleted tools/linear.mjs

### Grep evidence: no other dynamic `tools/linear.mjs` spawn/path.join remains

```
$ grep -rn 'tools/linear\.mjs\|"linear\.mjs"\|'"'"'linear\.mjs'"'"'' --include="*.mjs" --include="*.js" --include="*.jsx" --include="*.ts" --include="*.tsx" --include="*.sh" -- . | grep -v node_modules

tools/ticket.mjs:8: * deprecated `tools/linear.mjs` shim was removed in WM-2017.                         [prose/doc comment — #2035 scope]
runners/run-agent.sh:144,146,201,297:                                                                    [prose/doc comments — #2035 scope]
orchestrator/tick.mjs:789,866,867:                                                                        [prose/doc comments — #2035 scope]
lib/control-plane/types.mjs:12:                                                                           [prose/doc comment — #2035 scope]
lib/control-plane/labels.mjs:3:                                                                           [prose/doc comment — #2035 scope]
event-runtime/lib/worker-dispatch-hardening.test.mjs:911,943:                                             [prose comment + `fakeCli.calls()).not.toContain("linear.mjs")` — asserts against a fake tracker CLI double, not a real path.join/spawn to tools/linear.mjs]
event-runtime/lib/workspace.test.mjs:666:                                                                 [this PR's own new test title, names the file it fixed]
event-runtime/lib/dispatch.test.mjs:30,114:                                                               [prose comments — #2035 scope]
event-runtime/lib/adapters/pi.mjs:135:                                                                    [prose comment — #2035 scope]
event-runtime/lib/planner.test.mjs:4341: const cli = path.join(root, "linear.mjs");                       [test-local fake CLI file written under a tmp dir via FACTORY_LINEAR_CLI env override — not the real deleted tools/linear.mjs]
```

No other spawn/path.join in live (non-test-fixture, non-prose) code targets the real `tools/linear.mjs`. `event-runtime/lib/control-plane/linear.mjs` and `event-runtime/lib/linear.mjs` are unrelated, still-live modules (not the deleted CLI) and are excluded from this count per scope.