### PR TITLE
fix(ci-log-capture): surface authz 404 faults

### DIFF
--- a/event-runtime/lib/ci-log-capture.mjs
+++ b/event-runtime/lib/ci-log-capture.mjs
@@ -26,9 +26,11 @@
  * Precedence, when `gh` exits non-zero with nothing captured: an explicit
  * `HTTP NNN` token is authoritative. Only 404 and 410 are expected-missing;
  * every other status is a fault regardless of accompanying prose. Statusless
- * diagnostics use the narrow `EXPECTED_MISSING` fallback below. A failed
- * spawn is always a fault. Anything unrecognized is also a fault — the safe
- * default is to surface it.
+ * diagnostics use the narrow `EXPECTED_MISSING` fallback below. A 404 with
+ * authorization wording is the exception: treating that status alone as
+ * missing would mask a lost `actions:read` permission, so it remains a fault.
+ * A failed spawn is always a fault. Anything unrecognized is also a fault —
+ * the safe default is to surface it.
  */
 import { spawnSync } from "node:child_process";
 import {
@@ -59,7 +61,11 @@ const DETAIL_LIMIT = 400;
  * through to the fault branch and re-create the #2076 `agent_exit_1` flood.
  */
 const EXPECTED_MISSING =
-  /(?:no logs|logs? (?:have )?expired|run (?:was )?cancell?ed)/im;
+  /(?:no logs|logs? (?:have )?expired|run (?:was )?cancell?ed(?=[^\n]*(?:no logs|logs?\s+(?:(?:are|were|have been)\s+)?(?:unavailable|not produced))))/im;
+
+/** Authorization diagnostics GitHub can mask behind an HTTP 404 response. */
+const AUTHORIZATION_404 =
+  /(?:resource not accessible by integration|permission denied|must have admin rights|requires\b[^\n]*\bscope)/i;
 
 /**
  * Extract the authoritative HTTP status token that `gh` prints in an API
@@ -74,7 +80,7 @@ function isExpectedMissing(stderr) {
   const status = parseHttpStatus(stderr);
   return status === null
     ? EXPECTED_MISSING.test(stderr)
-    : status === 404 || status === 410;
+    : status === 410 || (status === 404 && !AUTHORIZATION_404.test(stderr));
 }
 
 /**

--- a/event-runtime/lib/ci-log-capture.test.mjs
+++ b/event-runtime/lib/ci-log-capture.test.mjs
@@ -95,10 +95,10 @@ describe("ci-log-capture command (#2076)", () => {
     for (const stderr of [
       "gh: Not Found (HTTP 404)",
       "no logs found for this run",
-      "run was cancelled",
+      "run was cancelled; logs were not produced",
       // `gh` prefixes its diagnostics; a prefixed missing-log message must
       // still be MISSING, not the #2076 agent_exit_1 fault.
-      "gh: run was cancelled",
+      "gh: run was cancelled; logs were unavailable",
       "gh: no logs found for this run",
       "error: logs expired",
       "error: no logs found for this run",
@@ -159,10 +159,7 @@ describe("ci-log-capture command (#2076)", () => {
       expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
     }
 
-    for (const stderr of [
-      "HTTP 404: resource not accessible by integration",
-      "HTTP 410: cancelled run logs expired",
-    ]) {
+    for (const stderr of ["HTTP 410: cancelled run logs expired"]) {
       const cwd = tmpDir("evrt-ci-log-capture-status-missing-");
       const outcome = captureCiLog({
         cwd,
@@ -175,6 +172,37 @@ describe("ci-log-capture command (#2076)", () => {
     }
   });
 
+  test("treats authorization-worded HTTP 404 responses as faults", () => {
+    for (const stderr of [
+      "HTTP 404: Resource not accessible by integration",
+      "HTTP 404: permission denied",
+      "HTTP 404: must have admin rights to Repository.",
+      "HTTP 404: requires actions:read scope",
+    ]) {
+      const cwd = tmpDir("evrt-ci-log-capture-authz-404-");
+      const outcome = captureCiLog({
+        cwd,
+        input: INPUT,
+        spawn: fakeGh({ stderr, exitCode: 1 }),
+      });
+
+      expect(outcome.ok).toBe(false);
+      expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
+    }
+  });
+
+  test("keeps a deleted HTTP 404 as expected-missing", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-deleted-404-");
+    const outcome = captureCiLog({
+      cwd,
+      input: INPUT,
+      spawn: fakeGh({ stderr: "HTTP 404: run was deleted", exitCode: 1 }),
+    });
+
+    expect(outcome.ok).toBe(true);
+    expect(readResult(cwd).artifact.captured).toBe(NO_CAPTURE);
+  });
+
   test("uses narrow missing-log text only when stderr has no HTTP status", () => {
     const cwd = tmpDir("evrt-ci-log-capture-statusless-missing-");
     const outcome = captureCiLog({
@@ -185,6 +213,18 @@ describe("ci-log-capture command (#2076)", () => {
 
     expect(outcome.ok).toBe(true);
     expect(readResult(cwd).artifact.captured).toBe(NO_CAPTURE);
+  });
+
+  test("does not treat a statusless cancelled run without log wording as missing", () => {
+    const cwd = tmpDir("evrt-ci-log-capture-cancelled-fault-");
+    const outcome = captureCiLog({
+      cwd,
+      input: INPUT,
+      spawn: fakeGh({ stderr: "run was cancelled by the user", exitCode: 1 }),
+    });
+
+    expect(outcome.ok).toBe(false);
+    expect(existsSync(path.join(cwd, "result.json"))).toBe(false);
   });
 
   test("a spawn failure remains a fault even when its message resembles missing logs", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2114

Surface authorization-masked log-capture failures instead of silently suppressing CI diagnosis.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/ci-log-capture.test.mjs event-runtime/lib/chain.test.mjs` | pass    | 49 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean (615 baseline warnings) |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend command classification; no user-facing surface
run:run_1339774a-d6e5-4476-bf5d-46589433ac96
