### PR TITLE
fix(event-runtime): distinguish invalid repo registries

### DIFF
--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -780,9 +780,17 @@ function dispatchToolchainEligibility(
   payload,
   { configSnapshot = null, toolchain = {} } = {},
 ) {
+  let repos;
+  try {
+    repos = snapshotRepos(configSnapshot);
+  } catch (err) {
+    // A registry failure is not an unknown-repo lookup. Avoid a toolchain
+    // probe; the worktree gate records its typed refusal and evidence.
+    return { registryInvalid: true, error: err };
+  }
   let repo;
   try {
-    repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
+    repo = getRepo(repos, payload?.repo);
   } catch (err) {
     // An unknown repo is not a toolchain fact: leave it to the worktree gate,
     // which refuses it as `human_needed repo_unknown` with full evidence.
@@ -1108,9 +1116,21 @@ export function worktreeDispatchAutoEligibility(
   // Keep it in the proof so bypasses are auditable alongside every other
   // dispatch admission fact.
   evidence.checks.operator_authorized = operatorAuthorized === true;
+  let repos;
+  try {
+    repos = snapshotRepos(configSnapshot);
+  } catch (err) {
+    evidence.checks.repo_registry_valid = false;
+    return refusal(
+      `repo_registry_invalid: ${err.message}`,
+      evidence,
+      "human_needed",
+    );
+  }
+  evidence.checks.repo_registry_valid = true;
   let repo;
   try {
-    repo = getRepo(snapshotRepos(configSnapshot), payload?.repo);
+    repo = getRepo(repos, payload?.repo);
   } catch (err) {
     evidence.checks.repo_found = false;
     return refusal(`repo_unknown: ${err.message}`, evidence, "human_needed");

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -2432,10 +2432,44 @@ describe("planEvent worktree gate (WM-108)", () => {
       expect(result.refusal).toMatchObject({
         decision: "human_needed",
       });
-      expect(result.refusal.reason).toMatch(/^repo_unknown: /);
+      expect(result.refusal.reason).toMatch(/^repo_registry_invalid: /);
       expect(result.refusal.reason).toContain(
         "repo malformed max_in_flight must be a positive number",
       );
+      expect(result.evidence.checks).toMatchObject({
+        repo_registry_valid: false,
+      });
+      expect(result.evidence.checks.repo_found).toBeUndefined();
+    });
+  });
+
+  test("a declared repo with an invalid unrelated registry stanza → human_needed repo_registry_invalid", () => {
+    const healthyRepo =
+      `repos:\n  - name: healthy\n    path: /tmp/healthy\n    base: develop\n` +
+      `    team: WM\n    project: Factory\n    worktree_up: bin/up\n    worktree_down: bin/down\n` +
+      `    worktree_root: /tmp/worktrees\n    escalate_paths: []\n` +
+      `  - name: malformed\n    path: /tmp/malformed\n    max_in_flight: many\n`;
+    withReposRoot(healthyRepo, () => {
+      const db = openDb(":memory:");
+      const ref = admit(db, {
+        type: "factory.dispatch.requested",
+        eventId: "registry-invalid",
+        correlationId: "registry-invalid",
+        payload: { repo: "healthy", ticket: "WM-694" },
+      });
+      const outcome = planEvent(db, registry, ref, {
+        now: NOW,
+        dispatch: tierDispatch(),
+        toolchain: {
+          cache: new Map(),
+          which: () => {
+            throw new Error("invalid registry must not probe toolchain");
+          },
+        },
+      });
+      expect(outcome.decision).toBe("human_needed");
+      expect(outcome.reason).toMatch(/^repo_registry_invalid: /);
+      expect(db.query(`SELECT COUNT(*) AS n FROM runs`).get().n).toBe(0);
     });
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2096

Registry load and validation failures now surface as repo_registry_invalid instead of misleading operators that a declared repo is unknown.

## Validation

| Check                | Command                                                                  | Result  | Notes                             |
| -------------------- | ------------------------------------------------------------------------ | ------- | --------------------------------- |
| Verification Command | `bun test event-runtime/lib/planner.test.mjs`                            | pass    | 121 tests, 0 failures             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 615 existing warnings |
| UX critique          | factory-ux-critic                                                        | not run | no user-facing surface            |

UX critique: skipped — no user-facing surface
run:run_9d9a7a56-7bf7-490e-b696-27d151bdde7b