### PR TITLE
Show agent and ticket identity on Runs

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -28,7 +28,7 @@ import {
   releaseStalledWorkerLease,
   retryRun,
 } from "./worker.mjs";
-import { proposalSubject } from "./proposal-subject.mjs";
+import { agentFamily, proposalSubject } from "./proposal-subject.mjs";
 import {
   ApiParameterError,
   parseListLimit,
@@ -785,6 +785,121 @@ const RUN_POPULATIONS = new Set([
 
 export const RUN_LIST_DEFAULT_LIMIT = 100;
 export const RUN_LIST_MAX_LIMIT = 200;
+export const RUN_SUBJECT_CACHE_TTL_MS = 30_000;
+
+// GET /runs is polled frequently. Resolve each distinct ticket once per short
+// window (including misses) so duplicate rows and the detail view never turn a
+// browser poll into one tracker request per row.
+const runSubjectCache = new Map();
+
+export function clearRunSubjectCache() {
+  runSubjectCache.clear();
+}
+
+function runSubjectLabel(subject) {
+  const ticket = normalizeTicketId(subject);
+  if (!ticket)
+    return typeof subject === "string" && subject.trim()
+      ? subject.trim()
+      : null;
+  const github = ticket.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+  return github ? `${github[2]}#${github[3]}` : ticket;
+}
+
+function runSubjectUrl(subject) {
+  const ticket = normalizeTicketId(subject);
+  if (!ticket) return null;
+  const github = ticket.match(/^([^/]+)\/([^#]+)#(\d+)$/);
+  if (github)
+    return `https://github.com/${github[1]}/${github[2]}/issues/${github[3]}`;
+  return `https://linear.app/watt-mind/issue/${encodeURIComponent(ticket)}`;
+}
+
+function runOriginLabel(type) {
+  if (typeof type !== "string" || !type.trim()) return null;
+  const parts = type.trim().split(".").filter(Boolean);
+  if (parts[0] === "factory") parts.shift();
+  if (["requested", "request", "tick"].includes(parts.at(-1))) parts.pop();
+  return parts.join(" ") || type.trim();
+}
+
+function embeddedRunSubjectTitle(spec) {
+  const candidates = [
+    spec?.approvalPolicy?.dispatchEvidence?.ticket?.title,
+    spec?.input?.ticketTitle,
+    spec?.input?.issueTitle,
+  ];
+  return (
+    candidates
+      .find((value) => typeof value === "string" && value.trim())
+      ?.trim() ?? null
+  );
+}
+
+function runIdentity(row, spec) {
+  return {
+    agentKind: agentFamily(spec.agent),
+    ticketSubject: row.subject ?? null,
+    subjectLabel: runSubjectLabel(row.subject),
+    subjectTitle: embeddedRunSubjectTitle(spec),
+    subjectUrl: runSubjectUrl(row.subject),
+    originType: row.event_type ?? null,
+    originLabel: runOriginLabel(row.event_type),
+  };
+}
+
+async function resolveRunSubjects(
+  runs,
+  { nowMs = Date.now(), controlPlane } = {},
+) {
+  const unresolved = new Set();
+  for (const run of runs) {
+    const ticket = normalizeTicketId(run.ticketSubject);
+    if (!ticket || run.subjectTitle) continue;
+    const cached = runSubjectCache.get(ticket);
+    if (cached && nowMs - cached.timestamp < RUN_SUBJECT_CACHE_TTL_MS) {
+      Object.assign(run, cached.data);
+    } else {
+      unresolved.add(ticket);
+    }
+  }
+  if (unresolved.size === 0) return runs;
+
+  let plane;
+  try {
+    plane = await ticketDetailControlPlane(controlPlane);
+  } catch {
+    plane = null;
+  }
+  await Promise.all(
+    [...unresolved].map(async (ticket) => {
+      let data = { subjectTitle: null, subjectUrl: runSubjectUrl(ticket) };
+      try {
+        const issue = await plane?.getTicket(ticket);
+        data = {
+          subjectTitle:
+            typeof issue?.title === "string" && issue.title.trim()
+              ? issue.title.trim()
+              : null,
+          subjectUrl:
+            typeof issue?.url === "string" && issue.url.trim()
+              ? issue.url.trim()
+              : runSubjectUrl(ticket),
+        };
+      } catch {
+        // A tracker outage degrades to the bare persisted subject. Cache the
+        // miss briefly as well, otherwise every 5s poll retries the outage.
+      }
+      runSubjectCache.set(ticket, { timestamp: nowMs, data });
+    }),
+  );
+  for (const run of runs) {
+    const ticket = normalizeTicketId(run.ticketSubject);
+    const cached = ticket ? runSubjectCache.get(ticket) : null;
+    if (cached && !run.subjectTitle) Object.assign(run, cached.data);
+  }
+  return runs;
+}
 
 class ListQueryError extends Error {
   constructor(error, details = {}) {
@@ -1859,10 +1974,12 @@ function runsView(db, filters = {}, page = {}) {
   const rows = db
     .query(
       `SELECT r.*, r.rowid AS list_rowid, a.reason_code, a.terminal_state AS attempt_terminal,
-              a.started_at, a.lease_expires_at, p.event_id, p.event_source
+              a.started_at, a.lease_expires_at, p.event_id, p.event_source,
+              e.type AS event_type
        FROM runs r
        LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
        LEFT JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
+       LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        ${where}
        ORDER BY r.created_at DESC, r.rowid DESC
        LIMIT ?`,
@@ -1884,6 +2001,7 @@ function runsView(db, filters = {}, page = {}) {
         modelTier: spec.modelTier ?? null,
         model: spec.model ?? null,
         idempotencyKey: row.idempotency_key,
+        ...runIdentity(row, spec),
       };
     }),
     nextBefore: hasNextPage ? encodeRunCursor(pageRows.at(-1)) : null,
@@ -2011,7 +2129,17 @@ function runView(
   runId,
   { artifactsDir, registry, readArtifactHead = artifactHead } = {},
 ) {
-  const row = db.query(`SELECT * FROM runs WHERE run_id = ?`).get(runId);
+  const row = db
+    .query(
+      `SELECT r.*,
+              (SELECT e.type
+               FROM proposals p
+               JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
+               WHERE p.run_id = r.run_id AND p.decision = 'run'
+               ORDER BY p.created_at DESC, p.rowid DESC LIMIT 1) AS event_type
+       FROM runs r WHERE r.run_id = ?`,
+    )
+    .get(runId);
   if (!row) return null;
   const attempts = db
     .query(`SELECT * FROM attempts WHERE run_id = ? ORDER BY attempt`)
@@ -2042,6 +2170,7 @@ function runView(
       spec,
     },
     subject: registry ? proposalSubject(registry, spec) : null,
+    identity: runIdentity(row, spec),
     lifecycle: lifecycleOf(db, runId),
     attempts,
     result,
@@ -2331,7 +2460,9 @@ export async function handleRunApiRoute({
         state: url.searchParams.get("state") ?? undefined,
         agent: url.searchParams.get("agent") ?? undefined,
       };
-      return send(200, runsView(db, filters, runPage(url)));
+      const view = runsView(db, filters, runPage(url));
+      await resolveRunSubjects(view.runs, { nowMs });
+      return send(200, view);
     } catch (err) {
       if (err instanceof ListQueryError) return send(422, err.body);
       throw err;
@@ -2465,6 +2596,7 @@ export async function handleRunApiRoute({
       readArtifactHead,
     });
     if (!view) return send(404, { error: `unknown run ${runGet[1]}` });
+    await resolveRunSubjects([view.identity], { nowMs });
     return send(200, view);
   }
 

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -786,6 +786,14 @@ const RUN_POPULATIONS = new Set([
 export const RUN_LIST_DEFAULT_LIMIT = 100;
 export const RUN_LIST_MAX_LIMIT = 200;
 export const RUN_SUBJECT_CACHE_TTL_MS = 30_000;
+// A cold cache can face up to RUN_LIST_MAX_LIMIT distinct unresolved tickets
+// in a single list request. Resolving all of them inline would fan out one
+// tracker read per row, every poll, from every open tab -- exactly the shape
+// that has caused two tracker rate-limit incidents. Cap the synchronous
+// resolution per request and let the rest fill in on later polls (misses are
+// not cached, so they stay eligible next time around).
+const RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST = 8;
+const RUN_SUBJECT_RESOLVE_CONCURRENCY = 4;
 
 // GET /runs is polled frequently. Resolve each distinct ticket once per short
 // window (including misses) so duplicate rows and the detail view never turn a
@@ -871,28 +879,41 @@ async function resolveRunSubjects(
   } catch {
     plane = null;
   }
-  await Promise.all(
-    [...unresolved].map(async (ticket) => {
-      let data = { subjectTitle: null, subjectUrl: runSubjectUrl(ticket) };
-      try {
-        const issue = await plane?.getTicket(ticket);
-        data = {
-          subjectTitle:
-            typeof issue?.title === "string" && issue.title.trim()
-              ? issue.title.trim()
-              : null,
-          subjectUrl:
-            typeof issue?.url === "string" && issue.url.trim()
-              ? issue.url.trim()
-              : runSubjectUrl(ticket),
-        };
-      } catch {
-        // A tracker outage degrades to the bare persisted subject. Cache the
-        // miss briefly as well, otherwise every 5s poll retries the outage.
-      }
-      runSubjectCache.set(ticket, { timestamp: nowMs, data });
-    }),
+
+  const toResolve = [...unresolved].slice(
+    0,
+    RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST,
   );
+
+  async function resolveOne(ticket) {
+    let data = { subjectTitle: null, subjectUrl: runSubjectUrl(ticket) };
+    try {
+      const issue = await plane?.getTicket(ticket);
+      data = {
+        subjectTitle:
+          typeof issue?.title === "string" && issue.title.trim()
+            ? issue.title.trim()
+            : null,
+        subjectUrl:
+          typeof issue?.url === "string" && issue.url.trim()
+            ? issue.url.trim()
+            : runSubjectUrl(ticket),
+      };
+    } catch {
+      // A tracker outage degrades to the bare persisted subject. Cache the
+      // miss briefly as well, otherwise every 5s poll retries the outage.
+    }
+    runSubjectCache.set(ticket, { timestamp: nowMs, data });
+  }
+
+  // Chunked loop: at most RUN_SUBJECT_RESOLVE_CONCURRENCY in flight at once,
+  // and never more than RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST tickets total for
+  // this request. Anything left in `unresolved` beyond the cap is simply not
+  // resolved here -- it stays a bare subject until a later poll picks it up.
+  for (let i = 0; i < toResolve.length; i += RUN_SUBJECT_RESOLVE_CONCURRENCY) {
+    const chunk = toResolve.slice(i, i + RUN_SUBJECT_RESOLVE_CONCURRENCY);
+    await Promise.all(chunk.map((ticket) => resolveOne(ticket)));
+  }
   for (const run of runs) {
     const ticket = normalizeTicketId(run.ticketSubject);
     const cached = ticket ? runSubjectCache.get(ticket) : null;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -14,7 +14,9 @@ import {
 import { memoryControlPlane } from "../../lib/control-plane/index.mjs";
 import {
   TICKET_DETAIL_CACHE_TTL_MS,
+  RUN_SUBJECT_CACHE_TTL_MS,
   clearObservedModelCache,
+  clearRunSubjectCache,
   clearTicketDetailCache,
   mergeTicketSupply,
   scanTicketSupply,
@@ -389,12 +391,19 @@ describe("run list deadlines (WM-692)", () => {
         state: "COMPLETED",
         attempts: 1,
         agent: "page-agent",
+        agentKind: "page-agent",
         adapter: "fake",
         created_at: new Date(start).toISOString(),
         updated_at: new Date(start).toISOString(),
         modelTier: null,
         model: null,
         idempotencyKey: "idem-run-page-c",
+        ticketSubject: null,
+        subjectLabel: null,
+        subjectTitle: null,
+        subjectUrl: null,
+        originType: null,
+        originLabel: null,
       });
       expect(typeof firstPage.nextBefore).toBe("string");
 
@@ -412,6 +421,105 @@ describe("run list deadlines (WM-692)", () => {
         const response = await fetch(s.url(`/runs?${query}`));
         expect(response.status).toBe(422);
       }
+    } finally {
+      s.close();
+    }
+  });
+});
+
+describe("run list human identity (#2025)", () => {
+  afterEach(() => {
+    setTicketDetailControlPlane(null);
+    clearRunSubjectCache();
+  });
+
+  test("enriches distinct ticket subjects once and falls back to the origin type", async () => {
+    const calls = [];
+    setTicketDetailControlPlane({
+      async getTicket(ticket) {
+        calls.push(ticket);
+        if (ticket === "WM-999") throw new Error("tracker unavailable");
+        return {
+          identifier: ticket,
+          title: "Show useful run identities",
+          url: "https://github.com/watt-mind/factory/issues/2025",
+        };
+      },
+    });
+    let nowMs = Date.parse("2026-08-31T10:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    const at = new Date(nowMs).toISOString();
+    const insertRun = (runId, agent, subject) => {
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+           VALUES (?, ?, ?, 'sha256:test', 'RUNNING', 1, ?, ?, ?)`,
+        )
+        .run(
+          runId,
+          `idem-${runId}`,
+          JSON.stringify({ agent, adapter: "pi", input: {} }),
+          at,
+          at,
+          subject,
+        );
+    };
+    try {
+      insertRun("run_ticket_a", "dispatch@1", "watt-mind/factory#2025");
+      insertRun("run_ticket_b", "merge-review@1", "watt-mind/factory#2025");
+      insertRun("run_unresolved", "dispatch@1", "WM-999");
+      insertRun("run_sweep", "work-scan@1", null);
+      await s.client.replay(
+        envelope({
+          eventId: "evt-sweep",
+          type: "factory.sweep.requested",
+          subject: null,
+        }),
+      );
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+           VALUES ('prop-sweep', 'test', 'evt-sweep', 'run_sweep', 'run', ?, 1800)`,
+        )
+        .run(at);
+
+      const first = await s.client.runs();
+      const byId = Object.fromEntries(
+        first.runs.map((run) => [run.runId, run]),
+      );
+      expect(byId.run_ticket_a).toMatchObject({
+        agent: "dispatch@1",
+        agentKind: "dispatch",
+        ticketSubject: "watt-mind/factory#2025",
+        subjectLabel: "factory#2025",
+        subjectTitle: "Show useful run identities",
+        subjectUrl: "https://github.com/watt-mind/factory/issues/2025",
+      });
+      expect(byId.run_unresolved).toMatchObject({
+        subjectLabel: "WM-999",
+        subjectTitle: null,
+      });
+      expect(byId.run_sweep).toMatchObject({
+        agentKind: "work-scan",
+        ticketSubject: null,
+        subjectLabel: null,
+        originType: "factory.sweep.requested",
+        originLabel: "sweep",
+      });
+      expect(calls.sort()).toEqual(["WM-999", "watt-mind/factory#2025"]);
+
+      const detail = await s.client.run("run_ticket_a");
+      expect(detail.identity).toMatchObject({
+        agentKind: "dispatch",
+        subjectLabel: "factory#2025",
+        subjectTitle: "Show useful run identities",
+      });
+      await s.client.runs();
+      expect(calls).toHaveLength(2);
+
+      nowMs += RUN_SUBJECT_CACHE_TTL_MS + 1;
+      await s.client.runs();
+      expect(calls).toHaveLength(4);
     } finally {
       s.close();
     }

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -524,6 +524,68 @@ describe("run list human identity (#2025)", () => {
       s.close();
     }
   });
+
+  test("caps unresolved ticket resolution per request instead of fanning out to every row", async () => {
+    const calls = [];
+    setTicketDetailControlPlane({
+      async getTicket(ticket) {
+        calls.push(ticket);
+        return {
+          identifier: ticket,
+          title: `Title for ${ticket}`,
+          url: `https://github.com/watt-mind/factory/issues/${ticket.split("#")[1]}`,
+        };
+      },
+    });
+    const nowMs = Date.parse("2026-08-31T10:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    const at = new Date(nowMs).toISOString();
+    const ticketCount = 20;
+    try {
+      for (let i = 0; i < ticketCount; i += 1) {
+        s.db
+          .query(
+            `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+             VALUES (?, ?, ?, 'sha256:test', 'RUNNING', 1, ?, ?, ?)`,
+          )
+          .run(
+            `run_cap_${i}`,
+            `idem-run_cap_${i}`,
+            JSON.stringify({ agent: "dispatch@1", adapter: "pi", input: {} }),
+            at,
+            at,
+            `watt-mind/factory#${3000 + i}`,
+          );
+      }
+
+      // Cold-cache first request: at most 8 distinct tickets get resolved
+      // inline, no matter how many distinct unresolved subjects are in the
+      // page -- an unbounded fan-out here is exactly the shape that has
+      // caused tracker rate-limit incidents.
+      const first = await s.client.runs();
+      expect(calls.length).toBeLessThanOrEqual(8);
+      const firstResolvedCount = first.runs.filter(
+        (run) => run.subjectTitle,
+      ).length;
+      expect(firstResolvedCount).toBeLessThanOrEqual(8);
+      expect(firstResolvedCount).toBeGreaterThan(0);
+      expect(first.runs.length).toBe(ticketCount);
+
+      // A later poll picks up more of the previously-unresolved tickets
+      // (cache misses are not cached, so they stay eligible), converging on
+      // full resolution across a few polls without ever exceeding the cap
+      // in a single request.
+      const callsAfterFirst = calls.length;
+      const second = await s.client.runs();
+      expect(calls.length - callsAfterFirst).toBeLessThanOrEqual(8);
+      const secondResolvedCount = second.runs.filter(
+        (run) => run.subjectTitle,
+      ).length;
+      expect(secondResolvedCount).toBeGreaterThan(firstResolvedCount);
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("repoNamesFromInput (OPS-356)", () => {

--- a/event-runtime/web/src/views/RunFull.test.tsx
+++ b/event-runtime/web/src/views/RunFull.test.tsx
@@ -81,6 +81,67 @@ describe("RunFull layout (WM-194)", () => {
 });
 
 describe("RunFull header (WM-193)", () => {
+  test("leads with the same linked agent, ticket, and title identity as the list", async () => {
+    const runId = "run_human_identity";
+    const identity = {
+      agentKind: "dispatch",
+      ticketSubject: "watt-mind/factory#2025",
+      subjectLabel: "factory#2025",
+      subjectTitle: "Show useful run identities",
+      subjectUrl: "https://github.com/watt-mind/factory/issues/2025",
+      originType: "factory.dispatch.requested",
+      originLabel: "dispatch",
+    };
+    const detail = Object.assign(
+      createRunDetailFixture({
+        run: {
+          runId,
+          state: "RUNNING",
+          spec: { agent: "dispatch@1" },
+        } as RunDetail["run"],
+      }),
+      { identity },
+    );
+    const listRun = Object.assign(
+      createRunListItemFixture({
+        runId,
+        state: "RUNNING",
+        agent: "dispatch@1",
+      }),
+      identity,
+    );
+
+    await withApi(
+      {
+        run: async () => detail,
+        runs: async () => ({ runs: [listRun] }),
+      },
+      async () => {
+        const view = renderRunFull(runId);
+        const human = await view.findByLabelText("Run identity");
+        expect(human.textContent).toBe(
+          "dispatchfactory#2025 — Show useful run identities",
+        );
+        const ticket = within(human).getByRole("link", {
+          name: "factory#2025 — Show useful run identities",
+        });
+        expect(ticket.getAttribute("href")).toBe(
+          "https://github.com/watt-mind/factory/issues/2025",
+        );
+        expect(ticket.getAttribute("title")).toBe(
+          "factory#2025 — Show useful run identities · Open watt-mind/factory#2025",
+        );
+        expect(human.firstElementChild?.classList.contains("flex-wrap")).toBe(
+          true,
+        );
+        const header = view.container.querySelector("header")!;
+        expect(header.textContent?.indexOf("dispatch")).toBeLessThan(
+          header.textContent?.indexOf("RUNNING") ?? 0,
+        );
+      },
+    );
+  });
+
   test("shows elapsed time, lease remaining, and a fresh worker heartbeat for an in-flight run", async () => {
     const runId = "run_inflight_fresh";
     const detail = createRunDetailFixture({
@@ -235,6 +296,7 @@ describe("RunFull header (WM-193)", () => {
         expect(header?.textContent).toContain("← Runs");
         expect(header?.textContent).toContain(shortId(runId));
         expect(header?.textContent).toContain("RUNNING");
+        expect(header?.textContent).toContain("header-agent");
         expect(header?.textContent).not.toContain("copy:");
         expect(header?.querySelector(`[title="${runId}"]`)?.textContent).toBe(
           shortId(runId),

--- a/event-runtime/web/src/views/RunFull.tsx
+++ b/event-runtime/web/src/views/RunFull.tsx
@@ -23,9 +23,13 @@ import {
   RunFailureBanner,
   isCancellable,
 } from "../components/RunDetailBlocks";
-import { handleRunArtifactClick, toggleRunPin } from "./Runs";
+import {
+  RunHumanIdentity,
+  handleRunArtifactClick,
+  toggleRunPin,
+  type RunIdentityFields,
+} from "./Runs";
 import { AgentHoverCard } from "../components/AgentHoverCard";
-import { TicketText } from "../components/TicketHoverCard";
 import type { RunSummary } from "../types";
 import { formatDuration, formatRelative } from "../format";
 import { leaseRemaining } from "./Runs";
@@ -125,6 +129,12 @@ export function RunFull({
   // detail without its root run as unpopulated so every guarded d.run access
   // below stays on the loading/fallback path.
   const d = detail.data?.run ? detail.data : undefined;
+  const identity =
+    (d as (typeof d & { identity?: RunIdentityFields }) | undefined)
+      ?.identity ??
+    (listRow as (RunSummary & RunIdentityFields) | null) ??
+    undefined;
+  const identityAgent = d?.run.spec.agent ?? listRow?.agent ?? "run";
   const attemptsExhausted = d
     ? d.run.attempts >= d.run.spec.maxAttempts
     : false;
@@ -430,23 +440,24 @@ export function RunFull({
                 <li aria-hidden="true" className="shrink-0 text-(--text-faint)">
                   /
                 </li>
-                <li
-                  className="flex min-w-0 items-center gap-2"
-                  aria-current="page"
-                >
-                  {(d?.run.state || listRow?.state) && (
-                    <StateBadge state={d?.run.state ?? listRow!.state} />
-                  )}
-                  <span
-                    className="display min-w-0 truncate text-[15px] font-semibold text-(--text)"
-                    title={d?.subject ? `${d.subject} · ${runId}` : runId}
+                <li className="min-w-0" aria-current="page">
+                  <div
+                    aria-label="Run identity"
+                    className="display min-w-0 text-[15px] text-(--text)"
                   >
-                    {d?.subject ? (
-                      <TicketText text={d.subject} />
-                    ) : (
-                      <span className="mono">{shortId(runId)}</span>
+                    <RunHumanIdentity
+                      agent={identityAgent}
+                      identity={identity}
+                    />
+                  </div>
+                  <div className="mt-1 flex min-w-0 items-center gap-2 text-[12px]">
+                    {(d?.run.state || listRow?.state) && (
+                      <StateBadge state={d?.run.state ?? listRow!.state} />
                     )}
-                  </span>
+                    <span className="mono text-(--text-dim)" title={runId}>
+                      {shortId(runId)}
+                    </span>
+                  </div>
                 </li>
               </ol>
             </nav>

--- a/event-runtime/web/src/views/Runs.test.tsx
+++ b/event-runtime/web/src/views/Runs.test.tsx
@@ -403,6 +403,69 @@ function ticketSchemaRegistry(): AgentsView {
 }
 
 describe("Runs sortable columns (OPS-492)", () => {
+  test("shows agent kinds and enriched subjects with an origin fallback", async () => {
+    const ticketRun = Object.assign(
+      stubListItem("run_ticket_identity", "RUNNING", {
+        agent: "dispatch@1",
+      }),
+      {
+        agentKind: "dispatch",
+        ticketSubject: "watt-mind/factory#2025",
+        subjectLabel: "factory#2025",
+        subjectTitle: "Show useful run identities",
+        subjectUrl: "https://github.com/watt-mind/factory/issues/2025",
+      },
+    );
+    const sweepRun = Object.assign(
+      stubListItem("run_sweep_identity", "COMPLETED", {
+        agent: "work-scan@1",
+      }),
+      {
+        agentKind: "work-scan",
+        ticketSubject: null,
+        subjectLabel: null,
+        subjectTitle: null,
+        subjectUrl: null,
+        originType: "factory.sweep.requested",
+        originLabel: "sweep",
+      },
+    );
+
+    await withApi(
+      {
+        runs: async () => ({ runs: [ticketRun, sweepRun] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const view = renderRuns();
+        await waitFor(() =>
+          expect(
+            view.getByRole("columnheader", { name: /Subject/ }),
+          ).toBeTruthy(),
+        );
+        expect(view.getAllByText("dispatch").length).toBeGreaterThan(0);
+        expect(view.getAllByText("work-scan").length).toBeGreaterThan(0);
+        expect(
+          [...view.container.querySelectorAll("thead th")]
+            .map((header) => header.textContent?.replace(/[↕↑↓×]/g, "").trim())
+            .slice(0, 4),
+        ).toEqual(["Run", "Agent", "Subject", "State"]);
+        const ticket = view.getByRole("link", {
+          name: "factory#2025 — Show useful run identities",
+        });
+        expect(ticket.getAttribute("href")).toBe(
+          "https://github.com/watt-mind/factory/issues/2025",
+        );
+        expect(ticket.getAttribute("title")).toBe(
+          "factory#2025 — Show useful run identities · Open watt-mind/factory#2025",
+        );
+        expect(
+          view.getByText("sweep").parentElement?.getAttribute("title"),
+        ).toBe("factory.sweep.requested");
+      },
+    );
+  });
+
   test("renders an x-ui ticket input column from its run agent schema", async () => {
     localStorage.setItem(
       "evrt-display-runs",
@@ -639,7 +702,7 @@ describe("Runs Duration column (WM-871)", () => {
           headers.indexOf("Remaining") + 1,
         );
         expect(r.container.querySelector("table")?.style.minWidth).toBe(
-          `${(headers.length - 1) * 112 + 176}px`,
+          `${(headers.length - 2) * 112 + 176 + 320}px`,
         );
         expect(cellFor(r, "run_completed", "Duration").textContent).toBe(
           "2m 30s",
@@ -810,9 +873,13 @@ describe("Runs component harness: selection & filter retention", () => {
 
         // The detail pane, not presence in the bounded list page, controls
         // the comparison rail.
-        expect(r.queryByRole("columnheader", { name: /^Agent/ })).toBeNull();
         expect(r.getByRole("columnheader", { name: /^Run/ })).toBeTruthy();
+        expect(r.getByRole("columnheader", { name: /^Agent/ })).toBeTruthy();
+        expect(r.getByRole("columnheader", { name: /^Subject/ })).toBeTruthy();
         expect(r.getByRole("columnheader", { name: /^State/ })).toBeTruthy();
+        expect(
+          r.queryByRole("columnheader", { name: /^Remaining/ }),
+        ).toBeNull();
 
         const actions = r.getByTestId("palette-probe").textContent ?? "";
         for (const label of [
@@ -1696,9 +1763,13 @@ describe("Runs copy chords and hints (WM-233)", () => {
         expect(cls).not.toContain("overflow-hidden");
         // The fixed table layout must reserve room for the badge and link.
         expect(cls).toMatch(/\bmin-w-/);
-        expect(
-          cell!.closest("table")?.querySelectorAll("col")[1]?.className,
-        ).toContain("w-44");
+        const table = cell!.closest("table")!;
+        const stateIndex = [...table.querySelectorAll("thead th")].findIndex(
+          (header) => header.textContent?.startsWith("State"),
+        );
+        expect(table.querySelectorAll("col")[stateIndex]?.className).toContain(
+          "w-44",
+        );
         // The row must still not wrap — that is the point of this PR.
         expect(cls).toContain("whitespace-nowrap");
 

--- a/event-runtime/web/src/views/Runs.tsx
+++ b/event-runtime/web/src/views/Runs.tsx
@@ -233,6 +233,75 @@ export function runDrilldownFilters(hash: string): RunListFilters | null {
  */
 const rowModel = (r: RunListItem) => pinnedModelText(r.adapter, r.model);
 
+export interface RunIdentityFields {
+  agentKind?: string | null;
+  ticketSubject?: string | null;
+  subjectLabel?: string | null;
+  subjectTitle?: string | null;
+  subjectUrl?: string | null;
+  originType?: string | null;
+  originLabel?: string | null;
+}
+
+type IdentityRun = RunListItem & RunIdentityFields;
+
+export function runAgentKind(agent: string, identity?: RunIdentityFields) {
+  return identity?.agentKind || agent.replace(/@\d+$/, "");
+}
+
+/** Ticket/title when present; origin event type for subject-less chain runs. */
+export function RunSubject({ identity }: { identity?: RunIdentityFields }) {
+  const subject = identity?.subjectLabel ?? identity?.originLabel ?? null;
+  if (!subject) return <span>{EMPTY}</span>;
+  const fullSubject = identity?.subjectTitle
+    ? `${subject} — ${identity.subjectTitle}`
+    : subject;
+  const content = (
+    <>
+      <span>{subject}</span>
+      {identity?.subjectTitle && (
+        <span className="text-(--text-dim)"> — {identity.subjectTitle}</span>
+      )}
+    </>
+  );
+  return identity?.subjectUrl ? (
+    <a
+      href={identity.subjectUrl}
+      target="_blank"
+      rel="noreferrer"
+      onClick={(event) => event.stopPropagation()}
+      className="hover:text-(--accent) hover:underline"
+      title={`${fullSubject} · Open ${identity.ticketSubject ?? subject}`}
+    >
+      {content}
+    </a>
+  ) : (
+    <span title={identity?.originType ?? identity?.ticketSubject ?? undefined}>
+      {content}
+    </span>
+  );
+}
+
+/** The shared human-readable identity used by the full-run header. */
+export function RunHumanIdentity({
+  agent,
+  identity,
+}: {
+  agent: string;
+  identity?: RunIdentityFields;
+}) {
+  return (
+    <span className="flex min-w-0 flex-wrap items-baseline gap-x-2 gap-y-0.5">
+      <span className="mono shrink-0 font-semibold">
+        {runAgentKind(agent, identity)}
+      </span>
+      <span className="min-w-0 break-words">
+        <RunSubject identity={identity} />
+      </span>
+    </span>
+  );
+}
+
 /** The budget deadline shared by the Remaining display and its sort order. */
 const remainingDeadline = (r: RunListItem): string => {
   if (r.deadlineAt) return r.deadlineAt;
@@ -289,6 +358,15 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
     },
     { key: "agent", label: "Agent", get: (r) => r.agent, column: "agent" },
     {
+      key: "subject",
+      label: "Subject",
+      get: (r) => {
+        const identity = r as IdentityRun;
+        return identity.subjectLabel ?? identity.originLabel ?? "";
+      },
+      column: "subject",
+    },
+    {
       key: "adapter",
       label: "Adapter",
       get: (r) => r.adapter,
@@ -330,10 +408,11 @@ const RUNS_DISPLAY: DisplayConfig<RunListItem> = {
   ],
   columns: [
     { key: "run", label: "Run", always: true },
+    { key: "agent", label: "Agent" },
+    { key: "subject", label: "Subject" },
     { key: "state", label: "State" },
     { key: "remaining", label: "Remaining" },
     { key: "duration", label: "Duration" },
-    { key: "agent", label: "Agent" },
     { key: "adapter", label: "Adapter" },
     { key: "model", label: "Model" },
     { key: "attempts", label: "Attempts" },
@@ -894,20 +973,11 @@ export function Runs({
       selectedId ? (visible.find((r) => r.runId === selectedId) ?? null) : null,
     [visible, selectedId],
   );
-  // A side pane turns the list into a compact comparison rail. Keep the five
-  // decision-bearing columns instead of forcing a horizontal scrollbar; the
-  // pane and the unselected list retain every configured column.
+  // A side pane turns the list into a compact comparison rail. Identity comes
+  // first there too: "what is this run?" matters before its secondary clocks.
   const listCols = selectedId
     ? cols.filter((c) =>
-        [
-          "run",
-          "state",
-          "remaining",
-          "duration",
-          "reason",
-          "origin",
-          "updated",
-        ].includes(c.key),
+        ["run", "agent", "subject", "state", "reason"].includes(c.key),
       )
     : cols;
   const show = useMemo(() => new Set(listCols.map((c) => c.key)), [listCols]);
@@ -1342,7 +1412,9 @@ export function Runs({
           }`}
           style={{
             minWidth: `${listCols.reduce(
-              (width, c) => width + (c.key === "state" ? 176 : 112),
+              (width, c) =>
+                width +
+                (c.key === "state" ? 176 : c.key === "subject" ? 320 : 112),
               0,
             )}px`,
           }}
@@ -1351,7 +1423,13 @@ export function Runs({
             {listCols.map((c) => (
               <col
                 key={c.key}
-                className={c.key === "state" ? "w-44" : "w-28"}
+                className={
+                  c.key === "state"
+                    ? "w-44"
+                    : c.key === "subject"
+                      ? "w-80"
+                      : "w-28"
+                }
               />
             ))}
           </colgroup>
@@ -1414,6 +1492,21 @@ export function Runs({
                       onJumpRun={onOpenFull}
                     />
                   </td>
+                  {show.has("agent") && (
+                    <td className="max-w-32 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
+                      <AgentHoverCard
+                        agentRef={r.agent}
+                        onJumpAgent={onJumpAgent}
+                      >
+                        {runAgentKind(r.agent, r as IdentityRun)}
+                      </AgentHoverCard>
+                    </td>
+                  )}
+                  {show.has("subject") && (
+                    <td className="max-w-80 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text)">
+                      <RunSubject identity={r as IdentityRun} />
+                    </td>
+                  )}
                   {/*
                     State cell carries no `max-w-*`/`truncate` (WM-505): its content is a
                     bounded-length badge plus an optional `proposal` jump link, and
@@ -1459,14 +1552,6 @@ export function Runs({
                   {show.has("duration") && (
                     <td className="max-w-24 overflow-hidden whitespace-nowrap border-b border-(--border) px-3 py-1.5 tabular-nums text-(--text-dim)">
                       <DurationCell r={r} now={now} />
-                    </td>
-                  )}
-                  {show.has("agent") && (
-                    <td className="max-w-32 truncate border-b border-(--border) px-3 py-1.5 whitespace-nowrap text-(--text-dim)">
-                      <AgentHoverCard
-                        agentRef={r.agent}
-                        onJumpAgent={onJumpAgent}
-                      />
                     </td>
                   )}
                   {show.has("adapter") && (


### PR DESCRIPTION
Fixes watt-mind/factory#2025

## Summary
- enrich bounded run summaries with normalized agent kinds and ticket/origin identity, using cached batched title lookup
- show Agent and linked Subject columns in Runs plus the same human identity in full-run headers
- prioritize identity columns on narrow layouts, expose full subject tooltips, and wrap detail identity text responsively
- cap `resolveRunSubjects` tracker fan-out to at most 8 unresolved tickets per request (concurrency 4); the rest resolve on later polls instead of a request awaiting up to 200 concurrent `plane.getTicket` calls

## Verification
- `bun test event-runtime/web/src/views/Runs.test.tsx event-runtime/web/src/views/RunFull.test.tsx` — 74 pass, 0 fail
- `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/api-status-view.test.mjs && bun run check && bun run lint` — pass
- `bun test event-runtime/lib --timeout 20000` — 2343 pass, 0 fail
- `bun run format:check` — pass
- `cd event-runtime/web && bunx tsc -b && bun run build` — pass
- UX critic round 2 — **SHIP** at 1440×900 and 780×437

Closes #2025

run:unknown (restored by orchestrator fixer)
