### PR TITLE
fix(stack): make live-stack shutdown signal-safe

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -99,8 +99,13 @@ untrack_up_pidfile() { # <pidfile>
     kept_pidfiles+=("${UP_STARTED_PIDFILES[$i]}")
     kept_labels+=("${UP_STARTED_LABELS[$i]}")
   done
-  UP_STARTED_PIDFILES=("${kept_pidfiles[@]}")
-  UP_STARTED_LABELS=("${kept_labels[@]}")
+  if [[ ${#kept_pidfiles[@]} -gt 0 ]]; then
+    UP_STARTED_PIDFILES=("${kept_pidfiles[@]}")
+    UP_STARTED_LABELS=("${kept_labels[@]}")
+  else
+    UP_STARTED_PIDFILES=()
+    UP_STARTED_LABELS=()
+  fi
 }
 
 track_up_pool_pidfiles() {

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -386,6 +386,28 @@ test("`up` adopts a lock-owning GitHub App daemon when its pidfile is missing", 
   }
 });
 
+test("untracking the only pidfile remains safe under nounset", () => {
+  const result = Bun.spawnSync({
+    cmd: [
+      "bash",
+      "-uc",
+      `source <(sed -n '48,109p' "$1")
+UP_STARTED_PIDFILES=("$2")
+UP_STARTED_LABELS=("GitHub App token daemon")
+untrack_up_pidfile "$2"
+[[ \${#UP_STARTED_PIDFILES[@]} -eq 0 ]]
+[[ \${#UP_STARTED_LABELS[@]} -eq 0 ]]`,
+      "bash",
+      LIVE_STACK,
+      "/tmp/only.pid",
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.exitCode).toBe(0);
+  expect(result.stderr.toString()).toBe("");
+});
+
 test("`up` keeps the existing live GitHub App daemon pidfile behavior", () => {
   const f = makeFixture();
   try {

--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -43,6 +43,8 @@ const MIN_REFRESH_DELAY_MS = 30 * 1000;
 /** A transient mint failure should recover promptly without hammering GitHub. */
 const RETRY_INITIAL_DELAY_MS = 60 * 1000;
 const RETRY_MAX_DELAY_MS = 5 * 60 * 1000;
+/** A hung token exchange must not prevent a supervised daemon from stopping. */
+const INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS = 10 * 1000;
 /** JWTs GitHub accepts must expire within 10 min; back-date `iat` for skew. */
 const JWT_LIFETIME_S = 9 * 60;
 const JWT_BACKDATE_S = 60;
@@ -93,6 +95,7 @@ export function buildAppJwt({ appId, privateKeyPem, now = () => Date.now() }) {
  *   privateKeyPem: string,
  *   fetchImpl?: typeof fetch,
  *   now?: () => number,
+ *   timeoutMs?: number,
  * }} args
  * @returns {Promise<{ token: string, expiresAt: string|null }>}
  */
@@ -102,24 +105,35 @@ export async function mintInstallationToken({
   privateKeyPem,
   fetchImpl = fetch,
   now = () => Date.now(),
+  timeoutMs = INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS,
 }) {
   if (!installationId)
     throw new Error("mintInstallationToken requires installationId");
   const jwt = buildAppJwt({ appId, privateKeyPem, now });
   let res;
   try {
-    res = await fetchImpl(
-      `https://api.github.com/app/installations/${installationId}/access_tokens`,
-      {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${jwt}`,
-          Accept: "application/vnd.github+json",
-          "X-GitHub-Api-Version": "2022-11-28",
-          "User-Agent": "watt-mind-factory",
+    const signal = AbortSignal.timeout(timeoutMs);
+    const timedOut = new Promise((_, reject) => {
+      signal.addEventListener("abort", () => reject(signal.reason), {
+        once: true,
+      });
+    });
+    res = await Promise.race([
+      fetchImpl(
+        `https://api.github.com/app/installations/${installationId}/access_tokens`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${jwt}`,
+            Accept: "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "watt-mind-factory",
+          },
+          signal,
         },
-      },
-    );
+      ),
+      timedOut,
+    ]);
   } catch {
     // Never surface the underlying error verbatim: it could carry the request
     // (and thus the Bearer JWT) in some runtimes. Report only that it failed.
@@ -421,10 +435,13 @@ export async function runDaemon({
  * a stale lock. The internal child writes the wrapper pid into the already
  * locked file; live-stack uses that as its startup/adoption handshake.
  */
-async function runLockedDaemon(config) {
+export async function runLockedDaemon(
+  config,
+  { spawnImpl = spawn, signals = process, selfKill = process.kill } = {},
+) {
   const lockFile = `${config.tokenFile}.lock`;
   mkdirSync(path.dirname(lockFile), { recursive: true });
-  const child = spawn(
+  const child = spawnImpl(
     "flock",
     [
       "--nonblock",
@@ -451,8 +468,8 @@ async function runLockedDaemon(config) {
   };
   const onTerm = () => forward("SIGTERM");
   const onInt = () => forward("SIGINT");
-  process.once("SIGTERM", onTerm);
-  process.once("SIGINT", onInt);
+  signals.on("SIGTERM", onTerm);
+  signals.on("SIGINT", onInt);
 
   let result;
   try {
@@ -461,16 +478,16 @@ async function runLockedDaemon(config) {
       child.once("exit", (code, signal) => resolve({ code, signal }));
     });
   } finally {
-    process.removeListener("SIGTERM", onTerm);
-    process.removeListener("SIGINT", onInt);
+    signals.removeListener("SIGTERM", onTerm);
+    signals.removeListener("SIGINT", onInt);
   }
 
   if (forwardedSignal) {
-    process.kill(process.pid, forwardedSignal);
+    selfKill(process.pid, forwardedSignal);
     return;
   }
   if (result.signal) {
-    process.kill(process.pid, result.signal);
+    selfKill(process.pid, result.signal);
     return;
   }
   if (result.code === DAEMON_ALREADY_RUNNING_EXIT_CODE) {

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -25,6 +25,7 @@ import {
   readCachedAppToken,
   resolveGhToken,
   runDaemon,
+  runLockedDaemon,
 } from "./gh-app-auth.mjs";
 
 const { privateKey, publicKey } = generateKeyPairSync("rsa", {
@@ -185,6 +186,69 @@ describe("mintInstallationToken", () => {
         fetchImpl,
       }),
     ).rejects.toThrow(/status 403/);
+  });
+
+  test("times out a fetch implementation that never settles", async () => {
+    let seenSignal;
+    await expect(
+      mintInstallationToken({
+        appId: "42",
+        installationId: "9001",
+        privateKeyPem: privateKey,
+        fetchImpl: (_url, init) => {
+          seenSignal = init.signal;
+          return new Promise(() => {});
+        },
+        timeoutMs: 20,
+      }),
+    ).rejects.toThrow("installation-token request failed to reach GitHub");
+    expect(seenSignal).toBeInstanceOf(AbortSignal);
+    expect(seenSignal.aborted).toBe(true);
+  }, 1_000);
+});
+
+describe("runLockedDaemon", () => {
+  test("forwards repeated SIGTERM while retaining the wrapper until child exit", async () => {
+    const handlers = new Map();
+    const forwarded = [];
+    const selfKills = [];
+    let exit;
+    const child = {
+      kill(signal) {
+        forwarded.push(signal);
+      },
+      once(event, handler) {
+        if (event === "exit") exit = handler;
+      },
+    };
+    const signals = {
+      on(signal, handler) {
+        handlers.set(signal, handler);
+      },
+      removeListener(signal, handler) {
+        if (handlers.get(signal) === handler) handlers.delete(signal);
+      },
+    };
+
+    const daemon = runLockedDaemon(
+      { tokenFile: path.join(tmp("gh-app-lock-signals-"), "token.json") },
+      {
+        spawnImpl: () => child,
+        signals,
+        selfKill(pid, signal) {
+          selfKills.push({ pid, signal });
+        },
+      },
+    );
+    handlers.get("SIGTERM")();
+    handlers.get("SIGTERM")();
+    expect(forwarded).toEqual(["SIGTERM", "SIGTERM"]);
+    expect(selfKills).toEqual([]);
+
+    exit(0, null);
+    await daemon;
+    expect(selfKills).toEqual([{ pid: process.pid, signal: "SIGTERM" }]);
+    expect(handlers.size).toBe(0);
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2094

Bound token requests and keep the supervisor lock alive through repeated shutdown signals (operator authorisation: operator:preapproved-2026-08-29, decided 2026-08-31T17:04:51.341Z).

## Validation

| Check                | Command                                                                                          | Result  | Notes                            |
| -------------------- | ------------------------------------------------------------------------------------------------ | ------- | -------------------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs lib/control-plane/gh-app-auth.test.mjs`                    | pass    | 74 tests, 0 failures             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; existing warnings only    |
| UX critique          | factory-ux-critic                                                                                | not run | no user-facing surface           |

UX critique: skipped — backend/supervisor and token-daemon hardening; no user-facing surface.
run:run_b36afa1e-4c91-4196-a3d9-e351107bd08d
