### PR TITLE
fix(cli): retry remaining ticket reads

### DIFF
--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -139,6 +139,7 @@ export async function retryControlPlaneMutation(
       await backoff(CONTROL_PLANE_MUTATION_RETRY_BACKOFF_MS);
     }
   }
+  throw new Error("unreachable: control-plane mutation retry loop exhausted");
 }
 
 /** Transition first, so a promotion rationale is never posted for a failed move. */
@@ -155,6 +156,16 @@ export async function setLabelsWithRetry(cp, key, options) {
 /** Read a ticket through the same timeout recovery used by state mutations. */
 export async function getTicketWithRetry(cp, key) {
   return retryControlPlaneMutation(cp, () => cp.getTicket(key));
+}
+
+/** Release a ticket only after its labels have been read through retry policy. */
+export async function unclaimTicket(cp, key) {
+  const issue = await getTicketWithRetry(cp, key);
+  const currentNames = (issue.labels ?? []).map((label) => label.name);
+  const { add, remove } = releaseLabels(currentNames, { to: "Todo" });
+  await retryControlPlaneMutation(cp, () =>
+    cp.transition(key, "Todo", { add, remove, unassign: true }),
+  );
 }
 
 /**
@@ -871,12 +882,7 @@ const VERBS = {
     if (!positional[0]) throw new Error(`usage: unclaim <ISSUE-ID>`);
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
-    const issue = await cp.getTicket(key);
-    const currentNames = (issue.labels ?? []).map((label) => label.name);
-    const { add, remove } = releaseLabels(currentNames, { to: "Todo" });
-    await retryControlPlaneMutation(cp, () =>
-      cp.transition(key, "Todo", { add, remove, unassign: true }),
-    );
+    await unclaimTicket(cp, key);
     out(
       { ok: true, identifier: key, state: "Todo" },
       `unclaimed ${key} -> Todo`,
@@ -910,7 +916,7 @@ const VERBS = {
       throw new Error(`usage: answer <ISSUE-ID> [--] "<text>"`);
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
-    const issue = await cp.getTicket(key);
+    const issue = await getTicketWithRetry(cp, key);
     if (issue.state?.name?.toLowerCase() === "blocked")
       await retryControlPlaneMutation(cp, () => cp.transition(key, "Todo"));
     await cp.comment(key, text);
@@ -924,7 +930,7 @@ const VERBS = {
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     if (has("replace")) {
-      const issue = await cp.getTicket(key);
+      const issue = await getTicketWithRetry(cp, key);
       const description = String(rawDetail).trim();
       const current = String(issue.description ?? "").trim();
       if (description === current) {

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -32,6 +32,7 @@ import {
   retryControlPlaneMutation,
   transitionThenComment,
   getTicketWithRetry,
+  unclaimTicket,
   fileTicket,
   closureCheckMessages,
   descriptionReplacementRequest,
@@ -467,6 +468,38 @@ test("ticket state and label reads retry one GraphQL timeout", async () => {
     retryControlPlaneMutation(cp, () => cp.transition("WM-910", "Todo")),
   ).resolves.toBeUndefined();
   expect(calls).toEqual({ getTicket: 2, transition: 2 });
+});
+
+test("unclaim retries its ticket read after a GraphQL timeout", async () => {
+  const calls = { getTicket: 0, transition: [] };
+  const cp = {
+    kind: "linear",
+    async getTicket() {
+      calls.getTicket += 1;
+      if (calls.getTicket === 1)
+        throw new Error("linear graphql timed out after 15000ms");
+      return { labels: [{ name: "ai:in-progress" }] };
+    },
+    async transition(...args) {
+      calls.transition.push(args);
+    },
+  };
+
+  await expect(unclaimTicket(cp, "WM-910")).resolves.toBeUndefined();
+  expect(calls).toEqual({
+    getTicket: 2,
+    transition: [
+      [
+        "WM-910",
+        "Todo",
+        {
+          add: ["ai:agent-ready"],
+          remove: ["ai:in-progress", "ai:blocked"],
+          unassign: true,
+        },
+      ],
+    ],
+  });
 });
 
 test("ticket timeout retry preserves non-timeout errors", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2081

Retries now protect all remaining pre-mutation ticket reads from transient GraphQL timeouts.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test tools/ticket.test.mjs` | pass    | 68 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2360 pass, 0 fail; 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_bdd25afd-fc34-49af-86bd-09f98b7bedfc
