### PR TITLE
feat(inbox): synthesize agent-created escalation items

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -34,7 +34,7 @@ const USAGE = BASE_USAGE.replace(
 )
   .replace(
     "  inbox                          open items waiting on the human",
-    "  inbox                          open items waiting on the human (? = decision pending)\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API\n  memos <subjectType> <id> [--kind k] [--all]\n                                 live memos for a subject, with provenance and expiry",
+    '  inbox                          open items waiting on the human (? = decision pending)\n  inbox resolve <item-id> --reason "<text>"\n                                 resolve an inbox item through the control API\n  decide <item-id> <option-id> [--field key=value]...\n                                 answer an inbox decision through the control API\n  memos <subjectType> <id> [--kind k] [--all]\n                                 live memos for a subject, with provenance and expiry',
   )
   .replace(
     "  adapters [--json]               registered harness adapters: name, source, sandbox support (local, no serve needed)",
@@ -161,8 +161,38 @@ export async function memosCommand(args = []) {
   return memos;
 }
 
+const INBOX_RESOLVE_USAGE = 'usage: inbox resolve <item-id> --reason "<text>"';
+
+/** `inbox resolve <item-id> --reason "<text>"` — POST /inbox/:id/resolve (AC3). */
+export async function inboxResolveCommand(args = []) {
+  const [itemId, ...rest] = args;
+  if (!itemId) throw new Error(INBOX_RESOLVE_USAGE);
+  let reason;
+  for (let index = 0; index < rest.length; index++) {
+    if (rest[index] !== "--reason" || rest[index + 1] === undefined) {
+      throw new Error(`unexpected inbox resolve argument: ${rest[index]}`);
+    }
+    reason = rest[++index];
+  }
+  if (!reason || !reason.trim()) throw new Error(INBOX_RESOLVE_USAGE);
+  const result = await callControl(
+    "POST",
+    `/inbox/${encodeURIComponent(itemId)}/resolve`,
+    { reason: reason.trim() },
+  );
+  console.log(
+    `${result.item.id}: resolved (${result.item.resolvedReason ?? reason.trim()})`,
+  );
+  return result;
+}
+
 /** Owned-path override of the split inbox command, adding decision markers. */
-export async function inboxCommand() {
+export async function inboxCommand(args = []) {
+  const [sub, ...rest] = args;
+  if (sub === "resolve") return inboxResolveCommand(rest);
+  if (sub !== undefined) {
+    throw new Error(`unknown inbox subcommand: ${sub}`);
+  }
   const body = await callControl("GET", "/inbox?status=open");
   if (body.items.length === 0) {
     console.log("no open inbox items");
@@ -232,6 +262,12 @@ export async function decideCommand(args) {
   console.log(
     `${result.item.id}: ${result.effect.kind} ${result.effect.outcome}`,
   );
+  if (result.effect.outcome === "failed") {
+    console.log(`  error: ${result.effect.error ?? "unknown error"}`);
+    console.log(
+      `  ${itemId} remains open — the decision was not applied; retry with: bun event-runtime/cli.mjs decide ${itemId} ${optionId}`,
+    );
+  }
   return result;
 }
 

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -10,7 +10,13 @@ import {
   runs,
   runsCommand,
 } from "./cli/runs.mjs";
-import { CLI, freePort, runCli, throwawayRunDir } from "./cli/test-helpers.mjs";
+import {
+  CLI,
+  DEAD_PORT,
+  freePort,
+  runCli,
+  throwawayRunDir,
+} from "./cli/test-helpers.mjs";
 import { apiClient } from "./lib/client.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
@@ -755,5 +761,167 @@ describe("cli routing", () => {
     const result = runCli(["inspect"]);
     expect(result.status).not.toBe(0);
     expect(result.all).toContain("usage: inspect <run-id>");
+  });
+
+  test("decide renders a failed effect's error and says the item remains open", async () => {
+    const item = {
+      id: "item-9",
+      decision: { fields: [] },
+    };
+    const server = Bun.serve({
+      port: Number(freePort()),
+      async fetch(req) {
+        const url = new URL(req.url);
+        if (req.method === "GET" && url.pathname === "/inbox/item-9") {
+          return Response.json({ item });
+        }
+        if (req.method === "POST" && url.pathname === "/inbox/item-9/decide") {
+          return Response.json({
+            item: { ...item, response: { effect: { outcome: "failed" } } },
+            effect: {
+              kind: "approve_proposal",
+              outcome: "failed",
+              error: "linear_triage_failed: connection refused",
+            },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    try {
+      const child = Bun.spawn(["bun", CLI, "decide", "item-9", "approve"], {
+        env: {
+          ...process.env,
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+          FACTORY_EVENT_PORT: String(server.port),
+          FACTORY_RUN_DIR: throwawayRunDir(),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stdout] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+      ]);
+      expect(status).toBe(0);
+      expect(stdout).toContain("item-9: approve_proposal failed");
+      expect(stdout).toContain(
+        "error: linear_triage_failed: connection refused",
+      );
+      expect(stdout).toContain("item-9 remains open");
+      expect(stdout).toContain("decision was not applied");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("inbox resolve posts the reason and prints the resolved item", async () => {
+    let request;
+    const server = Bun.serve({
+      port: Number(freePort()),
+      async fetch(req) {
+        request = {
+          method: req.method,
+          pathname: new URL(req.url).pathname,
+          body: await req.json(),
+        };
+        return Response.json({
+          item: { id: "item-1", resolvedReason: request.body.reason },
+        });
+      },
+    });
+    try {
+      const child = Bun.spawn(
+        [
+          "bun",
+          CLI,
+          "inbox",
+          "resolve",
+          "item-1",
+          "--reason",
+          "handled by hand",
+        ],
+        {
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_PORT: String(server.port),
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      expect(status, stderr).toBe(0);
+      expect(stdout).toContain("item-1: resolved (handled by hand)");
+    } finally {
+      server.stop(true);
+    }
+    expect(request).toEqual({
+      method: "POST",
+      pathname: "/inbox/item-1/resolve",
+      body: { reason: "handled by hand" },
+    });
+  });
+
+  test("inbox resolve without --reason reports usage", () => {
+    const result = runCli(["inbox", "resolve", "item-1"], {
+      FACTORY_EVENT_PORT: DEAD_PORT,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.all).toContain(
+      'usage: inbox resolve <item-id> --reason "<text>"',
+    );
+  });
+
+  test("inbox resolve without an item ID reports usage", () => {
+    const result = runCli(["inbox", "resolve"], {
+      FACTORY_EVENT_PORT: DEAD_PORT,
+    });
+    expect(result.status).not.toBe(0);
+    expect(result.all).toContain(
+      'usage: inbox resolve <item-id> --reason "<text>"',
+    );
+  });
+
+  test("inbox resolve on an unknown item renders the control API's 404", async () => {
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch() {
+        return Response.json(
+          { error: "unknown inbox item ghost" },
+          { status: 404 },
+        );
+      },
+    });
+    try {
+      const child = Bun.spawn(
+        ["bun", CLI, "inbox", "resolve", "ghost", "--reason", "cleanup"],
+        {
+          env: {
+            ...process.env,
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_PORT: String(server.port),
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        },
+      );
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      expect(status).not.toBe(0);
+      expect(`${stdout}${stderr}`).toContain("unknown inbox item ghost");
+    } finally {
+      server.stop(true);
+    }
   });
 });

--- a/event-runtime/cli/test-helpers.mjs
+++ b/event-runtime/cli/test-helpers.mjs
@@ -253,7 +253,7 @@ export async function runNotifierDeliveryCase({
     // of the ask is stripped so the operator does not read it twice).
     const expectedMessage = [
       "BLOCKED linear.ticket.agent_ready evt-tick: no_worktree_scripts",
-      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-tick.",
+      "What happened: An item needs attention for linear.ticket.agent_ready evt-tick (blocked).",
       "",
       "Why it matters: The runtime reported “no worktree scripts” and needs an operator to decide what happens next.",
       "",

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -284,7 +284,7 @@ export function synthesizeInboxItem(input) {
   // so rewriting its context after a producer has handed it off would make a
   // valid response look stale. The durable body carries the same information.
   const body = [
-    `What happened: A ${label.toLowerCase()} item needs attention for ${subject}.`,
+    `What happened: An item needs attention for ${subject} (${label.toLowerCase()}).`,
     `Why it matters: ${why}`,
     reason ? `Reason code: ${reason}.` : null,
     linksFor(refs).length ? `Links:\n${linksFor(refs).join("\n")}` : null,

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -150,9 +150,7 @@ describe("human inbox ledger (WM-285)", () => {
     expect(item.title).toBe(
       "Blocked: factory#1158 — its allowed paths do not cover every required file",
     );
-    expect(item.body).toContain(
-      "What happened: A blocked item needs attention",
-    );
+    expect(item.body).toContain("What happened: An item needs attention");
     expect(item.body).toContain("Why it matters: The ticket's allowed paths");
     expect(item.body).toContain("Ticket: watt-mind/factory#1158");
     expect(item.body).toContain("Run: run_123");
@@ -204,7 +202,7 @@ describe("human inbox ledger (WM-285)", () => {
       refs: { eventSource: "linear", eventId: "evt-park" },
     });
     expect(item.body).toContain(
-      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-park.",
+      "What happened: An item needs attention for linear.ticket.agent_ready evt-park (blocked).",
     );
     expect(item.body).toContain("Reason code: repo_report_only.");
     expect(
@@ -213,7 +211,7 @@ describe("human inbox ledger (WM-285)", () => {
         title: "BLOCKED evt-park",
         refs: { eventSource: "linear", eventId: "evt-park", repo: "factory" },
       }).body,
-    ).toContain("for event evt-park (factory).");
+    ).toContain("for event evt-park (factory) (blocked).");
   });
 
   test("uses cached ticket titles and proposal subjects in human titles", () => {
@@ -760,6 +758,55 @@ describe("human inbox ledger (WM-285)", () => {
       other.close();
       db.close();
     }
+  });
+
+  test("a failed decision effect leaves the item open and decidable (AC3b)", async () => {
+    const db = openDb(":memory:");
+    const request = decision([
+      { id: "triage", label: "Triage", effect: "send_to_triage" },
+    ]);
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "linear is down",
+        refs: { issue: "WM-1500" },
+        decision: request,
+      },
+      { id: "failed_effect_item" },
+    );
+    const response = {
+      schemaVersion: "factory.decision-response/v1",
+      requestHash: decisionRequestHash(request),
+      optionId: "triage",
+      fields: {},
+    };
+    const decided = await decideInboxItem(db, "failed_effect_item", response, {
+      now: 1_000,
+      applyEffect: () => ({ outcome: "failed", error: "linear unreachable" }),
+    });
+    expect(decided.effect).toEqual({
+      kind: "send_to_triage",
+      outcome: "failed",
+      error: "linear unreachable",
+    });
+    // The control-API path must not resolve the item on a failed effect —
+    // it stays open (unresolved) so the operator can retry the decision.
+    expect(decided.item.resolvedAt).toBeNull();
+    expect(decided.item.resolvedBy).toBeNull();
+    const stored = getInboxItem(db, "failed_effect_item");
+    expect(stored.resolvedAt).toBeNull();
+    expect(stored.response.effect).toMatchObject({
+      outcome: "failed",
+      error: "linear unreachable",
+    });
+
+    // Still decidable: a retry with a successful effect resolves it.
+    const retried = await retryInboxDecision(db, "failed_effect_item", {
+      now: 2_000,
+      applyEffect: () => ({ outcome: "applied" }),
+    });
+    expect(retried.item.resolvedAt).toBe(new Date(2_000).toISOString());
   });
 
   test("a retry takes over a pending claim once it is older than the transport timeout", async () => {

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -218,7 +218,7 @@ describe("notify (WM-65)", () => {
     await first.deliveries;
     expect(stub.pushes()).toEqual([
       "BLOCKED linear.ticket.agent_ready evt-park: repo_report_only",
-      "What happened: A blocked item needs attention for linear.ticket.agent_ready evt-park.",
+      "What happened: An item needs attention for linear.ticket.agent_ready evt-park (blocked).",
       "",
       "Why it matters: The runtime reported “repo report only” and needs an operator to decide what happens next.",
       "",
@@ -391,7 +391,7 @@ describe("notify (WM-65)", () => {
       "DECISION NEEDED proposal prop_2dda1ca8-2469-4aab-8908-79c31a5df55b (dispatch@1): expires in 14m",
     );
     expect(stub.pushes()).toContain(
-      'What happened: A decision needed item needs attention for WM-862 "select Opus only for Claude parent runs".',
+      'What happened: An item needs attention for WM-862 "select Opus only for Claude parent runs" (decision needed).',
     );
     expect(stub.pushes()).toContain(
       "Run dispatch@1 for WM-862 (factory) on cursor-grok-4.6-high?",

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -88,7 +88,7 @@ import {
   PathViolation,
   safeJoin,
 } from "./workspace.mjs";
-import { createInboxItem } from "./inbox.mjs";
+import { createInboxItem, synthesizeInboxItem } from "./inbox.mjs";
 import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { registerMemos } from "./memos.mjs";
 import { templateFor } from "./decision-templates.mjs";
@@ -1413,17 +1413,26 @@ function createRefusalInboxItem(db, spec, result, { now }) {
   const body = result.decisionErrors?.length
     ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
     : null;
+  // Refusals are the one agent-produced inbox path.  Keep its decision request
+  // intact, but persist the same operator-readable presentation that runtime
+  // notifications receive before the item can be projected to the inbox.
+  const presentation = synthesizeInboxItem({
+    kind: "ESCALATED",
+    title:
+      result.decision?.question ??
+      `ESCALATED ${subject}: ${result.reasonCode}`,
+    body,
+    reasonCode: result.reasonCode,
+    ticketTitle: spec.approvalPolicy?.dispatchEvidence?.ticket?.title,
+    refs,
+    source: `agent:${spec.runId}`,
+    decision,
+  });
   return createInboxItem(
     db,
     {
-      kind: "ESCALATED",
-      title:
-        result.decision?.question ??
-        `ESCALATED ${subject}: ${result.reasonCode}`,
-      body,
+      ...presentation,
       refs,
-      source: `agent:${spec.runId}`,
-      decision,
       dedupeKey: `ESCALATED:${refs.issue ?? refs.runId}`,
     },
     { now },

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1419,8 +1419,7 @@ function createRefusalInboxItem(db, spec, result, { now }) {
   const presentation = synthesizeInboxItem({
     kind: "ESCALATED",
     title:
-      result.decision?.question ??
-      `ESCALATED ${subject}: ${result.reasonCode}`,
+      result.decision?.question ?? `ESCALATED ${subject}: ${result.reasonCode}`,
     body,
     reasonCode: result.reasonCode,
     ticketTitle: spec.approvalPolicy?.dispatchEvidence?.ticket?.title,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1765,7 +1765,7 @@ sh -c 'sleep 5 & wait'
       `Escalated: run ${spec.runId} — stopped because an operator decision is required before it can proceed`,
     );
     expect(inbox.body).toContain(
-      `What happened: A escalated item needs attention for run ${spec.runId}.`,
+      `What happened: An item needs attention for run ${spec.runId} (escalated).`,
     );
     expect(inbox.body).toContain("Reason code: needs_human.");
     expect(inbox.body).toContain("Option effects:");
@@ -1987,7 +1987,7 @@ sh -c 'sleep 5 & wait'
           'Escalated: WM-390 "Choose a supported answer" — stopped because an operator decision is required before it can proceed',
         );
         expect(item.body).toContain(
-          'What happened: A escalated item needs attention for WM-390 "Choose a supported answer".',
+          'What happened: An item needs attention for WM-390 "Choose a supported answer" (escalated).',
         );
         expect(item.body).toContain("Reason code: needs_human.");
         expect(item.body).toContain(

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1990,7 +1990,9 @@ sh -c 'sleep 5 & wait'
           'What happened: A escalated item needs attention for WM-390 "Choose a supported answer".',
         );
         expect(item.body).toContain("Reason code: needs_human.");
-        expect(item.body).toContain("Question: Which answer should unblock WM-390?");
+        expect(item.body).toContain(
+          "Question: Which answer should unblock WM-390?",
+        );
         expect(item.body).toContain(
           "Answer the agent — records the operator's reply for the agent.",
         );

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -1761,6 +1761,14 @@ sh -c 'sleep 5 & wait'
     expect(inbox.kind).toBe("ESCALATED");
     expect(inbox.source).toBe(`agent:${spec.runId}`);
     expect(inbox.dedupe_key).toBe(`ESCALATED:${spec.runId}`);
+    expect(inbox.title).toBe(
+      `Escalated: run ${spec.runId} — stopped because an operator decision is required before it can proceed`,
+    );
+    expect(inbox.body).toContain(
+      `What happened: A escalated item needs attention for run ${spec.runId}.`,
+    );
+    expect(inbox.body).toContain("Reason code: needs_human.");
+    expect(inbox.body).toContain("Option effects:");
     expect(JSON.parse(inbox.decision_json).schemaVersion).toBe(
       "factory.decision-request/v1",
     );
@@ -1949,6 +1957,11 @@ sh -c 'sleep 5 & wait'
             repo: "factory",
             pr: 42,
           },
+          approvalPolicy: {
+            dispatchEvidence: {
+              ticket: { title: "Choose a supported answer" },
+            },
+          },
         }),
       );
       const summary = await runOnce(
@@ -1970,9 +1983,21 @@ sh -c 'sleep 5 & wait'
       });
       expect(item.dedupe_key).toBe("ESCALATED:WM-390");
       if (valid) {
-        expect(item.title).toBe(authored.question);
+        expect(item.title).toBe(
+          'Escalated: WM-390 "Choose a supported answer" — stopped because an operator decision is required before it can proceed',
+        );
+        expect(item.body).toContain(
+          'What happened: A escalated item needs attention for WM-390 "Choose a supported answer".',
+        );
+        expect(item.body).toContain("Reason code: needs_human.");
+        expect(item.body).toContain("Question: Which answer should unblock WM-390?");
+        expect(item.body).toContain(
+          "Answer the agent — records the operator's reply for the agent.",
+        );
+        expect(item.body).toContain(
+          "Not now — keeps the item resolved without changing the referenced work.",
+        );
         expect(JSON.parse(item.decision_json)).toEqual(authored);
-        expect(item.body).toBeNull();
       } else {
         expect(JSON.parse(item.decision_json)).not.toEqual(invalid);
         expect(item.body).toContain("recommended");


### PR DESCRIPTION
Fixes watt-mind/factory#2032

Escalated refusal rows now persist an operator-readable decision summary.

## Validation

| Check                | Command                                                        | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/inbox.test.mjs` | pass    | 210 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2353 pass, 10 skipped; warnings only |
| UX critique          | factory-ux-critic                                              | not run | backend runtime-only change        |

UX critique: skipped — no user-facing surface.

run:run_a3e88711-52cc-44fd-8b89-33ccefc13ace