### PR TITLE
fix(planner): consume effective in-repo escalate_paths overlay

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -1230,42 +1230,20 @@ function loadRepoEscalatePaths(repoName, root = reposRoot(), snapshot = null) {
     }
     return [...new Set(repo.escalatePaths.map((item) => item.trim()))];
   }
-  const file = reposConfigPath(root);
-  if (!existsSync(file)) {
-    throw new RepoError(
-      `${file}: cannot verify escalate_paths because repos.yaml is missing`,
-    );
-  }
-  let parsed;
+  let repo;
   try {
-    parsed = Bun.YAML.parse(readFileSync(file, "utf8"));
+    repo = getRepo(loadRepos({ root }), repoName);
   } catch (err) {
     throw new RepoError(
-      `${file}: cannot verify escalate_paths: ${err.message}`,
+      `${reposConfigPath(root)}: cannot verify escalate_paths: ${err.message}`,
     );
   }
-  const entry = (parsed?.repos ?? []).find((row) => row?.name === repoName);
-  if (!entry) {
+  if (!Array.isArray(repo.escalatePaths)) {
     throw new RepoError(
-      `${file}: cannot verify escalate_paths for unknown repo ${repoName}`,
+      `${reposConfigPath(root)}: repo ${repoName} must declare escalate_paths as an array (use [] only when deliberately empty)`,
     );
   }
-  const escalate = entry.escalate_paths ?? entry.escalatePaths;
-  if (!Array.isArray(escalate)) {
-    throw new RepoError(
-      `${file}: repo ${repoName} must declare escalate_paths as an array (use [] only when deliberately empty)`,
-    );
-  }
-  if (
-    !escalate.every(
-      (item) => typeof item === "string" && item.trim().length > 0,
-    )
-  ) {
-    throw new RepoError(
-      `${file}: repo ${repoName} has invalid escalate_paths (every glob must be a non-empty string)`,
-    );
-  }
-  return [...new Set(escalate.map((item) => item.trim()))];
+  return [...new Set(repo.escalatePaths.map((item) => item.trim()))];
 }
 
 function loadRuntimePolicy(root = reposRoot(), snapshot = null) {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2715,6 +2715,43 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
+  test("a direct dispatch enforces an in-repo-only escalate_paths overlay", () => {
+    const checkout = tmpDir("evrt-escalate-overlay-");
+    writeFileSync(
+      path.join(checkout, ".factory.yaml"),
+      "schemaVersion: factory.repo/v1\nescalate_paths:\n  - src/auth/**\n",
+    );
+    withReposRoot(
+      `repos:\n  - name: overlaid\n    path: ${checkout}\n    base: develop\n` +
+        `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+        `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,
+      () => {
+        const result = worktreeDispatchAutoEligibility(
+          { repo: "overlaid", ticket: "WM-1797" },
+          {
+            countLeases: () => 0,
+            budgetRefusal: () => null,
+            fetchTicket: () => ({
+              identifier: "WM-1797",
+              state: { name: "Todo" },
+              assignee: null,
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+              description: "## Owned Paths\n- src/auth/session.ts\n",
+            }),
+            fetchInFlight: () => [],
+          },
+        );
+        expect(result.refusal).toMatchObject({
+          decision: "noop",
+          reason: "escalate_paths_intersect",
+        });
+        expect(result.evidence.escalatePathIntersections).toEqual([
+          "src/auth/**",
+        ]);
+      },
+    );
+  });
+
   test("dispatch also defers when merge-fix already owns the ticket worktree", () => {
     withReposRoot(
       `repos:\n  - name: fixture\n    path: /tmp/fixture\n    base: develop\n    team: WM\n    project: Factory\n    worktree_up: /tmp/worktree-up\n    worktree_down: /tmp/worktree-down\n    worktree_root: /tmp/worktrees\n    escalate_paths: []\n`,


### PR DESCRIPTION
Fixes watt-mind/factory#1797

Enforces in-repo `escalate_paths` overlays during direct dispatch planning.

## Validation

| Check                | Command                                                                                                 | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs && bun run lint`                                          | pass    | 119 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 existing warnings |
| UX critique          | `factory-ux-critic`                                                                                     | not run | no user-facing surface        |

UX critique: skipped — no user-facing surface
run:run_82485286-0337-4099-838d-57bd463130ad
