### PR TITLE
fix(web): render UX critique artifact evidence links

### DIFF
--- a/event-runtime/agents/dispatch.view.json
+++ b/event-runtime/agents/dispatch.view.json
@@ -53,6 +53,9 @@
       "as": "keyvalue",
       "label": "UX critique",
       "keys": ["status", "verdict", "rounds", "prReady", "evidence"],
+      "formats": {
+        "evidence": "url"
+      },
       "tone": {
         "status": {
           "required": "neutral",

--- a/event-runtime/lib/artifact-view.test.mjs
+++ b/event-runtime/lib/artifact-view.test.mjs
@@ -583,6 +583,7 @@ describe("input view + subject (WM-897)", () => {
     expect(view.sections.find((s) => s.path === "/uxCritique")).toMatchObject({
       as: "keyvalue",
       keys: ["status", "verdict", "rounds", "prReady", "evidence"],
+      formats: { evidence: "url" },
     });
     const def = JSON.parse(
       readFileSync(path.join(RUNTIME_ROOT, "agents", "dispatch.json"), "utf8"),

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -1576,6 +1576,10 @@ describe("registry", () => {
       "/verification",
       "/uxCritique",
     ]);
+    expect(
+      dispatch.view.sections.find((s) => s.path === "/uxCritique").formats
+        .evidence,
+    ).toBe("url");
     const reconcile = getArtifactView(registry, "reconcile@1");
     expect(reconcile.source).toBe("contract");
     expect(reconcile.file).toBe(

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -306,3 +306,52 @@ describe("input view (WM-897)", () => {
     expect(r2.getByText("Input")).toBeTruthy();
   });
 });
+
+describe("dispatch UX critique evidence", () => {
+  test("links every durable artifact and preserves legacy text", () => {
+    const sha256a = "a".repeat(64);
+    const sha256b = "b".repeat(64);
+    const r = render(
+      <ArtifactView
+        artifact={{
+          uxCritique: {
+            status: "required",
+            verdict: "SHIP",
+            rounds: 1,
+            prReady: true,
+            evidence: [
+              `sha256:${sha256a}`,
+              `file:///var/lib/factory/artifacts/${sha256b}`,
+              "legacy browser note",
+            ],
+          },
+        }}
+        view={readView("dispatch")}
+      />,
+    );
+
+    expect(
+      (
+        r.getByRole("link", { name: `sha256:${sha256a}` }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe(`/api/artifacts/${sha256a}`);
+    expect(
+      (
+        r.getByRole("link", {
+          name: `file:///var/lib/factory/artifacts/${sha256b}`,
+        }) as HTMLAnchorElement
+      ).getAttribute("href"),
+    ).toBe(`/api/artifacts/${sha256b}`);
+    expect(r.getByText("legacy browser note").tagName).toBe("SPAN");
+  });
+
+  test("keeps empty evidence as an empty value", () => {
+    const r = render(
+      <ArtifactView
+        artifact={{ uxCritique: { evidence: [] } }}
+        view={readView("dispatch")}
+      />,
+    );
+    expect(r.getByText("evidence").parentElement?.textContent).toContain("—");
+  });
+});

--- a/event-runtime/web/src/components/ArtifactView.test.tsx
+++ b/event-runtime/web/src/components/ArtifactView.test.tsx
@@ -334,24 +334,25 @@ describe("dispatch UX critique evidence", () => {
       (
         r.getByRole("link", { name: `sha256:${sha256a}` }) as HTMLAnchorElement
       ).getAttribute("href"),
-    ).toBe(`/api/artifacts/${sha256a}`);
+    ).toBe(`#/artifacts/${sha256a}`);
     expect(
       (
         r.getByRole("link", {
           name: `file:///var/lib/factory/artifacts/${sha256b}`,
         }) as HTMLAnchorElement
       ).getAttribute("href"),
-    ).toBe(`/api/artifacts/${sha256b}`);
+    ).toBe(`#/artifacts/${sha256b}`);
     expect(r.getByText("legacy browser note").tagName).toBe("SPAN");
   });
 
-  test("keeps empty evidence as an empty value", () => {
+  test("empty evidence drops the row, like any other absent key", () => {
     const r = render(
       <ArtifactView
-        artifact={{ uxCritique: { evidence: [] } }}
+        artifact={{ uxCritique: { status: "skipped", evidence: [] } }}
         view={readView("dispatch")}
       />,
     );
-    expect(r.getByText("evidence").parentElement?.textContent).toContain("—");
+    expect(r.getByText("status")).toBeTruthy();
+    expect(r.queryByText("evidence")).toBeNull();
   });
 });

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -191,12 +191,7 @@ function Value({
           {f.items.map((item, index) => (
             <li key={`${item.text}:${index}`} className="break-all py-px">
               {item.href ? (
-                <a
-                  href={item.href}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-(--accent) hover:underline"
-                >
+                <a href={item.href} className="text-(--accent) hover:underline">
                   {item.text}
                 </a>
               ) : (

--- a/event-runtime/web/src/components/ArtifactView.tsx
+++ b/event-runtime/web/src/components/ArtifactView.tsx
@@ -185,6 +185,27 @@ function Value({
           {f.text}
         </a>
       );
+    case "links":
+      return (
+        <ul className="m-0 list-none p-0">
+          {f.items.map((item, index) => (
+            <li key={`${item.text}:${index}`} className="break-all py-px">
+              {item.href ? (
+                <a
+                  href={item.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-(--accent) hover:underline"
+                >
+                  {item.text}
+                </a>
+              ) : (
+                <span>{item.text}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      );
     case "json":
       if (block) {
         if (

--- a/event-runtime/web/src/components/BlockRenderer.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.tsx
@@ -117,12 +117,7 @@ function FormattedValue({
           {value.items.map((item, index) => (
             <li key={`${item.text}:${index}`} className="break-all py-px">
               {item.href ? (
-                <a
-                  href={item.href}
-                  target="_blank"
-                  rel="noreferrer"
-                  className="text-(--accent) hover:underline"
-                >
+                <a href={item.href} className="text-(--accent) hover:underline">
                   {item.text}
                 </a>
               ) : (

--- a/event-runtime/web/src/components/BlockRenderer.tsx
+++ b/event-runtime/web/src/components/BlockRenderer.tsx
@@ -111,6 +111,27 @@ function FormattedValue({
           {value.text}
         </a>
       );
+    case "links":
+      return (
+        <ul className="m-0 list-none p-0">
+          {value.items.map((item, index) => (
+            <li key={`${item.text}:${index}`} className="break-all py-px">
+              {item.href ? (
+                <a
+                  href={item.href}
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-(--accent) hover:underline"
+                >
+                  {item.text}
+                </a>
+              ) : (
+                <span>{item.text}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      );
     case "chip": {
       const href = value.chip === "run" ? runHref(value.id) : value.href;
       if (!href) return <span className="mono">{value.text}</span>;

--- a/event-runtime/web/src/lib/artifactView.test.ts
+++ b/event-runtime/web/src/lib/artifactView.test.ts
@@ -192,15 +192,33 @@ describe("formatValue", () => {
     ).toEqual({
       kind: "links",
       items: [
-        { text: `sha256:${sha256}`, href: `/api/artifacts/${sha256}` },
+        { text: `sha256:${sha256}`, href: `#/artifacts/${sha256}` },
         {
           text: `file:///var/lib/factory/artifacts/${sha256}`,
-          href: `/api/artifacts/${sha256}`,
+          href: `#/artifacts/${sha256}`,
         },
         { text: "http://127.0.0.1:7497/runs", href: null },
       ],
     });
     expect(formatValue([], "url")).toEqual({ kind: "empty" });
+  });
+
+  test("url arrays never leave an undefined-typed element (empty li, bad key)", () => {
+    const items = (
+      formatValue([undefined, { note: "not a string" }], "url") as {
+        kind: "links";
+        items: Array<{ text: string; href: string | null }>;
+      }
+    ).items;
+    expect(items).toHaveLength(2);
+    for (const item of items) {
+      expect(typeof item.text).toBe("string");
+      expect(item.text.length).toBeGreaterThan(0);
+    }
+    expect(items[1]).toEqual({
+      text: '{"note":"not a string"}',
+      href: null,
+    });
   });
 
   test("no format: prose is proportional, identifiers and numbers are mono, nested values are json, absent is empty", () => {

--- a/event-runtime/web/src/lib/artifactView.test.ts
+++ b/event-runtime/web/src/lib/artifactView.test.ts
@@ -178,6 +178,31 @@ describe("formatValue", () => {
     });
   });
 
+  test("url arrays link stored artifact identifiers and preserve legacy evidence", () => {
+    const sha256 = "a".repeat(64);
+    expect(
+      formatValue(
+        [
+          `sha256:${sha256}`,
+          `file:///var/lib/factory/artifacts/${sha256}`,
+          "http://127.0.0.1:7497/runs",
+        ],
+        "url",
+      ),
+    ).toEqual({
+      kind: "links",
+      items: [
+        { text: `sha256:${sha256}`, href: `/api/artifacts/${sha256}` },
+        {
+          text: `file:///var/lib/factory/artifacts/${sha256}`,
+          href: `/api/artifacts/${sha256}`,
+        },
+        { text: "http://127.0.0.1:7497/runs", href: null },
+      ],
+    });
+    expect(formatValue([], "url")).toEqual({ kind: "empty" });
+  });
+
   test("no format: prose is proportional, identifiers and numbers are mono, nested values are json, absent is empty", () => {
     expect(formatValue("Scope unclear.")).toEqual({
       kind: "text",

--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -10,6 +10,7 @@
  * simply drops its section (optional fields are optional, §2.2).
  */
 import { dur } from "../heartbeat";
+import { artifactUrl } from "../api";
 import type {
   ArtifactFormat,
   ArtifactTone,
@@ -159,6 +160,7 @@ export type Formatted =
     }
   | { kind: "state"; state: string }
   | { kind: "link"; href: string; text: string }
+  | { kind: "links"; items: Array<{ text: string; href: string | null }> }
   | { kind: "json"; value: unknown };
 
 const asText = (v: unknown): string => (typeof v === "string" ? v : String(v));
@@ -168,6 +170,30 @@ const looksLikeIdentifier = (s: string): boolean => !/\s/.test(s);
 
 const isScalar = (v: unknown): boolean =>
   v === null || ["string", "number", "boolean"].includes(typeof v);
+
+const SHA256_ID = /^sha256:([a-f0-9]{64})$/;
+const SHA256_HEX = /^[a-f0-9]{64}$/;
+
+/** The durable identifiers the artifact collector returns in result evidence. */
+function storedArtifactDigest(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const named = SHA256_ID.exec(value);
+  if (named) return named[1];
+  try {
+    const uri = new URL(value);
+    if (uri.protocol !== "file:") return null;
+    const digest = uri.pathname.split("/").pop();
+    return digest && SHA256_HEX.test(digest) ? digest : null;
+  } catch {
+    return null;
+  }
+}
+
+function evidenceItem(value: unknown): { text: string; href: string | null } {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  const digest = storedArtifactDigest(value);
+  return { text, href: digest ? artifactUrl(digest) : null };
+}
 
 /**
  * `formatValue(value, format)` for the closed §2.2 format set. Unknown or
@@ -181,6 +207,10 @@ export function formatValue(
 ): Formatted {
   if (value === undefined || value === null || value === "")
     return { kind: "empty" };
+  if (format === "url" && Array.isArray(value)) {
+    if (value.length === 0) return { kind: "empty" };
+    return { kind: "links", items: value.map(evidenceItem) };
+  }
   if (!isScalar(value)) return { kind: "json", value };
   const text = asText(value);
   switch (format) {

--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -10,7 +10,6 @@
  * simply drops its section (optional fields are optional, §2.2).
  */
 import { dur } from "../heartbeat";
-import { artifactUrl } from "../api";
 import type {
   ArtifactFormat,
   ArtifactTone,
@@ -190,9 +189,10 @@ function storedArtifactDigest(value: unknown): string | null {
 }
 
 function evidenceItem(value: unknown): { text: string; href: string | null } {
-  const text = typeof value === "string" ? value : JSON.stringify(value);
+  const text =
+    typeof value === "string" ? value : String(JSON.stringify(value) ?? value);
   const digest = storedArtifactDigest(value);
-  return { text, href: digest ? artifactUrl(digest) : null };
+  return { text, href: digest ? `#/artifacts/${digest}` : null };
 }
 
 /**


### PR DESCRIPTION
Fixes watt-mind/factory#2046

Renders durable UX evidence identifiers as artifact links and preserves legacy evidence text.

## Validation

| Check                | Command                          | Result       | Notes                              |
| -------------------- | -------------------------------- | ------------ | ---------------------------------- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/registry.test.mjs event-runtime/web/src/lib/artifactView.test.ts event-runtime/web/src/components/BlockRenderer.test.tsx && bun run lint` | pass | exit 0 |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | exit 0 |
| UX critique          | factory-ux-critic                | not assessed | UI shell loaded; runs API returned 401 |

UX critique: required
run:run_876ba417-2c75-47ed-b973-b57bed72cd93