### PR TITLE
fix(gh-app): redact installation-token response failures

### DIFF
--- a/lib/control-plane/gh-app-auth.mjs
+++ b/lib/control-plane/gh-app-auth.mjs
@@ -43,8 +43,11 @@ const MIN_REFRESH_DELAY_MS = 30 * 1000;
 /** A transient mint failure should recover promptly without hammering GitHub. */
 const RETRY_INITIAL_DELAY_MS = 60 * 1000;
 const RETRY_MAX_DELAY_MS = 5 * 60 * 1000;
-/** A hung token exchange must not prevent a supervised daemon from stopping. */
-const INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS = 10 * 1000;
+/**
+ * Bound the entire token exchange for supervised shutdown, without treating
+ * routine GitHub API latency as a failure.
+ */
+const INSTALLATION_TOKEN_REQUEST_TIMEOUT_MS = 30 * 1000;
 /** JWTs GitHub accepts must expire within 10 min; back-date `iat` for skew. */
 const JWT_LIFETIME_S = 9 * 60;
 const JWT_BACKDATE_S = 60;
@@ -111,9 +114,10 @@ export async function mintInstallationToken({
     throw new Error("mintInstallationToken requires installationId");
   const jwt = buildAppJwt({ appId, privateKeyPem, now });
   let res;
+  let timedOut;
   try {
     const signal = AbortSignal.timeout(timeoutMs);
-    const timedOut = new Promise((_, reject) => {
+    timedOut = new Promise((_, reject) => {
       signal.addEventListener("abort", () => reject(signal.reason), {
         once: true,
       });
@@ -143,7 +147,14 @@ export async function mintInstallationToken({
     throw new Error(
       `installation-token request rejected (status ${res?.status ?? "?"})`,
     );
-  const data = await res.json();
+  let data;
+  try {
+    // Keep body-read failures redacted too: runtime errors can include the
+    // request and its Bearer JWT, including when the timeout aborts the body.
+    data = await Promise.race([res.json(), timedOut]);
+  } catch {
+    throw new Error("installation-token response could not be read");
+  }
   if (!data?.token)
     throw new Error("installation-token response contained no token");
   return { token: data.token, expiresAt: data.expires_at ?? null };

--- a/lib/control-plane/gh-app-auth.test.mjs
+++ b/lib/control-plane/gh-app-auth.test.mjs
@@ -6,7 +6,7 @@
  * for the token exchange, and a temp file for the token cache. No real network
  * or `gh` calls are made.
  */
-import { afterAll, describe, expect, test } from "bun:test";
+import { afterAll, describe, expect, spyOn, test } from "bun:test";
 import { createVerify, generateKeyPairSync } from "node:crypto";
 import {
   existsSync,
@@ -205,6 +205,69 @@ describe("mintInstallationToken", () => {
     expect(seenSignal).toBeInstanceOf(AbortSignal);
     expect(seenSignal.aborted).toBe(true);
   }, 1_000);
+
+  test("redacts a JWT-bearing response body read failure", async () => {
+    let leakedJwt;
+    const error = new Error("placeholder");
+    const fetchImpl = async (_url, init) => {
+      leakedJwt = init.headers.Authorization;
+      error.message = `response body failed for ${leakedJwt}`;
+      return {
+        ok: true,
+        status: 201,
+        json: async () => {
+          throw error;
+        },
+      };
+    };
+
+    try {
+      await mintInstallationToken({
+        appId: "42",
+        installationId: "9001",
+        privateKeyPem: privateKey,
+        fetchImpl,
+      });
+      throw new Error("expected mintInstallationToken to reject");
+    } catch (caught) {
+      expect(caught).toBeInstanceOf(Error);
+      expect(caught.message).toBe(
+        "installation-token response could not be read",
+      );
+      expect(caught.message).not.toContain(leakedJwt);
+      expect(caught.message).not.toContain(privateKey);
+    }
+  });
+
+  test("uses a 30-second default timeout and preserves an explicit override", async () => {
+    const timeout = spyOn(AbortSignal, "timeout");
+    const fetchImpl = async () => ({
+      ok: true,
+      status: 201,
+      json: async () => ({ token: "ghs_installationtoken" }),
+    });
+
+    try {
+      await mintInstallationToken({
+        appId: "42",
+        installationId: "9001",
+        privateKeyPem: privateKey,
+        fetchImpl,
+      });
+      expect(timeout).toHaveBeenLastCalledWith(30 * 1000);
+
+      await mintInstallationToken({
+        appId: "42",
+        installationId: "9001",
+        privateKeyPem: privateKey,
+        fetchImpl,
+        timeoutMs: 1234,
+      });
+      expect(timeout).toHaveBeenLastCalledWith(1234);
+    } finally {
+      timeout.mockRestore();
+    }
+  });
 });
 
 describe("runLockedDaemon", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2106

Sanitizes installation-token body-read failures while retaining a bounded 30-second exchange timeout.
Authorization: inbox_f85b78be-8d58-4c2f-bb26-6d04e1f47850; decidedAt 2026-08-31T18:15:20.255Z.

## Validation

| Check                | Command                                                                                                       | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test lib/control-plane/gh-app-auth.test.mjs`                                                            | pass    | 25 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | completed; existing warnings only  |
| UX critique          | factory-ux-critic                                                                                             | not run | no user-facing surface             |

UX critique: skipped — backend credential-handling module; no user-facing surface

run:run_ee23c706-4f30-43a7-a70b-6533754fb853
