### PR TITLE
chore(docs): sweep remaining ticket tool references

### DIFF
--- a/event-runtime/agents/triage-scan.json
+++ b/event-runtime/agents/triage-scan.json
@@ -18,7 +18,7 @@
   "limits": { "timeout_seconds": 900, "attempts": 1 },
   "mutating": false,
   "pins": {
-    "agents/triage-scan.md": "sha256:464b324d2a2ef543542f6c1aa99de833dc48e933610856c9907b0cfe37cfe0ec",
+    "agents/triage-scan.md": "sha256:df4608545ce8a1d564785e6030c8fbd4514c7ef770e91a77f3322b854317c14d",
     "schemas/triage-scan.input.json": "sha256:0c01941a0901e4094caa5f79a9c14d1f22c2ac06c15981bdbd0dde9d85ebf937",
     "schemas/triage-scan.output.json": "sha256:7f9776d3e3c99cd59beb04a04fc15286bf63ecf33c1f790152c55b5a29ef8bcb"
   }

--- a/event-runtime/agents/triage-scan.md
+++ b/event-runtime/agents/triage-scan.md
@@ -36,7 +36,7 @@ github`: GitHub Projects v2 owns the status, so enumerate the exact-titled
    board's items and their `Status` values instead. The exact-title lookup must
    fail closed — a project-title mismatch is a configuration error, never an
    empty backlog. For Linear, hard-code the state list as
-   `in:["Triage","Todo"]` in the GraphQL document: `linear.mjs raw` passes every
+   `in:["Triage","Todo"]` in the GraphQL document: `ticket.mjs raw` passes every
    `--var` value as a string, so passing a JSON-looking array through `--var`
    silently searches for one state with that literal name and can return a
    false zero. The response is usable only when it contains the expected item

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -413,8 +413,10 @@ describe("registry", () => {
     // grammar and its prompt pin changes; the registry digest follows it.
     // Regenerated (#2023): dispatch declares UX screenshots as durable
     // result artifacts and cites their content-addressed identifiers.
+    // Regenerated (#2035): triage-scan names ticket.mjs as the active ticket
+    // CLI and re-pins its definition; the prompt pin is a registry input.
     const expected =
-      "sha256:1602d801ca413eb7093918e489bc51901b884fc39a1705ca91128694db306e4f";
+      "sha256:db13f68023714db1485bd79cc1359169f5d7056fcc1e44db307c6748e48fedfe";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/orchestrator/tick.mjs
+++ b/orchestrator/tick.mjs
@@ -786,7 +786,7 @@ export async function main(argv = process.argv.slice(2)) {
           // --strict makes this file the ONLY source of MCP servers: no user
           // scope, no project .mcp.json, no claude.ai connectors. What an
           // unattended agent can reach is declared in git and moves by PR.
-          // Drops the Linear MCP too — tools/linear.mjs replaces it, reached via
+          // Drops the Linear MCP too — tools/ticket.mjs replaces it, reached via
           // the FACTORY_ROOT set below. Mirrors run-agent.sh.
           "--mcp-config",
           path.join(ROOT, "config/mcp/claude.json"),
@@ -863,13 +863,13 @@ export async function main(argv = process.argv.slice(2)) {
         "-u",
         "CLAUDE_CODE_ENTRYPOINT",
         // Agents run in a worktree, not in this checkout, so `bun
-        // tools/linear.mjs` does not resolve for them. The floor tells them to
-        // use "$FACTORY_ROOT/tools/linear.mjs"; this is what makes that true.
+        // tools/ticket.mjs` does not resolve for them. The floor tells them to
+        // use "$FACTORY_ROOT/tools/ticket.mjs"; this is what makes that true.
         // Without it, --strict-mcp-config removes the Linear MCP and leaves no
         // replacement — the control plane goes silent.
         `FACTORY_ROOT=${ROOT}`,
         // Run id == transcript basename, same convention as run-agent.sh: the
-        // rollup keys on it, linear.mjs stamps it into comments, the floor puts
+        // rollup keys on it, ticket.mjs stamps it into comments, the floor puts
         // it in PR bodies. One key joins Linear/GitHub back to this log (OPS-76).
         `FACTORY_RUN_ID=${path.basename(log, ".jsonl")}`,
         harnessBin,


### PR DESCRIPTION
Fixes watt-mind/factory#2035

Replace active dispatcher and triage-scan ticket CLI references while preserving historical Linear test terminology.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs && bun build/emit.mjs --check && bun run lint` | pass | 178 tests; emit and lint passed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0; format check passed |
| UX critique          | `factory-ux-critic` | not run | documentation and comments only |

UX critique: skipped

run:run_208d55ab-94f3-426b-a1cc-d95eb4585b6c