### PR TITLE
fix(run-spec): restore RunSpec contracts

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2723,7 +2723,6 @@ export function planEvent(
         runId,
         policyVersion,
         adapterOverride,
-        now,
         approvalPolicy,
         modelTierOverride,
         modelOverride: overlayModel,

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3230,7 +3230,6 @@ describe("buildRunSpec", () => {
     const spec = buildRunSpec(registry, dispatch, mapping, {
       runId: "run_baseline",
       policyVersion: "git:test",
-      now: 0,
     });
     // Regenerated (#2071): unavailable worktree web UIs now block UX critique.
     expect(canonicalJson(spec)).toBe(
@@ -3244,7 +3243,6 @@ describe("buildRunSpec", () => {
     const spec = buildRunSpec(registry, envelope(), mapping, {
       runId: "run_defhash",
       policyVersion: "git:test",
-      now: NOW,
     });
     // Present and computed with the canonical helper the worker's
     // claim-time verifyDefHash consumes.
@@ -3254,7 +3252,6 @@ describe("buildRunSpec", () => {
     const again = buildRunSpec(registry, envelope(), mapping, {
       runId: "run_defhash_2",
       policyVersion: "git:test",
-      now: NOW,
     });
     expect(again.defHash).toBe(spec.defHash);
     // Changes when attested definition content changes.
@@ -3267,7 +3264,7 @@ describe("buildRunSpec", () => {
       synthetic,
       envelope(),
       synthetic.eventTypes["factory.status-report.requested"],
-      { runId: "run_defhash_3", policyVersion: "git:test", now: NOW },
+      { runId: "run_defhash_3", policyVersion: "git:test" },
     );
     expect(mutated.defHash).not.toBe(spec.defHash);
     // Per-ticket model/model-tier overrides must NOT redefine the attested
@@ -3275,16 +3272,15 @@ describe("buildRunSpec", () => {
     const overridden = buildRunSpec(registry, envelope(), mapping, {
       runId: "run_defhash_4",
       policyVersion: "git:test",
-      now: NOW,
       modelTierOverride: "strong",
       modelOverride: "openai-codex/gpt-5.6-terra",
     });
     expect(overridden.defHash).toBe(spec.defHash);
   });
 
-  test("is pure and honors adapterOverride", () => {
+  test("is clock-independent and honors adapterOverride", () => {
     const mapping = registry.eventTypes["factory.status-report.requested"];
-    const opts = { runId: "run_x", policyVersion: "git:abc", now: NOW };
+    const opts = { runId: "run_x", policyVersion: "git:abc" };
     const a = buildRunSpec(registry, envelope(), mapping, opts);
     const b = buildRunSpec(registry, envelope(), mapping, opts);
     expect(hashJson(a)).toBe(hashJson(b));
@@ -3310,7 +3306,6 @@ describe("buildRunSpec", () => {
     const spec = buildRunSpec(synthetic, envelope(), mapping, {
       runId: "run_harness_pins",
       policyVersion: "git:test",
-      now: NOW,
     });
 
     expect(spec.harness).toEqual({ commands: ["factory-ticket"] });

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -359,7 +359,6 @@ export function approveProposal(
         runId: proposal.run_id,
         policyVersion,
         adapterOverride,
-        now,
         ...replanOptions,
       }),
       // configSnapshot can affect planning and is itself part of specs that

--- a/event-runtime/lib/run-spec.mjs
+++ b/event-runtime/lib/run-spec.mjs
@@ -30,7 +30,25 @@ export function idempotencyKeyFor(mapping, def, envelope, inputHash) {
   return `${def.ref}:${def.output_contract}:${parts.join(":")}`;
 }
 
-/** Return a typed mismatch when a tier model belongs to another adapter. */
+/**
+ * A tier-resolved model must be one of the configured values for its adapter.
+ * Model tiers are portable intent; model names are not. Keep this at the
+ * planning boundary so a bad runtime overlay or carried-forward pin parks the
+ * event rather than producing a QUEUED run the adapter will reject.
+ *
+ * Explicit pins — a definition's `model:` or an agent overlay `model` — are
+ * operator intent: `resolveModel` returns them verbatim and no adapter
+ * publishes a known-model list to check them against, so they are accepted
+ * as-is. `explicitPin` states that provenance when the caller knows it. When
+ * it does not (a stored spec being approved as recorded), a model outside the
+ * adapter's map is refused only when it is a tier value of some *other*
+ * adapter — the signature of a pin carried across an adapter change — and is
+ * otherwise treated as a pin.
+ *
+ * An adapter that takes no model (`fake`, actions) cannot mismatch one: a
+ * model on such a spec is the registered route's pin carried across a
+ * process-wide `--adapter-override`, and that adapter ignores it.
+ */
 export function modelAdapterMismatch(
   spec,
   modelTiers,
@@ -146,7 +164,11 @@ export function normalizeHarness(raw, source = "harness") {
   return out;
 }
 
-/** Pure assembly of the §5.2 RunSpec from a registered mapping. */
+/**
+ * Pure assembly of the §5.2 RunSpec from a registered mapping. It has no
+ * clock-dependent inputs: the planner and proposal re-planner must construct
+ * the model-tier block byte-identically, so it lives in this shared module.
+ */
 export function buildRunSpec(
   registry,
   envelope,
@@ -207,6 +229,13 @@ export function buildRunSpec(
     promptVersion: policyVersion,
     policyVersion,
     outputContract: def.output_contract,
+    // Attested definition pin (WM-1056): the content sha256 of the registered
+    // agent definition, computed with the same helper the worker's claim-time
+    // verifyDefHash and the receipt seam use. Pinned at plan time so a proposal
+    // that crosses a registry reload is compared against the exact def it was
+    // planned against. Computed from `def`, NOT `planned`, so per-ticket
+    // model/model-tier overrides never redefine the attested definition or make
+    // otherwise identical planner inputs nondeterministic.
     defHash: computeDefHash(def),
     capabilities: def.capabilities.services,
     ...(def.mutating === false &&
@@ -221,6 +250,8 @@ export function buildRunSpec(
           return { harness, ...(harnessPins ? { harnessPins } : {}) };
         })()
       : {}),
+    // Initial planning and proposal re-planning must use this exact tier/model
+    // resolution. Keeping it here prevents either path from drifting.
     ...(modelTierOverride !== undefined ||
     planned.model_tier !== undefined ||
     planned.model !== undefined


### PR DESCRIPTION
Fixes watt-mind/factory#2083

Restore the documented RunSpec invariants and remove the silently ignored clock option.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs` | pass | 119 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2360 pass, 10 skip; 615 pre-existing warnings |
| UX critique          | factory-ux-critic                | not run | internal RunSpec assembly only |

UX critique: skipped — internal RunSpec assembly only; no user-facing surface

run:run_5a5f9a28-d33c-4c19-b55d-7f705bf0117a
