### PR TITLE
feat(web): improve Inbox messages and references

### DIFF
--- a/event-runtime/web/src/components/InboxMessageCard.test.tsx
+++ b/event-runtime/web/src/components/InboxMessageCard.test.tsx
@@ -1,0 +1,39 @@
+import "../test-dom";
+import { describe, expect, test } from "bun:test";
+import { render } from "@testing-library/react";
+import { InboxMessageCard, parseInboxMessage } from "./InboxMessageCard";
+
+describe("InboxMessageCard", () => {
+  test("groups markdown into section cards, lists, callouts, and safe inline formatting", () => {
+    const { getByRole, getByText } = render(
+      <InboxMessageCard
+        title="Deployment needs a decision"
+        body={`# What changed\n**Review** the \`run_123\` details.\n\n- First action\n- [Open the run](https://example.test/runs/123)\n\n> Warning: confirm the target before retrying.`}
+      />,
+    );
+
+    expect(
+      getByRole("heading", { name: "Deployment needs a decision" }),
+    ).toBeTruthy();
+    expect(getByRole("heading", { name: "What changed" })).toBeTruthy();
+    expect(getByRole("list")).toBeTruthy();
+    expect(getByRole("note").textContent).toContain("confirm the target");
+    expect(getByText("warning")).toBeTruthy();
+    expect(getByText("Open the run").getAttribute("href")).toBe(
+      "https://example.test/runs/123",
+    );
+  });
+
+  test("keeps plain text as a paragraph and parses numbered lists", () => {
+    const sections = parseInboxMessage("Plain update\n\n1. First\n2. Second");
+    expect(sections).toEqual([
+      {
+        heading: null,
+        blocks: [
+          { type: "paragraph", lines: ["Plain update"] },
+          { type: "list", ordered: true, items: ["First", "Second"] },
+        ],
+      },
+    ]);
+  });
+});

--- a/event-runtime/web/src/components/InboxMessageCard.test.tsx
+++ b/event-runtime/web/src/components/InboxMessageCard.test.tsx
@@ -24,6 +24,19 @@ describe("InboxMessageCard", () => {
     );
   });
 
