### PR TITLE
fix(ci): harden sandbox smoke gates (#2042)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -466,12 +466,13 @@ jobs:
         # WM-918: required lanes exclude the timing-bound group because its
         # wall-clock ceilings are not reliable under shared-host contention.
         env:
-          FACTORY_HANDOFF_SMOKE_COMMAND: >-
-            bun test event-runtime/lib --timeout 20000 --test-name-pattern "$(bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern)" && bun build/emit.mjs --check && bun run format:check && bun run lint
           FACTORY_HANDOFF_SMOKE_LANE: ${{ runner.environment }}
         shell: bash
         run: |
           set -euo pipefail
+          pat="$(bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern)"
+          [ -n "$pat" ] || exit 1
+          export FACTORY_HANDOFF_SMOKE_COMMAND="bun test event-runtime/lib --timeout 20000 --test-name-pattern \"$pat\" && bun build/emit.mjs --check && bun run format:check && bun run lint"
           bun -e '
             import { mkdtempSync } from "node:fs";
             import { tmpdir } from "node:os";

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -463,8 +463,12 @@ jobs:
         # config/repos.yaml. `runHandoffVerifySmoke` delegates to
         # `runHandoffCommand`, so unshare, env scrubbing, the worktree-only
         # mount, chroot, and HOME=/tmp/home all stay owned by production code.
+        # WM-918: required lanes exclude the timing-bound group because its
+        # wall-clock ceilings are not reliable under shared-host contention.
         env:
-          FACTORY_HANDOFF_SMOKE_COMMAND: bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint
+          FACTORY_HANDOFF_SMOKE_COMMAND: >-
+            bun test event-runtime/lib --timeout 20000 --test-name-pattern "$(bun event-runtime/lib/test-helpers-timing.mjs exclude-pattern)" && bun build/emit.mjs --check && bun run format:check && bun run lint
+          FACTORY_HANDOFF_SMOKE_LANE: ${{ runner.environment }}
         shell: bash
         run: |
           set -euo pipefail
@@ -472,20 +476,38 @@ jobs:
             import { mkdtempSync } from "node:fs";
             import { tmpdir } from "node:os";
             import path from "node:path";
-            import { runHandoffVerifySmoke } from "./event-runtime/lib/verify.mjs";
+            import {
+              handoffVerifySmokeErrorAnnotation,
+              runHandoffVerifySmoke,
+            } from "./event-runtime/lib/verify.mjs";
 
             const root = process.cwd();
             const logDir = mkdtempSync(path.join(tmpdir(), "factory-handoff-smoke-"));
-            const observation = runHandoffVerifySmoke({
-              command: process.env.FACTORY_HANDOFF_SMOKE_COMMAND,
-              cwd: root,
-              worktreePath: root,
-              logPath: path.join(logDir, "verify.log"),
-              timeoutMs: 600_000,
-            });
-            console.log(observation.sandboxFacts);
-            process.stdout.write(observation.output);
-            if (!observation.passed) process.exitCode = 1;
+            let observation;
+            try {
+              observation = runHandoffVerifySmoke({
+                command: process.env.FACTORY_HANDOFF_SMOKE_COMMAND,
+                cwd: root,
+                worktreePath: root,
+                logPath: path.join(logDir, "verify.log"),
+                timeoutMs: 600_000,
+              });
+            } catch (error) {
+              const annotation = handoffVerifySmokeErrorAnnotation(error, {
+                lane: process.env.FACTORY_HANDOFF_SMOKE_LANE,
+              });
+              if (!annotation) throw error;
+              // A cloud runner gets the same explicit non-green outcome; this
+              // preserves sandbox_unavailable as an environment diagnosis.
+              console.error(annotation);
+              process.exitCode = 1;
+            }
+            if (!observation) process.exitCode = 1;
+            else {
+              console.log(observation.sandboxFacts);
+              process.stdout.write(observation.output);
+              if (!observation.passed) process.exitCode = 1;
+            }
           '
 
   verify:

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -680,8 +680,8 @@ export function runHandoffCommand({
     command,
     cwd: commandCwd,
     confinement: nested
-      ? "inherited handoff sandbox (already namespaced + chrooted); minimal env"
-      : `user+mount+pid+network namespace; chroot; ${handoffSandboxLimits(sandboxTmpfsMb)}`,
+      ? `inherited handoff sandbox (already namespaced + chrooted); minimal env; HOME=${process.env.HOME ?? "/tmp/home"}; workspace=${commandCwd}`
+      : `env scrubbed; HOME=/tmp/home; workspace=/workspace; user+mount+pid+network namespace; chroot; ${handoffSandboxLimits(sandboxTmpfsMb)}`,
     sandbox: {
       tmpfsMb: sandboxTmpfsMb,
       namespaces: HANDOFF_SANDBOX_NAMESPACES,
@@ -703,13 +703,28 @@ export function runHandoffCommand({
  * from the worker's production handoff boundary.
  */
 export function handoffSandboxFacts(observation) {
+  const confinement =
+    typeof observation?.confinement === "string" &&
+    observation.confinement.trim().length > 0
+      ? observation.confinement.trim()
+      : "confinement=unknown";
   const namespaces = Array.isArray(observation?.sandbox?.namespaces)
     ? observation.sandbox.namespaces.join(",")
     : HANDOFF_SANDBOX_NAMESPACES.join(",");
   const tmpfs = Number.isSafeInteger(observation?.sandbox?.tmpfsMb)
     ? `${observation.sandbox.tmpfsMb}MiB`
     : "unknown";
-  return `Handoff sandbox facts: env scrubbed; HOME=/tmp/home; workspace=/workspace; namespaces=${namespaces}; tmpfs=${tmpfs}.`;
+  return `Handoff sandbox facts: ${confinement}; namespaces=${namespaces}; tmpfs=${tmpfs}.`;
+}
+
+/** Map the expected unavailable-sandbox refusal to a GitHub annotation. */
+export function handoffVerifySmokeErrorAnnotation(error, { lane } = {}) {
+  if (error?.reasonCode !== HANDOFF_SANDBOX_UNAVAILABLE) return null;
+  const runner =
+    typeof lane === "string" && lane.trim().length > 0
+      ? lane.trim()
+      : "unknown";
+  return `::error::sandbox_unavailable on ${runner} runner`;
 }
 
 /**

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -42,6 +42,7 @@ import {
   clampHandoffSandboxTmpfsMb,
   isBunTestFile,
   insideHandoffSandbox,
+  handoffVerifySmokeErrorAnnotation,
   handoffSandboxFacts,
   policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
@@ -2225,6 +2226,8 @@ describe("handoff verification helpers (WM-718)", () => {
   test("sandboxed verify smoke delegates to the production handoff seam and names its facts", () => {
     const worktree = tmpDir("evrt-handoff-smoke-");
     const calls = [];
+    const confinement =
+      "env scrubbed; HOME=/tmp/home; workspace=/workspace; user+mount+pid+network namespace; chroot; tmpfs=1024MiB";
     const observation = runHandoffVerifySmoke({
       command: "bun test event-runtime/lib --timeout 20000",
       cwd: worktree,
@@ -2237,6 +2240,7 @@ describe("handoff verification helpers (WM-718)", () => {
           passed: true,
           exitCode: 0,
           output: "2333 pass\n0 fail\n",
+          confinement,
           sandbox: {
             tmpfsMb: 1024,
             namespaces: HANDOFF_SANDBOX_NAMESPACES,
@@ -2254,12 +2258,27 @@ describe("handoff verification helpers (WM-718)", () => {
         timeoutMs: 600_000,
       },
     ]);
-    expect(observation.sandboxFacts).toBe(
-      "Handoff sandbox facts: env scrubbed; HOME=/tmp/home; workspace=/workspace; namespaces=user,mount,pid,network; tmpfs=1024MiB.",
-    );
-    expect(handoffSandboxFacts({ sandbox: {} })).toContain(
-      "env scrubbed; HOME=/tmp/home; workspace=/workspace",
-    );
+    expect(observation.sandboxFacts).toContain(confinement);
+    expect(
+      handoffSandboxFacts({
+        confinement:
+          "inherited handoff sandbox; minimal env; HOME=/tmp/nested-home; workspace=/tmp/nested-worktree",
+        sandbox: {},
+      }),
+    ).toContain("HOME=/tmp/nested-home; workspace=/tmp/nested-worktree");
+  });
+
+  test("sandboxed smoke maps an unavailable sandbox to a lane-specific annotation", () => {
+    expect(
+      handoffVerifySmokeErrorAnnotation(new SandboxUnavailable(), {
+        lane: "self-hosted",
+      }),
+    ).toBe("::error::sandbox_unavailable on self-hosted runner");
+    expect(
+      handoffVerifySmokeErrorAnnotation(new Error("unrelated failure"), {
+        lane: "github-hosted",
+      }),
+    ).toBeNull();
   });
 
   test("ticket commands get a credential-free environment and namespace/chroot confinement", () => {
@@ -2536,6 +2555,9 @@ describe("handoff verification helpers (WM-718)", () => {
       });
       expect(obs.passed).toBe(true);
       expect(obs.confinement).toContain("inherited handoff sandbox");
+      expect(handoffSandboxFacts(obs)).toContain(
+        `HOME=${process.env.HOME ?? "/tmp/home"}; workspace=${worktree}`,
+      );
       expect(invocation.args).not.toContain("/usr/bin/unshare");
       expect(invocation.args).toEqual([
         "--signal=TERM",


### PR DESCRIPTION
Fixes watt-mind/factory#2042

Keeps the required sandbox smoke deterministic and makes unavailable isolation explicit.

## Validation

| Check                | Command                                                                                                  | Result  | Notes                         |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/verify.test.mjs && bun run lint` | pass | tests and lint completed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | all stages completed |
| UX critique          | `factory-ux-critic`                                                                                      | not run | no user-facing surface        |

UX critique: skipped

run:run_d4c96527-937e-4fe8-a11e-c3e36f50da7c
