### PR TITLE
fix(worker): stamp PR head SHA into Handoff verification

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1062,8 +1062,12 @@ export function composeHandoffVerification(handoff) {
           ? "yes"
           : "no"
         : "unknown";
+    const headSha =
+      typeof handoff.pr?.headSha === "string" && handoff.pr.headSha.trim()
+        ? handoff.pr.headSha.trim().slice(0, 12)
+        : "unknown";
     lines.push(
-      `- PR: #${prNumber} (${draftState === "draft state unknown" ? draftState : `draft: ${draftState}`}) · Fixes: ${fixes} · run trailer: ${runTrailer}`,
+      `- PR: #${prNumber} (${draftState === "draft state unknown" ? draftState : `draft: ${draftState}`}) · head SHA: ${headSha} · Fixes: ${fixes} · run trailer: ${runTrailer}`,
     );
   }
   const primary = handoff.verification;

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -2942,6 +2942,7 @@ describe("handoff verification helpers (WM-718)", () => {
     const body = composeHandoffVerification({
       prNumber: 42,
       prDraft: true,
+      pr: { headSha: "a".repeat(40) },
       verification: {
         source: "ticket",
         command: "bun test",
@@ -2973,7 +2974,7 @@ describe("handoff verification helpers (WM-718)", () => {
     const lines = body.split("\n");
     expect(lines[0]).toBe("## Handoff verification (worker-observed)");
     expect(lines[1]).toBe(
-      "- PR: #42 (draft: yes) · Fixes: unknown · run trailer: unknown",
+      "- PR: #42 (draft: yes) · head SHA: aaaaaaaaaaaa · Fixes: unknown · run trailer: unknown",
     );
     expect(lines[2]).toBe("- Verification: `bun test` — exit 1 (FAIL)");
     expect(body).toContain("(fail) x > y");
@@ -2996,6 +2997,19 @@ describe("handoff verification helpers (WM-718)", () => {
     expect(body).toContain("- agent-reported: `bun test` — pass, all green");
     expect(lines.filter((l) => l.startsWith("- Verification:"))).toHaveLength(
       1,
+    );
+  });
+
+  test("composeHandoffVerification explicitly reports an unavailable PR head SHA", () => {
+    const body = composeHandoffVerification({
+      verification: null,
+      repoVerify: null,
+      webBuild: null,
+      pr: { number: 77, draft: false },
+    });
+
+    expect(body).toContain(
+      "- PR: #77 (draft: no) · head SHA: unknown · Fixes: unknown · run trailer: unknown",
     );
   });
 
@@ -3073,12 +3087,13 @@ describe("handoff verification helpers (WM-718)", () => {
       pr: {
         number: 77,
         draft: false,
+        headSha: "a".repeat(40),
         hasFixesLine: true,
         hasRunTrailer: false,
       },
     });
     expect(body).toContain(
-      "- PR: #77 (draft: no) · Fixes: yes · run trailer: no",
+      "- PR: #77 (draft: no) · head SHA: aaaaaaaaaaaa · Fixes: yes · run trailer: no",
     );
   });
 });

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3381,6 +3381,10 @@ export function assertHandoffPullRequestBase({
   handoff.pr = {
     number: prNumber,
     draft: pr?.isDraft === true,
+    headSha:
+      typeof pr?.headRefOid === "string" && pr.headRefOid.trim()
+        ? pr.headRefOid.trim()
+        : null,
     hasFixesLine,
     hasRunTrailer,
     hasUnexpandedRunTrailer,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6213,22 +6213,33 @@ sh -c 'sleep 5 & wait'
       runId: "run-1504",
     };
     const valid = { ...base };
+    const headSha = "a".repeat(40);
     assertHandoffPullRequestBase({
       handoff: valid,
       base: "develop",
       fetchPullRequest: () => ({
         baseRefName: "develop",
         isDraft: false,
+        headRefOid: headSha,
         body: "Fixes watt-mind/factory#1504\n\nImplemented\n\nrun:run-1504",
       }),
     });
     expect(valid.pr).toEqual({
       number: 77,
       draft: false,
+      headSha,
       hasFixesLine: true,
       hasRunTrailer: true,
       hasUnexpandedRunTrailer: false,
     });
+    expect(
+      composeHandoffVerification({
+        ...valid,
+        verification: null,
+        repoVerify: null,
+        webBuild: null,
+      }),
+    ).toContain("head SHA: aaaaaaaaaaaa");
 
     const warningOnly = { ...base };
     assertHandoffPullRequestBase({
@@ -6242,10 +6253,19 @@ sh -c 'sleep 5 & wait'
     });
     expect(warningOnly.pr).toMatchObject({
       draft: true,
+      headSha: null,
       hasFixesLine: true,
       hasRunTrailer: false,
       hasUnexpandedRunTrailer: false,
     });
+    expect(
+      composeHandoffVerification({
+        ...warningOnly,
+        verification: null,
+        repoVerify: null,
+        webBuild: null,
+      }),
+    ).toContain("head SHA: unknown");
 
     const missingFixes = { ...base };
     expect(() =>


### PR DESCRIPTION
Fixes watt-mind/factory#2050

Worker Handoff attestations now record the observed PR head SHA.

## Validation

| Check                | Command                          | Result  | Notes                         |
| -------------------- | -------------------------------- | ------- | ----------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs event-runtime/lib/verify.test.mjs event-runtime/lib/worker-handoff.test.mjs && bun run lint` | pass    | 280 tests; lint 0 errors     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | lib, emit, format, lint clean |
| UX critique          | factory-ux-critic                | skipped | backend worker change only    |

UX critique: skipped

run:run_ff60df8a-ea14-4241-acbd-c46947966ea7