### PR TITLE
fix(api-runs): bound run caches with shared LRU

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -34,18 +34,23 @@ import {
   parseListLimit,
   parseNonNegativeSince,
 } from "./api-params.mjs";
+import { createLruCache } from "./lru-cache.mjs";
 
 export const MAX_EXTENSION_SECONDS = 3600;
 export const OBSERVED_MODEL_CACHE_LIMIT = 512;
+export const TICKET_DETAIL_CACHE_LIMIT = 256;
+export const RUN_SUBJECT_CACHE_LIMIT = 512;
 export const RUN_STATE_GROUPS = Object.freeze({
   ACTIVE: Object.freeze(["QUEUED", "LEASED", "RUNNING", "VERIFYING"]),
   FAILED: Object.freeze(["FAILED", "TIMED_OUT", "REFUSED"]),
 });
 
 // Transcript artifacts are content-addressed, so a model observed for a hash
-// cannot change. Keep this module-local FIFO bounded because run detail views
+// cannot change. Keep this module-local cache bounded because run detail views
 // poll frequently and artifactHead performs synchronous I/O.
-const observedModelCache = new Map();
+const observedModelCache = createLruCache({
+  limit: OBSERVED_MODEL_CACHE_LIMIT,
+});
 
 export function clearObservedModelCache() {
   observedModelCache.clear();
@@ -673,7 +678,10 @@ export function ticketJourneyView(db, rawTicket, options = {}) {
 
 /** Short TTL so Ticket Journey can poll without exhausting Linear. */
 export const TICKET_DETAIL_CACHE_TTL_MS = 30_000;
-const ticketDetailCache = new Map();
+const ticketDetailCache = createLruCache({
+  limit: TICKET_DETAIL_CACHE_LIMIT,
+  ttlMs: TICKET_DETAIL_CACHE_TTL_MS,
+});
 let injectedTicketDetailControlPlane = null;
 
 /** Test seam: inject a ControlPlane (typically `memoryControlPlane`) or clear. */
@@ -714,10 +722,8 @@ export async function ticketDetailView(rawTicket, options = {}) {
   const nowMs = options.nowMs ?? Date.now();
   const cacheKey = ticket;
   if (options.noCache !== true) {
-    const cached = ticketDetailCache.get(cacheKey);
-    if (cached && nowMs - cached.timestamp < TICKET_DETAIL_CACHE_TTL_MS) {
-      return { ...cached.data, cached: true };
-    }
+    const cached = ticketDetailCache.get(cacheKey, nowMs);
+    if (cached) return { ...cached, cached: true };
   }
 
   try {
@@ -759,7 +765,7 @@ export async function ticketDetailView(rawTicket, options = {}) {
       fetchedAt: new Date(nowMs).toISOString(),
       cached: false,
     };
-    ticketDetailCache.set(cacheKey, { timestamp: nowMs, data });
+    ticketDetailCache.set(cacheKey, data, nowMs);
     return data;
   } catch (err) {
     const message = err?.message ? String(err.message) : "tracker read failed";
@@ -798,7 +804,10 @@ const RUN_SUBJECT_RESOLVE_CONCURRENCY = 4;
 // GET /runs is polled frequently. Resolve each distinct ticket once per short
 // window (including misses) so duplicate rows and the detail view never turn a
 // browser poll into one tracker request per row.
-const runSubjectCache = new Map();
+const runSubjectCache = createLruCache({
+  limit: RUN_SUBJECT_CACHE_LIMIT,
+  ttlMs: RUN_SUBJECT_CACHE_TTL_MS,
+});
 
 export function clearRunSubjectCache() {
   runSubjectCache.clear();
@@ -864,9 +873,9 @@ async function resolveRunSubjects(
   for (const run of runs) {
     const ticket = normalizeTicketId(run.ticketSubject);
     if (!ticket || run.subjectTitle) continue;
-    const cached = runSubjectCache.get(ticket);
-    if (cached && nowMs - cached.timestamp < RUN_SUBJECT_CACHE_TTL_MS) {
-      Object.assign(run, cached.data);
+    const cached = runSubjectCache.get(ticket, nowMs);
+    if (cached) {
+      Object.assign(run, cached);
     } else {
       unresolved.add(ticket);
     }
@@ -903,7 +912,7 @@ async function resolveRunSubjects(
       // A tracker outage degrades to the bare persisted subject. Cache the
       // miss briefly as well, otherwise every 5s poll retries the outage.
     }
-    runSubjectCache.set(ticket, { timestamp: nowMs, data });
+    runSubjectCache.set(ticket, data, nowMs);
   }
 
   // Chunked loop: at most RUN_SUBJECT_RESOLVE_CONCURRENCY in flight at once,
@@ -916,8 +925,8 @@ async function resolveRunSubjects(
   }
   for (const run of runs) {
     const ticket = normalizeTicketId(run.ticketSubject);
-    const cached = ticket ? runSubjectCache.get(ticket) : null;
-    if (cached && !run.subjectTitle) Object.assign(run, cached.data);
+    const cached = ticket ? runSubjectCache.get(ticket, nowMs) : null;
+    if (cached && !run.subjectTitle) Object.assign(run, cached);
   }
   return runs;
 }
@@ -2129,7 +2138,8 @@ function observedModelForRun({
   // Keyed by store root as well as hash: a test or a relocated store must not
   // serve an observation read from a different artifacts directory.
   const cacheKey = `${artifactsDir} ${sha256}`;
-  if (observedModelCache.has(cacheKey)) return observedModelCache.get(cacheKey);
+  const cachedModel = observedModelCache.get(cacheKey);
+  if (cachedModel !== undefined) return cachedModel;
 
   const observedModel = observedModelFromTranscript(
     readArtifactHead(artifactsDir, sha256),
@@ -2137,9 +2147,6 @@ function observedModelForRun({
   // A growing transcript may gain its model line later, but a terminal one
   // cannot. Cache null only for terminal runs while caching all model values.
   if (observedModel !== null || terminal) {
-    if (observedModelCache.size >= OBSERVED_MODEL_CACHE_LIMIT) {
-      observedModelCache.delete(observedModelCache.keys().next().value);
-    }
     observedModelCache.set(cacheKey, observedModel);
   }
   return observedModel;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -13,6 +13,7 @@ import {
 } from "bun:test";
 import { memoryControlPlane } from "../../lib/control-plane/index.mjs";
 import {
+  TICKET_DETAIL_CACHE_LIMIT,
   TICKET_DETAIL_CACHE_TTL_MS,
   RUN_SUBJECT_CACHE_TTL_MS,
   clearObservedModelCache,
@@ -24,6 +25,7 @@ import {
   ticketJourneyView,
   ticketIndexView,
   ticketSupplyView,
+  ticketDetailView,
 } from "./api-runs.mjs";
 import {
   CONTROL_TOKEN,
@@ -2636,6 +2638,28 @@ describe("GET /tickets/:id/detail (WM-914)", () => {
     } finally {
       s.close();
     }
+  });
+
+  test("evicts ticket details beyond the shared cache capacity", async () => {
+    const calls = [];
+    const controlPlane = {
+      async getTicket(ticket) {
+        calls.push(ticket);
+        return { identifier: ticket, title: ticket };
+      },
+      async listComments() {
+        return [];
+      },
+    };
+    const nowMs = Date.parse("2026-08-19T12:00:00.000Z");
+    for (let index = 1; index <= TICKET_DETAIL_CACHE_LIMIT + 1; index++) {
+      await ticketDetailView(`WM-${index}`, { controlPlane, nowMs });
+    }
+
+    expect(calls).toHaveLength(TICKET_DETAIL_CACHE_LIMIT + 1);
+    const firstAgain = await ticketDetailView("WM-1", { controlPlane, nowMs });
+    expect(firstAgain.cached).toBe(false);
+    expect(calls.filter((ticket) => ticket === "WM-1")).toHaveLength(2);
   });
 
   test("rejects malformed ids, missing issues, and tracker failures", async () => {

--- a/event-runtime/lib/lru-cache.mjs
+++ b/event-runtime/lib/lru-cache.mjs
@@ -1,0 +1,34 @@
+/** Create a small, bounded least-recently-used cache with optional TTL expiry. */
+export function createLruCache({ limit, ttlMs } = {}) {
+  if (!Number.isInteger(limit) || limit < 1)
+    throw new TypeError("limit must be a positive integer");
+  if (ttlMs !== undefined && (!Number.isFinite(ttlMs) || ttlMs < 0))
+    throw new TypeError("ttlMs must be a non-negative finite number");
+
+  const entries = new Map();
+
+  return {
+    get size() {
+      return entries.size;
+    },
+    clear() {
+      entries.clear();
+    },
+    get(key, nowMs = Date.now()) {
+      const entry = entries.get(key);
+      if (!entry) return undefined;
+      if (ttlMs !== undefined && nowMs - entry.timestamp >= ttlMs) {
+        entries.delete(key);
+        return undefined;
+      }
+      entries.delete(key);
+      entries.set(key, entry);
+      return entry.value;
+    },
+    set(key, value, nowMs = Date.now()) {
+      entries.delete(key);
+      while (entries.size >= limit) entries.delete(entries.keys().next().value);
+      entries.set(key, { value, timestamp: nowMs });
+    },
+  };
+}

--- a/event-runtime/lib/lru-cache.test.mjs
+++ b/event-runtime/lib/lru-cache.test.mjs
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+import { createLruCache } from "./lru-cache.mjs";
+
+describe("createLruCache", () => {
+  test("evicts the least recently used entry at capacity", () => {
+    const cache = createLruCache({ limit: 2 });
+    cache.set("first", 1);
+    cache.set("second", 2);
+    expect(cache.get("first")).toBe(1);
+
+    cache.set("third", 3);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("first")).toBe(1);
+    expect(cache.get("second")).toBeUndefined();
+    expect(cache.get("third")).toBe(3);
+  });
+
+  test("expires entries on read", () => {
+    const cache = createLruCache({ limit: 2, ttlMs: 1_000 });
+    cache.set("ticket", "cached", 10);
+
+    expect(cache.get("ticket", 1_009)).toBe("cached");
+    expect(cache.get("ticket", 1_010)).toBeUndefined();
+    expect(cache.size).toBe(0);
+  });
+
+  test("refreshes recency when an existing key is set again", () => {
+    const cache = createLruCache({ limit: 2 });
+    cache.set("first", 1);
+    cache.set("second", 2);
+    cache.set("first", 3);
+    cache.set("third", 4);
+
+    expect(cache.size).toBe(2);
+    expect(cache.get("first")).toBe(3);
+    expect(cache.get("second")).toBeUndefined();
+    expect(cache.get("third")).toBe(4);
+  });
+});


### PR DESCRIPTION
Fixes watt-mind/factory#2048

Review bounded cache eviction and TTL handling.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ----------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/api-runs.test.mjs event-runtime/lib/lru-cache.test.mjs && bun run lint` | pass | 51 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (615 existing warnings) |
| UX critique          | `factory-ux-critic`                                                                                          | not run | no user-facing surface        |

UX critique: skipped

run:run_d3f7335d-3ba7-4045-9d6e-d66cb0393ebb
