### PR TITLE
refactor(inbox): centralize presentation synthesis

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -605,12 +605,11 @@ export function createInboxItem(
     throw new Error(`unknown inbox source: ${source}`);
   }
   const refs = normalizeRefs(input?.refs);
-  // Runtime notifications are the high-volume producer that previously wrote
-  // machine-oriented titles and almost always a null body. Keep API/agent
-  // callers backward-compatible while making the durable notification ledger
-  // self-explanatory before it is projected to the operator.
+  // Runtime notifications and agent-produced items begin as machine-oriented
+  // events. Synthesize their durable presentation here so producers do not
+  // need to duplicate this policy before the item reaches the operator.
   const presentation =
-    source === "serve:notify"
+    source === "serve:notify" || source.startsWith("agent:")
       ? synthesizeInboxItem({ ...input, kind, refs, source })
       : input;
   const title = requiredString(presentation?.title, "title");

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -272,6 +272,34 @@ describe("human inbox ledger (WM-285)", () => {
     });
   });
 
+  test("synthesizes agent-source presentation inside createInboxItem", () => {
+    const db = openDb(":memory:");
+    const input = {
+      kind: "ESCALATED",
+      title: "ESCALATED WM-2047: needs_human",
+      body: "The agent needs an operator decision.",
+      reasonCode: "needs_human",
+      ticketTitle: "consolidate presentation synthesis",
+      refs: { issue: "WM-2047", repo: "factory", runId: "run_2047" },
+      source: "agent:run_2047",
+      decision: decision(),
+      dedupeKey: "ESCALATED:WM-2047",
+    };
+    const expected = synthesizeInboxItem(input);
+
+    const created = createInboxItem(db, input, {
+      id: "agent_presentation",
+      now: 1000,
+    });
+
+    expect({ title: created.title, body: created.body }).toEqual({
+      title: expected.title,
+      body: expected.body,
+    });
+    expect(created.decision).toEqual(input.decision);
+    expect(created.dedupeKey).toBe(input.dedupeKey);
+  });
+
   test("same-question open items attach as waiters instead of stacking rows", () => {
     const db = openDb(":memory:");
     const first = createInboxItem(
@@ -302,7 +330,7 @@ describe("human inbox ledger (WM-285)", () => {
     );
     expect(second.id).toBe(first.id);
     expect(second.attached).toBe(true);
-    expect(second.body).toBe("old");
+    expect(second.body).toContain("old");
     expect(second.refs).toEqual({ issue: "WM-1", runId: "run_1" });
     expect(second.decision).toEqual(decision());
     expect(second.waiters).toEqual([
@@ -401,8 +429,8 @@ describe("human inbox ledger (WM-285)", () => {
       { id: "second" },
     );
     expect(second.id).toBe(first.id);
-    expect(second.title).toBe("second");
-    expect(second.body).toBe("new");
+    expect(second.title).toBe("Escalated: WM-1");
+    expect(second.body).toContain("new");
     expect(second.refs).toEqual({ issue: "WM-1", runId: "run_2" });
     expect(second.decision).toEqual(replacement);
     expect(second.delivery.supersededDecisions).toBe(1);

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -88,7 +88,7 @@ import {
   PathViolation,
   safeJoin,
 } from "./workspace.mjs";
-import { createInboxItem, synthesizeInboxItem } from "./inbox.mjs";
+import { createInboxItem } from "./inbox.mjs";
 import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { registerMemos } from "./memos.mjs";
 import { templateFor } from "./decision-templates.mjs";
@@ -1413,25 +1413,19 @@ function createRefusalInboxItem(db, spec, result, { now }) {
   const body = result.decisionErrors?.length
     ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
     : null;
-  // Refusals are the one agent-produced inbox path.  Keep its decision request
-  // intact, but persist the same operator-readable presentation that runtime
-  // notifications receive before the item can be projected to the inbox.
-  const presentation = synthesizeInboxItem({
-    kind: "ESCALATED",
-    title:
-      result.decision?.question ?? `ESCALATED ${subject}: ${result.reasonCode}`,
-    body,
-    reasonCode: result.reasonCode,
-    ticketTitle: spec.approvalPolicy?.dispatchEvidence?.ticket?.title,
-    refs,
-    source: `agent:${spec.runId}`,
-    decision,
-  });
   return createInboxItem(
     db,
     {
-      ...presentation,
+      kind: "ESCALATED",
+      title:
+        result.decision?.question ??
+        `ESCALATED ${subject}: ${result.reasonCode}`,
+      body,
+      reasonCode: result.reasonCode,
+      ticketTitle: spec.approvalPolicy?.dispatchEvidence?.ticket?.title,
       refs,
+      source: `agent:${spec.runId}`,
+      decision,
       dedupeKey: `ESCALATED:${refs.issue ?? refs.runId}`,
     },
     { now },


### PR DESCRIPTION
Fixes watt-mind/factory#2047

Centralize agent inbox presentation synthesis before operator projection.

## Validation

| Check                | Command                                                                                                                       | Result  | Notes                                |
| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------ |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/worker.test.mjs event-runtime/lib/worker-handoff.test.mjs && bun run lint` | pass    | selected tests and lint passed       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`          | pass    | unit, emit, format, and lint passed  |
| UX critique          | factory-ux-critic                                                                                                             | not run | backend library refactor; no UI flow |

UX critique: skipped — no user-facing surface

run:run_538da211-b969-408a-8164-13e38ec0b134
