### PR TITLE
test(harness): harden fragile stack checks

### DIFF
--- a/bin/live-stack.sh
+++ b/bin/live-stack.sh
@@ -41,6 +41,7 @@ set -eEuo pipefail
 
 source "$(dirname "${BASH_SOURCE[0]}")/worktree-common.sh"
 
+# >>> up-pidfile-tracking
 # `up` can start several detached daemons before an endpoint health check
 # proves the stack is usable. Keep this invocation's pidfiles separate from
 # pre-existing daemons: an error must clean up what we started, but never tear
@@ -107,6 +108,7 @@ untrack_up_pidfile() { # <pidfile>
     UP_STARTED_LABELS=()
   fi
 }
+# <<< up-pidfile-tracking
 
 track_up_pool_pidfiles() {
   local pidfile label

--- a/bin/live-stack.test.mjs
+++ b/bin/live-stack.test.mjs
@@ -23,6 +23,36 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 
 const LIVE_STACK = path.resolve(import.meta.dir, "live-stack.sh");
+const UP_PIDFILE_TRACKING_START = "# >>> up-pidfile-tracking";
+const UP_PIDFILE_TRACKING_END = "# <<< up-pidfile-tracking";
+
+function extractMarkedBlock(source, startMarker, endMarker) {
+  const start = source.indexOf(startMarker);
+  if (start === -1) {
+    throw new Error(`missing extraction marker: ${startMarker}`);
+  }
+  const contentStart = source.indexOf("\n", start);
+  if (contentStart === -1) {
+    throw new Error(`missing extraction marker line ending: ${startMarker}`);
+  }
+  const end = source.indexOf(endMarker, contentStart + 1);
+  if (end === -1) {
+    throw new Error(`missing extraction marker: ${endMarker}`);
+  }
+  const block = source.slice(contentStart + 1, end).trim();
+  if (!block) {
+    throw new Error(
+      `empty extraction block between ${startMarker} and ${endMarker}`,
+    );
+  }
+  return block;
+}
+
+const upPidfileTrackingBlock = extractMarkedBlock(
+  readFileSync(LIVE_STACK, "utf8"),
+  UP_PIDFILE_TRACKING_START,
+  UP_PIDFILE_TRACKING_END,
+);
 
 /**
  * worktree-common.sh replaced by recorders: no daemon is ever started.
@@ -445,7 +475,7 @@ test("untracking the only pidfile remains safe under nounset", () => {
     cmd: [
       "bash",
       "-uc",
-      `source <(sed -n '48,109p' "$1")
+      `source <(printf '%s\\n' "$3")
 UP_STARTED_PIDFILES=("$2")
 UP_STARTED_LABELS=("GitHub App token daemon")
 untrack_up_pidfile "$2"
@@ -454,12 +484,22 @@ untrack_up_pidfile "$2"
       "bash",
       LIVE_STACK,
       "/tmp/only.pid",
+      upPidfileTrackingBlock,
     ],
     stdout: "pipe",
     stderr: "pipe",
   });
   expect(result.exitCode).toBe(0);
   expect(result.stderr.toString()).toBe("");
+});
+
+test("pidfile tracking extraction rejects missing or empty markers", () => {
+  expect(() =>
+    extractMarkedBlock("# start\nbody\n", "# start", "# end"),
+  ).toThrow("missing extraction marker: # end");
+  expect(() =>
+    extractMarkedBlock("# start\n# end\n", "# start", "# end"),
+  ).toThrow("empty extraction block");
 });
 
 test("`up` keeps the existing live GitHub App daemon pidfile behavior", () => {

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -337,7 +337,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
   );
 
   test(
-    "re-running seed with the SAME prefix fails immediately (<1s) on duplicate intake",
+    "re-running seed with the SAME prefix stays fast on duplicate intake",
     () => {
       const t0 = Date.now();
       const res = spawnSync("bun", [SEED, "--port", port, "--prefix", "t1"], {
@@ -346,7 +346,9 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
       });
       const elapsedMs = Date.now() - t0;
       expect(res.status).not.toBe(0);
-      expect(elapsedMs).toBeLessThan(2000);
+      // Protect the duplicate fast path from regressing into a full seed run;
+      // account for shared-runner contention without masking that regression.
+      expect(elapsedMs).toBeLessThan(loadAdjustedTimeout(2000));
       const output = `${res.stdout}${res.stderr}`;
       expect(output).toContain('duplicate prefix "t1"');
     },


### PR DESCRIPTION
Fixes watt-mind/factory#2107

Replace fragile line-number sourcing with marker-validated extraction and load-adjust the duplicate-seed timing bound.

## Validation

| Check                | Command                                                    | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test bin/live-stack.test.mjs event-runtime/demo/seed.test.mjs` | pass    | 61 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 0 errors, 615 warnings        |
| UX critique          | factory-ux-critic                                          | not run | backend/test-only maintenance |

UX critique: skipped — backend/test-only maintenance; no user-facing surface
run:run_1eb063da-6f04-4fcd-9974-2800cee50841