### PR TITLE
fix(event-runtime): reconcile stale inbox referents

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1543,6 +1543,13 @@ const TERMINAL_RUN_STATES = new Set([
 // ESCALATED item is *born* on a REFUSED run, and a decision the operator has
 // not answered stays open no matter what the run it names went on to do.
 const RUN_PROGRESS_KINDS = new Set(["CI RED", "SMOKE RED", "CIRCUIT BREAKER"]);
+// Notices parked on work the factory itself owns. Only these may be retired
+// automatically when the ticket moves on; an ESCALATED ask or any other kind
+// names something an operator still has to look at.
+const PARKED_KINDS = new Set(["BLOCKED", "human_needed"]);
+// Bounded fan-out for the per-tick PR referent sweep (#1069): a busy inbox
+// must not open one forge request per distinct PR all at once.
+const PR_FETCH_CONCURRENCY = 4;
 
 /** An ask the operator has been handed and has not answered yet. */
 function hasPendingDecision(row) {
@@ -1585,17 +1592,26 @@ async function fetchReferencedInboxPullRequests(rows, fetchPullRequest) {
     const github = githubRepoFor(refs);
     if (pr && github) unique.set(`${github}#${pr}`, { github, pr });
   }
-  const fetched = await Promise.all(
-    [...unique.entries()].map(async ([key, request]) => {
-      try {
-        return [key, await fetchPullRequest(request)];
-      } catch {
-        // A deleted PR or rate-limited repository must not stall unrelated
-        // inbox reconciliation. The next poll can retry this one referent.
-        return [key, null];
-      }
-    }),
-  );
+  const fetchOne = async ([key, request]) => {
+    try {
+      return [key, await fetchPullRequest(request)];
+    } catch {
+      // A deleted PR or rate-limited repository must not stall unrelated
+      // inbox reconciliation. The next poll can retry this one referent.
+      return [key, null];
+    }
+  };
+  // Chunked loop: at most PR_FETCH_CONCURRENCY forge reads in flight at once,
+  // so a wide inbox cannot burst a request per distinct PR every tick.
+  const entries = [...unique.entries()];
+  const fetched = [];
+  for (let i = 0; i < entries.length; i += PR_FETCH_CONCURRENCY) {
+    fetched.push(
+      ...(await Promise.all(
+        entries.slice(i, i + PR_FETCH_CONCURRENCY).map(fetchOne),
+      )),
+    );
+  }
   return new Map(fetched.filter(([, pull]) => pull));
 }
 
@@ -1622,7 +1638,7 @@ function hasNewerSubjectRun(db, subject, createdAt) {
 }
 
 function staleParkedItem(db, row, refs, now) {
-  if (!new Set(["BLOCKED", "human_needed"]).has(row.kind)) return false;
+  if (!PARKED_KINDS.has(row.kind)) return false;
   const createdAt = Date.parse(row.created_at);
   if (!Number.isFinite(createdAt) || now - createdAt < MAX_PARKED_INBOX_AGE_MS)
     return false;
@@ -1878,7 +1894,16 @@ export function reconcileInbox(
       if (event && event.status !== "human_needed")
         resolvedBy = "auto:event_requeued";
     }
-    if (!resolvedBy && hasNewerSubjectRun(db, refs.issue, row.created_at)) {
+    // A parked notice about a ticket the factory has already picked back up is
+    // stale. This never applies to an open ask or an escalation: a newer run
+    // does not answer a decision the operator still owes, and silently
+    // resolving one would discard it.
+    if (
+      !resolvedBy &&
+      PARKED_KINDS.has(row.kind) &&
+      !hasPendingDecision(row) &&
+      hasNewerSubjectRun(db, refs.issue, row.created_at)
+    ) {
       resolvedBy = "auto:superseded";
     }
     // A run-progress notice about a run that has already finished is stale.
@@ -1946,20 +1971,22 @@ export function reconcileInbox(
   ])
     .then(([issues, pulls]) => {
       const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
-      for (const row of rows) {
+      // Only the rows collected for the PR sweep are eligible here: a CI RED
+      // row that happens to share a PR reference with another item must not be
+      // retired by that item's fetch.
+      for (const { row, refs } of prRows) {
         if (resolved.some((entry) => entry.id === row.id)) continue;
-        const refs = parseObject(row.refs_json);
         const pr = prNumber(refs.pr);
         const github = githubRepoFor(refs);
         const pull = pr && github ? pulls.get(`${github}#${pr}`) : null;
-        if (["MERGED", "CLOSED"].includes(pull?.state)) {
-          const resolvedBy =
-            pull.state === "MERGED" ? "auto:pr_merged" : "auto:pr_closed";
-          resolveInboxItem(db, row.id, { now, resolvedBy });
-          resolved.push({ id: row.id, resolvedBy });
-          continue;
-        }
-        if (!refs.issue) continue;
+        if (!["MERGED", "CLOSED"].includes(pull?.state)) continue;
+        const resolvedBy =
+          pull.state === "MERGED" ? "auto:pr_merged" : "auto:pr_closed";
+        resolveInboxItem(db, row.id, { now, resolvedBy });
+        resolved.push({ id: row.id, resolvedBy });
+      }
+      for (const { row, refs } of linearRows) {
+        if (resolved.some((entry) => entry.id === row.id)) continue;
         const issue = byId.get(refs.issue);
         if (!issue) continue;
         const stale = issueIsClosed(issue);

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -10,6 +10,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { loadControlPlane } from "../../lib/control-plane/index.mjs";
+import { loadForge } from "../../lib/forge/index.mjs";
 import { hashJson } from "./canonical.mjs";
 import { ApiParameterError } from "./api-params.mjs";
 import {
@@ -24,6 +25,7 @@ import {
 } from "./decision-templates.mjs";
 import { txImmediate } from "./db.mjs";
 import { registerInboxDecisionMemos } from "./memos.mjs";
+import { loadRepos } from "./repos.mjs";
 
 export const INBOX_KINDS = Object.freeze([
   "BLOCKED",
@@ -1527,6 +1529,8 @@ export async function deliverInboxItem(
 
 const LINEAR_POLL_INTERVAL_MS = 60_000;
 const linearPollAt = new WeakMap();
+/** Unactionable parked notices must not remain in the operator queue forever. */
+export const MAX_PARKED_INBOX_AGE_MS = 48 * 60 * 60 * 1000;
 const TERMINAL_RUN_STATES = new Set([
   "COMPLETED",
   "FAILED",
@@ -1551,6 +1555,87 @@ function prNumber(ref) {
     /^(?:PR\s*)?#?(\d+)$/i.exec(ref.trim()) ??
     /\/pull\/(\d+)(?:[/?#]|$)/.exec(ref);
   return match ? Number(match[1]) : null;
+}
+
+function githubRepoFor(refs) {
+  const issueRepo =
+    typeof refs.issue === "string"
+      ? /^([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+)#\d+$/.exec(refs.issue.trim())?.[1]
+      : null;
+  if (issueRepo) return issueRepo;
+  if (typeof refs.repo !== "string" || refs.repo.trim() === "") return null;
+  if (refs.repo.includes("/")) return refs.repo;
+  try {
+    return loadRepos().get(refs.repo)?.github ?? null;
+  } catch {
+    // A missing or malformed local repository registry must not make an
+    // otherwise unrelated inbox sweep fail.
+    return null;
+  }
+}
+
+function defaultFetchPullRequest({ github, pr }) {
+  return loadForge().prView(github, pr, { fields: ["state"] });
+}
+
+async function fetchReferencedInboxPullRequests(rows, fetchPullRequest) {
+  const unique = new Map();
+  for (const { refs } of rows) {
+    const pr = prNumber(refs.pr);
+    const github = githubRepoFor(refs);
+    if (pr && github) unique.set(`${github}#${pr}`, { github, pr });
+  }
+  const fetched = await Promise.all(
+    [...unique.entries()].map(async ([key, request]) => {
+      try {
+        return [key, await fetchPullRequest(request)];
+      } catch {
+        // A deleted PR or rate-limited repository must not stall unrelated
+        // inbox reconciliation. The next poll can retry this one referent.
+        return [key, null];
+      }
+    }),
+  );
+  return new Map(fetched.filter(([, pull]) => pull));
+}
+
+function hasNewerSubjectRun(db, subject, createdAt) {
+  if (typeof subject !== "string" || subject.trim() === "") return false;
+  const newerRun = db
+    .query(
+      `SELECT 1 FROM runs
+       WHERE subject = ? AND created_at > ?
+       LIMIT 1`,
+    )
+    .get(subject, createdAt);
+  if (newerRun) return true;
+  return Boolean(
+    db
+      .query(
+        `SELECT 1 FROM events
+         WHERE subject = ? AND admitted_at > ?
+           AND status IN ('admitted', 'planned', 'human_needed')
+         LIMIT 1`,
+      )
+      .get(subject, createdAt),
+  );
+}
+
+function staleParkedItem(db, row, refs, now) {
+  if (!new Set(["BLOCKED", "human_needed"]).has(row.kind)) return false;
+  const createdAt = Date.parse(row.created_at);
+  if (!Number.isFinite(createdAt) || now - createdAt < MAX_PARKED_INBOX_AGE_MS)
+    return false;
+  if (refs.eventSource && refs.eventId) {
+    const event = db
+      .query("SELECT 1 FROM events WHERE source = ? AND event_id = ?")
+      .get(refs.eventSource, refs.eventId);
+    return !event;
+  }
+  // A parked row without an event, ticket, PR, proposal, or run cannot be
+  // acted on or reconciled later. Keep referent-backed asks for their normal
+  // reconciliation paths instead of expiring them merely because they age.
+  return !refs.issue && !refs.pr && !refs.proposalId && !refs.runId;
 }
 
 function completedShipProposal(db, proposalId) {
@@ -1715,6 +1800,7 @@ export function reconcileInbox(
     now = Date.now(),
     linearIssues = fetchLinearInboxIssues,
     controlPlane = loadControlPlane,
+    fetchPullRequest = defaultFetchPullRequest,
   } = {},
 ) {
   const resolved = [];
@@ -1758,6 +1844,7 @@ export function reconcileInbox(
             };
           });
   const linearRows = [];
+  const prRows = [];
   for (const row of rows) {
     // Pending decisions are not skipped: once the referent stops waiting the
     // ask is moot and resolveInboxItem records it as superseded (auto:*).
@@ -1791,6 +1878,9 @@ export function reconcileInbox(
       if (event && event.status !== "human_needed")
         resolvedBy = "auto:event_requeued";
     }
+    if (!resolvedBy && hasNewerSubjectRun(db, refs.issue, row.created_at)) {
+      resolvedBy = "auto:superseded";
+    }
     // A run-progress notice about a run that has already finished is stale.
     // This never applies to an open ask: the operator still owes an answer.
     if (
@@ -1807,6 +1897,10 @@ export function reconcileInbox(
         resolvedReason = "stale_ref";
       }
     }
+    if (!resolvedBy && staleParkedItem(db, row, refs, now)) {
+      resolvedBy = "auto:stale_ref";
+      resolvedReason = "stale_ref";
+    }
     if (!resolvedBy) continue;
     resolveInboxItem(db, row.id, {
       now,
@@ -1822,6 +1916,14 @@ export function reconcileInbox(
   for (const row of rows) {
     const refs = parseObject(row.refs_json);
     if (
+      refs.pr &&
+      row.kind !== "CI RED" &&
+      !resolved.some((entry) => entry.id === row.id) &&
+      !prRows.some((entry) => entry.row.id === row.id)
+    ) {
+      prRows.push({ row, refs });
+    }
+    if (
       refs.issue &&
       !resolved.some((entry) => entry.id === row.id) &&
       !linearRows.some((entry) => entry.row.id === row.id)
@@ -1830,16 +1932,34 @@ export function reconcileInbox(
     }
   }
 
-  if (linearRows.length === 0) return resolved;
+  if (linearRows.length === 0 && prRows.length === 0) return resolved;
   const lastPoll = linearPollAt.get(db) ?? -Infinity;
   if (now - lastPoll < LINEAR_POLL_INTERVAL_MS) return resolved;
   linearPollAt.set(db, now);
-  return Promise.resolve(
-    fetchReferencedInboxIssues(linearRows, linearIssues, controlPlane),
-  )
-    .then((issues) => {
+  return Promise.all([
+    linearRows.length
+      ? fetchReferencedInboxIssues(linearRows, linearIssues, controlPlane)
+      : [],
+    prRows.length
+      ? fetchReferencedInboxPullRequests(prRows, fetchPullRequest)
+      : new Map(),
+  ])
+    .then(([issues, pulls]) => {
       const byId = new Map(issues.map((issue) => [issue.identifier, issue]));
-      for (const { row, refs } of linearRows) {
+      for (const row of rows) {
+        if (resolved.some((entry) => entry.id === row.id)) continue;
+        const refs = parseObject(row.refs_json);
+        const pr = prNumber(refs.pr);
+        const github = githubRepoFor(refs);
+        const pull = pr && github ? pulls.get(`${github}#${pr}`) : null;
+        if (["MERGED", "CLOSED"].includes(pull?.state)) {
+          const resolvedBy =
+            pull.state === "MERGED" ? "auto:pr_merged" : "auto:pr_closed";
+          resolveInboxItem(db, row.id, { now, resolvedBy });
+          resolved.push({ id: row.id, resolvedBy });
+          continue;
+        }
+        if (!refs.issue) continue;
         const issue = byId.get(refs.issue);
         if (!issue) continue;
         const stale = issueIsClosed(issue);

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1610,6 +1610,53 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
+  test("a pending decision and an escalation survive a newer run for their ticket", async () => {
+    const db = openDb(":memory:");
+    insertEvent(db, { eventId: "ask-evt", status: "human_needed" });
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "unanswered ask",
+        refs: {
+          issue: "watt-mind/factory#1158",
+          eventSource: "test",
+          eventId: "ask-evt",
+        },
+        decision: decision(),
+        dedupeKey: "BLOCKED:ask-evt",
+      },
+      { id: "open-ask", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "refused run",
+        refs: { issue: "watt-mind/factory#1158" },
+      },
+      { id: "open-escalation", now: 1000 },
+    );
+    const at = new Date(2000).toISOString();
+    db.query(
+      `INSERT INTO runs
+       (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+       VALUES ('run-new', 'new-subject', '{}', 'sha256:test', 'PROPOSED', 0, ?, ?, 'watt-mind/factory#1158')`,
+    ).run(at, at);
+
+    await expect(
+      reconcileInbox(db, { now: 3000, linearIssues: async () => [] }),
+    ).resolves.toEqual([]);
+    expect(
+      db
+        .query(
+          "SELECT id FROM inbox_items WHERE resolved_at IS NULL ORDER BY id",
+        )
+        .all()
+        .map((row) => row.id),
+    ).toEqual(["open-ask", "open-escalation"]);
+  });
+
   test("expires an old parked item with no actionable referent", () => {
     const db = openDb(":memory:");
     createInboxItem(

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -15,6 +15,7 @@ import {
   inboxCounts,
   listInboxItems,
   markInboxDelivered,
+  MAX_PARKED_INBOX_AGE_MS,
   reconcileInbox,
   retryInboxDecision,
   resolveInboxItem,
@@ -1526,6 +1527,103 @@ describe("human inbox ledger (WM-285)", () => {
       { id: "gh-b", resolvedBy: "auto:stale_ref" },
     ]);
     expect(getInboxItem(db, "gh-c").resolvedAt).toBeNull();
+  });
+
+  test("reconciles merged and closed referenced pull requests", async () => {
+    const db = openDb(":memory:");
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "merged",
+        refs: { repo: "factory", pr: "PR#17" },
+      },
+      { id: "merged-pr", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "closed",
+        refs: { repo: "factory", pr: "PR#18" },
+      },
+      { id: "closed-pr", now: 1000 },
+    );
+
+    await expect(
+      reconcileInbox(db, {
+        now: 60_000,
+        fetchPullRequest: async ({ github, pr }) => {
+          expect(github).toBe("watt-mind/factory");
+          return { state: pr === 17 ? "MERGED" : "CLOSED" };
+        },
+      }),
+    ).resolves.toEqual([
+      { id: "merged-pr", resolvedBy: "auto:pr_merged" },
+      { id: "closed-pr", resolvedBy: "auto:pr_closed" },
+    ]);
+  });
+
+  test("supersedes an older parked item when a newer run owns its ticket", () => {
+    const db = openDb(":memory:");
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "old parked dispatch",
+        refs: { issue: "watt-mind/factory#1158" },
+      },
+      { id: "old-park", now: 1000 },
+    );
+    const at = new Date(2000).toISOString();
+    db.query(
+      `INSERT INTO runs
+       (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at, subject)
+       VALUES ('run-new', 'new-subject', '{}', 'sha256:test', 'PROPOSED', 0, ?, ?, 'watt-mind/factory#1158')`,
+    ).run(at, at);
+
+    expect(reconcileInbox(db, { now: 3000 })).toEqual([
+      { id: "old-park", resolvedBy: "auto:superseded" },
+    ]);
+  });
+
+  test("supersedes an older parked item when a newer ticket event is admitted", () => {
+    const db = openDb(":memory:");
+    createInboxItem(
+      db,
+      {
+        kind: "human_needed",
+        title: "old parked event",
+        refs: { issue: "watt-mind/factory#1158" },
+      },
+      { id: "old-event-park", now: 1000 },
+    );
+    const at = new Date(2000).toISOString();
+    db.query(
+      `INSERT INTO events
+       (source, event_id, type, subject, occurred_at, received_at, envelope_json, payload_hash, status, admitted_at)
+       VALUES ('github', 'new-ticket-event', 'factory.dispatch.requested', 'watt-mind/factory#1158', ?, ?, '{}', 'sha256:test', 'admitted', ?)`,
+    ).run(at, at, at);
+
+    expect(reconcileInbox(db, { now: 3000 })).toEqual([
+      { id: "old-event-park", resolvedBy: "auto:superseded" },
+    ]);
+  });
+
+  test("expires an old parked item with no actionable referent", () => {
+    const db = openDb(":memory:");
+    createInboxItem(
+      db,
+      { kind: "BLOCKED", title: "orphaned park" },
+      {
+        id: "orphaned-park",
+        now: 1000,
+      },
+    );
+
+    expect(reconcileInbox(db, { now: 1000 + MAX_PARKED_INBOX_AGE_MS })).toEqual(
+      [{ id: "orphaned-park", resolvedBy: "auto:stale_ref" }],
+    );
   });
 
   test("an escalation on a REFUSED run survives reconcile — it is born terminal", async () => {

--- a/event-runtime/lib/notify.mjs
+++ b/event-runtime/lib/notify.mjs
@@ -29,6 +29,7 @@
  */
 import { spawn } from "node:child_process";
 import { createInboxItem, deliverInboxItem } from "./inbox.mjs";
+import { loadRepos } from "./repos.mjs";
 import { txImmediate } from "./db.mjs";
 import { templateFor } from "./decision-templates.mjs";
 import { proposalSubject } from "./proposal-subject.mjs";
@@ -161,22 +162,63 @@ function alreadyNotified(db, kind, target) {
  *
  * @returns {Array<{ kind: string, dedupKind?: string, target: string, title: string, message?: string, refs: object, source: string }>}
  */
-/** Ticket/repo the parked event's own envelope already names, if any. */
+const COMPOUND_EVENT_ISSUE =
+  /([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#\d+)(?:$|[\s:)\]])/g;
+
+function regexEscape(value) {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function issueFromEventId(eventId) {
+  if (typeof eventId !== "string") return {};
+  // Event coordinates prefix a configured GitHub issue with an opaque chain
+  // id. Resolve against the registry rather than greedily treating that
+  // prefix as part of an owner name (owners themselves may contain hyphens).
+  let issue;
+  try {
+    const github = [...loadRepos().values()]
+      .map((repo) => repo.github)
+      .filter(
+        (repo) =>
+          typeof repo === "string" &&
+          new RegExp(`${regexEscape(repo)}#\\d+$`).test(eventId),
+      )
+      .sort((a, b) => b.length - a.length)[0];
+    if (github)
+      issue = eventId.match(new RegExp(`(${regexEscape(github)}#\\d+)$`))?.[1];
+  } catch {
+    // Registry availability is not required for direct GitHub coordinates.
+  }
+  if (!issue) {
+    const matches = [...eventId.matchAll(COMPOUND_EVENT_ISSUE)];
+    const candidate = matches.at(-1)?.[1];
+    if (candidate && candidate === eventId) issue = candidate;
+  }
+  if (!issue) return {};
+  return { issue, repo: issue.slice(0, issue.lastIndexOf("#")) };
+}
+
+/** Ticket/repo the parked event's own envelope or coordinate names, if any. */
 function eventRefs(row) {
   let payload;
   try {
     payload = JSON.parse(row.envelopeJson ?? "{}")?.payload;
   } catch {
-    return {};
+    return issueFromEventId(row.eventId);
   }
-  if (!payload || typeof payload !== "object") return {};
+  const coordinate = issueFromEventId(row.eventId);
+  if (!payload || typeof payload !== "object") return coordinate;
   return {
     ...(typeof payload.ticket === "string" && payload.ticket
       ? { issue: payload.ticket }
-      : {}),
+      : coordinate.issue
+        ? { issue: coordinate.issue }
+        : {}),
     ...(typeof payload.repo === "string" && payload.repo
       ? { repo: payload.repo }
-      : {}),
+      : coordinate.repo
+        ? { repo: coordinate.repo }
+        : {}),
   };
 }
 

--- a/event-runtime/lib/notify.test.mjs
+++ b/event-runtime/lib/notify.test.mjs
@@ -575,6 +575,25 @@ describe("notify (WM-65)", () => {
     expect(outcome.error).toContain("timed out after 250ms");
   });
 
+  test("extracts a GitHub issue from a compound parked-event coordinate", () => {
+    const db = openDb(":memory:");
+    insertEvent(db, {
+      eventId: "chain-run_123-watt-mind/factory#1158",
+      status: "human_needed",
+    });
+
+    expect(pendingNotifications(db)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          refs: expect.objectContaining({
+            issue: "watt-mind/factory#1158",
+            repo: "watt-mind/factory",
+          }),
+        }),
+      ]),
+    );
+  });
+
   test("a missing notifier binary resolves as a failure instead of throwing", async () => {
     const outcome = await sendNotification(
       "/nonexistent/notifier-binary",


### PR DESCRIPTION
Fixes #2117

## Verification
- `bun test event-runtime/lib/inbox.test.mjs event-runtime/lib/notify.test.mjs`
- configured verify command

UX critique: skipped — internal runtime reconciliation with no user-completable flow.
run:run_e9931248-52af-4d16-8d50-ea4248fecb87