### PR TITLE
fix(cli): retry ticket comment and detail writes after timeouts

### DIFF
--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -97,22 +97,21 @@ const CONTROL_PLANE_MUTATION_RETRY_BACKOFF_MS = 250;
 const controlPlaneMutationBackoff = (ms) =>
   new Promise((resolve) => setTimeout(resolve, ms));
 
-function graphqlTimeoutMessage(controlPlane, error) {
+function controlPlaneTimeoutMessage(controlPlane, error) {
   const message = String(error?.message ?? "");
-  const endpoint =
-    controlPlane?.kind === "github"
-      ? "github projects graphql"
-      : controlPlane?.kind === "linear"
-        ? "linear graphql"
-        : null;
-  const match = endpoint
-    ? new RegExp(
-        `^${
-          controlPlane.kind === "github" ? "github(?: projects)?" : "linear"
-        } graphql timed out after (\\d+)ms$`,
-      ).exec(message)
-    : null;
-  return match ? `${endpoint} timed out after ${match[1]}ms` : null;
+  if (controlPlane?.kind === "linear") {
+    const match = /^linear graphql timed out after (\d+)ms$/.exec(message);
+    return match ? `linear graphql timed out after ${match[1]}ms` : null;
+  }
+  if (controlPlane?.kind === "github") {
+    const graphql =
+      /^github(?: projects)? graphql timed out after (\d+)ms$/.exec(message);
+    if (graphql)
+      return `github projects graphql timed out after ${graphql[1]}ms`;
+    const api = /^gh timed out after (\d+)ms$/.exec(message);
+    return api ? `github api timed out after ${api[1]}ms` : null;
+  }
+  return null;
 }
 
 /**
@@ -129,7 +128,7 @@ export async function retryControlPlaneMutation(
     try {
       return await mutation();
     } catch (cause) {
-      const timeout = graphqlTimeoutMessage(controlPlane, cause);
+      const timeout = controlPlaneTimeoutMessage(controlPlane, cause);
       if (!timeout) throw cause;
       if (attempt === 1)
         throw new ControlPlaneError(timeout, {
@@ -142,10 +141,46 @@ export async function retryControlPlaneMutation(
   throw new Error("unreachable: control-plane mutation retry loop exhausted");
 }
 
+function commentBodyMatches(body, expected) {
+  if (body === expected) return true;
+  const runId = process.env.FACTORY_RUN_ID;
+  return (
+    process.env.FACTORY_COMMENT_ATTRIBUTION === "1" &&
+    Boolean(runId) &&
+    !expected.includes(`run:${runId}`) &&
+    body === `${expected}\n\nrun:${runId}`
+  );
+}
+
+/**
+ * Retry a comment only after checking whether the timed-out write landed.
+ *
+ * Comment creation is not idempotent: blindly replaying a request after its
+ * response timed out can create a duplicate timeline entry. The check runs
+ * only on the retry path, so ordinary comments remain one write.
+ */
+export async function commentWithRetry(cp, key, body) {
+  let retrying = false;
+  return retryControlPlaneMutation(cp, async () => {
+    if (retrying) {
+      const comments = await getCommentsWithRetry(cp, key);
+      if (comments.some((comment) => commentBodyMatches(comment.body, body)))
+        return;
+    }
+    retrying = true;
+    return cp.comment(key, body);
+  });
+}
+
+/** Read comments through the same timeout recovery used by other ticket reads. */
+export async function getCommentsWithRetry(cp, key) {
+  return retryControlPlaneMutation(cp, () => cp.listComments(key));
+}
+
 /** Transition first, so a promotion rationale is never posted for a failed move. */
 export async function transitionThenComment(cp, key, state, options, comment) {
   await retryControlPlaneMutation(cp, () => cp.transition(key, state, options));
-  if (comment?.trim()) await cp.comment(key, comment);
+  if (comment?.trim()) await commentWithRetry(cp, key, comment);
 }
 
 /** Apply a complete label delta through the same retry policy as state writes. */
@@ -156,6 +191,39 @@ export async function setLabelsWithRetry(cp, key, options) {
 /** Read a ticket through the same timeout recovery used by state mutations. */
 export async function getTicketWithRetry(cp, key) {
   return retryControlPlaneMutation(cp, () => cp.getTicket(key));
+}
+
+/** Move a ticket to Triage, then safely add the required rationale. */
+export async function triageTicket(cp, key, comment) {
+  await retryControlPlaneMutation(cp, () =>
+    cp.transition(key, "Triage", { remove: ["ai:agent-ready"] }),
+  );
+  if (comment.trim()) await commentWithRetry(cp, key, comment);
+}
+
+/** Answer a blocked ticket without replaying its state transition on retry. */
+export async function answerTicket(cp, key, text) {
+  const issue = await getTicketWithRetry(cp, key);
+  if (issue.state?.name?.toLowerCase() === "blocked")
+    await retryControlPlaneMutation(cp, () => cp.transition(key, "Todo"));
+  await commentWithRetry(cp, key, text);
+}
+
+/** Replace a ticket body with a retried absolute write. */
+export async function replaceTicketDetail(cp, key, rawDetail) {
+  const issue = await getTicketWithRetry(cp, key);
+  const description = String(rawDetail).trim();
+  const current = String(issue.description ?? "").trim();
+  if (description === current) return { replaced: false };
+  const request = descriptionReplacementRequest(key, issue.id, description, {
+    kind: cp.kind,
+  });
+  const result = await retryControlPlaneMutation(cp, () =>
+    cp.raw(request.query, request.variables),
+  );
+  if (!replacementSucceeded(result, request.resultAt))
+    throw new Error(`detail replacement failed for ${key}`);
+  return { replaced: true };
 }
 
 /** Release a ticket only after its labels have been read through retry policy. */
@@ -903,10 +971,7 @@ const VERBS = {
       throw new Error(`usage: triage <ISSUE-ID> --comment "<text>"`);
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
-    await retryControlPlaneMutation(cp, () =>
-      cp.transition(key, "Triage", { remove: ["ai:agent-ready"] }),
-    );
-    if (comment.trim()) await cp.comment(key, comment);
+    await triageTicket(cp, key, comment);
     out({ ok: true, identifier: key }, `${key} -> Triage`);
   },
 
@@ -916,10 +981,7 @@ const VERBS = {
       throw new Error(`usage: answer <ISSUE-ID> [--] "<text>"`);
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
-    const issue = await getTicketWithRetry(cp, key);
-    if (issue.state?.name?.toLowerCase() === "blocked")
-      await retryControlPlaneMutation(cp, () => cp.transition(key, "Todo"));
-    await cp.comment(key, text);
+    await answerTicket(cp, key, text);
     out({ ok: true, identifier: key }, `answered ${key}`);
   },
 
@@ -930,25 +992,14 @@ const VERBS = {
     const key = normalizeTicketRef(positional[0]);
     const cp = controlPlane(key);
     if (has("replace")) {
-      const issue = await getTicketWithRetry(cp, key);
-      const description = String(rawDetail).trim();
-      const current = String(issue.description ?? "").trim();
-      if (description === current) {
+      const { replaced } = await replaceTicketDetail(cp, key, rawDetail);
+      if (!replaced) {
         out(
           { ok: true, identifier: key, replaced: false },
           `${key} detail already matches`,
         );
         return;
       }
-      const request = descriptionReplacementRequest(
-        key,
-        issue.id,
-        description,
-        { kind: cp.kind },
-      );
-      const result = await cp.raw(request.query, request.variables);
-      if (!replacementSucceeded(result, request.resultAt))
-        throw new Error(`detail replacement failed for ${key}`);
       out(
         { ok: true, identifier: key, replaced: true },
         `${key} detail replaced`,

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -32,6 +32,9 @@ import {
   retryControlPlaneMutation,
   transitionThenComment,
   getTicketWithRetry,
+  triageTicket,
+  answerTicket,
+  replaceTicketDetail,
   unclaimTicket,
   fileTicket,
   closureCheckMessages,
@@ -442,6 +445,117 @@ test("state does not post a comment when the transition fails", async () => {
     transitionThenComment(cp, "WM-910", "Todo", {}, "do not post"),
   ).rejects.toThrow("transition rejected");
   expect(calls).toEqual(["transition"]);
+});
+
+test("state comment retry does not repeat a timed-out comment that landed", async () => {
+  const calls = { transition: 0, comment: 0, listComments: 0 };
+  const comments = [];
+  const cp = {
+    kind: "github",
+    async transition() {
+      calls.transition += 1;
+    },
+    async comment(_key, body) {
+      calls.comment += 1;
+      comments.push({ body });
+      throw new Error("gh timed out after 15000ms");
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return comments;
+    },
+  };
+
+  await expect(
+    transitionThenComment(cp, "WM-910", "Todo", {}, "explain the move"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ transition: 1, comment: 1, listComments: 1 });
+  expect(comments).toEqual([{ body: "explain the move" }]);
+});
+
+test("answer retries a timed-out comment without repeating its transition", async () => {
+  const calls = { getTicket: 0, transition: 0, comment: 0, listComments: 0 };
+  const comments = [];
+  const cp = {
+    kind: "linear",
+    async getTicket() {
+      calls.getTicket += 1;
+      return { state: { name: "Blocked" } };
+    },
+    async transition() {
+      calls.transition += 1;
+    },
+    async comment(_key, body) {
+      calls.comment += 1;
+      if (calls.comment === 1)
+        throw new Error("linear graphql timed out after 15000ms");
+      comments.push({ body });
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return comments;
+    },
+  };
+
+  await expect(
+    answerTicket(cp, "WM-910", "the answer"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({
+    getTicket: 1,
+    transition: 1,
+    comment: 2,
+    listComments: 1,
+  });
+  expect(comments).toEqual([{ body: "the answer" }]);
+});
+
+test("triage retries its trailing comment without repeating its transition", async () => {
+  const calls = { transition: 0, comment: 0, listComments: 0 };
+  const comments = [];
+  const cp = {
+    kind: "linear",
+    async transition() {
+      calls.transition += 1;
+    },
+    async comment(_key, body) {
+      calls.comment += 1;
+      if (calls.comment === 1)
+        throw new Error("linear graphql timed out after 15000ms");
+      comments.push({ body });
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return comments;
+    },
+  };
+
+  await expect(
+    triageTicket(cp, "WM-910", "scope needs revision"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ transition: 1, comment: 2, listComments: 1 });
+  expect(comments).toEqual([{ body: "scope needs revision" }]);
+});
+
+test("detail replacement retries a timed-out absolute write", async () => {
+  const calls = { getTicket: 0, raw: 0 };
+  const cp = {
+    kind: "github",
+    async getTicket() {
+      calls.getTicket += 1;
+      return { id: "issue-910", description: "old detail" };
+    },
+    async raw() {
+      calls.raw += 1;
+      if (calls.raw === 1)
+        throw new Error("github graphql timed out after 15000ms");
+      return { updateIssue: { issue: { id: "issue-910" } } };
+    },
+  };
+
+  await expect(
+    replaceTicketDetail(cp, "WM-910", "new detail"),
+  ).resolves.toEqual({ replaced: true });
+  expect(calls).toEqual({ getTicket: 1, raw: 2 });
 });
 
 test("ticket state and label reads retry one GraphQL timeout", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2095

Retries safe ticket comments and description replacements after control-plane timeouts.

## Validation

| Check                | Command                                                                                     | Result  | Notes                          |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test tools/ticket.test.mjs`                                                           | pass    | 72 tests, 0 failures           |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2369 pass, 10 skipped, 0 fail |
| UX critique          | `factory-ux-critic`                                                                         | not run | no user-facing surface         |

UX critique: skipped — CLI control-plane reliability change with no user-facing surface

run:run_83db3970-90d7-48ec-8600-fa50157fa294