### PR TITLE
fix(stack): signal the gh-app flock subtree on SIGTERM (#2098)

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -313,7 +313,7 @@ gh_app_release_root() {
 
 gh_app_daemon_command_matches() { # <ps command>
   local command="$1" script release_root relative release_id
-  [[ "$command" =~ ^([^[:space:]]*/)?bun[[:space:]]+([^[:space:]]+)[[:space:]]+--daemon$ ]] \
+  [[ "$command" =~ ^([^[:space:]]*/)?bun[[:space:]]+([^[:space:]]+)[[:space:]]+--daemon(-held)?$ ]] \
     || return 1
   script="${BASH_REMATCH[2]}"
   [[ "$script" == "$REPO/lib/control-plane/gh-app-auth.mjs" ]] && return 0
@@ -366,6 +366,15 @@ wait_for_started_gh_app_daemon() { # <spawned pid>
     owner="$(cat "$(gh_app_lock_file)" 2>/dev/null || true)"
     if [[ "$owner" == "$started_pid" ]] \
       && pid_alive "$RUN_DIR/gh-app-auth.pid"; then
+      return 0
+    fi
+    # Wrapper still alive: lock file now names the --daemon-held grandchild
+    # that actually holds flock. Rewrite the pidfile so down/cleanup signal
+    # the lock owner, but keep tracking so a later up-failure still stops it.
+    if pid_alive "$RUN_DIR/gh-app-auth.pid" \
+      && [[ "$owner" =~ ^[0-9]+$ ]] \
+      && gh_app_daemon_pid_is_valid "$owner"; then
+      printf '%s\n' "$owner" >"$RUN_DIR/gh-app-auth.pid"
       return 0
     fi
     if winner="$(gh_app_daemon_pid)"; then

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -313,7 +313,10 @@ function runStack(fixture, args, extraEnv = {}) {
 const spawnFor = (spawns, pidfile) =>
   spawns.find((line) => line.includes(`pid=${pidfile}`)) ?? "";
 
-async function startLockOwningGhAppProcess(fixture) {
+async function startLockOwningGhAppProcess(
+  fixture,
+  daemonArgument = "--daemon",
+) {
   const script = path.join(
     fixture.root,
     "lib",
@@ -323,7 +326,7 @@ async function startLockOwningGhAppProcess(fixture) {
   mkdirSync(path.dirname(script), { recursive: true });
   writeFileSync(script, "setInterval(() => {}, 60_000);\n", "utf8");
   const child = Bun.spawn({
-    cmd: [process.execPath, script, "--daemon"],
+    cmd: [process.execPath, script, daemonArgument],
     stdout: "ignore",
     stderr: "ignore",
   });
@@ -334,7 +337,7 @@ async function startLockOwningGhAppProcess(fixture) {
       stdout: "pipe",
       stderr: "ignore",
     }).stdout.toString();
-    if (command.trim().endsWith(`${script} --daemon`)) {
+    if (command.trim().endsWith(`${script} ${daemonArgument}`)) {
       writeFileSync(
         path.join(fixture.root, "gh-app-token.json.lock"),
         `${child.pid}\n`,
@@ -384,6 +387,57 @@ test("`up` adopts a lock-owning GitHub App daemon when its pidfile is missing", 
     await stopProcess(daemon);
     f.cleanup();
   }
+});
+
+test("`up` adopts a lock-owning --daemon-held GitHub App process", async () => {
+  const f = makeFixture();
+  const daemon = await startLockOwningGhAppProcess(f, "--daemon-held");
+  try {
+    const r = runStack(f, ["up"], {
+      FACTORY_GH_APP_ID: "test-app",
+      FACTORY_GH_APP_PRIVATE_KEY_PATH: "/tmp/test-key",
+      FACTORY_HOME: f.root,
+      FACTORY_ROOT: f.root,
+    });
+    expect(r.status).toBe(0);
+    expect(r.stdout).toContain(
+      `GitHub App token daemon already running (adopted pid ${daemon.pid})`,
+    );
+    expect(readFileSync(path.join(f.runDir, "gh-app-auth.pid"), "utf8")).toBe(
+      `${daemon.pid}\n`,
+    );
+    expect(spawnFor(r.spawns, "gh-app-auth.pid")).toBe("");
+  } finally {
+    await stopProcess(daemon);
+    f.cleanup();
+  }
+});
+
+test("gh_app_daemon_command_matches accepts --daemon and --daemon-held", () => {
+  const repo = path.resolve(import.meta.dir, "..");
+  const script = `${repo}/lib/control-plane/gh-app-auth.mjs`;
+  const result = Bun.spawnSync({
+    cmd: [
+      "bash",
+      "-uc",
+      `REPO="$2"
+# Isolate the matcher + the release-root helper it calls.
+eval "$(sed -n '/^gh_app_release_root()/,/^}/p; /^gh_app_daemon_command_matches()/,/^}/p' "$1")"
+gh_app_daemon_command_matches "bun $3 --daemon"
+gh_app_daemon_command_matches "bun $3 --daemon-held"
+! gh_app_daemon_command_matches "bun $3 --daemon-other"
+! gh_app_daemon_command_matches "bun $3 --daemonize"
+`,
+      "bash",
+      LIVE_STACK,
+      repo,
+      script,
+    ],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  expect(result.stderr.toString()).toBe("");
+  expect(result.exitCode).toBe(0);
 });
 
 test("untracking the only pidfile remains safe under nounset", () => {

--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -432,12 +432,22 @@ export async function runDaemon({
 /**
  * Public `--daemon` wrapper. `flock` owns the kernel advisory lock and runs an
  * internal child only after acquisition, so crashes and reboots cannot strand
- * a stale lock. The internal child writes the wrapper pid into the already
- * locked file; live-stack uses that as its startup/adoption handshake.
+ * a stale lock. The internal child writes its own pid into the already locked
+ * file; live-stack uses the process that actually holds the lock as its
+ * startup/adoption handshake.
+ *
+ * `flock` forks rather than execing, so a signal to the flock process does
+ * not reach `--daemon-held`. Spawn flock in its own process group and forward
+ * to that group so the grandchild dies with it.
  */
 export async function runLockedDaemon(
   config,
-  { spawnImpl = spawn, signals = process, selfKill = process.kill } = {},
+  {
+    spawnImpl = spawn,
+    signals = process,
+    selfKill = process.kill,
+    killProcess = process.kill,
+  } = {},
 ) {
   const lockFile = `${config.tokenFile}.lock`;
   mkdirSync(path.dirname(lockFile), { recursive: true });
@@ -458,13 +468,19 @@ export async function runLockedDaemon(
         FACTORY_GH_APP_DAEMON_OWNER_PID: String(process.pid),
       },
       stdio: "inherit",
+      detached: true,
     },
   );
 
   let forwardedSignal = null;
   const forward = (signal) => {
     forwardedSignal ??= signal;
-    child.kill(signal);
+    try {
+      killProcess(-child.pid, signal);
+    } catch {
+      // The group can disappear between spawn and forwarding (ESRCH).
+      child.kill(signal);
+    }
   };
   const onTerm = () => forward("SIGTERM");
   const onInt = () => forward("SIGINT");
@@ -514,11 +530,11 @@ if (import.meta.main) {
       process.stderr.write("gh-app-auth: daemon lock owner pid is missing\n");
       process.exit(1);
     }
-    // Publish the wrapper pid only after daemon startup has passed its one
+    // Publish the lock-owning pid only after daemon startup has passed its one
     // synchronous failure boundary. A missing/unreadable key must look like a
     // failed startup to live-stack, not a briefly successful handshake.
     readFileSync(config.privateKeyPath, "utf8");
-    writeFileSync(lockFile, `${ownerPid}\n`, { mode: 0o600 });
+    writeFileSync(lockFile, `${process.pid}\n`, { mode: 0o600 });
     chmodSync(lockFile, 0o600);
     await runDaemon().catch((err) => {
       process.stderr.write(`gh-app-auth: ${err?.message ?? err}\n`);

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -208,14 +208,16 @@ describe("mintInstallationToken", () => {
 });
 
 describe("runLockedDaemon", () => {
-  test("forwards repeated SIGTERM while retaining the wrapper until child exit", async () => {
+  test("forwards repeated SIGTERM to the flock process group until child exit", async () => {
     const handlers = new Map();
     const forwarded = [];
     const selfKills = [];
+    const spawnCalls = [];
     let exit;
     const child = {
+      pid: 4242,
       kill(signal) {
-        forwarded.push(signal);
+        forwarded.push(["child", signal]);
       },
       once(event, handler) {
         if (event === "exit") exit = handler;
@@ -233,22 +235,77 @@ describe("runLockedDaemon", () => {
     const daemon = runLockedDaemon(
       { tokenFile: path.join(tmp("gh-app-lock-signals-"), "token.json") },
       {
-        spawnImpl: () => child,
+        spawnImpl: (...args) => {
+          spawnCalls.push(args);
+          return child;
+        },
         signals,
         selfKill(pid, signal) {
           selfKills.push({ pid, signal });
+        },
+        killProcess(pid, signal) {
+          forwarded.push(["group", pid, signal]);
         },
       },
     );
     handlers.get("SIGTERM")();
     handlers.get("SIGTERM")();
-    expect(forwarded).toEqual(["SIGTERM", "SIGTERM"]);
+    expect(forwarded).toEqual([
+      ["group", -4242, "SIGTERM"],
+      ["group", -4242, "SIGTERM"],
+    ]);
     expect(selfKills).toEqual([]);
+    expect(spawnCalls[0][2]).toMatchObject({
+      stdio: "inherit",
+      detached: true,
+    });
 
     exit(0, null);
     await daemon;
     expect(selfKills).toEqual([{ pid: process.pid, signal: "SIGTERM" }]);
     expect(handlers.size).toBe(0);
+  });
+
+  test("falls back to signaling the flock child when the process group is gone", async () => {
+    const handlers = new Map();
+    const forwarded = [];
+    let exit;
+    const child = {
+      pid: 4242,
+      kill(signal) {
+        forwarded.push(["child", signal]);
+      },
+      once(event, handler) {
+        if (event === "exit") exit = handler;
+      },
+    };
+    const signals = {
+      on(signal, handler) {
+        handlers.set(signal, handler);
+      },
+      removeListener(signal, handler) {
+        if (handlers.get(signal) === handler) handlers.delete(signal);
+      },
+    };
+
+    const daemon = runLockedDaemon(
+      { tokenFile: path.join(tmp("gh-app-lock-group-gone-"), "token.json") },
+      {
+        spawnImpl: () => child,
+        signals,
+        selfKill() {},
+        killProcess() {
+          const err = new Error("No such process");
+          err.code = "ESRCH";
+          throw err;
+        },
+      },
+    );
+    handlers.get("SIGTERM")();
+    expect(forwarded).toEqual([["child", "SIGTERM"]]);
+
+    exit(0, null);
+    await daemon;
   });
 });
 
@@ -414,11 +471,19 @@ describe("runDaemon", () => {
       while (
         Date.now() < deadline &&
         (!existsSync(lockFile) ||
-          readFileSync(lockFile, "utf8").trim() !== String(first.pid))
+          !/^\d+$/.test(readFileSync(lockFile, "utf8").trim()))
       ) {
         await Bun.sleep(5);
       }
-      expect(readFileSync(lockFile, "utf8").trim()).toBe(String(first.pid));
+      const lockOwner = readFileSync(lockFile, "utf8").trim();
+      expect(lockOwner).toMatch(/^\d+$/);
+      expect(lockOwner).not.toBe(String(first.pid));
+      const ownerCommand = Bun.spawnSync({
+        cmd: ["ps", "-p", lockOwner, "-o", "command="],
+        stdout: "pipe",
+        stderr: "pipe",
+      }).stdout.toString();
+      expect(ownerCommand.trim()).toEndWith(`${script} --daemon-held`);
 
       const second = Bun.spawnSync({
         cmd: [process.execPath, script, "--daemon"],
@@ -433,6 +498,77 @@ describe("runDaemon", () => {
     } finally {
       first.kill("SIGTERM");
       await first.exited;
+    }
+  });
+
+  test("SIGTERM stops the entire flock subtree and releases its lock", async () => {
+    const dir = tmp("gh-app-daemon-subtree-stop-");
+    const env = appEnv(dir);
+    writeFileSync(env.FACTORY_GH_APP_PRIVATE_KEY_PATH, privateKey);
+    writeFileSync(
+      env.FACTORY_GH_APP_TOKEN_FILE,
+      JSON.stringify({
+        token: "ghs_cached",
+        expiresAt: "2099-01-01T00:00:00Z",
+      }),
+    );
+    const script = path.join(import.meta.dir, "gh-app-auth.mjs");
+    const lockFile = `${env.FACTORY_GH_APP_TOKEN_FILE}.lock`;
+    const daemon = Bun.spawn({
+      cmd: [process.execPath, script, "--daemon"],
+      env: { ...process.env, ...env },
+      stdout: "ignore",
+      stderr: "ignore",
+    });
+
+    const daemonHeldCommand = `${script} --daemon-held`;
+    try {
+      const deadline = Date.now() + 2_000;
+      let lockOwner = "";
+      while (Date.now() < deadline) {
+        if (existsSync(lockFile)) {
+          lockOwner = readFileSync(lockFile, "utf8").trim();
+          if (/^\d+$/.test(lockOwner) && lockOwner !== String(daemon.pid)) {
+            break;
+          }
+        }
+        await Bun.sleep(5);
+      }
+      expect(lockOwner).toMatch(/^\d+$/);
+      expect(lockOwner).not.toBe(String(daemon.pid));
+
+      daemon.kill("SIGTERM");
+      await daemon.exited;
+
+      const stopDeadline = Date.now() + 2_000;
+      let heldProcesses = ["pending"];
+      let lockIsFree = { exitCode: 1 };
+      while (Date.now() < stopDeadline) {
+        heldProcesses = Bun.spawnSync({
+          cmd: ["ps", "-axo", "command="],
+          stdout: "pipe",
+          stderr: "pipe",
+        })
+          .stdout.toString()
+          .split("\n")
+          .filter((command) => command.includes(daemonHeldCommand));
+        lockIsFree = Bun.spawnSync({
+          cmd: ["flock", "--nonblock", lockFile, "true"],
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        if (heldProcesses.length === 0 && lockIsFree.exitCode === 0) break;
+        await Bun.sleep(5);
+      }
+      expect(lockIsFree.exitCode).toBe(0);
+      expect(heldProcesses).toEqual([]);
+    } finally {
+      try {
+        daemon.kill("SIGKILL");
+      } catch {
+        // The expected path has already exited.
+      }
+      await daemon.exited;
     }
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2098

SIGTERM on the gh-app wrapper now kills the flock subtree so live-stack down cannot orphan the token lock.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/gh-app-auth.test.mjs bin/live-stack.test.mjs` | pass    | 78 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 0 errors, format clean |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface (daemon/infra)

run:run_f2dfcfd5-1087-47f9-8c63-6e3e8008a6e9
