### PR TITLE
fix(ci-log-capture): classify gh failures by HTTP status

### DIFF
--- a/event-runtime/lib/ci-log-capture.mjs
+++ b/event-runtime/lib/ci-log-capture.mjs
@@ -23,15 +23,12 @@
  * simply does not fire. Genuine faults — auth, network, quota, a missing
  * `gh` — still exit non-zero and are still `agent_exit_<code>`.
  *
- * Precedence, when `gh` exits non-zero with nothing captured: FAULT wins over
- * MISSING. GitHub masks some authorization failures as 404, so stderr that
- * matches `EXPECTED_FAULT` is a fault even when it also reads as a missing
- * log; only stderr that matches `EXPECTED_MISSING` and no fault signal exits
- * 0. Anything unrecognized is a fault — the safe default is to surface it.
- * That precedence makes `EXPECTED_FAULT` the narrower of the two: it lists
- * explicit auth/network/quota signals only, never bare words like `auth` or
- * `timeout` that appear in `gh`'s routine "Try authenticating with: gh auth
- * login" hint printed alongside an ordinary deleted-run 404.
+ * Precedence, when `gh` exits non-zero with nothing captured: an explicit
+ * `HTTP NNN` token is authoritative. Only 404 and 410 are expected-missing;
+ * every other status is a fault regardless of accompanying prose. Statusless
+ * diagnostics use the narrow `EXPECTED_MISSING` fallback below. A failed
+ * spawn is always a fault. Anything unrecognized is also a fault — the safe
+ * default is to surface it.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -62,19 +59,23 @@ const DETAIL_LIMIT = 400;
  * through to the fault branch and re-create the #2076 `agent_exit_1` flood.
  */
 const EXPECTED_MISSING =
-  /(?:\bHTTP (?:404|410)\b|no logs|logs? (?:have )?expired|run (?:was )?cancell?ed)/im;
+  /(?:no logs|logs? (?:have )?expired|run (?:was )?cancell?ed)/im;
 
 /**
- * A missing-log response must never conceal a failure to make the request.
- * GitHub deliberately masks some authorization failures as 404, so this
- * check deliberately wins over `EXPECTED_MISSING` above.
- *
- * Explicit signals only. Bare `auth`/`timeout`/`permission`/`forbidden` were
- * removed: `gh` appends "Try authenticating with: gh auth login" to plain
- * 404s, which would classify an ordinary deleted run as a fault.
+ * Extract the authoritative HTTP status token that `gh` prints in an API
+ * diagnostic. Message text must not influence a classification once present.
  */
-const EXPECTED_FAULT =
-  /HTTP (?:401|403)\b|bad credentials|rate limit|context cancell?ed|context deadline exceeded|connection refused|EAI_AGAIN|ENOTFOUND|resource not accessible/i;
+export function parseHttpStatus(stderr) {
+  const match = /\bHTTP\s+(\d{3})\b/i.exec(String(stderr ?? ""));
+  return match ? Number.parseInt(match[1], 10) : null;
+}
+
+function isExpectedMissing(stderr) {
+  const status = parseHttpStatus(stderr);
+  return status === null
+    ? EXPECTED_MISSING.test(stderr)
+    : status === 404 || status === 410;
+}
 
 /**
  * The pinned-attempt argv, and the legacy fallback when the event carries no
@@ -115,9 +116,14 @@ function spawnToFile(argv, logPath) {
       return {
         exitCode: child.status ?? 1,
         stderr: String(child.error.message),
+        spawnError: child.error,
       };
     }
-    return { exitCode: child.status ?? 1, stderr: child.stderr ?? "" };
+    return {
+      exitCode: child.status ?? 1,
+      stderr: child.stderr ?? "",
+      spawnError: null,
+    };
   } finally {
     closeSync(fd);
   }
@@ -136,7 +142,7 @@ export function captureCiLog({
 } = {}) {
   const logPath = path.join(cwd, LOG_FILE);
   const { argv, attempt } = buildArgv(input);
-  const { exitCode, stderr } = spawn(argv, logPath);
+  const { exitCode, stderr, spawnError = null } = spawn(argv, logPath);
 
   const bytes = existsSync(logPath) ? statSync(logPath).size : 0;
   const captured = exitCode === 0 && bytes > 0;
@@ -148,7 +154,7 @@ export function captureCiLog({
   if (
     !captured &&
     exitCode !== 0 &&
-    (EXPECTED_FAULT.test(detail) || !EXPECTED_MISSING.test(detail))
+    (spawnError || !isExpectedMissing(detail))
   ) {
     return {
       ok: false,

--- a/event-runtime/lib/ci-log-capture.test.mjs
+++ b/event-runtime/lib/ci-log-capture.test.mjs
@@ -14,12 +14,12 @@ const registry = loadRegistry();
 const INPUT = { repo: "watt-mind/factory", runId: 33300511167 };
 
 /** A `gh` stand-in: writes `stdout` to the log file and returns its exit. */
