### PR TITLE
test(chain): cover ci-log capture no-artifact edge suppression

### DIFF
--- a/event-runtime/lib/chain.test.mjs
+++ b/event-runtime/lib/chain.test.mjs
@@ -545,6 +545,33 @@ describe("multi-emit chain resolution (WM-119)", () => {
     ).run(eventId, now, now, `corr-${runId}`, runId, now);
   }
 
+  test("ci-log-capture with no captured artifact does not emit a ci-diagnose event", () => {
+    const db = openDb(":memory:");
+    seedCompletedRun(db, {
+      runId: "run-no-capture",
+      agent: "ci-log-capture@1",
+      input: { repo: "wm/factory", runId: 12345 },
+      artifact: { captured: "none", exitCode: 0 },
+    });
+
+    expect(resolveChains(db, registry)).toEqual({
+      emitted: 0,
+      skipped: 1,
+      errors: [],
+    });
+    expect(
+      db
+        .query(
+          `SELECT * FROM events WHERE source = 'chain' AND causation_id = 'run-no-capture'`,
+        )
+        .get(),
+    ).toBeNull();
+    expect(chainResolution(db, "run-no-capture")).toMatchObject({
+      note: "chain_resolved",
+      reason: "no_edge_selected",
+    });
+  });
+
   test("fans out N planned items into N admitted chain events with chain-<runId>-<itemKey> IDs", () => {
     const dir = tmpDir("evrt-chain-multi-");
     const db = openDb(path.join(dir, "runtime.db"));


### PR DESCRIPTION
Fixes watt-mind/factory#2086

Add regression coverage proving empty CI-log captures do not trigger diagnosis dispatch.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/chain.test.mjs`    | pass    | 34 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | exit 0; lint warnings only |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_4c7b7a39-7a11-4b75-b2ed-8192999024fb