### PR TITLE
fix(ci-log-capture): pin failed workflow attempts

### DIFF
--- a/event-runtime/agents/ci-log-capture.json
+++ b/event-runtime/agents/ci-log-capture.json
@@ -5,17 +5,8 @@
   "input_schema": "schemas/ci-log-capture.input.json",
   "output_schema": "schemas/ci-log-captured.output.json",
   "output_contract": "factory.ci-log/v1",
-  "command": [
-    "gh",
-    "run",
-    "view",
-    "{runId}",
-    "--repo",
-    "{repo}",
-    "--log-failed"
-  ],
-  "captureStdout": "failed.log",
-  "captureKind": "ci-log",
+  "command": ["bun", "{factoryRoot}/event-runtime/lib/ci-log-capture.mjs"],
+  "writesResult": true,
   "workspace": {
     "type": "ephemeral",
     "retainOnFailure": true
@@ -30,8 +21,8 @@
   },
   "mutating": false,
   "pins": {
-    "agents/ci-log-capture.md": "sha256:64e2d368336668dd308376e36cdfd65566171aff3c224282b6c06e6109a3d47a",
-    "schemas/ci-log-capture.input.json": "sha256:ed7be9a461a6a228c883cc86abdba47124c11cb643673830efc8c36650928aab",
+    "agents/ci-log-capture.md": "sha256:374503ad5d9165653e20b38bad4e5a4bf669189f23cb222a5a34363b0fb632d7",
+    "schemas/ci-log-capture.input.json": "sha256:dfc36e45e029ca657faed46b092b8ae8cb1e559bf3aba0895520f9a26060e82a",
     "schemas/ci-log-captured.output.json": "sha256:8aac0c5e79334909cbd2883ecdc5acab7ab5f7385fd74e251606ef66978b33b5"
   }
 }

--- a/event-runtime/agents/ci-log-capture.md
+++ b/event-runtime/agents/ci-log-capture.md
@@ -1,14 +1,37 @@
-# ci-log-capture — closed-registry action
+# ci-log-capture@1
 
 Not a prompt: this definition runs a fixed command template via the
 deterministic command adapter (`lib/adapters/command.mjs`). No model runs.
 
 ```
-gh run view {runId} --repo {repo} --log-failed
+bun {factoryRoot}/event-runtime/lib/ci-log-capture.mjs
 ```
 