-function fakeGh({ stdout = "", stderr = "", exitCode = 0 }) {
+function fakeGh({ stdout = "", stderr = "", exitCode = 0, spawnError = null }) {
   const calls = [];
   const spawn = (argv, logPath) => {
     calls.push(argv);
     writeFileSync(logPath, stdout, "utf8");
-    return { exitCode, stderr };
+    return { exitCode, stderr, spawnError };
   };
   spawn.calls = calls;
   return spawn;
@@ -129,7 +129,6 @@ describe("ci-log-capture command (#2076)", () => {
       "HTTP 401: Bad credentials",
       "HTTP 403: rate limit exceeded",
       'Post "https://api.github.com/repos/watt-mind/factory": context canceled',
-      "HTTP 404: Not Found: Resource not accessible by integration (permission denied)",
     ]) {
       const cwd = tmpDir("evrt-ci-log-capture-fault-taxonomy-");
       const outcome = captureCiLog({
@@ -142,6 +141,66 @@ describe("ci-log-capture command (#2076)", () => {
       expect(outcome.exitCode).toBe(1);
       expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
     }
+  });
+
+  test("classifies an HTTP status before its accompanying message", () => {
+    for (const stderr of [
+      "HTTP 500: log not found in cache",
+      "HTTP 403: the cancelled run cannot be read",
+    ]) {
+      const cwd = tmpDir("evrt-ci-log-capture-status-fault-");
+      const outcome = captureCiLog({
+        cwd,
+        input: INPUT,
+        spawn: fakeGh({ stderr, exitCode: 1 }),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
+    }
+
+    for (const stderr of [
+      "HTTP 404: resource not accessible by integration",
+      "HTTP 410: cancelled run logs expired",
+    ]) {
+      const cwd = tmpDir("evrt-ci-log-capture-status-missing-");
+      const outcome = captureCiLog({
+        cwd,
+        input: INPUT,
+        spawn: fakeGh({ stderr, exitCode: 1 }),
+      });
+
+      expect(outcome.ok).toBe(true);
+      expect(readResult(cwd).artifact.captured).toBe(NO_CAPTURE);
+    }
+  });
+
+  test("uses narrow missing-log text only when stderr has no HTTP status", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-statusless-missing-");
+    const outcome = captureCiLog({
+      cwd,
+      input: INPUT,
+      spawn: fakeGh({ stderr: "failed job logs have expired", exitCode: 1 }),
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(readResult(cwd).artifact.captured).toBe(NO_CAPTURE);
+  });
+
+  test("a spawn failure remains a fault even when its message resembles missing logs", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-spawn-failure-");
+    const outcome = captureCiLog({
+      cwd,
+      input: INPUT,
+      spawn: fakeGh({
+        stderr: "logs expired",
+        exitCode: 1,
+        spawnError: new Error("gh executable not found"),
+      }),
+    });
+
+    expect(outcome.ok).toBe(false);
+    expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
   });
 
   test("gh's routine auth hint on a plain 404 stays a missing log", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2108

Classify gh failures by HTTP status so server and auth faults reach ci-diagnose.

## Validation

| Check                | Command                                                                            | Result  | Notes                                  |
| -------------------- | ---------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/ci-log-capture.test.mjs`                              | pass    | 12 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | lib tests, emit, format, lint; clean   |
| UX critique          | factory-ux-critic                                                                  | not run | no user-facing surface                 |

UX critique: skipped — backend failure classification has no user-facing surface.

run:run_ecc62e54-92a9-40da-a7cb-92c488cbb444