### PR TITLE
fix(ticket): safely detect landed timeout comments

### DIFF
--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -88,6 +88,30 @@ const FIND_ORGANIZATION_PROJECT = `query FindOrganizationProject($login: String!
   }
 }`;
 
+/**
+ * Who the credential this adapter writes with is, as GitHub reports it.
+ *
+ * GraphQL `viewer` is the only identity read that answers for BOTH credential
+ * kinds the adapter runs under, which is exactly what a "did my comment land?"
+ * check needs (#2105):
+ *   - a PAT / `gh auth login` user resolves to that human (`hdkiller`);
+ *   - an App **installation** token resolves to the installation's bot user
+ *     (`<slug>[bot]`), the account that authors every comment the App posts.
+ * The REST alternatives cannot: `GET /user` answers 403 "Resource not
+ * accessible by integration" for an installation token (which is why
+ * `makeGhApi` deliberately routes the claim's viewer read around App auth),
+ * and `GET /app` needs an App JWT, which the adapter never holds.
+ *
+ * `databaseId` is the REST numeric id, so it compares directly against the
+ * `user.id` that `listComments` returns.
+ */
+const VIEWER_IDENTITY = `query ViewerIdentity {
+  viewer {
+    login
+    databaseId
+  }
+}`;
+
 const FIND_VIEWER_PROJECT = `query FindViewerProject($title: String!, $statusField: String!) {
   viewer {
     projectsV2(first: 20, query: $title) {
@@ -1552,8 +1576,43 @@ export function githubControlPlane(options = {}) {
     return { issue, status, ticket: normalizeIssue(issue, repo, status) };
   }
 
+  // Memoized viewer identity. The credential is stable for the life of the
+  // adapter (the App daemon rotates the token hourly, but the installation —
+  // and so the bot user — does not change), so one GraphQL read serves every
+  // comment-landed check. A failed read is NOT cached: an identity that is
+  // merely unreachable right now must not pin this adapter to "unknown".
+  let actorPromise = null;
+
+  async function readActor() {
+    const d = await call("POST", "graphql", {
+      body: { query: VIEWER_IDENTITY },
+    });
+    const viewer = d?.viewer;
+    if (viewer?.databaseId == null) return null;
+    return Object.freeze({
+      id: String(viewer.databaseId),
+      name: viewer.login ?? null,
+    });
+  }
+
   return {
     kind: "github",
+
+    /**
+     * The account this adapter's writes are attributed to, or null when the
+     * identity read fails. Callers use it to tell their own timeline entries
+     * from someone else's; it is corroborating evidence, never a gate, so a
+     * null must never be read as "not ours".
+     */
+    async actor() {
+      if (!actorPromise) {
+        actorPromise = readActor().catch((cause) => {
+          actorPromise = null;
+          throw cause;
+        });
+      }
+      return actorPromise;
+    },
 
     async getTicket(identifier) {
       const { repo, number } = locate(identifier);

--- a/lib/control-plane/github.test.mjs
+++ b/lib/control-plane/github.test.mjs
@@ -256,6 +256,21 @@ function fakeApi(seed) {
           },
         };
       }
+      if (gqlQuery.includes("ViewerIdentity")) {
+        if (seed.viewerIdentityFails)
+          fail("github graphql timed out after 15000ms", 504);
+        return {
+          data: {
+            // GraphQL shape: `databaseId` is the REST numeric user id, and
+            // `seed.viewerIdentity` stands in for an App installation token,
+            // whose viewer is the `<slug>[bot]` account.
+            viewer: seed.viewerIdentity ?? {
+              login: seed.viewer.login,
+              databaseId: seed.viewer.id,
+            },
+          },
+        };
+      }
       if (gqlQuery.includes("FindViewerProject")) {
         return {
           data: {
@@ -650,6 +665,43 @@ describe("control-plane contract: github", () => {
     }
     expect(err).toBeInstanceOf(ControlPlaneError);
     expect(err.message).toMatch(/no such issue/i);
+  });
+
+  test("actor resolves the writing credential's numeric id, once", async () => {
+    const { api, cp } = makePlane();
+    // The id is the REST `databaseId`, so it compares directly against the
+    // `user.id` listComments reports for a comment this adapter posted.
+    expect(await cp.actor()).toEqual({ id: "1", name: "Ada" });
+    expect(await cp.actor()).toEqual({ id: "1", name: "Ada" });
+    const identityReads = api.calls.filter((call) =>
+      String(call.body?.query ?? "").includes("ViewerIdentity"),
+    );
+    expect(identityReads).toHaveLength(1);
+  });
+
+  test("actor under an App installation token is the bot user", async () => {
+    const seed = contractSeed();
+    // An installation token has no human viewer: GraphQL answers with the
+    // App's own `<slug>[bot]` account, which is what authors its comments.
+    seed.viewerIdentity = {
+      login: "watt-mind-factory[bot]",
+      databaseId: 322488792,
+    };
+    const cp = githubControlPlane({ api: fakeApi(seed), repo: REPO });
+    expect(await cp.actor()).toEqual({
+      id: "322488792",
+      name: "watt-mind-factory[bot]",
+    });
+  });
+
+  test("a failed actor read rejects and is not cached as unknown", async () => {
+    const seed = contractSeed();
+    seed.viewerIdentityFails = true;
+    const cp = githubControlPlane({ api: fakeApi(seed), repo: REPO });
+
+    await expect(cp.actor()).rejects.toThrow(ControlPlaneError);
+    seed.viewerIdentityFails = false;
+    expect(await cp.actor()).toMatchObject({ id: "1" });
   });
 
   test("listComments returns the comment bodies", async () => {

--- a/lib/control-plane/types.mjs
+++ b/lib/control-plane/types.mjs
@@ -107,6 +107,12 @@
  *   without the status/trust/pin reads getTicket pays for. Planes that
  *   omit it are read through getTicket instead.
  * @property {(identifier: string) => Promise<TicketComment[]>} listComments
+ * @property {(() => Promise<{id: string, name: string|null}|null>)=} actor
+ *   Optional: the account this adapter's writes are attributed to, used to
+ *   tell our own timeline entries from someone else's when recovering from a
+ *   timed-out comment (#2105). Adapters that cannot answer omit it; callers
+ *   must treat an absent or failed identity as "no evidence either way", never
+ *   as "not ours" — a veto there duplicates every recovered comment.
  * @property {(opts: { team: string, project?: string, states?: string[], includeFinished?: boolean }) => Promise<Ticket[]>} listTickets
  *   Every ticket in the given factory states (default: all not-finished),
  *   in queue order — priority asc, then createdAt asc. `description`,

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -179,7 +179,8 @@ function commentBodyMatches(comment, expected, actor) {
  */
 async function resolveCommentActor(cp) {
   try {
-    const actor = typeof cp?.actor === "function" ? await cp.actor() : cp?.actor;
+    const actor =
+      typeof cp?.actor === "function" ? await cp.actor() : cp?.actor;
     return actor ?? null;
   } catch {
     return null;

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -155,19 +155,35 @@ function commentBodyMatches(comment, expected, actor) {
   ]);
   if (!landedBodies.has(body)) return false;
 
-  const authorId = comment?.user?.id;
-  if (authorId) return Boolean(actor?.id) && authorId === actor.id;
+  // Author metadata REFINES the body match; it never vetoes it. Only a
+  // positive mismatch — we know who we write as, the timeline says someone
+  // else wrote this — is evidence that our own write never landed. Treating
+  // "no identity available" as a mismatch would be strictly worse than not
+  // checking at all: control planes that expose no actor (linear, memory, or a
+  // github adapter whose identity read failed) still populate `comment.user`,
+  // so every landed comment would be judged foreign and double-posted.
+  const authorId = comment?.user?.id == null ? null : String(comment.user.id);
+  const actorId = actor?.id == null ? null : String(actor.id);
+  if (!authorId || !actorId) return true;
+  return authorId === actorId;
+}
 
-  // A comment list without author metadata cannot distinguish a human's
-  // identical text from our timed-out write. The optional run trailer is the
-  // only ownership evidence in that case; otherwise replay rather than lose a
-  // rationale that may never have landed.
-  const runId = process.env.FACTORY_RUN_ID;
-  return (
-    process.env.FACTORY_COMMENT_ATTRIBUTION === "1" &&
-    Boolean(runId) &&
-    body.endsWith(`run:${runId}`)
-  );
+/**
+ * The identity the control plane writes as, or null when it has none to give.
+ *
+ * Adapters may expose `actor` as a value (tests, fakes) or as an async verb
+ * that costs a request (github's viewer read). A failure resolves to null,
+ * which `commentBodyMatches` treats as "no refinement available" rather than
+ * as a mismatch — an identity lookup outage must not start duplicating
+ * comments.
+ */
+async function resolveCommentActor(cp) {
+  try {
+    const actor = typeof cp?.actor === "function" ? await cp.actor() : cp?.actor;
+    return actor ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -176,15 +192,22 @@ function commentBodyMatches(comment, expected, actor) {
  * Comment creation is not idempotent: blindly replaying a request after its
  * response timed out can create a duplicate timeline entry. The check runs
  * only on the retry path, so ordinary comments remain one write.
+ *
+ * This is also where ticket item (c) — "a replayed transition must not re-post
+ * its rationale" — is satisfied: `transitionThenComment` and `triageTicket`
+ * retry the transition and the comment as two separate mutations, and their
+ * comment half is always routed through this function, so a transition replay
+ * cannot reach `cp.comment` without first passing the landed-check.
  */
 export async function commentWithRetry(cp, key, body) {
   let retrying = false;
   return retryControlPlaneMutation(cp, async () => {
     if (retrying) {
-      const comments = await getCommentsWithRetry(cp, key);
-      if (
-        comments.some((comment) => commentBodyMatches(comment, body, cp.actor))
-      )
+      const [comments, actor] = await Promise.all([
+        getCommentsWithRetry(cp, key),
+        resolveCommentActor(cp),
+      ]);
+      if (comments.some((comment) => commentBodyMatches(comment, body, actor)))
         return;
     }
     retrying = true;

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -74,7 +74,11 @@ import {
   claimLabels,
   appendIssueDetail,
 } from "../lib/control-plane/index.mjs";
-import { releaseLabels } from "../lib/control-plane/labels.mjs";
+import {
+  clampGithubBody,
+  releaseLabels,
+  stampRun,
+} from "../lib/control-plane/labels.mjs";
 import {
   parseOwnedPaths,
   ownedPathsClosureGaps,
@@ -141,14 +145,28 @@ export async function retryControlPlaneMutation(
   throw new Error("unreachable: control-plane mutation retry loop exhausted");
 }
 
-function commentBodyMatches(body, expected) {
-  if (body === expected) return true;
+function commentBodyMatches(comment, expected, actor) {
+  const body = String(comment?.body ?? "");
+  const landedBodies = new Set([
+    expected,
+    stampRun(expected),
+    clampGithubBody(expected),
+    clampGithubBody(stampRun(expected)),
+  ]);
+  if (!landedBodies.has(body)) return false;
+
+  const authorId = comment?.user?.id;
+  if (authorId) return Boolean(actor?.id) && authorId === actor.id;
+
+  // A comment list without author metadata cannot distinguish a human's
+  // identical text from our timed-out write. The optional run trailer is the
+  // only ownership evidence in that case; otherwise replay rather than lose a
+  // rationale that may never have landed.
   const runId = process.env.FACTORY_RUN_ID;
   return (
     process.env.FACTORY_COMMENT_ATTRIBUTION === "1" &&
     Boolean(runId) &&
-    !expected.includes(`run:${runId}`) &&
-    body === `${expected}\n\nrun:${runId}`
+    body.endsWith(`run:${runId}`)
   );
 }
 
@@ -164,7 +182,9 @@ export async function commentWithRetry(cp, key, body) {
   return retryControlPlaneMutation(cp, async () => {
     if (retrying) {
       const comments = await getCommentsWithRetry(cp, key);
-      if (comments.some((comment) => commentBodyMatches(comment.body, body)))
+      if (
+        comments.some((comment) => commentBodyMatches(comment, body, cp.actor))
+      )
         return;
     }
     retrying = true;

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -30,6 +30,7 @@ import {
   formatComments,
   parsePositionalArgs,
   retryControlPlaneMutation,
+  commentWithRetry,
   transitionThenComment,
   getTicketWithRetry,
   triageTicket,
@@ -53,6 +54,7 @@ import {
   linearNetworkIsOffline,
 } from "./ticket.mjs";
 import { gql } from "../orchestrator/reaper.mjs";
+import { clampGithubBody, stampRun } from "../lib/control-plane/labels.mjs";
 
 const LABELS = [
   { id: "l-ready", name: "ai:agent-ready" },
@@ -452,12 +454,13 @@ test("state comment retry does not repeat a timed-out comment that landed", asyn
   const comments = [];
   const cp = {
     kind: "github",
+    actor: { id: "factory-app" },
     async transition() {
       calls.transition += 1;
     },
     async comment(_key, body) {
       calls.comment += 1;
-      comments.push({ body });
+      comments.push({ body, user: { id: "factory-app" } });
       throw new Error("gh timed out after 15000ms");
     },
     async listComments() {
@@ -470,7 +473,85 @@ test("state comment retry does not repeat a timed-out comment that landed", asyn
     transitionThenComment(cp, "WM-910", "Todo", {}, "explain the move"),
   ).resolves.toBeUndefined();
   expect(calls).toEqual({ transition: 1, comment: 1, listComments: 1 });
-  expect(comments).toEqual([{ body: "explain the move" }]);
+  expect(comments).toEqual([
+    { body: "explain the move", user: { id: "factory-app" } },
+  ]);
+});
+
+test("comment retry recognizes the clamped, stamped body that GitHub landed", async () => {
+  const beforeAttribution = process.env.FACTORY_COMMENT_ATTRIBUTION;
+  const beforeRunId = process.env.FACTORY_RUN_ID;
+  process.env.FACTORY_COMMENT_ATTRIBUTION = "1";
+  process.env.FACTORY_RUN_ID = "run-ticket-clamp";
+  try {
+    const calls = { comment: 0, listComments: 0 };
+    const body = "x".repeat(70_000);
+    const landed = clampGithubBody(stampRun(body));
+    const cp = {
+      kind: "github",
+      async comment() {
+        calls.comment += 1;
+        throw new Error("gh timed out after 15000ms");
+      },
+      async listComments() {
+        calls.listComments += 1;
+        return [
+          {
+            body: landed,
+          },
+        ];
+      },
+    };
+
+    await expect(commentWithRetry(cp, "WM-910", body)).resolves.toBeUndefined();
+    expect(calls).toEqual({ comment: 1, listComments: 1 });
+  } finally {
+    if (beforeAttribution === undefined)
+      delete process.env.FACTORY_COMMENT_ATTRIBUTION;
+    else process.env.FACTORY_COMMENT_ATTRIBUTION = beforeAttribution;
+    if (beforeRunId === undefined) delete process.env.FACTORY_RUN_ID;
+    else process.env.FACTORY_RUN_ID = beforeRunId;
+  }
+});
+
+test("comment retry does not mistake another actor's identical comment for ours", async () => {
+  const calls = { comment: 0, listComments: 0 };
+  const cp = {
+    kind: "github",
+    actor: { id: "factory-app" },
+    async comment() {
+      calls.comment += 1;
+      if (calls.comment === 1) throw new Error("gh timed out after 15000ms");
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return [{ body: "explain the move", user: { id: "human" } }];
+    },
+  };
+
+  await expect(
+    commentWithRetry(cp, "WM-910", "explain the move"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ comment: 2, listComments: 1 });
+});
+
+test("a transition retried after its response times out posts its rationale once", async () => {
+  const calls = { transition: 0, comment: 0 };
+  const cp = {
+    kind: "github",
+    async transition() {
+      calls.transition += 1;
+      if (calls.transition === 1) throw new Error("gh timed out after 15000ms");
+    },
+    async comment() {
+      calls.comment += 1;
+    },
+  };
+
+  await expect(
+    transitionThenComment(cp, "WM-910", "Todo", {}, "explain the move"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ transition: 2, comment: 1 });
 });
 
 test("answer retries a timed-out comment without repeating its transition", async () => {

--- a/tools/ticket.test.mjs
+++ b/tools/ticket.test.mjs
@@ -514,6 +514,93 @@ test("comment retry recognizes the clamped, stamped body that GitHub landed", as
   }
 });
 
+// Production shape, not a fixture shape: a control plane that exposes no
+// actor at all (linear, memory, or a github adapter whose identity read
+// failed) still returns `user` on every listed comment. Missing identity must
+// therefore refine nothing rather than veto the body match — otherwise every
+// timed-out-but-landed comment is posted twice.
+test("comment retry trusts the body match when the plane exposes no actor", async () => {
+  const beforeAttribution = process.env.FACTORY_COMMENT_ATTRIBUTION;
+  const beforeRunId = process.env.FACTORY_RUN_ID;
+  process.env.FACTORY_COMMENT_ATTRIBUTION = "1";
+  process.env.FACTORY_RUN_ID = "run-no-actor";
+  try {
+    const calls = { comment: 0, listComments: 0 };
+    const body = "explain the move";
+    const cp = {
+      kind: "github",
+      async comment() {
+        calls.comment += 1;
+        throw new Error("gh timed out after 15000ms");
+      },
+      async listComments() {
+        calls.listComments += 1;
+        return [{ body: clampGithubBody(stampRun(body)), user: { id: "123" } }];
+      },
+    };
+
+    await expect(commentWithRetry(cp, "WM-910", body)).resolves.toBeUndefined();
+    expect(calls).toEqual({ comment: 1, listComments: 1 });
+  } finally {
+    if (beforeAttribution === undefined)
+      delete process.env.FACTORY_COMMENT_ATTRIBUTION;
+    else process.env.FACTORY_COMMENT_ATTRIBUTION = beforeAttribution;
+    if (beforeRunId === undefined) delete process.env.FACTORY_RUN_ID;
+    else process.env.FACTORY_RUN_ID = beforeRunId;
+  }
+});
+
+// The github adapter resolves its identity lazily, with a request; the guard
+// must await that verb, not read a property that is always undefined on it.
+test("comment retry awaits an async actor and re-posts on a real mismatch", async () => {
+  const calls = { comment: 0, listComments: 0, actor: 0 };
+  const cp = {
+    kind: "github",
+    async actor() {
+      calls.actor += 1;
+      return { id: "322488792", name: "watt-mind-factory[bot]" };
+    },
+    async comment() {
+      calls.comment += 1;
+      if (calls.comment === 1) throw new Error("gh timed out after 15000ms");
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return [{ body: "explain the move", user: { id: "10578603" } }];
+    },
+  };
+
+  await expect(
+    commentWithRetry(cp, "WM-910", "explain the move"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ comment: 2, listComments: 1, actor: 1 });
+});
+
+// An identity read that throws must degrade to the body match, never to a
+// duplicate post.
+test("comment retry falls back to the body match when the actor read fails", async () => {
+  const calls = { comment: 0, listComments: 0 };
+  const cp = {
+    kind: "github",
+    async actor() {
+      throw new Error("github graphql timed out after 15000ms");
+    },
+    async comment() {
+      calls.comment += 1;
+      throw new Error("gh timed out after 15000ms");
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return [{ body: "explain the move", user: { id: "123" } }];
+    },
+  };
+
+  await expect(
+    commentWithRetry(cp, "WM-910", "explain the move"),
+  ).resolves.toBeUndefined();
+  expect(calls).toEqual({ comment: 1, listComments: 1 });
+});
+
 test("comment retry does not mistake another actor's identical comment for ours", async () => {
   const calls = { comment: 0, listComments: 0 };
   const cp = {
@@ -535,23 +622,39 @@ test("comment retry does not mistake another actor's identical comment for ours"
   expect(calls).toEqual({ comment: 2, listComments: 1 });
 });
 
+// Ticket item (c) — a replayed transition must not re-post its rationale — is
+// satisfied structurally: `transitionThenComment` retries the transition and
+// the comment as two separate mutations, and routes the comment half through
+// `commentWithRetry`, so the rationale can never reach `cp.comment` twice
+// without the landed-check running. Exercise both halves timing out at once,
+// which is the only shape in which the pairing could double-post.
 test("a transition retried after its response times out posts its rationale once", async () => {
-  const calls = { transition: 0, comment: 0 };
+  const calls = { transition: 0, comment: 0, listComments: 0 };
+  const posted = [];
   const cp = {
     kind: "github",
+    actor: { id: "322488792" },
     async transition() {
       calls.transition += 1;
       if (calls.transition === 1) throw new Error("gh timed out after 15000ms");
     },
-    async comment() {
+    async comment(_key, body) {
       calls.comment += 1;
+      posted.push(body);
+      // Landed on the timeline, then the response timed out.
+      throw new Error("gh timed out after 15000ms");
+    },
+    async listComments() {
+      calls.listComments += 1;
+      return posted.map((body) => ({ body, user: { id: "322488792" } }));
     },
   };
 
   await expect(
     transitionThenComment(cp, "WM-910", "Todo", {}, "explain the move"),
   ).resolves.toBeUndefined();
-  expect(calls).toEqual({ transition: 2, comment: 1 });
+  expect(calls).toEqual({ transition: 2, comment: 1, listComments: 1 });
+  expect(posted).toEqual(["explain the move"]);
 });
 
 test("answer retries a timed-out comment without repeating its transition", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2105

Prevent timeout recovery from duplicating clamped comments or dropping a rationale after another actor posts matching text.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test tools/ticket.test.mjs` | pass    | 75 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,372 pass, 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend/internal control-plane retry logic; no user-facing surface

run:run_109040a7-18a9-4035-a7bc-e71829594766
