### PR TITLE
fix(dispatch): classify unavailable web UI as blocked

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:d3910acad4ab461416f372fafcc6e88b8ba490e4bc87939b29b84aff1a7f65ab",
+    "agents/dispatch.md": "sha256:38b1bb3499f85ad0522e8327597a5b341d9e71610c82413be1f76e25539e293c",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -119,8 +119,11 @@ new ticket.
 
    Before the critic navigates, verify the fixture with
    `curl -fsS http://127.0.0.1:<web>/api/runs`: it must return HTTP 200 and a
-   `runs` payload. The critic must then observe the same successful
-   `GET /api/runs` and live run data in the browser before issuing `SHIP` or
+   `runs` payload. If the curl cannot connect (connection refused or no
+   listener), or `bin/worktree-up.sh` reported the web UI unavailable, report
+   `blocked — worktree web UI unavailable (baseline web build failed)` in the
+   Handoff and do not launch the critic. The critic must then observe the same
+   successful `GET /api/runs` and live run data in the browser before issuing `SHIP` or
    `FIX-FIRST`. A 401 or 403 is an **auth-fixture failure**, not a genuinely
    unassessable flow: report `required — NOT-ASSESSED, auth fixture failure
 (GET /api/runs HTTP <status>)` in the Handoff. Use
@@ -256,7 +259,7 @@ shell` means the spawn prompt was defective: correct its path/launch details
    ## Handoff
    - PR: <url>
    - Verification: `<exact command>` — pass, <one-line result>
-   - UX critique: required — SHIP | required — FIX-FIRST unresolved | required — NOT-ASSESSED, auth fixture failure (GET /api/runs HTTP 401/403) | required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); <genuinely unassessable reason> | blocked — <reason> | skipped — <reason>; evidence: <page URL or screenshot path, when required>
+   - UX critique: required — SHIP | required — FIX-FIRST unresolved | required — NOT-ASSESSED, auth fixture failure (GET /api/runs HTTP 401/403) | required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); <genuinely unassessable reason> | blocked — worktree web UI unavailable (baseline web build failed) | blocked — <reason> | skipped — <reason>; evidence: <page URL or screenshot path, when required>
    - Files: <n> changed, all within Owned Paths
    - Risks: <reviewer focus, or "none known">
    ```

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3232,9 +3232,9 @@ describe("buildRunSpec", () => {
       policyVersion: "git:test",
       now: 0,
     });
-    // Regenerated (#2013): dispatch documents draft PR readiness; prompt pin only.
+    // Regenerated (#2071): unavailable worktree web UIs now block UX critique.
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:4a12ffc0fa80ad8b97a9757361ee319589c3567de36f8d9aa33ef917ff26a4d2","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:1843e0a20438d74a3ec58d766c020a13c4677da3da00b72e907fd02e4f3dfe00","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -270,6 +270,9 @@ describe("registry", () => {
     expect(prompt).toContain("auth-fixture failure");
     expect(prompt).toContain("HTTP 401/403");
     expect(prompt).toContain("genuinely unassessable");
+    expect(prompt).toContain(
+      "blocked — worktree web UI unavailable (baseline web build failed)",
+    );
   });
 
   test("zero-pack merged-view digest matches the develop baseline", () => {
@@ -432,8 +435,10 @@ describe("registry", () => {
     // CLI and re-pins its definition; the prompt pin is a registry input.
     // Regenerated (#2013): dispatch documents draft PR readiness and refreshes
     // its prompt pin; the registry digest follows it.
+    // Regenerated (#2071): unavailable worktree web UIs are blocked before a
+    // UX critic can misclassify a connection failure as an auth-fixture issue.
     const expected =
-      "sha256:3d12b762b3946e9e6e95e033d28f628affa970e27bf4633c695b2d8be0b11013";
+      "sha256:2f271e47dad4a9e1b03ba3f1febed267b1ae97968828934bcaa855b28dcf6a86";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -734,8 +739,10 @@ describe("registry", () => {
     // prompt pin only, `pack` remains non-enumerable.
     // Regenerated (#2013): dispatch documents draft PR readiness; prompt pin
     // only, `pack` remains non-enumerable.
+    // Regenerated (#2071): dispatch blocks an unavailable web UI before UX
+    // critique, then re-pins the prompt definition.
     expect(computeDefHash(def)).toBe(
-      "sha256:4a12ffc0fa80ad8b97a9757361ee319589c3567de36f8d9aa33ef917ff26a4d2",
+      "sha256:1843e0a20438d74a3ec58d766c020a13c4677da3da00b72e907fd02e4f3dfe00",
     );
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2071

Classify unavailable worktree web UIs as blocked before a UX critic is launched.

## Validation

| Check                | Command                                                        | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/registry.test.mjs` | pass | 180 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | all gates passed; 615 existing warnings |
| UX critique          | factory-ux-critic                                              | not run | documentation-only; no user-facing surface |

UX critique: skipped — documentation-only dispatch prompt and contract-test update; no user-facing surface

run:run_ab383c46-8c53-4b97-8508-e543b6da9f72