### PR TITLE
fix(dispatch): authenticate UX critique Runs fixture

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:d6bcafb9e2daab29ffcfc837f851063712d21f3011e4f29d21bdba4f1bb34214",
+    "agents/dispatch.md": "sha256:28b2639252a55058e978c00464c81e59bf9947ef8dd1c292dd24c39f23a1f9a8",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -109,6 +109,25 @@ new ticket.
    running app and write every screenshot to `artifactDir` rather than `/tmp`
    or another workspace path.
 
+   **Worktree web fixture.** Read `<worktree>/.factory/run/ports` for the
+   allocated `api` and `web` ports. The provisioned static proxy is already
+   running; do not start a server or a second proxy. Direct the critic to
+   `http://127.0.0.1:<web>/#/runs`; the login route is **none**. The worktree
+   proxy, not the browser, holds the control bearer and injects it for
+   same-origin `/api` reads. Never pass, print, or ask the critic to set
+   `FACTORY_CONTROL_API_TOKEN` or an `Authorization` header.
+
+   Before the critic navigates, verify the fixture with
+   `curl -fsS http://127.0.0.1:<web>/api/runs`: it must return HTTP 200 and a
+   `runs` payload. The critic must then observe the same successful
+   `GET /api/runs` and live run data in the browser before issuing `SHIP` or
+   `FIX-FIRST`. A 401 or 403 is an **auth-fixture failure**, not a genuinely
+   unassessable flow: report `required — NOT-ASSESSED, auth fixture failure
+(GET /api/runs HTTP <status>)` in the Handoff. Use
+   `required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs
+HTTP 200); <genuinely unassessable reason>` only after the authenticated
+   fixture was observed and the flow itself could not be assessed.
+
    Screenshot evidence must survive workspace cleanup. For every screenshot the
    critic creates, calculate its SHA-256 and declare it in the outer
    `result.json` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`
@@ -233,7 +252,7 @@ shell` means the spawn prompt was defective: correct its path/launch details
    ## Handoff
    - PR: <url>
    - Verification: `<exact command>` — pass, <one-line result>
-   - UX critique: required — SHIP | required — FIX-FIRST unresolved | required — NOT-ASSESSED, <reason> | blocked — <reason> | skipped — <reason>; evidence: <page URL or screenshot path, when required>
+   - UX critique: required — SHIP | required — FIX-FIRST unresolved | required — NOT-ASSESSED, auth fixture failure (GET /api/runs HTTP 401/403) | required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); <genuinely unassessable reason> | blocked — <reason> | skipped — <reason>; evidence: <page URL or screenshot path, when required>
    - Files: <n> changed, all within Owned Paths
    - Risks: <reviewer focus, or "none known">
    ```

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3196,7 +3196,7 @@ describe("buildRunSpec", () => {
       now: 0,
     });
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:d71406671c4b9addd6b5184f18eb2919b0d2b40d57640bffc56927c3e3e9231d","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:de6c15bb144b71b99530807f819e0a5246c9c4442c8bf8d4d2162cd3ced63463","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -260,6 +260,18 @@ describe("registry", () => {
     });
   });
 
+  test("dispatch prompt gives UX critics the authenticated worktree Runs fixture", () => {
+    const prompt = getAgent(loadRegistry(), "dispatch@1").promptText;
+    expect(prompt).toContain(".factory/run/ports");
+    expect(prompt).toContain("do not start a server or a second proxy");
+    expect(prompt).toContain("/#/runs");
+    expect(prompt).toContain("GET /api/runs");
+    expect(prompt).toContain("HTTP 200");
+    expect(prompt).toContain("auth-fixture failure");
+    expect(prompt).toContain("HTTP 401/403");
+    expect(prompt).toContain("genuinely unassessable");
+  });
+
   test("zero-pack merged-view digest matches the develop baseline", () => {
     // Regenerate with registryDigest(loadRegistry({ packRoots: [] })) on develop.
     // The serializer omits only WM-470's new pack provenance and normalizes
@@ -413,10 +425,13 @@ describe("registry", () => {
     // grammar and its prompt pin changes; the registry digest follows it.
     // Regenerated (#2023): dispatch declares UX screenshots as durable
     // result artifacts and cites their content-addressed identifiers.
+    // Regenerated (#2057): dispatch gives UX critics the worktree's
+    // authenticated Runs fixture and distinguishes an auth-fixture 401/403
+    // from a genuinely unassessable flow; dispatch.json is re-pinned.
     // Regenerated (#2035): triage-scan names ticket.mjs as the active ticket
     // CLI and re-pins its definition; the prompt pin is a registry input.
     const expected =
-      "sha256:db13f68023714db1485bd79cc1359169f5d7056fcc1e44db307c6748e48fedfe";
+      "sha256:d7990996b96367144944af86799c85cb1448aba9c0b7c38cd3cdfee451b433ec";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -712,8 +727,11 @@ describe("registry", () => {
     // Regenerated (#1925): dispatch specifies the exact Fixes-line grammar;
     // its prompt pin legitimately changes while `pack` remains non-enumerable.
     // #2023 adds durable UX screenshot artifact declarations to that prompt.
+    // Regenerated (#2057): dispatch names the authenticated worktree Runs
+    // fixture and the explicit auth-fixture NOT-ASSESSED classification;
+    // prompt pin only, `pack` remains non-enumerable.
     expect(computeDefHash(def)).toBe(
-      "sha256:d71406671c4b9addd6b5184f18eb2919b0d2b40d57640bffc56927c3e3e9231d",
+      "sha256:de6c15bb144b71b99530807f819e0a5246c9c4442c8bf8d4d2162cd3ced63463",
     );
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2057

Authenticated provisioned Runs fixture instructions let UX critics verify live data and distinguish auth outages.

Authorization: operator:preapproved-2026-08-29 (2026-08-31T13:11:06.735Z).

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/api.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs && bun build/emit.mjs --check && bun run lint` | pass | 201 tests, 0 failures; lint 0 errors |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,355 passed, 10 QEMU skips; lint 0 errors |
| UX critique | factory-ux-critic | SHIP | round 2; browser GET /api/runs HTTP 200, 6 live rows |

UX critique: required — SHIP; evidence: http://127.0.0.1:7589/#/runs
run:run_854232e7-6b1f-4f68-9e89-7b4f2eac5d34
