### PR TITLE
fix(event-runtime): clarify refusal escalations

### DIFF
--- a/event-runtime/lib/decision-templates.mjs
+++ b/event-runtime/lib/decision-templates.mjs
@@ -4,9 +4,9 @@ import {
   proposalQuestion,
 } from "./proposal-subject.mjs";
 
-const dismiss = () => ({
+const dismiss = (label = "Not now") => ({
   id: "dismiss",
-  label: "Not now",
+  label,
   effect: "dismiss",
   tone: "neutral",
 });
@@ -41,12 +41,17 @@ function escalation(refs) {
       tone: "primary",
     });
   }
-  options.push(dismiss());
+  options.push(dismiss("Acknowledge"));
+  const subject = refs.pr
+    ? `PR ${refs.pr}`
+    : refs.runId
+      ? `run ${refs.runId}`
+      : "this refused run";
   return {
     schemaVersion: "factory.decision-request/v1",
     question: refs.issue
       ? `How should the factory proceed with ${refs.issue}?`
-      : "How should the factory handle this refused run?",
+      : `What follow-up is needed for ${subject}?`,
     options,
     fields: refs.issue
       ? [textField({ required: true, whenOption: ["answer"] })]
@@ -113,12 +118,15 @@ function mergeEscalation(refs) {
       tone: "primary",
     });
   }
-  options.push(dismiss());
+  options.push(dismiss("Acknowledge"));
+  const subject = refs.pr
+    ? `PR ${refs.pr}`
+    : refs.runId
+      ? `run ${refs.runId}`
+      : "this merge escalation";
   return {
     schemaVersion: "factory.decision-request/v1",
-    question: refs.pr
-      ? `How should the merge escalation for ${refs.pr} be handled?`
-      : "How should this merge escalation be handled?",
+    question: `How should the merge escalation for ${subject} be handled?`,
     options,
     fields: refs.issue
       ? [textField({ required: true, whenOption: ["answer"] })]

--- a/event-runtime/lib/decision-templates.test.mjs
+++ b/event-runtime/lib/decision-templates.test.mjs
@@ -43,6 +43,49 @@ describe("default decision templates (WM-390)", () => {
     );
   });
 