-The **whole** stream is captured to `failed.log` and declared as an artifact,
-so the worker stores it content-addressed. Downstream `ci-doctor@2` reads
-those exact bytes instead of calling GitHub again: the diagnosis becomes
-reproducible and re-runnable offline, and a multi-megabyte log lives in the
-artifact store rather than blowing the inline-evidence limit.
+The script reads `input.json` from the workspace and writes `result.json`
+itself (`writesResult: true`). When the webhook carried `runAttempt`, it pins
+the read to that attempt instead of the run's latest one:
+
+```
+gh run view {runId} --log-failed --attempt {runAttempt} --repo {repo}
+```
+
+Inputs without a usable `runAttempt` fall back to the previous
+`gh run view {runId} --log-failed --repo {repo}` command unchanged. Pinning
+matters because the failed-run webhook routinely arrives while a re-run is
+already in flight: `--log-failed` reads the LATEST attempt, finds it still
+running, prints nothing, and exits 1 — the failure this definition exists to
+capture is lost and the dispatch is recorded as `agent_exit_1` (#2076).
+
+"Nothing to capture" is a normal terminal outcome, not a fault. A deleted
+run, a 404/410 attempt, an expired or cancelled attempt, and an empty
+download all record `captured: "none"` with an explicit `no_logs` reason,
+declare no `ci-log` artifact, and exit 0. Auth, network, quota, and a missing
+`gh` remain non-zero. The `factory.ci-diagnose.requested` edge keys on
+`captured: "failed.log"` (`edges.json`), so a no-log capture completes without
+asking for a diagnosis of bytes that do not exist.
+
+When the download has bytes, `failed.log` is declared as the `ci-log`
+artifact, so the worker stores it content-addressed. Downstream `ci-doctor@2`
+then reads those exact bytes instead of calling GitHub again: the diagnosis
+becomes reproducible and re-runnable offline, and a multi-megabyte log lives
+in the artifact store rather than blowing the inline-evidence limit.

--- a/event-runtime/edges.json
+++ b/event-runtime/edges.json
@@ -67,9 +67,9 @@
     }
   },
   "ci-log-capture@1": {
-    "recommendationField": "exitCode",
+    "recommendationField": "captured",
     "edges": {
-      "0": {
+      "failed.log": {
         "eventType": "factory.ci-diagnose.requested",
         "input": {
           "repo": "$.input.repo",

--- a/event-runtime/lib/ci-log-capture.mjs
+++ b/event-runtime/lib/ci-log-capture.mjs
@@ -1,0 +1,177 @@
+/**
+ * ci-log-capture@1's command (#2076).
+ *
+ * `gh run view --log-failed` always reads a run's LATEST attempt, and the
+ * failed-run webhook fires while a re-run is often already in flight — so by
+ * capture time the failed attempt has been superseded, `gh` prints nothing,
+ * exits 1, and the whole dispatch is recorded as `agent_exit_1`. The webhook
+ * does carry `workflow_run.run_attempt` (lib/intake.mjs puts it in the
+ * payload), so when it is present this pins the read to that exact attempt:
+ *
+ *     gh run view <runId> --log-failed --attempt <runAttempt> --repo <repo>
+ *
+ * Plaintext, failed jobs only — the same bytes ci-doctor@2 already consumes
+ * from `failed.log`. (`gh api .../attempts/{n}/logs` is NOT usable here: it
+ * returns a ZIP of every job's log, and `gh api` has no output-to-file flag.)
+ * Without an attempt the pre-#2076 command is used unchanged.
+ *
+ * The second half of the ticket: "there is nothing to capture" is a normal
+ * terminal outcome. A deleted run, an expired or cancelled attempt, or an
+ * empty log leaves `artifact.captured === "none"`, declares no `ci-log`
+ * artifact, and exits 0 — so the run records COMPLETED-with-no-logs and the
+ * `captured: "failed.log"` edge to factory.ci-diagnose.requested (edges.json)
+ * simply does not fire. Genuine faults — auth, network, quota, a missing
+ * `gh` — still exit non-zero and are still `agent_exit_<code>`.
+ */
+import { spawnSync } from "node:child_process";
+import {
+  closeSync,
+  existsSync,
+  openSync,
+  readFileSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+/** The capture target, and the `captured` value the ci-diagnose edge keys on. */
+export const LOG_FILE = "failed.log";
+/** `captured` when the attempt had no retrievable log. No edge keys on it. */
+export const NO_CAPTURE = "none";
+
+const DETAIL_LIMIT = 400;
+
+/**
+ * `gh` output that means "this attempt's logs are gone", not "the capture
+ * broke": the run was deleted, the attempt 404/410s, the log retention window
+ * closed, or the run was cancelled before any job produced a log.
+ */
+const EXPECTED_MISSING =
+  /HTTP (?:404|410)|not found|no logs|log[s]? (?:have )?expired|cancell?ed/i;
+
+/**
+ * The pinned-attempt argv, and the legacy fallback when the event carries no
+ * usable attempt. A non-integer or sub-1 attempt degrades to the fallback
+ * rather than producing a nonsense `--attempt` value.
+ */
+export function buildArgv(input = {}) {
+  const raw = input.runAttempt;
+  const attempt = Number.isInteger(raw) && raw >= 1 ? raw : null;
+  return {
+    attempt,
+    argv: [
+      "gh",
+      "run",
+      "view",
+      String(input.runId),
+      "--log-failed",
+      ...(attempt === null ? [] : ["--attempt", String(attempt)]),
+      "--repo",
+      String(input.repo),
+    ],
+  };
+}
+
+/**
+ * Spawn `gh` with stdout wired straight to the log file: a failed-job log is
+ * routinely multi-megabyte, so it must never pass through a stdout buffer.
+ */
+function spawnToFile(argv, logPath) {
+  const fd = openSync(logPath, "w");
+  try {
+    const child = spawnSync(argv[0], argv.slice(1), {
+      stdio: ["ignore", fd, "pipe"],
+      encoding: "utf8",
+    });
+    if (child.error) {
+      // Could not even start `gh` — a fault, never an expected-missing log.
+      return {
+        exitCode: child.status ?? 1,
+        stderr: String(child.error.message),
+      };
+    }
+    return { exitCode: child.status ?? 1, stderr: child.stderr ?? "" };
+  } finally {
+    closeSync(fd);
+  }
+}
+
+/**
+ * @returns {{ ok: boolean, captured: string, reason: string, argv: string[],
+ *             exitCode: number, result?: object }}
+ *   `ok: false` is a genuine fault: the caller exits `exitCode` and writes no
+ *   result, so the worker records FAILED as it always has.
+ */
+export function captureCiLog({
+  cwd = process.cwd(),
+  input,
+  spawn = spawnToFile,
+} = {}) {
+  const logPath = path.join(cwd, LOG_FILE);
+  const { argv, attempt } = buildArgv(input);
+  const { exitCode, stderr } = spawn(argv, logPath);
+
+  const bytes = existsSync(logPath) ? statSync(logPath).size : 0;
+  const captured = exitCode === 0 && bytes > 0;
+  // An empty or partial file is not an artifact; leaving it would declare
+  // zero bytes to the store and hand ci-doctor@2 an empty log.
+  if (!captured && existsSync(logPath)) unlinkSync(logPath);
+
+  const detail = String(stderr ?? "");
+  if (!captured && exitCode !== 0 && !EXPECTED_MISSING.test(detail)) {
+    return {
+      ok: false,
+      captured: NO_CAPTURE,
+      reason: detail.trim().slice(0, DETAIL_LIMIT) || "gh failed",
+      argv,
+      exitCode: exitCode || 1,
+    };
+  }
+
+  const reason = captured
+    ? `captured ${attempt === null ? "current run" : `attempt ${attempt}`} logs`
+    : exitCode === 0
+      ? "no_logs: gh reported no failed-job logs"
+      : `no_logs: ${detail.trim().slice(0, DETAIL_LIMIT) || "logs unavailable"}`;
+
+  const result = {
+    schemaVersion: "factory.agent-result/v1",
+    terminalState: "completed",
+    reasonCode: "ok",
+    artifact: {
+      command: argv,
+      exitCode: 0,
+      outputTail: reason,
+      captured: captured ? LOG_FILE : NO_CAPTURE,
+    },
+    evidence: { command: argv, outputTail: reason },
+    ...(captured ? { artifacts: [{ kind: "ci-log", path: LOG_FILE }] } : {}),
+  };
+  writeFileSync(
+    path.join(cwd, "result.json"),
+    `${JSON.stringify(result, null, 2)}\n`,
+    "utf8",
+  );
+  return {
+    ok: true,
+    captured: result.artifact.captured,
+    reason,
+    argv,
+    exitCode: 0,
+    result,
+  };
+}
+
+export function main(cwd = process.cwd()) {
+  const input = JSON.parse(readFileSync(path.join(cwd, "input.json"), "utf8"));
+  const outcome = captureCiLog({ cwd, input });
+  if (!outcome.ok) {
+    process.stderr.write(`${outcome.reason}\n`);
+    return outcome.exitCode;
+  }
+  process.stdout.write(`${outcome.reason}\n`);
+  return 0;
+}
+
+if (import.meta.main) process.exit(main());

--- a/event-runtime/lib/ci-log-capture.test.mjs
+++ b/event-runtime/lib/ci-log-capture.test.mjs
@@ -1,0 +1,140 @@
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-ci-log-capture-test-mjs";
+import { describe, expect, test } from "bun:test";
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+import {
+  LOG_FILE,
+  NO_CAPTURE,
+  buildArgv,
+  captureCiLog,
+} from "./ci-log-capture.mjs";
+import { loadRegistry } from "./registry.mjs";
+
+const registry = loadRegistry();
+const INPUT = { repo: "watt-mind/factory", runId: 33300511167 };
+
+/** A `gh` stand-in: writes `stdout` to the log file and returns its exit. */
+function fakeGh({ stdout = "", stderr = "", exitCode = 0 }) {
+  const calls = [];
+  const spawn = (argv, logPath) => {
+    calls.push(argv);
+    writeFileSync(logPath, stdout, "utf8");
+    return { exitCode, stderr };
+  };
+  spawn.calls = calls;
+  return spawn;
+}
+
+function readResult(cwd) {
+  return JSON.parse(readFileSync(path.join(cwd, "result.json"), "utf8"));
+}
+
+describe("ci-log-capture command (#2076)", () => {
+  test("pins the failed attempt with gh run view --log-failed --attempt", () => {
+    expect(buildArgv({ ...INPUT, runAttempt: 3 }).argv).toEqual([
+      "gh",
+      "run",
+      "view",
+      "33300511167",
+      "--log-failed",
+      "--attempt",
+      "3",
+      "--repo",
+      "watt-mind/factory",
+    ]);
+  });
+
+  // `gh api` has no output-to-file flag and its attempts/logs endpoint returns
+  // a ZIP; ci-doctor@2 reads failed.log as plaintext, so the argv must stay
+  // `gh run view`.
+  test("never reaches for gh api", () => {
+    for (const runAttempt of [undefined, 2]) {
+      const { argv } = buildArgv({ ...INPUT, runAttempt });
+      expect(argv.slice(0, 3)).toEqual(["gh", "run", "view"]);
+      expect(argv).not.toContain("api");
+      expect(argv).not.toContain("--output");
+    }
+  });
+
+  test("an unusable attempt degrades to the no-attempt fallback", () => {
+    for (const runAttempt of [undefined, null, 0, -1, 1.5, "2"]) {
+      const { attempt, argv } = buildArgv({ ...INPUT, runAttempt });
+      expect(attempt).toBeNull();
+      expect(argv).not.toContain("--attempt");
+    }
+  });
+
+  test("a captured attempt declares the ci-log artifact and fires the ci-diagnose edge", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-hit-");
+    const spawn = fakeGh({ stdout: "##[error]socket hang up\n" });
+    const outcome = captureCiLog({
+      cwd,
+      input: { ...INPUT, runAttempt: 1 },
+      spawn,
+    });
+
+    expect(spawn.calls[0]).toContain("--attempt");
+    expect(outcome.ok).toBe(true);
+    expect(existsSync(path.join(cwd, LOG_FILE))).toBe(true);
+
+    const result = readResult(cwd);
+    expect(result.artifact.captured).toBe("failed.log");
+    expect(result.terminalState).toBe("completed");
+    expect(result.artifacts).toEqual([{ kind: "ci-log", path: "failed.log" }]);
+
+    // The captured value is exactly the edge key the chain resolver selects on
+    // (lib/chain.mjs reads result.artifact[recommendationField]).
+    const rule = registry.edges["ci-log-capture@1"];
+    expect(rule.recommendationField).toBe("captured");
+    expect(rule.edges[result.artifact.captured].eventType).toBe(
+      "factory.ci-diagnose.requested",
+    );
+  });
+
+  test("a superseded or deleted attempt completes with captured: none and no edge", () => {
+    for (const stderr of [
+      "gh: Not Found (HTTP 404)",
+      "no logs found for this run",
+      "run was cancelled",
+    ]) {
+      const cwd = tmpDir("evrt-ci-log-capture-miss-");
+      const outcome = captureCiLog({
+        cwd,
+        input: { ...INPUT, runAttempt: 2 },
+        spawn: fakeGh({ stderr, exitCode: 1 }),
+      });
+      expect(outcome.ok).toBe(true);
+
+      const result = readResult(cwd);
+      expect(result.artifact.captured).toBe(NO_CAPTURE);
+      expect(result.artifact.exitCode).toBe(0);
+      expect(result.artifact.outputTail).toStartWith("no_logs:");
+      expect(result.artifacts).toBeUndefined();
+      // No zero-byte file is left behind to be stored as an "artifact".
+      expect(existsSync(path.join(cwd, LOG_FILE))).toBe(false);
+      expect(
+        registry.edges["ci-log-capture@1"].edges[result.artifact.captured],
+      ).toBeUndefined();
+    }
+  });
+
+  test("an empty log on a clean exit is no_logs, not a zero-byte artifact", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-empty-");
+    captureCiLog({ cwd, input: INPUT, spawn: fakeGh({ stdout: "" }) });
+    const result = readResult(cwd);
+    expect(result.artifact.captured).toBe(NO_CAPTURE);
+    expect(existsSync(path.join(cwd, LOG_FILE))).toBe(false);
+  });
+
+  test("a genuine fault stays non-zero and writes no result", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-fault-");
+    const outcome = captureCiLog({
+      cwd,
+      input: INPUT,
+      spawn: fakeGh({ stderr: "gh: authentication required", exitCode: 4 }),
+    });
+    expect(outcome.ok).toBe(false);
+    expect(outcome.exitCode).toBe(4);
+    expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
+  });
+});

--- a/event-runtime/lib/intake.mjs
+++ b/event-runtime/lib/intake.mjs
@@ -202,7 +202,9 @@ function repoForSlug(repos, slug) {
  *                 (short name); `report_only` repos never yield it.
  *   workflow_run  completed + failure on a configured repo → the EXISTING
  *                 `github.workflow-run.failed` shape ci-log-capture consumes
- *                 ({repo: owner/name slug, runId}); report_only repos included.
+ *                 ({repo: owner/name slug, runId, runAttempt?}); report_only
+ *                 repos included. The attempt keeps a later re-run from
+ *                 replacing the failed attempt's capture target.
  *
  * eventId is GitHub's delivery GUID, so at-least-once delivery dedupes on the
  * (source, eventId) key like every other admission. Anything else is a typed
@@ -280,15 +282,28 @@ export function translateGitHubEvent({
     if (!repo) return { ok: false, ignored: true, reason: "unconfigured_repo" };
     if (run.id === undefined || run.id === null)
       return { ok: false, ignored: false, reason: "malformed_payload" };
+    // A malformed attempt is not a malformed event: the run id — the thing
+    // the capture actually needs — is intact, so drop the attempt and let
+    // ci-log-capture take its no-attempt fallback rather than losing the
+    // failure entirely.
+    const attempt =
+      Number.isInteger(run.run_attempt) && run.run_attempt >= 1
+        ? run.run_attempt
+        : null;
     return {
       ok: true,
       // The existing shape ci-log-capture@1 consumes: the GitHub slug, not the
-      // short name — see schemas/ci-log-capture.input.json.
+      // short name — see schemas/ci-log-capture.input.json. Including the
+      // webhook's attempt also makes each re-run a distinct input hash.
       envelope: {
         ...base,
         type: "github.workflow-run.failed",
         subject: "ci",
-        payload: { repo: slug, runId: run.id },
+        payload: {
+          repo: slug,
+          runId: run.id,
+          ...(attempt === null ? {} : { runAttempt: attempt }),
+        },
       },
     };
   }

--- a/event-runtime/lib/intake.test.mjs
+++ b/event-runtime/lib/intake.test.mjs
@@ -464,20 +464,37 @@ describe("translateGitHubEvent repository slug matching (WM-1803)", () => {
     });
   });
 
-  test("emits workflow failures for mixed-case repository slugs without changing the delivered slug", () => {
+  test("emits workflow failures with their attempt for mixed-case repository slugs", () => {
     expect(
       translate("workflow_run", {
         action: "completed",
-        workflow_run: { id: 1803, conclusion: "failure" },
+        workflow_run: { id: 1803, run_attempt: 2, conclusion: "failure" },
         repository: { full_name: "wATT-mIND/fACTORY" },
       }),
     ).toMatchObject({
       ok: true,
       envelope: {
         type: "github.workflow-run.failed",
-        payload: { repo: "wATT-mIND/fACTORY", runId: 1803 },
+        payload: { repo: "wATT-mIND/fACTORY", runId: 1803, runAttempt: 2 },
       },
     });
+  });
+
+  // The run id is what the capture needs; a junk attempt only costs the pin,
+  // so the event still admits and ci-log-capture takes its fallback (#2076).
+  test("degrades an unusable run_attempt to the no-attempt fallback instead of rejecting", () => {
+    for (const run_attempt of [0, -1, 1.5, "2", null, {}]) {
+      const outcome = translate("workflow_run", {
+        action: "completed",
+        workflow_run: { id: 2076, run_attempt, conclusion: "failure" },
+        repository: { full_name: "watt-mind/factory" },
+      });
+      expect(outcome.ok).toBe(true);
+      expect(outcome.envelope.payload).toEqual({
+        repo: "watt-mind/factory",
+        runId: 2076,
+      });
+    }
   });
 
   test("keeps empty and non-string repository slugs unconfigured", () => {

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -437,8 +437,12 @@ describe("registry", () => {
     // its prompt pin; the registry digest follows it.
     // Regenerated (#2071): unavailable worktree web UIs are blocked before a
     // UX critic can misclassify a connection failure as an auth-fixture issue.
+    // Regenerated (#2076): ci-log-capture pins the failed workflow attempt via
+    // an auditable script, records expected missing logs as a completed
+    // no-artifact outcome, and only chains a diagnosis when a ci-log artifact
+    // was captured.
     const expected =
-      "sha256:2f271e47dad4a9e1b03ba3f1febed267b1ae97968828934bcaa855b28dcf6a86";
+      "sha256:5e787a02b59c4816c24abde6225cb568673d85f9d1fa3a6a1706d4468ca35015";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/ci-log-capture.input.json
+++ b/event-runtime/schemas/ci-log-capture.input.json
@@ -12,6 +12,11 @@
     "runId": {
       "type": ["string", "integer"],
       "description": "GitHub Actions run id whose failed-job logs to capture (number, or numeric string as gh prints it)"
+    },
+    "runAttempt": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "GitHub Actions attempt from the failed workflow_run webhook; when absent, capture falls back to the run's current failed-job logs for compatibility"
     }
   }
 }


### PR DESCRIPTION
## Summary
- propagate GitHub workflow `run_attempt` into failed-run events and the ci-log capture input
- fetch attempt-scoped logs when available and retain the legacy capture fallback for old events
- complete successfully for expired, cancelled, or empty logs without emitting a ci-log artifact or diagnosis edge

## Verification
- `bun test event-runtime/lib/intake.test.mjs event-runtime/lib/intake-github.test.mjs event-runtime/lib/chain.test.mjs`
- `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`

Closes #2076
