### PR TITLE
fix(dispatch): persist UX screenshot evidence (#2023)

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:5c73ac1b9d839b22b9c08164daf564b035c983ba0c021599d82edc37897b797a",
+    "agents/dispatch.md": "sha256:e3dd2939e3649d26e56793b18770b64a1b9b83101f6ed89110a0ba506b2b7b67",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:e3dd2939e3649d26e56793b18770b64a1b9b83101f6ed89110a0ba506b2b7b67",
+    "agents/dispatch.md": "sha256:d6bcafb9e2daab29ffcfc837f851063712d21f3011e4f29d21bdba4f1bb34214",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -100,7 +100,7 @@ new ticket.
    critic concluded, and a critic that never ran concluded nothing.
 
    Spawn the `factory-ux-critic` subagent after verification and before opening
-   the PR. Before spawning it, create `./ux-artifacts/` at the run workspace
+   the PR. Before spawning it, create `ux-artifacts/` at the run workspace
    root (beside `repo`, never inside it) and pass its absolute path as
    `artifactDir: <absolute workspace path>/ux-artifacts` in the prompt. Its
    prompt must also spell out `worktree: <absolute path>` plus the exact
@@ -111,8 +111,13 @@ new ticket.
 
    Screenshot evidence must survive workspace cleanup. For every screenshot the
    critic creates, calculate its SHA-256 and declare it in the outer
-   `result.json` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`.
-   In `artifact.uxCritique.evidence`, cite the matching durable identifier as
+   `result.json` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`
+   only after confirming the file exists under `artifactDir`; if the critic
+   produced no file there, omit the declaration entirely and record the
+   ephemeral URL instead — a declared artifact whose file is missing hard-fails
+   the run with `artifact_missing` (`ContractViolation`, `verify.mjs`
+   collection step), it does not degrade to `NOT-ASSESSED`. In
+   `artifact.uxCritique.evidence`, cite the matching durable identifier as
    `sha256:<64-hex-digest>`, never the workspace screenshot path. The worker
    copies declared artifacts to its content-addressed store before teardown, so
    that identifier resolves after the workspace is gone. Keep observed

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -100,12 +100,27 @@ new ticket.
    critic concluded, and a critic that never ran concluded nothing.
 
    Spawn the `factory-ux-critic` subagent after verification and before opening
-   the PR. Its prompt must spell out `worktree: <absolute path>` plus the exact
+   the PR. Before spawning it, create `./ux-artifacts/` at the run workspace
+   root (beside `repo`, never inside it) and pass its absolute path as
+   `artifactDir: <absolute workspace path>/ux-artifacts` in the prompt. Its
+   prompt must also spell out `worktree: <absolute path>` plus the exact
    dev-server command and this worktree's port (or simulator/Electron target),
    login route, ticket criteria, flow, and persona. The critic must use the
-   running app. A valid `SHIP` or `FIX-FIRST` report cites at least one observed
-   page URL or screenshot path; without browser evidence, treat it as
-   `NOT-ASSESSED`, never as approval.
+   running app and write every screenshot to `artifactDir` rather than `/tmp`
+   or another workspace path.
+
+   Screenshot evidence must survive workspace cleanup. For every screenshot the
+   critic creates, calculate its SHA-256 and declare it in the outer
+   `result.json` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`.
+   In `artifact.uxCritique.evidence`, cite the matching durable identifier as
+   `sha256:<64-hex-digest>`, never the workspace screenshot path. The worker
+   copies declared artifacts to its content-addressed store before teardown, so
+   that identifier resolves after the workspace is gone. Keep observed
+   dev-server URLs only as explicitly ephemeral records (for example,
+   `ephemeral-url:http://127.0.0.1:7497/runs`), never as durable screenshot
+   evidence. A valid `SHIP` or `FIX-FIRST` report cites at least one observed
+   page URL or stored screenshot identifier; without browser evidence, treat it
+   as `NOT-ASSESSED`, never as approval.
 
    Resolve in-scope `FIX-FIRST` findings and re-run the critic, for at most two
    review rounds. A startup `BLOCKED - environment mismatch or unresponsive

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3196,7 +3196,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:c9c95b3482cd08600d034c5524a7dade9330010ef711edfbca35ca161e607628","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5feb08bd0bf15a3a355a8e211f47a7ba58b07546a6c43a4cbab00e151b5fb1c6","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3196,7 +3196,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:5feb08bd0bf15a3a355a8e211f47a7ba58b07546a6c43a4cbab00e151b5fb1c6","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:d71406671c4b9addd6b5184f18eb2919b0d2b40d57640bffc56927c3e3e9231d","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -414,7 +414,7 @@ describe("registry", () => {
     // Regenerated (#2023): dispatch declares UX screenshots as durable
     // result artifacts and cites their content-addressed identifiers.
     const expected =
-      "sha256:90c2596362835cdc75a13a0c8bb52f64423078b2ed61ce448c321256c67f4b01";
+      "sha256:1602d801ca413eb7093918e489bc51901b884fc39a1705ca91128694db306e4f";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -711,7 +711,7 @@ describe("registry", () => {
     // its prompt pin legitimately changes while `pack` remains non-enumerable.
     // #2023 adds durable UX screenshot artifact declarations to that prompt.
     expect(computeDefHash(def)).toBe(
-      "sha256:5feb08bd0bf15a3a355a8e211f47a7ba58b07546a6c43a4cbab00e151b5fb1c6",
+      "sha256:d71406671c4b9addd6b5184f18eb2919b0d2b40d57640bffc56927c3e3e9231d",
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -411,8 +411,10 @@ describe("registry", () => {
     // in-flight/fresh Full verification; merge-fix re-checks that CI guard.
     // Regenerated (#1925): dispatch spells out the exact first-line Fixes
     // grammar and its prompt pin changes; the registry digest follows it.
+    // Regenerated (#2023): dispatch declares UX screenshots as durable
+    // result artifacts and cites their content-addressed identifiers.
     const expected =
-      "sha256:dde1373788b1ecea1e8c11d130c42b0a0fa93ff0df2c9616a50beba6e556c10a";
+      "sha256:90c2596362835cdc75a13a0c8bb52f64423078b2ed61ce448c321256c67f4b01";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -707,8 +709,9 @@ describe("registry", () => {
     // so quoted PR-body files cannot leave the environment variable literal.
     // Regenerated (#1925): dispatch specifies the exact Fixes-line grammar;
     // its prompt pin legitimately changes while `pack` remains non-enumerable.
+    // #2023 adds durable UX screenshot artifact declarations to that prompt.
     expect(computeDefHash(def)).toBe(
-      "sha256:c9c95b3482cd08600d034c5524a7dade9330010ef711edfbca35ca161e607628",
+      "sha256:5feb08bd0bf15a3a355a8e211f47a7ba58b07546a6c43a4cbab00e151b5fb1c6",
     );
   });
 

--- a/event-runtime/lib/worker-handoff.test.mjs
+++ b/event-runtime/lib/worker-handoff.test.mjs
@@ -3,10 +3,10 @@ import "../test-helpers.mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { insideHandoffSandbox } from "./verify.mjs";
 import { execFileSync } from "node:child_process";
-import { mkdirSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
-import { hashJson } from "./canonical.mjs";
+import { hashJson, sha256Hex } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
 import { lifecycleOf } from "./lifecycle.mjs";
 import {
@@ -205,7 +205,15 @@ describe("handoff verification gate (WM-718)", () => {
   }
 
   /** A fake dispatch agent: writes files, commits, claims whatever it likes. */
-  function agent({ files = {}, claim = {}, prNumber = 77 }) {
+  function agent({
+    files = {},
+    workspaceFiles = {},
+    artifacts = [],
+    claim = {},
+    prNumber = 77,
+    uxCritique,
+    onWorkspace,
+  }) {
     return {
       async execute({ spec, workspaceDir }) {
         writeFileSync(
@@ -217,6 +225,12 @@ describe("handoff verification gate (WM-718)", () => {
           mkdirSync(path.dirname(path.join(repo, rel)), { recursive: true });
           writeFileSync(path.join(repo, rel), content);
         }
+        for (const [rel, content] of Object.entries(workspaceFiles)) {
+          const file = path.join(workspaceDir, rel);
+          mkdirSync(path.dirname(file), { recursive: true });
+          writeFileSync(file, content);
+        }
+        onWorkspace?.(workspaceDir);
         execFileSync("git", ["add", "-A"], { cwd: repo });
         execFileSync(
           "git",
@@ -244,7 +258,7 @@ describe("handoff verification gate (WM-718)", () => {
                 ...claim,
               },
               summary: `implemented ${spec.input.ticket}`,
-              uxCritique: {
+              uxCritique: uxCritique ?? {
                 status: "skipped",
                 verdict: null,
                 evidence: [],
@@ -253,6 +267,7 @@ describe("handoff verification gate (WM-718)", () => {
               },
             },
             evidence: { commands: ["bash run-tests.sh"] },
+            artifacts,
           })}\n`,
         );
         return { exitCode: 0, timedOut: false };
