### PR TITLE
docs(inbox): document source presentation synthesis

### DIFF
--- a/docs/event-runtime-inbox.md
+++ b/docs/event-runtime-inbox.md
@@ -504,11 +504,24 @@ API:
 
 ```
 GET  /inbox/:id                → the item, with decision, response, responseHistory
+POST /inbox                    → creates an item; optional decision is validated
 POST /inbox/:id/decide         → body: factory.decision-response/v1 minus decidedAt
                                   200 { item, effect: { kind, outcome } }
 POST /inbox/:id/decide/retry   → re-run a failed effect with the stored response,
                                   or take over a pending claim abandoned by a crash (§3)
 ```
+
+`POST /inbox` has source-specific presentation rules. `serve:notify` and
+`agent:*` sources are machine-oriented inputs: their submitted `title` and
+`body` are passed through `synthesizeInboxItem()` and are not necessarily the
+persisted values. The synthesized body starts with `What happened:` and `Why
+it matters:`, then includes the reason code, links, and decision paragraphs
+when available, with the producer's original body appended last. For
+`decision_needed` and `proposal_expired` items with a proposal, the synthesized
+title is `Approve <agent> run (<subject>)?`. By contrast, `cli` items are
+stored verbatim, including their supplied title and body. Synthesis deliberately
+does not rewrite the serialized decision request: decision responses hash that
+request, so changing it would make an otherwise valid response stale.
 
 Decision endpoints return `{ error, message, errors? }`; `errors` is present
 only when validation supplies individual errors. The routes return

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -296,8 +296,29 @@ describe("human inbox ledger (WM-285)", () => {
       title: expected.title,
       body: expected.body,
     });
+    expect(created.title).not.toBe(input.title);
+    expect(created.body).not.toBe(input.body);
+    expect(created.body).toContain("What happened:");
+    expect(created.body).toContain("Why it matters:");
     expect(created.decision).toEqual(input.decision);
     expect(created.dedupeKey).toBe(input.dedupeKey);
+
+    const cli = createInboxItem(
+      db,
+      {
+        ...input,
+        title: "CLI title stays verbatim",
+        body: "CLI body stays verbatim.",
+        refs: { issue: "WM-2048", repo: "factory", runId: "run_cli" },
+        source: "cli",
+        dedupeKey: null,
+      },
+      { id: "cli_presentation", now: 1000 },
+    );
+    expect({ title: cli.title, body: cli.body }).toEqual({
+      title: "CLI title stays verbatim",
+      body: "CLI body stays verbatim.",
+    });
   });
 
   test("same-question open items attach as waiters instead of stacking rows", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2072

Documented source-specific inbox presentation so producers can predict stored content.

## Validation

| Check                | Command                                                                     | Result  | Notes                         |
| -------------------- | --------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs`                               | pass    | 52 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 existing warnings  |
| UX critique          | `factory-ux-critic`                                                       | not run | docs and unit test only       |

UX critique: skipped — docs and unit test only; no user-facing surface

run:run_863ab59f-7f4c-4924-a1d0-eb5599a635c1