### PR TITLE
fix(api-runs): guard runs list proposal cardinality

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1999,7 +1999,11 @@ function runsView(db, filters = {}, page = {}) {
               e.type AS event_type
        FROM runs r
        LEFT JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-       LEFT JOIN proposals p ON p.run_id = r.run_id AND p.decision = 'run'
+       LEFT JOIN proposals p ON p.rowid = (
+         SELECT p2.rowid FROM proposals p2
+         WHERE p2.run_id = r.run_id AND p2.decision = 'run'
+         ORDER BY p2.created_at DESC, p2.rowid DESC LIMIT 1
+       )
        LEFT JOIN events e ON e.source = p.event_source AND e.event_id = p.event_id
        ${where}
        ORDER BY r.created_at DESC, r.rowid DESC

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -379,6 +379,36 @@ describe("run list deadlines (WM-692)", () => {
             new Date(start).toISOString(),
           );
       }
+      for (const [eventId, type] of [
+        ["evt-page-old", "factory.page.old"],
+        ["evt-page-latest", "factory.page.latest"],
+      ]) {
+        s.db
+          .query(
+            `INSERT INTO events
+             (source, event_id, type, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+             VALUES ('test', ?, ?, ?, ?, '{}', 'sha256:test', ?)`,
+          )
+          .run(
+            eventId,
+            type,
+            new Date(start).toISOString(),
+            new Date(start).toISOString(),
+            new Date(start).toISOString(),
+          );
+      }
+      for (const [id, eventId] of [
+        ["prop-page-old", "evt-page-old"],
+        ["prop-page-latest", "evt-page-latest"],
+      ]) {
+        s.db
+          .query(
+            `INSERT INTO proposals
+             (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+             VALUES (?, 'test', ?, 'run-page-c', 'run', ?, 1800)`,
+          )
+          .run(id, eventId, new Date(start).toISOString());
+      }
       const first = await fetch(s.url("/runs?limit=2"));
       expect(first.status).toBe(200);
       const firstPage = await first.json();
@@ -386,6 +416,10 @@ describe("run list deadlines (WM-692)", () => {
         "run-page-c",
         "run-page-b",
       ]);
+      expect(firstPage.runs[0].originType).toBe("factory.page.latest");
+      expect(firstPage.runs[0].originType).toBe(
+        (await s.client.run("run-page-c")).identity.originType,
+      );
       expect(firstPage.runs[0]).toEqual({
         runId: "run-page-c",
         state: "COMPLETED",
@@ -402,8 +436,8 @@ describe("run list deadlines (WM-692)", () => {
         subjectLabel: null,
         subjectTitle: null,
         subjectUrl: null,
-        originType: null,
-        originLabel: null,
+        originType: "factory.page.latest",
+        originLabel: "page latest",
       });
       expect(typeof firstPage.nextBefore).toBe("string");
 


### PR DESCRIPTION
Fixes watt-mind/factory#2049

Lists now select one latest run proposal so duplicate rows cannot consume pagination slots.

## Validation

| Check                | Command                                                                                           | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/api-runs.test.mjs && bun run lint` | pass    | 47 tests; lint passed with 615 warnings    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2348 pass, 10 skip; emit/format clean      |
| UX critique          | factory-ux-critic                                                                                 | not run | skipped: backend API query, no user flow   |

UX critique: skipped
run:run_405ec104-9276-49ac-a744-86f760355c5e
