### PR TITLE
fix(stack): dedupe GitHub App auth daemon

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -90,6 +90,19 @@ track_up_pidfile() { # <label> <pidfile>
   UP_STARTED_LABELS+=("$label")
 }
 
+untrack_up_pidfile() { # <pidfile>
+  local target="$1" i
+  local kept_pidfiles=() kept_labels=()
+  [[ ${#UP_STARTED_PIDFILES[@]} -gt 0 ]] || return 0
+  for i in "${!UP_STARTED_PIDFILES[@]}"; do
+    [[ "${UP_STARTED_PIDFILES[$i]}" == "$target" ]] && continue
+    kept_pidfiles+=("${UP_STARTED_PIDFILES[$i]}")
+    kept_labels+=("${UP_STARTED_LABELS[$i]}")
+  done
+  UP_STARTED_PIDFILES=("${kept_pidfiles[@]}")
+  UP_STARTED_LABELS=("${kept_labels[@]}")
+}
+
 track_up_pool_pidfiles() {
   local pidfile label
   for pidfile in "$RUN_DIR/supervisor.pid" "$RUN_DIR"/worker-[0-9]*.pid; do
@@ -282,6 +295,83 @@ if [[ "$ACTION" != "up" ]]; then
   mkdir -p "$RUN_DIR" "$HOME_DIR"
 fi
 REPO="$(repo_root)"
+
+gh_app_release_root() {
+  if [[ -n "${FACTORY_HOME:-}" ]]; then
+    printf '%s\n' "${FACTORY_HOME%/}/releases"
+  elif [[ "${FACTORY_ROOT:-}" == */releases/* ]]; then
+    printf '%s\n' "${FACTORY_ROOT%%/releases/*}/releases"
+  elif [[ "$REPO" == */releases/* ]]; then
+    printf '%s\n' "${REPO%%/releases/*}/releases"
+  fi
+}
+
+gh_app_daemon_command_matches() { # <ps command>
+  local command="$1" script release_root relative release_id
+  [[ "$command" =~ ^([^[:space:]]*/)?bun[[:space:]]+([^[:space:]]+)[[:space:]]+--daemon$ ]] \
+    || return 1
+  script="${BASH_REMATCH[2]}"
+  [[ "$script" == "$REPO/lib/control-plane/gh-app-auth.mjs" ]] && return 0
+
+  release_root="$(gh_app_release_root)"
+  [[ -n "$release_root" && "$script" == "$release_root/"* ]] || return 1
+  relative="${script#"$release_root/"}"
+  release_id="${relative%%/*}"
+  [[ -n "$release_id" && "$release_id" != "$relative" \
+    && "$relative" == "$release_id/lib/control-plane/gh-app-auth.mjs" ]]
+}
+
+gh_app_lock_file() {
+  printf '%s.lock\n' "${FACTORY_GH_APP_TOKEN_FILE:-$HOME/.factory/gh-app-token.json}"
+}
+
+gh_app_daemon_pid_is_valid() { # <pid>
+  local pid="$1" command owner
+  [[ "$pid" =~ ^[0-9]+$ && "$pid" -ne $$ ]] || return 1
+  kill -0 "$pid" 2>/dev/null || return 1
+  command="$(ps -p "$pid" -o command= 2>/dev/null || true)"
+  gh_app_daemon_command_matches "$command" || return 1
+  owner="$(cat "$(gh_app_lock_file)" 2>/dev/null || true)"
+  [[ "$owner" == "$pid" ]]
+}
+
+gh_app_daemon_pid() {
+  local pid command processes
+  processes="$(ps -axo pid=,command= 2>/dev/null || true)"
+  while read -r pid command; do
+    if gh_app_daemon_command_matches "$command" \
+      && gh_app_daemon_pid_is_valid "$pid"; then
+      printf '%s\n' "$pid"
+      return 0
+    fi
+  done <<<"$processes"
+  return 1
+}
+
+adopt_gh_app_daemon() { # <pid>
+  local pid="$1"
+  gh_app_daemon_pid_is_valid "$pid" || return 1
+  printf '%s\n' "$pid" >"$RUN_DIR/gh-app-auth.pid"
+  info "GitHub App token daemon already running (adopted pid $pid)"
+}
+
+wait_for_started_gh_app_daemon() { # <spawned pid>
+  local started_pid="$1" owner winner _
+  for _ in {1..50}; do
+    owner="$(cat "$(gh_app_lock_file)" 2>/dev/null || true)"
+    if [[ "$owner" == "$started_pid" ]] \
+      && pid_alive "$RUN_DIR/gh-app-auth.pid"; then
+      return 0
+    fi
+    if winner="$(gh_app_daemon_pid)"; then
+      untrack_up_pidfile "$RUN_DIR/gh-app-auth.pid"
+      rm -f "$RUN_DIR/gh-app-auth.pid"
+      adopt_gh_app_daemon "$winner" && return 0
+    fi
+    sleep 0.1
+  done
+  return 1
+}
 
 elapsed_seconds() {
   local elapsed="${1//[[:space:]]/}" days=0 rest hours=0 minutes=0 seconds=0
@@ -632,6 +722,8 @@ case "$ACTION" in
     if [[ -n "${FACTORY_GH_APP_ID:-}" && -n "${FACTORY_GH_APP_PRIVATE_KEY_PATH:-}" ]]; then
       if pid_alive "$RUN_DIR/gh-app-auth.pid"; then
         info "GitHub App token daemon already running (pid $(cat "$RUN_DIR/gh-app-auth.pid"))"
+      elif GH_APP_DAEMON_PID="$(gh_app_daemon_pid)"; then
+        adopt_gh_app_daemon "$GH_APP_DAEMON_PID"
       else
         info "minting initial GitHub App installation token"
         if ! (cd "$REPO" && bun "$REPO/lib/control-plane/gh-app-auth.mjs" >>"$RUN_DIR/gh-app-auth.log" 2>&1); then
@@ -640,6 +732,9 @@ case "$ACTION" in
         info "starting GitHub App token-refresh daemon"
         spawn_daemon_tracked "GitHub App token daemon" "$RUN_DIR/gh-app-auth.pid" "$RUN_DIR/gh-app-auth.log" "$REPO" \
           bun "$REPO/lib/control-plane/gh-app-auth.mjs" --daemon
+        GH_APP_STARTED_PID="$(cat "$RUN_DIR/gh-app-auth.pid")"
+        wait_for_started_gh_app_daemon "$GH_APP_STARTED_PID" \
+          || die "GitHub App token daemon exited during startup without an adoptable lock owner"
       fi
     fi
 

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -63,6 +63,10 @@ pid_alive() {
     [[ -f "$1.terminated" || -f "$1.exited" ]] && return 1
     return 0
   fi
+  if [[ "$(basename "$1")" == "gh-app-auth.pid" && -f "$1.fake" ]]; then
+    [[ -f "$1.terminated" || -f "$1.exited" ]] && return 1
+    return 0
+  fi
   [[ "\${FAKE_ALIVE:-0}" == "1" ]] || return 1
   [[ -f "$1" ]] || return 1
   [[ -f "$1.terminated" ]] && return 1
@@ -74,6 +78,10 @@ spawn_daemon() { # <pidfile> <logfile> <workdir> <cmd...>
   printf 'SPAWN pid=%s workdir=%s cmd=%s\\n' "$(basename "$pidfile")" "$workdir" "$*" >>"$SPAWN_LOG"
   if [[ "$(basename "$pidfile")" == "\${FAKE_SPAWN_FAIL_PIDFILE:-}" ]]; then return 1; fi
   printf '1\\n' >"$pidfile"
+  if [[ "$(basename "$pidfile")" == "gh-app-auth.pid" ]]; then
+    touch "$pidfile.fake"
+    printf '1\\n' >"\${FACTORY_GH_APP_TOKEN_FILE}.lock"
+  fi
   if [[ -n "\${FAKE_DAEMON_DIES_FOR:-}" && "$*" == *"\${FAKE_DAEMON_DIES_FOR}"* ]]; then
     printf 'fake daemon exited 1\\n' >"$logfile"
     touch "$pidfile.exited"
@@ -282,6 +290,7 @@ function runStack(fixture, args, extraEnv = {}) {
       BUILD_LOG: fixture.buildLog,
       FACTORY_RUN_DIR: path.join(fixture.root, "run"),
       FACTORY_EVENT_HOME: path.join(fixture.root, "home"),
+      FACTORY_GH_APP_TOKEN_FILE: path.join(fixture.root, "gh-app-token.json"),
       // Startup survival is covered by focused cases below. Keep unrelated
       // command-wiring tests immediate instead of paying the production 5s.
       FACTORY_WORKER_READY_TIMEOUT: "0",
@@ -303,6 +312,102 @@ function runStack(fixture, args, extraEnv = {}) {
 
 const spawnFor = (spawns, pidfile) =>
   spawns.find((line) => line.includes(`pid=${pidfile}`)) ?? "";
+
+async function startLockOwningGhAppProcess(fixture) {
+  const script = path.join(
+    fixture.root,
+    "lib",
+    "control-plane",
+    "gh-app-auth.mjs",
+  );
+  mkdirSync(path.dirname(script), { recursive: true });
+  writeFileSync(script, "setInterval(() => {}, 60_000);\n", "utf8");
+  const child = Bun.spawn({
+    cmd: [process.execPath, script, "--daemon"],
+    stdout: "ignore",
+    stderr: "ignore",
+  });
+  const deadline = Date.now() + 2_000;
+  while (Date.now() < deadline) {
+    const command = Bun.spawnSync({
+      cmd: ["ps", "-p", String(child.pid), "-o", "command="],
+      stdout: "pipe",
+      stderr: "ignore",
+    }).stdout.toString();
+    if (command.trim().endsWith(`${script} --daemon`)) {
+      writeFileSync(
+        path.join(fixture.root, "gh-app-token.json.lock"),
+        `${child.pid}\n`,
+      );
+      return child;
+    }
+    await Bun.sleep(5);
+  }
+  child.kill();
+  await child.exited;
+  throw new Error(`fake gh-app-auth process ${child.pid} did not start`);
+}
+
+async function stopProcess(child) {
+  try {
+    child.kill();
+  } catch {
+    // Already exited.
+  }
+  await child.exited;
+}
+
+test("`up` adopts a lock-owning GitHub App daemon when its pidfile is missing", async () => {
+  const f = makeFixture();
+  const daemon = await startLockOwningGhAppProcess(f);
+  try {
+    const r = runStack(f, ["up"], {
+      FACTORY_GH_APP_ID: "test-app",
+      FACTORY_GH_APP_PRIVATE_KEY_PATH: "/tmp/test-key",
+      FACTORY_HOME: f.root,
+      FACTORY_ROOT: f.root,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(
+      `GitHub App token daemon already running (adopted pid ${daemon.pid})`,
+    );
+    expect(readFileSync(path.join(f.runDir, "gh-app-auth.pid"), "utf8")).toBe(
+      `${daemon.pid}\n`,
+    );
+    expect(spawnFor(r.spawns, "gh-app-auth.pid")).toBe("");
+
+    const down = runStack(f, ["down"], { FAKE_ALIVE: "1" });
+    expect(down.status).toBe(0);
+    expect(down.spawns).toContain("TERM GitHub App token daemon");
+    expect(down.spawns).toContain("AWAIT GitHub App token daemon");
+  } finally {
+    await stopProcess(daemon);
+    f.cleanup();
+  }
+});
+
+test("`up` keeps the existing live GitHub App daemon pidfile behavior", () => {
+  const f = makeFixture();
+  try {
+    mkdirSync(f.runDir, { recursive: true });
+    writeFileSync(path.join(f.runDir, "gh-app-auth.pid"), "31337\n");
+    const r = runStack(f, ["up"], {
+      FACTORY_GH_APP_ID: "test-app",
+      FACTORY_GH_APP_PRIVATE_KEY_PATH: "/tmp/test-key",
+      FAKE_ALIVE: "1",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(
+      "GitHub App token daemon already running (pid 31337)",
+    );
+    expect(readFileSync(path.join(f.runDir, "gh-app-auth.pid"), "utf8")).toBe(
+      "31337\n",
+    );
+    expect(spawnFor(r.spawns, "gh-app-auth.pid")).toBe("");
+  } finally {
+    f.cleanup();
+  }
+});
 
 test("plain `up` spawns serve, worker, and the static web server — unchanged by --dev existing", () => {
   const f = makeFixture();

--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -23,6 +23,7 @@
  * codes and file paths only.
  */
 import { createSign } from "node:crypto";
+import { spawn } from "node:child_process";
 import {
   chmodSync,
   mkdirSync,
@@ -45,6 +46,8 @@ const RETRY_MAX_DELAY_MS = 5 * 60 * 1000;
 /** JWTs GitHub accepts must expire within 10 min; back-date `iat` for skew. */
 const JWT_LIFETIME_S = 9 * 60;
 const JWT_BACKDATE_S = 60;
+/** sysexits.h EX_TEMPFAIL: another daemon owns the token-cache lock. */
+export const DAEMON_ALREADY_RUNNING_EXIT_CODE = 75;
 
 const b64url = (input) => Buffer.from(input).toString("base64url");
 
@@ -335,12 +338,18 @@ export async function runDaemon({
   await new Promise((resolve) => {
     let timer = null;
     let stopped = false;
+    let refreshInFlight = false;
     let retryDelayMs = RETRY_INITIAL_DELAY_MS;
+    const finishStop = () => {
+      if (stopped && !refreshInFlight) resolve();
+    };
     const stop = () => {
       if (stopped) return;
       stopped = true;
       if (timer) clearTimeoutImpl(timer);
-      resolve();
+      // A signal must not release the advisory lock while resolveGhToken may
+      // still be rewriting the shared token cache.
+      finishStop();
     };
     signals.on?.("SIGTERM", stop);
     signals.on?.("SIGINT", stop);
@@ -356,9 +365,9 @@ export async function runDaemon({
     // timer is still re-armed, so one bad tick cannot kill the chain.
     const scheduleRefresh = async () => {
       let delayMs;
+      refreshInFlight = true;
       try {
         const { ok, expiresAt } = await refresh();
-        if (stopped) return;
         if (!ok) {
           delayMs = backoff();
         } else if (expiresAt == null) {
@@ -380,7 +389,6 @@ export async function runDaemon({
           delayMs = Math.min(intervalMs, refreshFromExpiry);
         }
       } catch (err) {
-        if (stopped) return;
         try {
           log.warn?.(
             `[gh-app-auth] refresh scheduling failed: ${err?.message ?? err}`,
@@ -389,6 +397,12 @@ export async function runDaemon({
           // A throwing logger must not take the daemon down with it.
         }
         delayMs = backoff();
+      } finally {
+        refreshInFlight = false;
+      }
+      if (stopped) {
+        finishStop();
+        return;
       }
       delayMs = Math.max(MIN_REFRESH_DELAY_MS, delayMs);
       // Keep the daemon's only wakeup handle referenced. In Bun, unref'ing it
@@ -401,8 +415,73 @@ export async function runDaemon({
   });
 }
 
+/**
+ * Public `--daemon` wrapper. `flock` owns the kernel advisory lock and runs an
+ * internal child only after acquisition, so crashes and reboots cannot strand
+ * a stale lock. The internal child writes the wrapper pid into the already
+ * locked file; live-stack uses that as its startup/adoption handshake.
+ */
+async function runLockedDaemon(config) {
+  const lockFile = `${config.tokenFile}.lock`;
+  mkdirSync(path.dirname(lockFile), { recursive: true });
+  const child = spawn(
+    "flock",
+    [
+      "--nonblock",
+      "--conflict-exit-code",
+      String(DAEMON_ALREADY_RUNNING_EXIT_CODE),
+      lockFile,
+      process.execPath,
+      import.meta.filename,
+      "--daemon-held",
+    ],
+    {
+      env: {
+        ...process.env,
+        FACTORY_GH_APP_DAEMON_OWNER_PID: String(process.pid),
+      },
+      stdio: "inherit",
+    },
+  );
+
+  let forwardedSignal = null;
+  const forward = (signal) => {
+    forwardedSignal ??= signal;
+    child.kill(signal);
+  };
+  const onTerm = () => forward("SIGTERM");
+  const onInt = () => forward("SIGINT");
+  process.once("SIGTERM", onTerm);
+  process.once("SIGINT", onInt);
+
+  let result;
+  try {
+    result = await new Promise((resolve, reject) => {
+      child.once("error", reject);
+      child.once("exit", (code, signal) => resolve({ code, signal }));
+    });
+  } finally {
+    process.removeListener("SIGTERM", onTerm);
+    process.removeListener("SIGINT", onInt);
+  }
+
+  if (forwardedSignal) {
+    process.kill(process.pid, forwardedSignal);
+    return;
+  }
+  if (result.signal) {
+    process.kill(process.pid, result.signal);
+    return;
+  }
+  if (result.code === DAEMON_ALREADY_RUNNING_EXIT_CODE) {
+    process.stderr.write(`[gh-app-auth] another daemon holds ${lockFile}\n`);
+  }
+  process.exitCode = result.code ?? 1;
+}
+
 if (import.meta.main) {
   const daemon = process.argv.includes("--daemon");
+  const daemonHeld = process.argv.includes("--daemon-held");
   const config = readAppConfig(process.env);
   if (!config) {
     process.stderr.write(
@@ -411,9 +490,28 @@ if (import.meta.main) {
     );
     process.exit(2);
   }
-  if (daemon) {
+  if (daemonHeld) {
+    const ownerPid = process.env.FACTORY_GH_APP_DAEMON_OWNER_PID;
+    const lockFile = `${config.tokenFile}.lock`;
+    if (!/^\d+$/.test(ownerPid ?? "")) {
+      process.stderr.write("gh-app-auth: daemon lock owner pid is missing\n");
+      process.exit(1);
+    }
+    // Publish the wrapper pid only after daemon startup has passed its one
+    // synchronous failure boundary. A missing/unreadable key must look like a
+    // failed startup to live-stack, not a briefly successful handshake.
+    readFileSync(config.privateKeyPath, "utf8");
+    writeFileSync(lockFile, `${ownerPid}\n`, { mode: 0o600 });
+    chmodSync(lockFile, 0o600);
     await runDaemon().catch((err) => {
       process.stderr.write(`gh-app-auth: ${err?.message ?? err}\n`);
+      process.exit(1);
+    });
+  } else if (daemon) {
+    await runLockedDaemon(config).catch((err) => {
+      process.stderr.write(
+        `gh-app-auth: failed to start daemon lock: ${err?.message ?? err}\n`,
+      );
       process.exit(1);
     });
   } else {

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -8,12 +8,19 @@
  */
 import { afterAll, describe, expect, test } from "bun:test";
 import { createVerify, generateKeyPairSync } from "node:crypto";
-import { mkdtempSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { rmSync } from "node:fs";
 import {
   buildAppJwt,
+  DAEMON_ALREADY_RUNNING_EXIT_CODE,
   mintInstallationToken,
   readCachedAppToken,
   resolveGhToken,
@@ -317,6 +324,88 @@ describe("runDaemon", () => {
     log: { log() {}, warn() {} },
     setTimeoutImpl: timers.setTimeoutImpl,
     clearTimeoutImpl: timers.clearTimeoutImpl,
+  });
+
+  test("a second CLI daemon exits 75 with the lock-holder message", async () => {
+    const dir = tmp("gh-app-daemon-lock-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: "2099-01-01T00:00:00Z",
+      }),
+    );
+    const script = path.join(import.meta.dir, "gh-app-auth.mjs");
+    const first = Bun.spawn({
+      cmd: [process.execPath, script, "--daemon"],
+      env: { ...process.env, ...env },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+    const lockFile = `${env.FACTORY_GH_APP_TOKEN_FILE}.lock`;
+    try {
+      const deadline = Date.now() + 2_000;
+      while (
+        Date.now() < deadline &&
+        (!existsSync(lockFile) ||
+          readFileSync(lockFile, "utf8").trim() !== String(first.pid))
+      ) {
+        await Bun.sleep(5);
+      }
+      expect(readFileSync(lockFile, "utf8").trim()).toBe(String(first.pid));
+
+      const second = Bun.spawnSync({
+        cmd: [process.execPath, script, "--daemon"],
+        env: { ...process.env, ...env },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      expect(second.exitCode).toBe(DAEMON_ALREADY_RUNNING_EXIT_CODE);
+      expect(second.stderr.toString().trim()).toBe(
+        `[gh-app-auth] another daemon holds ${lockFile}`,
+      );
+    } finally {
+      first.kill("SIGTERM");
+      await first.exited;
+    }
+  });
+
+  test("SIGTERM waits for an in-flight refresh before daemon shutdown", async () => {
+    const start = Date.parse("2026-08-29T12:00:00Z");
+    const dir = tmp("gh-app-daemon-stop-refresh-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    const timers = fakeTimers(start);
+    const signals = daemonSignals();
+    let settleFetch;
+    const fetchImpl = () =>
+      new Promise((resolve) => {
+        settleFetch = resolve;
+      });
+    let settled = false;
+    const daemon = runDaemon(
+      daemonOptions(env, timers, signals, fetchImpl),
+    ).then(() => {
+      settled = true;
+    });
+    await flushDaemon();
+
+    signals.stop();
+    await flushDaemon();
+    expect(settled).toBe(false);
+
+    settleFetch({
+      ok: true,
+      status: 201,
+      json: async () => ({
+        token: "ghs_after_stop",
+        expires_at: new Date(start + 60 * 60 * 1000).toISOString(),
+      }),
+    });
+    await daemon;
+    expect(settled).toBe(true);
   });
 
   test("re-mints a cached token before its seven-minute expiry", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#1842

Adopts existing GitHub App auth daemons and prevents duplicate refreshers with a flock-backed lock.

## Validation

| Check                | Command                                                                                                                                              | Result  | Notes                                  |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs && bun test lib/control-plane/gh-app-auth.test.mjs && bun run lint`                                                | pass    | 71 tests, 0 failures; lint 0 errors    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                                    | pass    | 2360 tests; emit and formatting clean  |
| UX critique          | factory-ux-critic                                                                                                                                    | not run | backend daemon lifecycle; no UX surface |

UX critique: skipped — backend daemon lifecycle; no user-facing surface

run:run_dc59e863-f14c-4397-aa93-6f710afd031e
