### PR TITLE
fix(ci-log-capture): preserve auth and network faults

### DIFF
--- a/event-runtime/lib/ci-log-capture.mjs
+++ b/event-runtime/lib/ci-log-capture.mjs
@@ -22,6 +22,16 @@
  * `captured: "failed.log"` edge to factory.ci-diagnose.requested (edges.json)
  * simply does not fire. Genuine faults — auth, network, quota, a missing
  * `gh` — still exit non-zero and are still `agent_exit_<code>`.
+ *
+ * Precedence, when `gh` exits non-zero with nothing captured: FAULT wins over
+ * MISSING. GitHub masks some authorization failures as 404, so stderr that
+ * matches `EXPECTED_FAULT` is a fault even when it also reads as a missing
+ * log; only stderr that matches `EXPECTED_MISSING` and no fault signal exits
+ * 0. Anything unrecognized is a fault — the safe default is to surface it.
+ * That precedence makes `EXPECTED_FAULT` the narrower of the two: it lists
+ * explicit auth/network/quota signals only, never bare words like `auth` or
+ * `timeout` that appear in `gh`'s routine "Try authenticating with: gh auth
+ * login" hint printed alongside an ordinary deleted-run 404.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -46,17 +56,25 @@ const DETAIL_LIMIT = 400;
  * `gh` output that means "this attempt's logs are gone", not "the capture
  * broke": the run was deleted, the attempt 404/410s, the log retention window
  * closed, or the run was cancelled before any job produced a log.
+ *
+ * Matched anywhere in the line: `gh` prefixes its diagnostics ("gh: ",
+ * "error: "), and a prefixed genuine missing-log message must not fall
+ * through to the fault branch and re-create the #2076 `agent_exit_1` flood.
  */
 const EXPECTED_MISSING =
-  /(?:^|\n)(?:.*\bHTTP (?:404|410)\b.*|no logs(?: found)?(?: for (?:this )?run)?|logs? (?:have )?expired|run (?:was )?cancell?ed)\b/im;
+  /(?:\bHTTP (?:404|410)\b|no logs|logs? (?:have )?expired|run (?:was )?cancell?ed)/im;
 
 /**
  * A missing-log response must never conceal a failure to make the request.
  * GitHub deliberately masks some authorization failures as 404, so this
- * check deliberately wins over `EXPECTED_MISSING` below.
+ * check deliberately wins over `EXPECTED_MISSING` above.
+ *
+ * Explicit signals only. Bare `auth`/`timeout`/`permission`/`forbidden` were
+ * removed: `gh` appends "Try authenticating with: gh auth login" to plain
+ * 404s, which would classify an ordinary deleted run as a fault.
  */
 const EXPECTED_FAULT =
-  /HTTP (?:401|403)\b|bad credentials|rate limit|context cancell?ed|context deadline exceeded|connection refused|timeout|gh auth login|EAI_AGAIN|ENOTFOUND|auth(?:entication|orization)?|permission|forbidden|access denied|resource not accessible/i;
+  /HTTP (?:401|403)\b|bad credentials|rate limit|context cancell?ed|context deadline exceeded|connection refused|EAI_AGAIN|ENOTFOUND|resource not accessible/i;
 
 /**
  * The pinned-attempt argv, and the legacy fallback when the event carries no

--- a/event-runtime/lib/ci-log-capture.mjs
+++ b/event-runtime/lib/ci-log-capture.mjs
@@ -48,7 +48,15 @@ const DETAIL_LIMIT = 400;
  * closed, or the run was cancelled before any job produced a log.
  */
 const EXPECTED_MISSING =
