### PR TITLE
refactor(planner): dedupe escalation path loading

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -920,25 +920,14 @@ export function inFlightDispatchForTicket(db, payload) {
 }
 
 function loadRepoEscalatePaths(repoName, root = reposRoot(), snapshot = null) {
-  if (snapshot) {
-    let repo;
-    try {
-      repo = getRepo(snapshotRepos(snapshot), repoName);
-    } catch (err) {
-      throw new RepoError(
-        `${reposConfigPath(root)}: cannot verify escalate_paths: ${err.message}`,
-      );
-    }
-    if (!Array.isArray(repo.escalatePaths)) {
-      throw new RepoError(
-        `${reposConfigPath(root)}: repo ${repoName} must declare escalate_paths as an array (use [] only when deliberately empty)`,
-      );
-    }
-    return [...new Set(repo.escalatePaths.map((item) => item.trim()))];
-  }
   let repo;
   try {
-    repo = getRepo(loadRepos({ root }), repoName);
+    // `loadRepos` validates the entire host registry deliberately: host-wide
+    // routing, lifecycle, and capacity facts must come from one coherent
+    // configuration revision. An invalid unrelated stanza therefore blocks
+    // dispatch rather than letting this gate evaluate against a partial view.
+    const repos = snapshot ? snapshotRepos(snapshot) : loadRepos({ root });
+    repo = getRepo(repos, repoName);
   } catch (err) {
     throw new RepoError(
       `${reposConfigPath(root)}: cannot verify escalate_paths: ${err.message}`,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2416,6 +2416,29 @@ describe("planEvent worktree gate (WM-108)", () => {
     );
   });
 
+  test("an invalid unrelated registry stanza blocks dispatch from a partial config", () => {
+    const healthyRepo =
+      `repos:\n  - name: healthy\n    path: /tmp/healthy\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n` +
+      `  - name: malformed\n    path: /tmp/malformed\n    max_in_flight: many\n`;
+    withReposRoot(healthyRepo, () => {
+      const result = worktreeDispatchAutoEligibility(
+        { repo: "healthy", ticket: "WM-694" },
+        tierDispatch(),
+      );
+      // The registry is host-wide policy. Do not dispatch from a partial
+      // parse, even though the malformed entry is not the target repo.
+      expect(result.refusal).toMatchObject({
+        decision: "human_needed",
+      });
+      expect(result.refusal.reason).toMatch(/^repo_unknown: /);
+      expect(result.refusal.reason).toContain(
+        "repo malformed max_in_flight must be a positive number",
+      );
+    });
+  });
+
   test("whole-repo Owned Paths refuses distinctly before wildcard escalation", () => {
     withReposRoot(
       `repos:\n  - name: gated\n    path: /tmp/nowhere\n    base: develop\n` +


### PR DESCRIPTION
Fixes watt-mind/factory#2080

Deduplicate escalation-path validation while documenting registry-wide fail-closed behavior.

## Validation

| Check                | Command                                                                                                 | Result  | Notes                    |
| -------------------- | ------------------------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs event-runtime/lib/repos.test.mjs`                         | pass    | 194 tests, 0 failures    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean (warnings only)    |
| UX critique          | factory-ux-critic                                                                                       | not run | no user-facing surface   |

UX critique: skipped — backend planner refactor with no user-facing surface
run:run_ff057928-0a25-4e59-bea6-5cc53183265f
