### PR TITLE
fix(floor): explicit browser tab routing and reload re-read rules (#2061)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -200,6 +200,13 @@ A tool result is not paid for once. It stays in the context window and is re-sen
 
 Factory-spawned sessions get their **own isolated headless Chrome** (via `--mcp-config`, `config/mcp/claude.json` in the factory repo) — a temp profile per session, screenshots served as capped webp. There is nothing to share and nothing to fight over.
 
+**Tab routing across concurrent subagents.** In harnesses sharing a browser pane (e.g. Claude Browser pane), all subagents in a session share a single flat tab pool and one global fronted tab. Calls omitting `tabId` race on whatever tab a sibling fronted, silently reading or writing another ticket's app (misdiagnosed as product or auth bugs).
+
+- **Pass `tabId` explicitly on every browser call** — `navigate`, `get_page_text`, `read_page`, `computer`, `javascript_tool`. Explicit `tabId` routes correctly; omitting it targets the fronted tab, which any sibling can steal.
+- **Own a tab from `tabs_create`** and never rely on the fronted tab — fronting is global mutable state.
+- **Assert origin before trusting a read** — verify the host/port in the page output matches your ticket's app before acting on page text or screenshots.
+- **Re-read after reload** — reading immediately after `location.reload()` can return the pre-reload DOM; take a second read before concluding a session or auth state is invalid.
+
 If an IDE browser tool reports a stale/missing tab, its tab listing disagrees with navigation, or a call deadlocks, use **one bounded recovery**: record the backend/tool/URL and exact error (or the harness timeout with no result), call `list_pages`/`tabs` once, discard every cached tab ID, select or create a page from the fresh result, and navigate once. If listing and navigation still disagree or either call times out, that browser backend is unavailable — never retry it in a loop.
 
 Use an independent isolated headless backend when the harness provides one (the factory Chrome DevTools MCP or Pi `chrome_devtools_*`), rather than reusing the broken IDE registry. Let the backend own the browser lifecycle whenever possible. On display-less Linux, launch through the factory wrapper. If `FACTORY_ROOT` is unset, do not guess its location: run `factory doctor`, record that the fallback is not configured, and stop browser recovery. For a CDP-capable fallback driver, kept in one managed shell session:

--- a/build/emit.test.mjs
+++ b/build/emit.test.mjs
@@ -54,6 +54,17 @@ test("delivered floor documents valid Owned Paths bullets", () => {
   );
 });
 