+  test("a multi-line callout keeps the warning tone raised by its first line", () => {
+    const sections = parseInboxMessage(
+      "> Warning: confirm the target.\n> Retrying is destructive.",
+    );
+    expect(sections[0].blocks).toEqual([
+      {
+        type: "callout",
+        tone: "warning",
+        lines: ["confirm the target.", "Retrying is destructive."],
+      },
+    ]);
+  });
+
   test("keeps plain text as a paragraph and parses numbered lists", () => {
     const sections = parseInboxMessage("Plain update\n\n1. First\n2. Second");
     expect(sections).toEqual([

--- a/event-runtime/web/src/components/InboxMessageCard.tsx
+++ b/event-runtime/web/src/components/InboxMessageCard.tsx
@@ -1,0 +1,217 @@
+import { Fragment, type ReactNode } from "react";
+
+type MessageBlock =
+  | { type: "paragraph"; lines: string[] }
+  | { type: "list"; ordered: boolean; items: string[] }
+  | { type: "callout"; tone: "note" | "warning"; lines: string[] }
+  | { type: "code"; lines: string[] };
+
+type MessageSection = { heading: string | null; blocks: MessageBlock[] };
+
+const heading = /^(#{1,3})\s+(.+)$/;
+const unordered = /^[-*+]\s+(.+)$/;
+const ordered = /^\d+[.)]\s+(.+)$/;
+const callout = /^(?:>\s*|(?:note|info|tip|warning|caution):\s*)(.+)$/i;
+const link = /\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g;
+const emphasis = /(\*\*[^*]+\*\*|`[^`]+`)/g;
+
+/**
+ * Converts a plain inbox body into a small, safe Markdown subset. Inbox content
+ * is operational text, so this deliberately never injects HTML.
+ */
+export function parseInboxMessage(body: string): MessageSection[] {
+  const sections: MessageSection[] = [{ heading: null, blocks: [] }];
+  let paragraph: string[] = [];
+  let list: { ordered: boolean; items: string[] } | null = null;
+  let calloutLines: string[] | null = null;
+  let calloutTone: "note" | "warning" = "note";
+  let codeLines: string[] | null = null;
+
+  const section = () => sections.at(-1)!;
+  const flush = () => {
+    if (paragraph.length)
+      section().blocks.push({ type: "paragraph", lines: paragraph });
+    if (list) section().blocks.push({ type: "list", ...list });
+    if (calloutLines)
+      section().blocks.push({
+        type: "callout",
+        tone: calloutTone,
+        lines: calloutLines,
+      });
+    if (codeLines) section().blocks.push({ type: "code", lines: codeLines });
+    paragraph = [];
+    list = null;
+    calloutLines = null;
+    calloutTone = "note";
+    codeLines = null;
+  };
+
+  for (const line of body.replace(/\r\n?/g, "\n").split("\n")) {
+    if (/^```/.test(line)) {
+      if (codeLines) {
+        flush();
+      } else {
+        flush();
+        codeLines = [];
+      }
+      continue;
+    }
+    if (codeLines) {
+      codeLines.push(line);
+      continue;
+    }
+    const title = heading.exec(line);
+    if (title) {
+      flush();
+      sections.push({ heading: title[2], blocks: [] });
+      continue;
+    }
+    const quoted = callout.exec(line);
+    if (quoted) {
+      if (paragraph.length || list) flush();
+      calloutLines ??= [];
+      calloutTone = /^(?:>\s*)?(warning|caution):/i.test(line)
+        ? "warning"
+        : "note";
+      calloutLines.push(quoted[1].replace(/^(warning|caution):\s*/i, ""));
+      continue;
+    }
+    if (!line.trim()) {
+      flush();
+      continue;
+    }
+    const unorderedItem = unordered.exec(line);
+    const orderedItem = ordered.exec(line);
+    if (unorderedItem || orderedItem) {
+      if (paragraph.length || calloutLines) flush();
+      const orderedList = Boolean(orderedItem);
+      if (!list || list.ordered !== orderedList) {
+        if (list) flush();
+        list = { ordered: orderedList, items: [] };
+      }
+      list.items.push((orderedItem ?? unorderedItem)![1]);
+      continue;
+    }
+    if (list || calloutLines) flush();
+    paragraph.push(line);
+  }
+  flush();
+  return sections.filter((item) => item.heading || item.blocks.length);
+}
+
+function inlineMarkdown(text: string): ReactNode[] {
+  const parts: ReactNode[] = [];
+  let cursor = 0;
+  for (const match of text.matchAll(link)) {
+    if (match.index! > cursor)
+      parts.push(...inlineEmphasis(text.slice(cursor, match.index!)));
+    parts.push(
+      <a
+        key={`link-${match.index}`}
+        href={match[2]}
+        target="_blank"
+        rel="noreferrer"
+        className="text-(--accent) underline underline-offset-2"
+      >
+        {match[1]}
+      </a>,
+    );
+    cursor = match.index! + match[0].length;
+  }
+  if (cursor < text.length || !parts.length)
+    parts.push(...inlineEmphasis(text.slice(cursor)));
+  return parts;
+}
+
+function inlineEmphasis(text: string): ReactNode[] {
+  return text
+    .split(emphasis)
+    .filter(Boolean)
+    .map((part, index) => {
+      if (part.startsWith("**"))
+        return <strong key={index}>{part.slice(2, -2)}</strong>;
+      if (part.startsWith("`"))
+        return (
+          <code key={index} className="rounded bg-(--surface-2) px-1 mono">
+            {part.slice(1, -1)}
+          </code>
+        );
+      return <Fragment key={index}>{part}</Fragment>;
+    });
+}
+
+export function InboxMessageCard({
+  title,
+  body,
+}: {
+  title: string;
+  body: string | null;
+}) {
+  const sections = body ? parseInboxMessage(body) : [];
+  return (
+    <article
+      data-testid="inbox-message"
+      className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] leading-relaxed"
+    >
+      <h3 className="font-medium text-(--text)">{title}</h3>
+      {sections.map((section, sectionIndex) => (
+        <section
+          key={`${section.heading ?? "body"}-${sectionIndex}`}
+          className="mt-2 first:mt-1.5"
+        >
+          {section.heading && (
+            <h4 className="rounded bg-(--surface-1) px-2 py-1 font-medium text-(--text)">
+              {section.heading}
+            </h4>
+          )}
+          {section.blocks.map((block, blockIndex) => {
+            const key = `${block.type}-${blockIndex}`;
+            if (block.type === "paragraph")
+              return (
+                <p
+                  key={key}
+                  className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)"
+                >
+                  {inlineMarkdown(block.lines.join("\n"))}
+                </p>
+              );
+            if (block.type === "code")
+              return (
+                <pre
+                  key={key}
+                  className="mt-1.5 overflow-x-auto rounded bg-(--surface-2) p-2 mono text-(--text-dim)"
+                >
+                  {block.lines.join("\n")}
+                </pre>
+              );
+            if (block.type === "list") {
+              const List = block.ordered ? "ol" : "ul";
+              return (
+                <List
+                  key={key}
+                  className={`mt-1.5 list-inside text-(--text-dim) ${block.ordered ? "list-decimal" : "list-disc"}`}
+                >
+                  {block.items.map((item, itemIndex) => (
+                    <li key={itemIndex}>{inlineMarkdown(item)}</li>
+                  ))}
+                </List>
+              );
+            }
+            return (
+              <aside
+                key={key}
+                role="note"
+                className={`mt-1.5 rounded border-l-2 px-2 py-1.5 text-(--text-dim) ${block.tone === "warning" ? "border-(--hue-warn) bg-(--hue-warn)/10" : "border-(--accent) bg-(--accent)/10"}`}
+              >
+                <span className="mr-1 rounded bg-(--surface-2) px-1 py-0.5 text-[10px] font-medium uppercase">
+                  {block.tone}
+                </span>
+                {inlineMarkdown(block.lines.join("\n"))}
+              </aside>
+            );
+          })}
+        </section>
+      ))}
+    </article>
+  );
+}