@@ -262,6 +277,7 @@ describe("handoff verification gate (WM-718)", () => {
 
   async function dispatch({ spec, adapter, description, hooks = {} }) {
     const db = openDb(":memory:");
+    const artifactStore = tmpDir("evrt-handoff-artifacts-");
     queueRun(db, spec);
     const calls = { unclaim: [], returned: [], held: [], comments: [] };
     const summary = await runOnce(
@@ -269,6 +285,7 @@ describe("handoff verification gate (WM-718)", () => {
       registry,
       { fake: adapter },
       opts({
+        artifactStore,
         dispatch: {
           locksDir: tmpDir("evrt-handoff-locks-"),
           leasesDir: tmpDir("evrt-handoff-leases-"),
@@ -296,7 +313,7 @@ describe("handoff verification gate (WM-718)", () => {
         },
       }),
     );
-    return { db, summary, calls };
+    return { db, summary, calls, artifactStore };
   }
 
   test("a fake agent that leaves a failing test is refused handoff_verification_failed: no result row, ticket back to Todo + agent-ready, PR held, tail in the receipt", async () => {
@@ -401,6 +418,55 @@ describe("handoff verification gate (WM-718)", () => {
       "- Verification: `echo repo_verified` — exit 0 (pass)",
     );
     expect(calls.comments[0].body).toContain("repo `verify:` command stood in");
+  });
+
+  test("declared UX screenshots are content-addressed before workspace cleanup and their evidence stays durable", async () => {
+    const screenshot = Buffer.from("fake-png-bytes");
+    const sha256 = sha256Hex(screenshot);
+    let screenshotPath;
+    const spec = handoffSpec({ ticket: "WM-2023" });
+    const { artifactStore, db, summary } = await dispatch({
+      spec,
+      description: withCommand("bash run-tests.sh"),
+      adapter: agent({
+        files: {
+          "run-tests.sh": "echo ux handoff verified\n",
+          "src/feature/impl.txt": "done\n",
+        },
+        workspaceFiles: { "ux-artifacts/runs.png": screenshot },
+        artifacts: [{ kind: "ux-screenshot", path: "ux-artifacts/runs.png" }],
+        uxCritique: {
+          status: "required",
+          verdict: "SHIP",
+          evidence: [`sha256:${sha256}`],
+          rounds: 1,
+          prReady: true,
+        },
+        onWorkspace: (workspaceDir) => {
+          screenshotPath = path.join(workspaceDir, "ux-artifacts/runs.png");
+        },
+      }),
+    });
+
+    expect(summary.terminalState).toBe("COMPLETED");
+    const result = JSON.parse(
+      db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(spec.runId).result_json,
+    );
+    const stored = result.artifacts.find(
+      (entry) => entry.kind === "ux-screenshot",
+    );
+    const storedPath = path.join(artifactStore, sha256);
+    expect(stored).toEqual({
+      kind: "ux-screenshot",
+      sha256,
+      uri: `file://${storedPath}`,
+      sizeBytes: screenshot.length,
+    });
+    expect(result.artifact.uxCritique.evidence).toEqual([`sha256:${sha256}`]);
+    expect(existsSync(screenshotPath)).toBe(false);
+    expect(readFileSync(storedPath)).toEqual(screenshot);
   });
 
   test("a PR targeting the wrong base fails handoff verification and is returned", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2023

Dispatch UX screenshots are declared and preserved as content-addressed artifacts after workspace cleanup.

AC4 (dispatch.view.json stored-identifier link rendering) is deferred — not implemented in this PR; follow-up noted by orchestrator.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker-handoff.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs && bun build/emit.mjs --check && bun run lint` | pass | 198 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2342 passed, 10 skipped |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped

run:run_109e33c5-35f1-44f1-97c4-f43d2c796a74