+  test("escalations without a ticket name their PR or run and offer acknowledgement", () => {
+    const cases = [
+      [{ pr: "42", runId: "run_pr" }, "PR 42"],
+      [{ runId: "run_42" }, "run run_42"],
+    ];
+    for (const [refs, subject] of cases) {
+      const request = templateFor("ESCALATED", {
+        producer: "escalation",
+        refs,
+      });
+      expect(validateDecisionRequest(request, { refs })).toEqual({
+        valid: true,
+        errors: [],
+      });
+      expect(request.question).toContain(subject);
+      expect(request.options).toEqual([
+        {
+          id: "dismiss",
+          label: "Acknowledge",
+          effect: "dismiss",
+          tone: "neutral",
+        },
+      ]);
+    }
+  });
+
+  test("merge escalations without tickets name their PR and offer acknowledgement", () => {
+    const refs = { pr: "42", runId: "run_merge" };
+    const request = templateFor("ESCALATED", {
+      producer: "merge-escalation",
+      refs,
+    });
+    expect(validateDecisionRequest(request, { refs })).toEqual({
+      valid: true,
+      errors: [],
+    });
+    expect(request.question).toContain("PR 42");
+    expect(request.options[0]).toMatchObject({
+      label: "Acknowledge",
+      effect: "dismiss",
+    });
+  });
+
   test("a dispatch proposal names the ticket, repo, model, and why-line (WM-896)", () => {
     const refs = {
       proposalId: "prop_2dda1ca8-2469-4aab-8908-79c31a5df55b",

--- a/event-runtime/lib/proposal-subject.mjs
+++ b/event-runtime/lib/proposal-subject.mjs
@@ -25,6 +25,9 @@ const REASON_PLAIN = Object.freeze({
   "auto_approval_ineligible:capacity_full": "Repo at in-flight cap",
   "auto_approval_ineligible:evidence_changed_since_plan":
     "Ticket changed since planning",
+  owned_paths_not_closed:
+    "The ticket's allowed paths do not cover every required file.",
+  merge_barrier_unverified: "Merge barrier has not been verified.",
 });
 
 const PRIMARY_INPUT_KEYS = Object.freeze([
@@ -151,7 +154,14 @@ export function proposalReasonPlain(reason) {
   const prefixed = code.startsWith("auto_approval_ineligible:")
     ? code
     : `auto_approval_ineligible:${code}`;
-  return REASON_PLAIN[prefixed] ?? code;
+  if (REASON_PLAIN[prefixed]) return REASON_PLAIN[prefixed];
+
+  const barrier =
+    /^(?:auto_approval_ineligible:)?merge_barrier_unverified(?::.+)?$/.test(
+      code,
+    );
+  if (barrier) return REASON_PLAIN.merge_barrier_unverified;
+  return code;
 }
 
 /**

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -92,6 +92,7 @@ import { createInboxItem } from "./inbox.mjs";
 import { persistMergeReviewFromResult } from "./merge-reviews.mjs";
 import { registerMemos } from "./memos.mjs";
 import { templateFor } from "./decision-templates.mjs";
+import { proposalReasonPlain } from "./proposal-subject.mjs";
 import {
   DETACHED_SPAWN_OPTIONS,
   killProcessGroup,
@@ -1400,6 +1401,57 @@ function refusalInboxRefs(spec) {
   return refs;
 }
 
+function refusalText(value) {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  for (const key of ["message", "summary", "reason", "finding", "title"]) {
+    const text = refusalText(value[key]);
+    if (text) return text;
+  }
+  return null;
+}
+
+function refusalFindingLines(...values) {
+  return [
+    ...new Set(
+      values.flatMap((value) => {
+        const entries = Array.isArray(value) ? value : [value];
+        return entries.map(refusalText).filter(Boolean);
+      }),
+    ),
+  ];
+}
+
+function refusalEvidenceBody(result) {
+  const evidence = result?.evidence ?? {};
+  const lines = [];
+  const summary =
+    refusalText(evidence.summary) ??
+    refusalText(evidence.agentSummary) ??
+    refusalText(result?.summary);
+  if (summary) lines.push(`Agent summary: ${summary}`);
+
+  const reason = refusalText(evidence.reason);
+  if (reason)
+    lines.push(`Agent reason: ${proposalReasonPlain(reason) ?? reason}`);
+
+  const message = refusalText(evidence.message);
+  if (message) lines.push(`Agent message: ${message}`);
+
+  const findings = refusalFindingLines(
+    evidence.findings,
+    evidence.finding,
+    result?.findings,
+    result?.finding,
+  );
+  if (findings.length)
+    lines.push(
+      `Agent findings:\n${findings.map((item) => `- ${item}`).join("\n")}`,
+    );
+  return lines.join("\n\n");
+}
+
 function createRefusalInboxItem(db, spec, result, { now }) {
   if (result.reasonCode !== "needs_human") return null;
   const refs = refusalInboxRefs(spec);
@@ -1410,9 +1462,15 @@ function createRefusalInboxItem(db, spec, result, { now }) {
       refs,
     });
   const subject = refs.issue ?? refs.runId;
-  const body = result.decisionErrors?.length
-    ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
-    : null;
+  const body =
+    [
+      refusalEvidenceBody(result),
+      result.decisionErrors?.length
+        ? `The agent's decision request was rejected:\n${result.decisionErrors.join("\n")}`
+        : null,
+    ]
+      .filter(Boolean)
+      .join("\n\n") || null;
   return createInboxItem(
     db,
     {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2007,6 +2007,45 @@ sh -c 'sleep 5 & wait'
     }
   });
 
+  test("needs_human surfaces agent evidence, summaries, and findings in the inbox", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(
+      db,
+      makeSpec({
+        adapter: "refuse-with-evidence",
+        input: { repos: ["evidence"], ticket: "WM-2118", repo: "factory" },
+      }),
+    );
+    const adapter = {
+      async execute({ workspaceDir }) {
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({
+            schemaVersion: "factory.agent-result/v1",
+            terminalState: "refused",
+            reasonCode: "needs_human",
+            evidence: {
+              summary: "The PR is already closed.",
+              reason: "auto_approval_ineligible:merge_barrier_unverified:pr-42",
+              message: "Confirm the merge barrier before retrying.",
+              findings: ["PR #42 was closed before review."],
+            },
+          }),
+        );
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+
+    await runOnce(db, registry, { "refuse-with-evidence": adapter }, opts());
+    const body = db.query("SELECT body FROM inbox_items").get().body;
+    expect(body).toContain("Agent summary: The PR is already closed.");
+    expect(body).toContain("Agent reason: Merge barrier has not been verified");
+    expect(body).toContain(
+      "Agent message: Confirm the merge barrier before retrying.",
+    );
+    expect(body).toContain("PR #42 was closed before review.");
+  });
+
   test("a failing refusal inbox write never rolls back the terminal REFUSED state", async () => {
     const db = openDb(":memory:");
     // Force createInboxItem to throw inside the REFUSED transaction; the


### PR DESCRIPTION
Fixes watt-mind/factory#2118

Review the clearer refusal evidence and escalation acknowledgement copy.

## Validation

| Check                | Command                                                                                                            | Result  | Notes                                |
| -------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------ |
| Verification Command | `bun test event-runtime/lib/decision-templates.test.mjs event-runtime/lib/worker.test.mjs`                       | pass    | 172 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2,382 tests; 616 existing warnings   |
| UX critique          | `factory-ux-critic`                                                                                               | not run | backend runtime, no user-facing flow |

UX critique: skipped — backend runtime, no user-facing surface

run:run_30fb6641-7305-44cb-b362-26e1ef4fbcb0