-  /HTTP (?:404|410)|not found|no logs|log[s]? (?:have )?expired|cancell?ed/i;
+  /(?:^|\n)(?:.*\bHTTP (?:404|410)\b.*|no logs(?: found)?(?: for (?:this )?run)?|logs? (?:have )?expired|run (?:was )?cancell?ed)\b/im;
+
+/**
+ * A missing-log response must never conceal a failure to make the request.
+ * GitHub deliberately masks some authorization failures as 404, so this
+ * check deliberately wins over `EXPECTED_MISSING` below.
+ */
+const EXPECTED_FAULT =
+  /HTTP (?:401|403)\b|bad credentials|rate limit|context cancell?ed|context deadline exceeded|connection refused|timeout|gh auth login|EAI_AGAIN|ENOTFOUND|auth(?:entication|orization)?|permission|forbidden|access denied|resource not accessible/i;
 
 /**
  * The pinned-attempt argv, and the legacy fallback when the event carries no
@@ -119,7 +127,11 @@ export function captureCiLog({
   if (!captured && existsSync(logPath)) unlinkSync(logPath);
 
   const detail = String(stderr ?? "");
-  if (!captured && exitCode !== 0 && !EXPECTED_MISSING.test(detail)) {
+  if (
+    !captured &&
+    exitCode !== 0 &&
+    (EXPECTED_FAULT.test(detail) || !EXPECTED_MISSING.test(detail))
+  ) {
     return {
       ok: false,
       captured: NO_CAPTURE,

--- a/event-runtime/lib/ci-log-capture.test.mjs
+++ b/event-runtime/lib/ci-log-capture.test.mjs
@@ -96,6 +96,12 @@ describe("ci-log-capture command (#2076)", () => {
       "gh: Not Found (HTTP 404)",
       "no logs found for this run",
       "run was cancelled",
+      // `gh` prefixes its diagnostics; a prefixed missing-log message must
+      // still be MISSING, not the #2076 agent_exit_1 fault.
+      "gh: run was cancelled",
+      "gh: no logs found for this run",
+      "error: logs expired",
+      "error: no logs found for this run",
     ]) {
       const cwd = tmpDir("evrt-ci-log-capture-miss-");
       const outcome = captureCiLog({
@@ -136,6 +142,24 @@ describe("ci-log-capture command (#2076)", () => {
       expect(outcome.exitCode).toBe(1);
       expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
     }
+  });
+
+  test("gh's routine auth hint on a plain 404 stays a missing log", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-404-hint-");
+    const outcome = captureCiLog({
+      cwd,
+      input: { ...INPUT, runAttempt: 2 },
+      spawn: fakeGh({
+        stderr: "HTTP 404: Not Found\nTry authenticating with: gh auth login",
+        exitCode: 1,
+      }),
+    });
+
+    expect(outcome.ok).toBe(true);
+    const result = readResult(cwd);
+    expect(result.artifact.captured).toBe(NO_CAPTURE);
+    expect(result.artifact.exitCode).toBe(0);
+    expect(existsSync(path.join(cwd, LOG_FILE))).toBe(false);
   });
 
   test("an empty log on a clean exit is no_logs, not a zero-byte artifact", () => {

--- a/event-runtime/lib/ci-log-capture.test.mjs
+++ b/event-runtime/lib/ci-log-capture.test.mjs
@@ -118,6 +118,26 @@ describe("ci-log-capture command (#2076)", () => {
     }
   });
 
+  test("auth and network failures do not masquerade as missing logs", () => {
+    for (const stderr of [
+      "HTTP 401: Bad credentials",
+      "HTTP 403: rate limit exceeded",
+      'Post "https://api.github.com/repos/watt-mind/factory": context canceled',
+      "HTTP 404: Not Found: Resource not accessible by integration (permission denied)",
+    ]) {
+      const cwd = tmpDir("evrt-ci-log-capture-fault-taxonomy-");
+      const outcome = captureCiLog({
+        cwd,
+        input: INPUT,
+        spawn: fakeGh({ stderr, exitCode: 1 }),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(outcome.exitCode).toBe(1);
+      expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
+    }
+  });
+
   test("an empty log on a clean exit is no_logs, not a zero-byte artifact", () => {
     const cwd = tmpDir("evrt-ci-log-capture-empty-");
     captureCiLog({ cwd, input: INPUT, spawn: fakeGh({ stdout: "" }) });


### PR DESCRIPTION
Fixes watt-mind/factory#2099

Auth and transient network failures now fail CI log capture instead of completing silently.

## Validation

| Check                | Command                                                                                     | Result  | Notes                                            |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | ------------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/ci-log-capture.test.mjs`                                        | pass    | 8 tests, 0 failures                              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; existing lint warnings only               |
| UX critique          | factory-ux-critic                                                                           | not run | skipped — backend library; no user-facing surface |

UX critique: skipped — backend library change; no user-facing surface

run:run_ea6c7571-df91-42cc-b81a-edf1e8098e95
