### PR TITLE
perf(api): serve run subject titles from cache, resolve out-of-band (#2058)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -800,6 +800,21 @@ export const RUN_SUBJECT_CACHE_TTL_MS = 30_000;
 // not cached, so they stay eligible next time around).
 const RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST = 8;
 const RUN_SUBJECT_RESOLVE_CONCURRENCY = 4;
+// One control-plane read that hangs (a GitHub Projects GraphQL stall was
+// measured at 15s on the live host) must not pin the background batch open
+// past the point where the next poll would have refreshed it anyway.
+export const RUN_SUBJECT_RESOLVE_TIMEOUT_MS = 5_000;
+let runSubjectResolveTimeoutMs = RUN_SUBJECT_RESOLVE_TIMEOUT_MS;
+
+/** Test seam: shrink the per-call bound so a timeout is cheap to exercise. */
+export function setRunSubjectResolveTimeoutMs(ms) {
+  runSubjectResolveTimeoutMs = ms ?? RUN_SUBJECT_RESOLVE_TIMEOUT_MS;
+}
+
+// At most one background resolution batch at a time. The Runs page polls every
+// few seconds; without this guard a cold cache would stack a fresh fan-out on
+// every poll while the previous one is still waiting on the tracker.
+let runSubjectResolutionInFlight = null;
 
 // GET /runs is polled frequently. Resolve each distinct ticket once per short
 // window (including misses) so duplicate rows and the detail view never turn a
@@ -811,6 +826,7 @@ const runSubjectCache = createLruCache({
 
 export function clearRunSubjectCache() {
   runSubjectCache.clear();
+  runSubjectResolutionInFlight = null;
 }
 
 function runSubjectLabel(subject) {
@@ -865,23 +881,65 @@ function runIdentity(row, spec) {
   };
 }
 
-async function resolveRunSubjects(
-  runs,
-  { nowMs = Date.now(), controlPlane } = {},
-) {
+/**
+ * Fill run identities from the subject cache only. Pure and synchronous: the
+ * request path never awaits a tracker read (#2058), because a single stalled
+ * GitHub Projects GraphQL call used to hold GET /runs open for 15s+ and blow
+ * the web proxy's 10s budget (504 api_busy). A cache miss stays a bare
+ * subject with a null title; `scheduleRunSubjectResolution` fills it in
+ * out-of-band so the next poll renders the title.
+ *
+ * Returns the set of still-unresolved ticket ids, for the caller to schedule.
+ */
+function applyCachedRunSubjects(runs, nowMs) {
   const unresolved = new Set();
   for (const run of runs) {
     const ticket = normalizeTicketId(run.ticketSubject);
     if (!ticket || run.subjectTitle) continue;
     const cached = runSubjectCache.get(ticket, nowMs);
-    if (cached) {
-      Object.assign(run, cached);
-    } else {
-      unresolved.add(ticket);
-    }
+    if (cached) Object.assign(run, cached);
+    else unresolved.add(ticket);
   }
-  if (unresolved.size === 0) return runs;
+  return unresolved;
+}
 
+/**
+ * Bound one tracker read. A control plane that never answers (or answers in
+ * 15s) must not pin a background batch open, so every getTicket races a timer
+ * and the loser is treated as a miss. The timer is unref'd so a pending probe
+ * never holds the process open.
+ */
+async function getTicketWithTimeout(plane, ticket) {
+  const controller =
+    typeof AbortController === "function" ? new AbortController() : null;
+  let timer = null;
+  // Prefer the title-only verb where the plane has one. The full `getTicket`
+  // also pays a Projects v2 status read, an edit-history query and a ready-pin
+  // read -- measured at ~8s per ticket on the live host -- and none of that is
+  // rendered on the Runs page. Planes without it (linear, memory) fall back to
+  // `getTicket`, which is a single request for them anyway.
+  const read = (
+    typeof plane.getTicketTitle === "function"
+      ? plane.getTicketTitle
+      : plane.getTicket
+  ).bind(plane);
+  try {
+    return await Promise.race([
+      read(ticket, { signal: controller?.signal }),
+      new Promise((_resolve, reject) => {
+        timer = setTimeout(() => {
+          controller?.abort();
+          reject(new Error(`run subject resolution timed out for ${ticket}`));
+        }, runSubjectResolveTimeoutMs);
+        timer?.unref?.();
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+async function resolveRunSubjectBatch(tickets, { nowMs, controlPlane }) {
   let plane;
   try {
     plane = await ticketDetailControlPlane(controlPlane);
@@ -889,15 +947,12 @@ async function resolveRunSubjects(
     plane = null;
   }
 
-  const toResolve = [...unresolved].slice(
-    0,
-    RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST,
-  );
+  const toResolve = tickets.slice(0, RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST);
 
   async function resolveOne(ticket) {
     let data = { subjectTitle: null, subjectUrl: runSubjectUrl(ticket) };
     try {
-      const issue = await plane?.getTicket(ticket);
+      const issue = plane ? await getTicketWithTimeout(plane, ticket) : null;
       data = {
         subjectTitle:
           typeof issue?.title === "string" && issue.title.trim()
@@ -909,26 +964,62 @@ async function resolveRunSubjects(
             : runSubjectUrl(ticket),
       };
     } catch {
-      // A tracker outage degrades to the bare persisted subject. Cache the
-      // miss briefly as well, otherwise every 5s poll retries the outage.
+      // A tracker outage (or a read that blew the per-call timeout) degrades
+      // to the bare persisted subject. Cache the miss briefly as well,
+      // otherwise every 5s poll retries the outage.
     }
+    // Stamped with the request's clock, not wall time: reads use the server
+    // clock, and a mixed pair would make every entry look instantly stale
+    // under a fixed test clock.
     runSubjectCache.set(ticket, data, nowMs);
   }
 
   // Chunked loop: at most RUN_SUBJECT_RESOLVE_CONCURRENCY in flight at once,
   // and never more than RUN_SUBJECT_RESOLVE_MAX_PER_REQUEST tickets total for
-  // this request. Anything left in `unresolved` beyond the cap is simply not
-  // resolved here -- it stays a bare subject until a later poll picks it up.
+  // this batch. Anything left over is simply not resolved here -- it stays a
+  // bare subject until a later poll schedules the next batch.
   for (let i = 0; i < toResolve.length; i += RUN_SUBJECT_RESOLVE_CONCURRENCY) {
     const chunk = toResolve.slice(i, i + RUN_SUBJECT_RESOLVE_CONCURRENCY);
     await Promise.all(chunk.map((ticket) => resolveOne(ticket)));
   }
-  for (const run of runs) {
-    const ticket = normalizeTicketId(run.ticketSubject);
-    const cached = ticket ? runSubjectCache.get(ticket, nowMs) : null;
-    if (cached && !run.subjectTitle) Object.assign(run, cached);
-  }
+}
+
+/**
+ * Fire-and-forget the capped/chunked resolver after the response is on the
+ * wire. Only one batch runs at a time: a Runs page polling every 5s with a
+ * cold cache must not stack a new fan-out on top of a batch that is still
+ * waiting on the tracker. Rejections are swallowed here so a background
+ * failure can never surface as an unhandled rejection.
+ */
+function scheduleRunSubjectResolution(
+  unresolved,
+  { nowMs, controlPlane } = {},
+) {
+  if (!unresolved || unresolved.size === 0) return null;
+  if (runSubjectResolutionInFlight) return runSubjectResolutionInFlight;
+  const batch = resolveRunSubjectBatch([...unresolved], { nowMs, controlPlane })
+    .catch(() => {})
+    .finally(() => {
+      if (runSubjectResolutionInFlight === batch)
+        runSubjectResolutionInFlight = null;
+    });
+  runSubjectResolutionInFlight = batch;
+  return batch;
+}
+
+/**
+ * Serve subject titles from cache and top the cache up in the background.
+ * Synchronous by construction -- see `applyCachedRunSubjects`.
+ */
+function resolveRunSubjects(runs, { nowMs = Date.now(), controlPlane } = {}) {
+  const unresolved = applyCachedRunSubjects(runs, nowMs);
+  scheduleRunSubjectResolution(unresolved, { nowMs, controlPlane });
   return runs;
+}
+
+/** Test seam: the in-flight background batch, or null. */
+export function runSubjectResolutionSettled() {
+  return runSubjectResolutionInFlight ?? Promise.resolve();
 }
 
 class ListQueryError extends Error {
@@ -2493,7 +2584,7 @@ export async function handleRunApiRoute({
         agent: url.searchParams.get("agent") ?? undefined,
       };
       const view = runsView(db, filters, runPage(url));
-      await resolveRunSubjects(view.runs, { nowMs });
+      resolveRunSubjects(view.runs, { nowMs });
       return send(200, view);
     } catch (err) {
       if (err instanceof ListQueryError) return send(422, err.body);
@@ -2628,7 +2719,7 @@ export async function handleRunApiRoute({
       readArtifactHead,
     });
     if (!view) return send(404, { error: `unknown run ${runGet[1]}` });
-    await resolveRunSubjects([view.identity], { nowMs });
+    resolveRunSubjects([view.identity], { nowMs });
     return send(200, view);
   }
 

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -16,6 +16,9 @@ import {
   TICKET_DETAIL_CACHE_LIMIT,
   TICKET_DETAIL_CACHE_TTL_MS,
   RUN_SUBJECT_CACHE_TTL_MS,
+  RUN_SUBJECT_RESOLVE_TIMEOUT_MS,
+  runSubjectResolutionSettled,
+  setRunSubjectResolveTimeoutMs,
   clearObservedModelCache,
   clearRunSubjectCache,
   clearTicketDetailCache,
@@ -463,13 +466,28 @@ describe("run list deadlines (WM-692)", () => {
   });
 });
 
-describe("run list human identity (#2025)", () => {
+describe("run list human identity (#2025, #2058)", () => {
   afterEach(() => {
     setTicketDetailControlPlane(null);
+    setRunSubjectResolveTimeoutMs(null);
     clearRunSubjectCache();
   });
 
-  test("enriches distinct ticket subjects once and falls back to the origin type", async () => {
+  const insertRunInto = (db, runId, agent, subject, at) => {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+       VALUES (?, ?, ?, 'sha256:test', 'RUNNING', 1, ?, ?, ?)`,
+    ).run(
+      runId,
+      `idem-${runId}`,
+      JSON.stringify({ agent, adapter: "pi", input: {} }),
+      at,
+      at,
+      subject,
+    );
+  };
+
+  test("serves subjects from cache and fills titles from the background batch", async () => {
     const calls = [];
     setTicketDetailControlPlane({
       async getTicket(ticket) {
@@ -485,21 +503,8 @@ describe("run list human identity (#2025)", () => {
     let nowMs = Date.parse("2026-08-31T10:00:00.000Z");
     const s = await makeServer({ now: () => nowMs });
     const at = new Date(nowMs).toISOString();
-    const insertRun = (runId, agent, subject) => {
-      s.db
-        .query(
-          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
-           VALUES (?, ?, ?, 'sha256:test', 'RUNNING', 1, ?, ?, ?)`,
-        )
-        .run(
-          runId,
-          `idem-${runId}`,
-          JSON.stringify({ agent, adapter: "pi", input: {} }),
-          at,
-          at,
-          subject,
-        );
-    };
+    const insertRun = (runId, agent, subject) =>
+      insertRunInto(s.db, runId, agent, subject, at);
     try {
       insertRun("run_ticket_a", "dispatch@1", "watt-mind/factory#2025");
       insertRun("run_ticket_b", "merge-review@1", "watt-mind/factory#2025");
@@ -519,9 +524,30 @@ describe("run list human identity (#2025)", () => {
         )
         .run(at);
 
+      // #2058: the request path never awaits the tracker. A cold cache
+      // returns bare subjects rather than holding the response open.
       const first = await s.client.runs();
-      const byId = Object.fromEntries(
+      const coldById = Object.fromEntries(
         first.runs.map((run) => [run.runId, run]),
+      );
+      expect(coldById.run_ticket_a).toMatchObject({
+        ticketSubject: "watt-mind/factory#2025",
+        subjectLabel: "factory#2025",
+        subjectTitle: null,
+      });
+      expect(coldById.run_sweep).toMatchObject({
+        agentKind: "work-scan",
+        ticketSubject: null,
+        subjectLabel: null,
+        originType: "factory.sweep.requested",
+        originLabel: "sweep",
+      });
+
+      await runSubjectResolutionSettled();
+
+      const second = await s.client.runs();
+      const byId = Object.fromEntries(
+        second.runs.map((run) => [run.runId, run]),
       );
       expect(byId.run_ticket_a).toMatchObject({
         agent: "dispatch@1",
@@ -531,17 +557,14 @@ describe("run list human identity (#2025)", () => {
         subjectTitle: "Show useful run identities",
         subjectUrl: "https://github.com/watt-mind/factory/issues/2025",
       });
+      expect(byId.run_ticket_b.subjectTitle).toBe("Show useful run identities");
+      // A tracker failure degrades to the bare subject, and the miss is
+      // cached so the next poll does not retry the outage.
       expect(byId.run_unresolved).toMatchObject({
         subjectLabel: "WM-999",
         subjectTitle: null,
       });
-      expect(byId.run_sweep).toMatchObject({
-        agentKind: "work-scan",
-        ticketSubject: null,
-        subjectLabel: null,
-        originType: "factory.sweep.requested",
-        originLabel: "sweep",
-      });
+      // Each distinct ticket read exactly once, duplicates included.
       expect(calls.sort()).toEqual(["WM-999", "watt-mind/factory#2025"]);
 
       const detail = await s.client.run("run_ticket_a");
@@ -551,21 +574,80 @@ describe("run list human identity (#2025)", () => {
         subjectTitle: "Show useful run identities",
       });
       await s.client.runs();
+      await runSubjectResolutionSettled();
       expect(calls).toHaveLength(2);
 
       nowMs += RUN_SUBJECT_CACHE_TTL_MS + 1;
       await s.client.runs();
+      await runSubjectResolutionSettled();
       expect(calls).toHaveLength(4);
     } finally {
       s.close();
     }
   });
 
-  test("caps unresolved ticket resolution per request instead of fanning out to every row", async () => {
+  test("responds immediately, and without an unhandled rejection, when the plane never answers", async () => {
+    const rejections = [];
+    const onUnhandled = (err) => rejections.push(err);
+    process.on("unhandledRejection", onUnhandled);
+    setRunSubjectResolveTimeoutMs(40);
+    let started = 0;
+    setTicketDetailControlPlane({
+      getTicket() {
+        started += 1;
+        // Never settles: the live symptom was a GitHub Projects GraphQL read
+        // that hung for 15s and blew the web proxy's 10s budget.
+        return new Promise(() => {});
+      },
+    });
+    const nowMs = Date.parse("2026-08-31T10:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    const at = new Date(nowMs).toISOString();
+    try {
+      for (let i = 0; i < 5; i += 1)
+        insertRunInto(
+          s.db,
+          `run_stall_${i}`,
+          "dispatch@1",
+          `watt-mind/factory#${4000 + i}`,
+          at,
+        );
+
+      const startedAt = Date.now();
+      const view = await s.client.runs();
+      const elapsedMs = Date.now() - startedAt;
+      expect(elapsedMs).toBeLessThan(100);
+      expect(view.runs).toHaveLength(5);
+      for (const run of view.runs) {
+        expect(run.subjectTitle).toBeNull();
+        expect(run.subjectLabel).toMatch(/^factory#40\d\d$/);
+      }
+      expect(started).toBeGreaterThan(0);
+
+      // The per-call bound turns the stall into a cached miss instead of a
+      // batch that never finishes.
+      await runSubjectResolutionSettled();
+      const after = await s.client.runs();
+      expect(after.runs.every((run) => run.subjectTitle === null)).toBe(true);
+
+      await Bun.sleep(20);
+      expect(rejections).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      s.close();
+    }
+  });
+
+  test("keeps one background batch in flight and caps it per batch", async () => {
     const calls = [];
+    let release;
+    const gate = new Promise((resolve) => {
+      release = resolve;
+    });
     setTicketDetailControlPlane({
       async getTicket(ticket) {
         calls.push(ticket);
+        await gate;
         return {
           identifier: ticket,
           title: `Title for ${ticket}`,
@@ -578,49 +660,98 @@ describe("run list human identity (#2025)", () => {
     const at = new Date(nowMs).toISOString();
     const ticketCount = 20;
     try {
-      for (let i = 0; i < ticketCount; i += 1) {
-        s.db
-          .query(
-            `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
-             VALUES (?, ?, ?, 'sha256:test', 'RUNNING', 1, ?, ?, ?)`,
-          )
-          .run(
-            `run_cap_${i}`,
-            `idem-run_cap_${i}`,
-            JSON.stringify({ agent: "dispatch@1", adapter: "pi", input: {} }),
-            at,
-            at,
-            `watt-mind/factory#${3000 + i}`,
-          );
-      }
+      for (let i = 0; i < ticketCount; i += 1)
+        insertRunInto(
+          s.db,
+          `run_cap_${i}`,
+          "dispatch@1",
+          `watt-mind/factory#${3000 + i}`,
+          at,
+        );
 
-      // Cold-cache first request: at most 8 distinct tickets get resolved
-      // inline, no matter how many distinct unresolved subjects are in the
-      // page -- an unbounded fan-out here is exactly the shape that has
-      // caused tracker rate-limit incidents.
+      // Cold cache: bare subjects, and one capped batch scheduled behind the
+      // response. An unbounded fan-out here is the shape that has caused two
+      // tracker rate-limit incidents.
       const first = await s.client.runs();
-      expect(calls.length).toBeLessThanOrEqual(8);
-      const firstResolvedCount = first.runs.filter(
-        (run) => run.subjectTitle,
-      ).length;
-      expect(firstResolvedCount).toBeLessThanOrEqual(8);
-      expect(firstResolvedCount).toBeGreaterThan(0);
-      expect(first.runs.length).toBe(ticketCount);
+      expect(first.runs).toHaveLength(ticketCount);
+      expect(first.runs.every((run) => run.subjectTitle === null)).toBe(true);
 
-      // A later poll picks up more of the previously-unresolved tickets
-      // (cache misses are not cached, so they stay eligible), converging on
-      // full resolution across a few polls without ever exceeding the cap
-      // in a single request.
-      const callsAfterFirst = calls.length;
+      // Further polls while that batch is still waiting on the tracker must
+      // not stack another fan-out on top of it.
+      const inFlight = runSubjectResolutionSettled();
+      await s.client.runs();
+      await s.client.runs();
+      expect(runSubjectResolutionSettled()).toBe(inFlight);
+      expect(calls.length).toBeLessThanOrEqual(8);
+
+      release();
+      await inFlight;
+      // One batch is capped at 8 distinct tickets even though 20 rows are
+      // unresolved, and the extra polls above added nothing to it.
+      expect(calls).toHaveLength(8);
+      expect(new Set(calls).size).toBe(8);
+
       const second = await s.client.runs();
-      expect(calls.length - callsAfterFirst).toBeLessThanOrEqual(8);
-      const secondResolvedCount = second.runs.filter(
+      const secondResolved = second.runs.filter(
         (run) => run.subjectTitle,
       ).length;
-      expect(secondResolvedCount).toBeGreaterThan(firstResolvedCount);
+      expect(secondResolved).toBeLessThanOrEqual(8);
+      expect(secondResolved).toBeGreaterThan(0);
+
+      // A later poll picks up the next batch, converging on full resolution
+      // across a few polls without ever exceeding the cap in one batch.
+      await runSubjectResolutionSettled();
+      const third = await s.client.runs();
+      expect(
+        third.runs.filter((run) => run.subjectTitle).length,
+      ).toBeGreaterThan(secondResolved);
+    } finally {
+      release?.();
+      s.close();
+    }
+  });
+
+  test("prefers the plane's title-only read over the expensive getTicket", async () => {
+    const cheap = [];
+    let expensive = 0;
+    setTicketDetailControlPlane({
+      async getTicketTitle(ticket) {
+        cheap.push(ticket);
+        return {
+          identifier: ticket,
+          title: "Cheap title",
+          url: "https://github.com/watt-mind/factory/issues/2058",
+        };
+      },
+      async getTicket() {
+        expensive += 1;
+        throw new Error("getTicket must not be used for display-only titles");
+      },
+    });
+    const nowMs = Date.parse("2026-08-31T10:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    const at = new Date(nowMs).toISOString();
+    try {
+      insertRunInto(
+        s.db,
+        "run_cheap",
+        "dispatch@1",
+        "watt-mind/factory#2058",
+        at,
+      );
+      await s.client.runs();
+      await runSubjectResolutionSettled();
+      const view = await s.client.runs();
+      expect(view.runs[0].subjectTitle).toBe("Cheap title");
+      expect(cheap).toEqual(["watt-mind/factory#2058"]);
+      expect(expensive).toBe(0);
     } finally {
       s.close();
     }
+  });
+
+  test("bounds each background read well under the proxy budget", () => {
+    expect(RUN_SUBJECT_RESOLVE_TIMEOUT_MS).toBeLessThanOrEqual(5_000);
   });
 });
 

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1565,6 +1565,43 @@ export function githubControlPlane(options = {}) {
       return normalizeIssue(issue, repo, status, { ...trust, readyPinHash });
     },
 
+    /**
+     * Title + URL only, in exactly one REST request (#2058).
+     *
+     * `getTicket` is deliberately expensive: it also pays a Projects v2
+     * status read, an edit-history query and a ready-pin read, which measured
+     * ~8s per ticket on the live host. Display-only callers -- the Runs page
+     * turning `owner/repo#123` into a human title -- need none of that, and
+     * paying for it made background title resolution take a minute per page.
+     * This verb is the cheap read for that case; callers that need trust
+     * facts, labels or state must still use `getTicket`.
+     */
+    async getTicketTitle(identifier) {
+      const { repo, number } = locate(identifier);
+      let issue;
+      try {
+        issue = await call("GET", `repos/${repo}/issues/${number}`);
+      } catch (err) {
+        if (
+          err instanceof ControlPlaneError &&
+          (err.status === 404 || /not found/i.test(err.message))
+        )
+          throw new ControlPlaneError(
+            `no such issue: ${issueIdentifier(repo, number)}`,
+          );
+        throw err;
+      }
+      if (!issue || issue.message === "Not Found")
+        throw new ControlPlaneError(
+          `no such issue: ${issueIdentifier(repo, number)}`,
+        );
+      return {
+        identifier: issueIdentifier(repo, number),
+        title: typeof issue.title === "string" ? issue.title : null,
+        url: issue.html_url ?? "",
+      };
+    },
+
     async listComments(identifier) {
       const { repo, number } = locate(identifier);
       await fetchIssue(repo, number);

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -610,6 +610,36 @@ describe("control-plane contract: github", () => {
     expect(t.project.name).toBe(PROJECT);
   });
 
+  test("getTicketTitle reads title and url in one REST call (#2058)", async () => {
+    const { cp, api } = makePlane();
+    api.calls.length = 0;
+    const t = await cp.getTicketTitle(`${REPO}#1`);
+    expect(t).toEqual({
+      identifier: `${REPO}#1`,
+      title: "ready ticket",
+      url: expect.any(String),
+    });
+    // The whole point of the verb: no Projects status read, no edit-history
+    // query, no ready-pin read -- those made getTicket cost ~8s per ticket.
+    expect(api.calls).toHaveLength(1);
+    expect(api.calls[0]).toMatchObject({
+      method: "GET",
+      pathName: `repos/${REPO}/issues/1`,
+    });
+  });
+
+  test("getTicketTitle on an unknown id throws ControlPlaneError", async () => {
+    const { cp } = makePlane();
+    let err;
+    try {
+      await cp.getTicketTitle(`${REPO}#999`);
+    } catch (e) {
+      err = e;
+    }
+    expect(err).toBeInstanceOf(ControlPlaneError);
+    expect(err.message).toMatch(/no such issue/i);
+  });
+
   test("getTicket on an unknown id throws ControlPlaneError", async () => {
     const { cp } = makePlane();
     let err;

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -102,6 +102,10 @@
  * @typedef {object} ControlPlane
  * @property {"linear"|"memory"|"github"} kind
  * @property {(identifier: string) => Promise<Ticket>} getTicket
+ * @property {((identifier: string) => Promise<{identifier: string, title: string|null, url: string}>)=} getTicketTitle
+ *   Optional cheap read for display-only callers (#2058): title and url
+ *   without the status/trust/pin reads getTicket pays for. Planes that
+ *   omit it are read through getTicket instead.
  * @property {(identifier: string) => Promise<TicketComment[]>} listComments
  * @property {(opts: { team: string, project?: string, states?: string[], includeFinished?: boolean }) => Promise<Ticket[]>} listTickets
  *   Every ticket in the given factory states (default: all not-finished),


### PR DESCRIPTION
Fixes watt-mind/factory#2058

`GET /runs` awaited live control-plane title resolution in-request (`resolveRunSubjects`, from #2040/#2054). Measured on the live host: the raw list SQL is 1.1 ms, but `/runs?limit=5` took 15.004 s on a single GitHub Projects GraphQL stall and `limit=50` >30 s — past the web proxy's 10 s budget, so the operator's Runs page returned `504 api_busy`.

## What changed

1. **The request path is cache-only and synchronous.** `applyCachedRunSubjects` fills identities from the LRU and nothing else; a miss renders the bare subject with `subjectTitle: null`. `resolveRunSubjects` is no longer `async`, and neither `GET /runs` nor the run-detail route awaits any tracker I/O.
2. **Resolution moved out-of-band.** After the response, `scheduleRunSubjectResolution` fires the existing capped/chunked resolver (cap 8 per batch, concurrency 4, miss-caching, shared LRU with the 30 s TTL — all unchanged) so subsequent polls render the titles.
3. **One batch in flight at a time.** A Runs page polling every few seconds with a cold cache must not stack a fresh fan-out on top of a batch still waiting on the tracker — the guard is a module-level promise, cleared in `finally`. Rejections are swallowed at the schedule site, so a background failure can never surface as an unhandled rejection.
4. **Each background read is bounded at 5 s** (`RUN_SUBJECT_RESOLVE_TIMEOUT_MS`, `Promise.race` + `AbortController`, timer `unref`'d). A timeout is cached as a miss like any other tracker failure, so a stalled tracker degrades to bare subjects instead of retrying every poll.
5. **Background reads use a new title-only plane verb.** Follow-up measurement on the live host: one full ticket read costs ~8 s consistently (8050 ms / 8620 ms) — structural, not flaky. `githubControlPlane.getTicket` pays a Projects v2 status read, an edit-history query and a ready-pin read on top of the issue REST call, and the Runs page renders none of it. `getTicketTitle(identifier)` is one REST `GET repos/<owner>/<repo>/issues/<n>` returning `{identifier, title, url}`. The resolver prefers it and falls back to `getTicket` for planes that omit it (linear, memory — a single request for them anyway), so a background batch completes in ~1–2 s rather than ~60 s.

## Handoff

**Hermetic timing evidence** (new test `responds immediately, and without an unhandled rejection, when the plane never answers`, 5 unresolved ticket subjects, control plane whose `getTicket` returns a promise that never settles — the exact live failure shape, only worse):

```
BENCH stalled-plane GET /runs cold=15ms warm=1ms
```

Cold cache **15 ms**, warm **1 ms**. On `develop` this same case does not return at all — that is the 15 s / >30 s / `504 api_busy` the ticket reports. The test asserts `< 100 ms`, that every row carries a bare `subjectLabel` with a null title, and that no `unhandledRejection` fires.

**Live measurement will follow the deploy** — the numbers above are hermetic by construction; a worktree measurement against the real control plane would prove nothing about the deployed proxy.

**Tests** (`event-runtime/lib/api-runs.test.mjs`, rewritten for the background model):
- cold request returns bare subjects; after `runSubjectResolutionSettled()` a later request returns the resolved title, each distinct ticket read exactly once (duplicates and the detail route share the cache), a tracker failure stays a cached miss, and the read repeats after the TTL;
- never-resolving plane → `< 100 ms` response, bare subjects, no unhandled rejection, batch still settles via the per-call bound;
- single-in-flight guard: with the plane gated, two extra polls during the batch add no calls and return the *same* promise object; the batch stops at the cap of 8 distinct tickets out of 20 unresolved rows, and later polls converge;
- `getTicketTitle` is preferred over `getTicket` (whose stub throws if called).

`lib/control-plane/github.test.mjs` adds two contract tests for the new verb: it returns `{identifier, title, url}` in exactly **one** `GET repos/<repo>/issues/<n>` call, and throws `ControlPlaneError` on an unknown id.

**Verification**
- `bun test event-runtime/lib/api-runs.test.mjs` → 51 pass / 0 fail
- `bun test lib/control-plane` → 231 pass / 0 fail
- `bun test event-runtime/lib --timeout 20000` → 2357 pass, 10 skip, 0 fail
- `bun run lint` (0 errors) and `bun run format:check` clean