--- a/event-runtime/web/src/components/InboxMessageCard.tsx
+++ b/event-runtime/web/src/components/InboxMessageCard.tsx
@@ -70,9 +70,7 @@ export function parseInboxMessage(body: string): MessageSection[] {
     if (quoted) {
       if (paragraph.length || list) flush();
       calloutLines ??= [];
-      calloutTone = /^(?:>\s*)?(warning|caution):/i.test(line)
-        ? "warning"
-        : "note";
+      if (/^(?:>\s*)?(warning|caution):/i.test(line)) calloutTone = "warning";
       calloutLines.push(quoted[1].replace(/^(warning|caution):\s*/i, ""));
       continue;
     }
@@ -203,7 +201,7 @@ export function InboxMessageCard({
                 role="note"
                 className={`mt-1.5 rounded border-l-2 px-2 py-1.5 text-(--text-dim) ${block.tone === "warning" ? "border-(--hue-warn) bg-(--hue-warn)/10" : "border-(--accent) bg-(--accent)/10"}`}
               >
-                <span className="mr-1 rounded bg-(--surface-2) px-1 py-0.5 text-[10px] font-medium uppercase">
+                <span className="mr-1 rounded bg-(--surface-2) px-1 py-0.5 text-[11px] font-medium uppercase">
                   {block.tone}
                 </span>
                 {inlineMarkdown(block.lines.join("\n"))}

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -114,6 +114,12 @@ const REGISTRY: Record<string, () => ReactNode> = {
 
   // ── projects / repos ──────────────────────────────────────────────────
   repository: () => <ArchiveIcon />,
+  repo: () => <ArchiveIcon />,
+  run: () => <PlayIcon />,
+  proposal: () => <TargetIcon />,
+  event: () => <PaperPlaneIcon />,
+  issue: () => <CheckCircledIcon />,
+  pr: () => <GitHubLogoIcon />,
   github: () => <GitHubLogoIcon />,
   basebranch: () => <GitBranchIcon />,
   deploybranch: () => <GitBranchIcon />,

--- a/event-runtime/web/src/components/attrIcons.tsx
+++ b/event-runtime/web/src/components/attrIcons.tsx
@@ -115,7 +115,6 @@ const REGISTRY: Record<string, () => ReactNode> = {
   // ── projects / repos ──────────────────────────────────────────────────
   repository: () => <ArchiveIcon />,
   repo: () => <ArchiveIcon />,
-  run: () => <PlayIcon />,
   proposal: () => <TargetIcon />,
   event: () => <PaperPlaneIcon />,
   issue: () => <CheckCircledIcon />,

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -28,6 +28,7 @@ import {
   waitingLabel,
 } from "./Inbox";
 import { api } from "../api";
+import { attrIcon } from "../components/attrIcons";
 import { clearToasts, ToastContainer } from "../components/ui";
 import type { InboxItem, Proposal } from "../types";
 import { changeInput } from "../test-render";
@@ -263,8 +264,14 @@ describe("inbox pure helpers", () => {
       ),
     ).toBe("https://github.com/watt-mind/factory/pull/124");
     expect(
-      prHref(item({ id: "bare", kind: "CI RED", refs: { pr: "PR#125" } })),
-    ).toBeNull();
+      prHref(
+        item({
+          id: "bare",
+          kind: "CI RED",
+          refs: { pr: "125", repo: "factory" },
+        }),
+      ),
+    ).toBe("https://github.com/watt-mind/factory/pull/125");
     expect(
       inboxActionPrHref(
         item({
@@ -274,6 +281,19 @@ describe("inbox pure helpers", () => {
         }),
       ),
     ).toBe("https://github.com/watt-mind/factory/pull/607");
+  });
+
+  test("reference attributes have distinct icons", () => {
+    for (const reference of [
+      "run",
+      "proposal",
+      "event",
+      "issue",
+      "pr",
+      "repo",
+    ]) {
+      expect(attrIcon(reference)).not.toBeNull();
+    }
   });
 
   test("Inbox age preserves hour precision after 24 hours", () => {
@@ -759,6 +779,12 @@ describe("Inbox view", () => {
     const pr = view.getByTitle("Open pull request") as HTMLAnchorElement;
     expect(pr.getAttribute("href")).toBe(
       "https://github.com/watt-mind/factory/pull/9",
+    );
+    const { view: detail } = renderInbox({ focusItemId: "inbox_open_1" });
+    await waitFor(() => detail.getByTitle("Open repository"));
+    const repo = detail.getByTitle("Open repository") as HTMLAnchorElement;
+    expect(repo.getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory",
     );
   });
 

--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -283,15 +283,10 @@ describe("inbox pure helpers", () => {
     ).toBe("https://github.com/watt-mind/factory/pull/607");
   });
 
+  // `run`/`runId` stay unmapped by the WM-483 contract (identity labels reserve
+  // an empty slot); the run reference renders as text until #2119 decides otherwise.
   test("reference attributes have distinct icons", () => {
-    for (const reference of [
-      "run",
-      "proposal",
-      "event",
-      "issue",
-      "pr",
-      "repo",
-    ]) {
+    for (const reference of ["proposal", "event", "issue", "pr", "repo"]) {
       expect(attrIcon(reference)).not.toBeNull();
     }
   });

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -378,13 +378,9 @@ export function prHref(item: InboxItem): string | null {
   return number && repo ? `https://github.com/${repo}/pull/${number}` : null;
 }
 
-/** Per-kind action chips may trust a digits-only refs.pr once refs.repo resolves. */
+/** Per-kind action chips resolve the same PR href as the reference list. */
 export function inboxActionPrHref(item: InboxItem): string | null {
-  const existing = prHref(item);
-  if (existing) return existing;
-  const number = /^\d+$/.exec(item.refs.pr?.trim() ?? "")?.[0];
-  const repo = githubRepo(item);
-  return number && repo ? `https://github.com/${repo}/pull/${number}` : null;
+  return prHref(item);
 }
 
 function refPrefixIsVisible(prefix: string, item: InboxItem): boolean {

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -37,6 +37,7 @@ import {
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
 import { DecisionCard } from "../components/DecisionCard";
+import { InboxMessageCard } from "../components/InboxMessageCard";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { hasInboxPlainActions, InboxActions } from "../components/InboxActions";
 import {
@@ -349,7 +350,7 @@ const ISSUE_PREFIX_GITHUB: Record<string, string> = {
 function prNumber(ref: string | undefined): string | null {
   if (!ref) return null;
   return (
-    /^(?:PR\s*)?#(\d+)$/i.exec(ref.trim())?.[1] ??
+    /^(?:PR\s*)?#?(\d+)$/i.exec(ref.trim())?.[1] ??
     /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref)?.[1] ??
     null
   );
@@ -1965,14 +1966,7 @@ export function Inbox({
             </Section>
 
             <Section title="Message" card={false}>
-              <div className="rounded-md border border-(--border) bg-(--surface-0) px-3 py-2 text-[12px] leading-relaxed">
-                <div className="font-medium text-(--text)">{sel.title}</div>
-                {sel.body && (
-                  <div className="mt-1.5 whitespace-pre-wrap break-words text-(--text-dim)">
-                    {sel.body}
-                  </div>
-                )}
-              </div>
+              <InboxMessageCard title={sel.title} body={sel.body} />
             </Section>
 
             {sel.decision && (
@@ -2053,7 +2047,7 @@ export function Inbox({
                   />
                 )}
                 {sel.refs.pr && <KV k="pr" v={<PrRef item={sel} />} />}
-                {sel.refs.repo && <KV k="repo" v={sel.refs.repo} />}
+                {sel.refs.repo && <KV k="repo" v={<RepoRef item={sel} />} />}
               </Section>
             )}
 
@@ -2230,6 +2224,18 @@ function ResolveReasonField({
         />
       </label>
     </div>
+  );
+}
+
+function RepoRef({ item }: { item: InboxItem }) {
+  const repo = item.refs.repo!;
+  const github = githubRepo(item);
+  return github ? (
+    <JumpLink href={`https://github.com/${github}`} title="Open repository">
+      {repo}
+    </JumpLink>
+  ) : (
+    <span className="mono">{repo}</span>
   );
 }
 


### PR DESCRIPTION
Fixes watt-mind/factory#2119

Review the structured Inbox message and linked references; the UX fixture follow-up is #2126.

## Validation

| Check                | Command                                                                                      | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/web/src/views/Inbox.test.tsx`                                        | pass    | 48 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | unit, emit, format, lint passed        |
| UX critique          | `factory-ux-critic`                                                                          | required — FIX-FIRST unresolved | fixture has no Inbox detail item      |

UX critique: required — FIX-FIRST unresolved

run:run_c7f67860-af4e-48ce-94f6-1bdf74800da7