+test("delivered floor documents explicit browser tab routing and reload re-read rules", () => {
+  const floor = readFileSync(
+    path.join(ROOT, "dist", "AGENTS.floor.md"),
+    "utf8",
+  );
+  expect(floor).toContain("Pass `tabId` explicitly on every browser call");
+  expect(floor).toContain("Own a tab from `tabs_create`");
+  expect(floor).toContain("Assert origin before trusting a read");
+  expect(floor).toContain("Re-read after reload");
+});
+
 test.each([
   ["git@github.com:Owner/Repository.git", "owner/repository"],
   ["https://github.com/Owner/Repository", "owner/repository"],

--- a/dist/AGENTS.floor.md
+++ b/dist/AGENTS.floor.md
@@ -194,6 +194,13 @@ A tool result is not paid for once. It stays in the context window and is re-sen
 
 Factory-spawned sessions get their **own isolated headless Chrome** (via `--mcp-config`, `config/mcp/claude.json` in the factory repo) — a temp profile per session, screenshots served as capped webp. There is nothing to share and nothing to fight over.
 
+**Tab routing across concurrent subagents.** In harnesses sharing a browser pane (e.g. Claude Browser pane), all subagents in a session share a single flat tab pool and one global fronted tab. Calls omitting `tabId` race on whatever tab a sibling fronted, silently reading or writing another ticket's app (misdiagnosed as product or auth bugs).
+
+- **Pass `tabId` explicitly on every browser call** — `navigate`, `get_page_text`, `read_page`, `computer`, `javascript_tool`. Explicit `tabId` routes correctly; omitting it targets the fronted tab, which any sibling can steal.
+- **Own a tab from `tabs_create`** and never rely on the fronted tab — fronting is global mutable state.
+- **Assert origin before trusting a read** — verify the host/port in the page output matches your ticket's app before acting on page text or screenshots.
+- **Re-read after reload** — reading immediately after `location.reload()` can return the pre-reload DOM; take a second read before concluding a session or auth state is invalid.
+
 If an IDE browser tool reports a stale/missing tab, its tab listing disagrees with navigation, or a call deadlocks, use **one bounded recovery**: record the backend/tool/URL and exact error (or the harness timeout with no result), call `list_pages`/`tabs` once, discard every cached tab ID, select or create a page from the fresh result, and navigate once. If listing and navigation still disagree or either call times out, that browser backend is unavailable — never retry it in a loop.
 
 Use an independent isolated headless backend when the harness provides one (the factory Chrome DevTools MCP or Pi `chrome_devtools_*`), rather than reusing the broken IDE registry. Let the backend own the browser lifecycle whenever possible. On display-less Linux, launch through the factory wrapper. If `FACTORY_ROOT` is unset, do not guess its location: run `factory doctor`, record that the fallback is not configured, and stop browser recovery. For a CDP-capable fallback driver, kept in one managed shell session:

--- a/event-runtime/pins.json
+++ b/event-runtime/pins.json
@@ -21,7 +21,7 @@
       "commands/factory-triage.md": "sha256:20d538ca3c7358b22ea2f263fa1ec8b75affbf222e58c77989b43d34750c0ff1",
       "commands/factory-unblock.md": "sha256:496bffc002afea8eca9d6c1b80f38c6732eb2163f3e41f6d04f0357c4e2905cb",
       "commands/factory-work.md": "sha256:c69095b7697fb4f0599ed6f2da40a4f6495e74bc5cfed90f41a4bc786d9cc72a",
-      "floor.md": "sha256:448930a5705b4f919059696e941239a4c50a30d78a5847dbaadea99ea10dfdf3",
+      "floor.md": "sha256:d3658d5c8ce6090c57fc3ff89dccdf3050180adb2e041352de2ea4a327c71fe8",
       "skills/factory-handoff/SKILL.md": "sha256:c6e452e33a8101cd4fdca70f650c52b626688a5555826039ebfac26847de8fd9",
       "skills/ticket-spec/SKILL.md": "sha256:6cd7e613072a1f4bd360389b62f3482432cbeb167b1e34b27b4a6099d4685b23"
     }

--- a/shared/floor.md
+++ b/shared/floor.md
@@ -194,6 +194,13 @@ A tool result is not paid for once. It stays in the context window and is re-sen
 
 Factory-spawned sessions get their **own isolated headless Chrome** (via `--mcp-config`, `config/mcp/claude.json` in the factory repo) — a temp profile per session, screenshots served as capped webp. There is nothing to share and nothing to fight over.
 
+**Tab routing across concurrent subagents.** In harnesses sharing a browser pane (e.g. Claude Browser pane), all subagents in a session share a single flat tab pool and one global fronted tab. Calls omitting `tabId` race on whatever tab a sibling fronted, silently reading or writing another ticket's app (misdiagnosed as product or auth bugs).
+
+- **Pass `tabId` explicitly on every browser call** — `navigate`, `get_page_text`, `read_page`, `computer`, `javascript_tool`. Explicit `tabId` routes correctly; omitting it targets the fronted tab, which any sibling can steal.
+- **Own a tab from `tabs_create`** and never rely on the fronted tab — fronting is global mutable state.
+- **Assert origin before trusting a read** — verify the host/port in the page output matches your ticket's app before acting on page text or screenshots.
+- **Re-read after reload** — reading immediately after `location.reload()` can return the pre-reload DOM; take a second read before concluding a session or auth state is invalid.
+
 If an IDE browser tool reports a stale/missing tab, its tab listing disagrees with navigation, or a call deadlocks, use **one bounded recovery**: record the backend/tool/URL and exact error (or the harness timeout with no result), call `list_pages`/`tabs` once, discard every cached tab ID, select or create a page from the fresh result, and navigate once. If listing and navigation still disagree or either call times out, that browser backend is unavailable — never retry it in a loop.
 
 Use an independent isolated headless backend when the harness provides one (the factory Chrome DevTools MCP or Pi `chrome_devtools_*`), rather than reusing the broken IDE registry. Let the backend own the browser lifecycle whenever possible. On display-less Linux, launch through the factory wrapper. If `FACTORY_ROOT` is unset, do not guess its location: run `factory doctor`, record that the fallback is not configured, and stop browser recovery. For a CDP-capable fallback driver, kept in one managed shell session:


### PR DESCRIPTION
## Summary
Addresses #2061 by updating `shared/floor.md` (and emitted / synced files) with rules preventing cross-subagent browser tab hijacking and reload DOM races:
- Pass `tabId` explicitly on every browser call (`navigate`, `get_page_text`, `read_page`, `computer`, `javascript_tool`) rather than relying on the shared fronted tab.
- Own a tab from `tabs_create` and never rely on "the fronted tab" (global mutable state across subagents).
- Assert origin before trusting a read (verify host/port in page output before acting on page text or screenshots).
- Re-read after reload (`location.reload()`) before concluding anything about session state.

Fixes #2061