### PR TITLE
serve: keep control API responsive under tick load

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -232,18 +232,21 @@ export async function tick({
   subsystems = {},
   skipPlan = false,
   proposalSweepLimit,
+  onStep = () => {},
 } = {}) {
   const tickStart = Date.now();
   const stepMs = {};
   let expiredScheduledProposals = 0;
   const runStep = async (name, fn) => {
     const start = Date.now();
+    onStep({ name, startedAt: start });
     try {
       await (subsystems[name] ?? fn)();
     } catch (err) {
       logLine(`tick ${name}: ${err.message}`);
     } finally {
       stepMs[name] = Date.now() - start;
+      onStep({ name: null, finishedAt: Date.now() });
     }
   };
 
@@ -282,12 +285,12 @@ export async function tick({
   });
 
   await runStep("auto-approve-chains", async () => {
-    const { worktreeDispatchAutoEligibility } =
+    const { worktreeDispatchAutoEligibilityAsync } =
       await import("../lib/planner.mjs");
     const auto = await autoApproveChains(db, registry, {
       now,
       policyVersion: pv,
-      dispatchEligibility: worktreeDispatchAutoEligibility,
+      dispatchEligibility: worktreeDispatchAutoEligibilityAsync,
       dispatch: db ? db : null,
     });
     for (const a of auto.approved)
@@ -642,6 +645,9 @@ export default async function serve(args) {
   let tickOverruns = 0;
   let lastTickMs = 0;
   let lastOverrunAt = null;
+  let lastTickAt = null;
+  let currentTickStep = null;
+  let tickStartedAt = null;
   let plannerWorker = null;
 
   function getTickStats() {
@@ -651,7 +657,13 @@ export default async function serve(args) {
         .get() != null;
     return {
       lastMs: lastTickMs,
+      lastTickMs,
       overruns: tickOverruns,
+      tickOverruns,
+      lastTickAt,
+      currentStep: currentTickStep,
+      stallMs:
+        busy && tickStartedAt ? Math.max(0, Date.now() - tickStartedAt) : 0,
       ...(lastOverrunAt ? { lastOverrunAt } : {}),
       planner: plannerWorker?.state({ queued }) ?? null,
     };
@@ -668,6 +680,7 @@ export default async function serve(args) {
     }
     busy = true;
     const start = Date.now();
+    tickStartedAt = start;
     try {
       registryRef.poll();
       const result = await tick({
@@ -683,10 +696,14 @@ export default async function serve(args) {
         announceProposals,
         announceTransitions,
         skipPlan: !noPlanner,
+        onStep: ({ name }) => {
+          currentTickStep = name;
+        },
       });
       lastPrune = result.lastPrune;
       const duration = Date.now() - start;
       lastTickMs = duration;
+      lastTickAt = new Date().toISOString();
       if (duration > 1000) {
         tickOverruns++;
         lastOverrunAt = new Date().toISOString();
@@ -698,6 +715,8 @@ export default async function serve(args) {
       log(`tick error: ${err.message}`);
     } finally {
       busy = false;
+      currentTickStep = null;
+      tickStartedAt = null;
     }
   }
 

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -285,13 +285,17 @@ export async function tick({
   });
 
   await runStep("auto-approve-chains", async () => {
-    const { worktreeDispatchAutoEligibilityAsync } =
+    const { worktreeDispatchAutoEligibilityAsync, createAutoApprovalDispatch } =
       await import("../lib/planner.mjs");
+    // A real dispatch bag, not the raw DB handle: awaited readers memoised by
+    // `wrapLinearReads` (ticket/viewer/in-flight plus the rate-limit latch) and
+    // by `withPassInFlightCache` for the pass (#1064), each read bounded well
+    // under the tracker's own 15s request timeout.
     const auto = await autoApproveChains(db, registry, {
       now,
       policyVersion: pv,
       dispatchEligibility: worktreeDispatchAutoEligibilityAsync,
-      dispatch: db ? db : null,
+      dispatch: createAutoApprovalDispatch(),
     });
     for (const a of auto.approved)
       logLine(
@@ -649,6 +653,12 @@ export default async function serve(args) {
   let currentTickStep = null;
   let tickStartedAt = null;
   let plannerWorker = null;
+  // Chain approval has exactly one owner in this process: the tick step below,
+  // which runs it with awaited, memoised, per-row-bounded control-plane reads.
+  // Without this the planner would run the same pass again — inline under
+  // `--no-planner`, and in the worker thread otherwise (the worker inherits
+  // this env at creation) — concurrently against the same rows.
+  process.env.FACTORY_PLANNER_AUTO_APPROVE_CHAINS = "0";
 
   function getTickStats() {
     const queued =
@@ -656,12 +666,15 @@ export default async function serve(args) {
         .query(`SELECT 1 FROM events WHERE status = 'admitted' LIMIT 1`)
         .get() != null;
     return {
+      // `lastMs`/`overruns` are the published /health names (orchestrator
+      // watchdog and the web dashboard read them) — keep exactly one spelling.
       lastMs: lastTickMs,
-      lastTickMs,
       overruns: tickOverruns,
-      tickOverruns,
       lastTickAt,
       currentStep: currentTickStep,
+      // How long the in-progress tick has been running. Non-zero here with a
+      // stale `lastTickAt` distinguishes "wedged inside <currentStep>" from
+      // "idle" without waiting for the after-the-fact overrun log.
       stallMs:
         busy && tickStartedAt ? Math.max(0, Date.now() - tickStartedAt) : 0,
       ...(lastOverrunAt ? { lastOverrunAt } : {}),

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -765,6 +765,55 @@ export default async function start() {
     db.close();
   });
 
+  test("tick names the step it is inside to onStep, and clears it on the way out (#2123)", async () => {
+    // The tick telemetry serve reports as `currentStep`/`stallMs`: while a step
+    // runs its name is live, and the step's own body must be able to observe
+    // it — that is what turns a wedged loop into "wedged inside <step>" instead
+    // of an after-the-fact overrun log that a blocked loop cannot even write.
+    const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
+    const { loadRegistry } = await import("../lib/registry.mjs");
+    const db = openDb(":memory:");
+    const now = Date.parse("2026-08-31T19:01:40.738Z");
+    let current = "sentinel";
+    let observedInsideStep = null;
+    const steps = [];
+    const subsystems = Object.fromEntries(
+      TICK_SUBSYSTEMS.filter((name) => name !== "plan").map((name) => [
+        name,
+        () => {},
+      ]),
+    );
+    subsystems["auto-approve-chains"] = () => {
+      observedInsideStep = current;
+    };
+
+    const result = await tick({
+      db,
+      registry: loadRegistry(),
+      now,
+      policyVersion: "git:test",
+      skipPlan: true,
+      subsystems,
+      log: () => {},
+      onStep: ({ name }) => {
+        current = name;
+        steps.push(name);
+      },
+    });
+
+    expect(observedInsideStep).toBe("auto-approve-chains");
+    expect(steps[0]).toBe("tick emit");
+    expect(steps.at(-1)).toBeNull();
+    // Every step opens with its name and closes with null: an odd count would
+    // leave `currentStep` naming a step that already finished.
+    expect(steps.filter((name) => name === null)).toHaveLength(
+      steps.length / 2,
+    );
+    expect(current).toBeNull();
+    expect(Object.keys(result.stepMs)).toContain("auto-approve-chains");
+    db.close();
+  });
+
   test("tick bounds orphaned non-run proposal sweeps and logs the remainder", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/lib/auto-approval.mjs
+++ b/event-runtime/lib/auto-approval.mjs
@@ -60,6 +60,16 @@ const ENVIRONMENT_FAILURE_REASONS = new Set([
 ]);
 const RUNTIME_POLICY_LOAD_ERROR = Symbol("runtime_policy_load_error");
 
+/** Leave the remainder of a one-second serve cadence to local tick work. */
+export const DEFAULT_CHAIN_AUTO_APPROVAL_DEADLINE_MS = 2_000;
+
+function chainAutoApprovalDeadlineMs() {
+  const value = Number(process.env.FACTORY_CHAIN_AUTO_APPROVAL_DEADLINE_MS);
+  return Number.isFinite(value) && value > 0
+    ? value
+    : DEFAULT_CHAIN_AUTO_APPROVAL_DEADLINE_MS;
+}
+
 function loadRuntimePolicy(root = reposRoot()) {
   const file = chainApprovalPolicyPath(root);
   if (!existsSync(file)) return null;
@@ -256,10 +266,7 @@ function dispatchSafe(
     return "dispatch_recheck_deferred";
   }
 
-  let result;
-  try {
-    result = dispatchEligibility(envelope.payload, dispatch);
-  } catch (err) {
+  const failed = (err) => {
     const message = String(err?.message ?? err);
     console.error(`dispatch_recheck_failed: ${message}`);
     if (isLinearRateLimited(err) || isLinearRateLimitMessage(message)) {
@@ -272,33 +279,44 @@ function dispatchSafe(
       return "dispatch_recheck_deferred";
     }
     return `dispatch_recheck_failed:${clipReason(message)}`;
+  };
+  const checked = (result) => {
+    if (!result?.ok)
+      return `dispatch_ineligible:${result?.refusal?.reason ?? "unknown"}`;
+
+    const expectedEvidenceHash =
+      stableChainApprovalPolicyForHash(approvalPolicy)?.dispatchEvidenceHash;
+    if (!expectedEvidenceHash)
+      return "dispatch_ineligible:approval_policy_missing_evidence";
+    const { checkedAt, ...currentEvidence } = result.evidence ?? {};
+    if (expectedEvidenceHash !== hashJson(currentEvidence)) {
+      return "dispatch_ineligible:evidence_changed_since_plan";
+    }
+
+    // The escalated/security-label refusal ran inline here before WM-842; it is
+    // now the built-in `factory:escalation-labels` hook, first in the waterfall,
+    // and every hook deny keeps the `dispatch_ineligible:<reason>` shape.
+    return after(
+      approveBeforeHooks(hookCtx.hooks, hookCtx, { evidence: result.evidence }),
+      (verdict) => {
+        if (verdict.decision === "deny")
+          return `dispatch_ineligible:${verdict.reason}`;
+        if ((result.evidence?.escalatePathIntersections ?? []).length > 0)
+          return "dispatch_ineligible:escalate_paths_intersect";
+        return null;
+      },
+    );
+  };
+
+  let result;
+  try {
+    result = dispatchEligibility(envelope.payload, dispatch);
+  } catch (err) {
+    return failed(err);
   }
-
-  if (!result?.ok)
-    return `dispatch_ineligible:${result?.refusal?.reason ?? "unknown"}`;
-
-  const expectedEvidenceHash =
-    stableChainApprovalPolicyForHash(approvalPolicy)?.dispatchEvidenceHash;
-  if (!expectedEvidenceHash)
-    return "dispatch_ineligible:approval_policy_missing_evidence";
-  const { checkedAt, ...currentEvidence } = result.evidence ?? {};
-  if (expectedEvidenceHash !== hashJson(currentEvidence)) {
-    return "dispatch_ineligible:evidence_changed_since_plan";
-  }
-
-  // The escalated/security-label refusal ran inline here before WM-842; it is
-  // now the built-in `factory:escalation-labels` hook, first in the waterfall,
-  // and every hook deny keeps the `dispatch_ineligible:<reason>` shape.
-  return after(
-    approveBeforeHooks(hookCtx.hooks, hookCtx, { evidence: result.evidence }),
-    (verdict) => {
-      if (verdict.decision === "deny")
-        return `dispatch_ineligible:${verdict.reason}`;
-      if ((result.evidence?.escalatePathIntersections ?? []).length > 0)
-        return "dispatch_ineligible:escalate_paths_intersect";
-      return null;
-    },
-  );
+  return isThenable(result)
+    ? Promise.resolve(result).then(checked, failed)
+    : checked(result);
 }
 
 function mergeBarrierReason(db, registry, candidate, now) {
@@ -904,6 +922,18 @@ function pinnedToOlderRegistry(row, registryVersion) {
   return pinned !== null && pinned !== registryVersion;
 }
 
+function staleRevisitJitter(row, revisitMs) {
+  // Stable, bounded jitter is deterministic across a restart while ensuring a
+  // batch that became stale together does not become due together again.
+  const window = Math.floor(revisitMs / 10);
+  if (window < 1) return 0;
+  const key = `${row.run_id}\0${row.id}`;
+  let hash = 0;
+  for (let index = 0; index < key.length; index += 1)
+    hash = (hash * 31 + key.charCodeAt(index)) >>> 0;
+  return hash % (window + 1);
+}
+
 /**
  * Recheck and approve the currently open, eligible chain proposals once.
  * A second pass finds no approved proposal and therefore cannot double-approve.
@@ -968,6 +998,7 @@ async function runPass(
     hookTimeoutMs,
     maxRows = DEFAULT_MAX_CHAIN_AUTO_APPROVALS_PER_TICK,
     staleRevisitMs = DEFAULT_STALE_CHAIN_REVISIT_MS,
+    deadlineMs = chainAutoApprovalDeadlineMs(),
   } = {},
   marker = { settled: false },
 ) {
@@ -984,6 +1015,11 @@ async function runPass(
       Number.isFinite(staleRevisitMs) && staleRevisitMs >= 0
         ? staleRevisitMs
         : DEFAULT_STALE_CHAIN_REVISIT_MS;
+    const passDeadlineMs =
+      Number.isFinite(deadlineMs) && deadlineMs > 0
+        ? deadlineMs
+        : DEFAULT_CHAIN_AUTO_APPROVAL_DEADLINE_MS;
+    const passStartedAt = Date.now();
     const memo = staleVerdictsFor(db);
     let skipped = 0;
     let memoised = 0;
@@ -1053,13 +1089,20 @@ async function runPass(
         skipped += 1;
         continue;
       }
+      // Check immediately before the potentially remote eligibility read. A
+      // slow row may finish, but it cannot start another backlog row in the
+      // same pass.
+      if (Date.now() - passStartedAt >= passDeadlineMs) {
+        skipped += 1;
+        continue;
+      }
       evaluated += 1;
       const hold = (reason) => {
         if (stale)
           memo.set(memoKey, {
             proposalId: row.id,
             reason,
-            until: now + revisitMs,
+            until: now + revisitMs + staleRevisitJitter(row, revisitMs),
           });
         else memo.delete(memoKey);
       };

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -11,6 +11,7 @@ import {
   CHAIN_AUTO_APPROVAL_EVENT_TYPES,
   DEFAULT_STALE_CHAIN_REVISIT_MS,
   CHAIN_AUTO_APPROVAL_REASON,
+  DEFAULT_CHAIN_AUTO_APPROVAL_DEADLINE_MS,
   loadChainAutoApprovalPolicy,
 } from "./auto-approval.mjs";
 import { canonicalJson, hashJson } from "./canonical.mjs";
@@ -2355,6 +2356,30 @@ describe("chain auto approval (WM-357)", () => {
     ).toBe(backlog.length);
   });
 
+  test("an asynchronous dispatch recheck yields and the pass defers remaining rows at its deadline (#2123)", async () => {
+    const db = openDb(":memory:");
+    const backlog = Array.from({ length: 3 }, (_, index) =>
+      dispatchSeed(db, `deadline-${index}`, { ticket: `WM-${21230 + index}` }),
+    );
+    let checks = 0;
+    const result = await auto(db, {
+      deadlineMs: 100,
+      dispatchEligibility: async () => {
+        checks += 1;
+        await new Promise((resolve) => setTimeout(resolve, 120));
+        return dispatchOk();
+      },
+      runtimeGuard: () => null,
+    });
+
+    expect(DEFAULT_CHAIN_AUTO_APPROVAL_DEADLINE_MS).toBe(2_000);
+    expect(checks).toBe(1);
+    expect(result.approved).toEqual([
+      { proposalId: backlog[0].id, runId: backlog[0].runId },
+    ]);
+    expect(result.skipped).toBe(2);
+  });
+
   test("registry-stale rows are evaluated once per (run, registryVersion) and then memoised (#1706)", async () => {
     const db = openDb(":memory:");
     const backlog = Array.from({ length: 60 }, (_, i) =>
@@ -2399,7 +2424,7 @@ describe("chain auto approval (WM-357)", () => {
     // The hold expires, and a registry bump re-evaluates immediately.
     const revisited = await auto(db, {
       ...options,
-      now: now + DEFAULT_STALE_CHAIN_REVISIT_MS,
+      now: now + Math.ceil(DEFAULT_STALE_CHAIN_REVISIT_MS * 1.1) + 1,
     });
     expect(revisited.memoised).toBe(0);
     expect(revisited.open).toHaveLength(backlog.length);

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -437,6 +437,18 @@ export function wrapLinearReads(
       ? resetMs
       : resolveNow() + 60_000;
   };
+  // The serve-loop chain pass injects awaited readers, so a rate limit arrives
+  // as a rejected promise the synchronous `catch` below never sees. Latch it
+  // from the promise too, and drop the memo entry so one transient failure is
+  // not replayed to every later row in the pass as a cached value.
+  const trackAsync = (value, forget) => {
+    if (!value || typeof value.then !== "function") return value;
+    value.then(undefined, (err) => {
+      remember(err);
+      forget();
+    });
+    return value;
+  };
 
   // Bind policy dependencies into production fetchers rather than appending
   // them to every call. In particular, fetchViewer's second positional value
@@ -471,7 +483,7 @@ export function wrapLinearReads(
       try {
         const value = fetchTicket(id, repo);
         cache.tickets.set(key, value);
-        return value;
+        return trackAsync(value, () => cache.tickets.delete(key));
       } catch (err) {
         remember(err);
         throw err;
@@ -485,7 +497,7 @@ export function wrapLinearReads(
       try {
         const value = fetchViewer(repo, ...args);
         cache.viewers.set(key, value);
-        return value;
+        return trackAsync(value, () => cache.viewers.delete(key));
       } catch (err) {
         remember(err);
         throw err;
@@ -502,7 +514,7 @@ export function wrapLinearReads(
         cache.inFlightCalls += 1;
         const value = fetchInFlight(repo);
         cache.inFlight.set(key, { value, at });
-        return value;
+        return trackAsync(value, () => cache.inFlight.delete(key));
       } catch (err) {
         remember(err);
         throw err;
@@ -757,21 +769,59 @@ async function spawnRead(args, timeoutMs) {
     stdin: "ignore",
     stdout: "pipe",
     stderr: "pipe",
-    timeout: timeoutMs,
+    // Backstop only: the explicit timer below owns the classification, and a
+    // child that ignores SIGTERM still has to die.
+    timeout: Math.max(1, timeoutMs) + 500,
+    killSignal: "SIGKILL",
   });
-  const [stdout, stderr, exitCode] = await Promise.all([
-    new Response(proc.stdout).text(),
-    new Response(proc.stderr).text(),
-    proc.exited,
-  ]);
-  if (exitCode !== 0) {
-    const err = new Error(stderr.trim() || `command exited ${exitCode}`);
+  let timedOut = false;
+  const timer = setTimeout(
+    () => {
+      timedOut = true;
+      try {
+        proc.kill("SIGTERM");
+      } catch {
+        // Already exited: the awaited result below is authoritative.
+      }
+    },
+    Math.max(1, timeoutMs),
+  );
+  let stdout;
+  let stderr;
+  let exitCode;
+  try {
+    [stdout, stderr, exitCode] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+  if (exitCode === 0) return stdout;
+  // `linearReadTimedOut` is the only thing standing between a stalled control
+  // plane and a hard `dispatch_recheck_failed: linear_read_failed` that the
+  // chain memo then holds for a full stale window. It recognises a timeout by
+  // `code === "ETIMEDOUT"` or by `signal === "SIGTERM" && status == null` —
+  // the shape `child_process` gives a killed sync read — so reproduce exactly
+  // that shape here instead of a bare non-zero exit.
+  if (timedOut) {
+    const err = new Error(
+      `command timed out after ${timeoutMs}ms: ${args.join(" ")}`,
+    );
+    err.code = "ETIMEDOUT";
+    err.signal = proc.signalCode ?? "SIGTERM";
+    err.status = null;
     err.stderr = stderr;
     err.stdout = stdout;
-    err.status = exitCode;
     throw err;
   }
-  return stdout;
+  const err = new Error(stderr.trim() || `command exited ${exitCode}`);
+  err.stderr = stderr;
+  err.stdout = stdout;
+  err.status = exitCode;
+  err.signal = proc.signalCode ?? null;
+  throw err;
 }
 
 function autoApprovalReadTimeout(readBudget) {
@@ -857,54 +907,67 @@ async function fetchInFlightAsync(repoConfig, { readBudget = null } = {}) {
   }
 }
 
+// Escalation-only forge reads. These run at most twice per escalated
+// continuation (never on the ordinary dispatch path), so they reuse the forge
+// client the synchronous gate already uses rather than re-deriving the REST
+// shapes: `prView`'s field projection, `prList`'s `cwd: workspacePath` repo
+// resolution, and the explicit `headRefName === branch` match that a bare
+// `pulls[0]` would silently get wrong when the forge returns more than one row.
 async function fetchPullRequestAsync(payload) {
-  try {
-    const pull = JSON.parse(
-      await spawnRead(
-        ["gh", "api", `repos/${payload?.github}/pulls/${payload?.pr}`],
-        AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
-      ),
-    );
-    return { state: pull.state?.toUpperCase(), headRefOid: pull.head?.sha };
-  } catch (err) {
-    const stderr = String(err?.stderr ?? "");
-    if (/not found|no pull request/i.test(stderr)) return null;
-    throw new Error(
-      `github_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
-      { cause: err },
-    );
-  }
+  return fetchPullRequestDefault(payload);
 }
 
 async function findWorkspacePullRequestAsync(payload) {
-  const workspacePath = payload?.workspacePath;
-  if (!workspacePath || !existsSync(workspacePath)) return null;
-  const branch = (
-    await spawnRead(
-      ["git", "-C", workspacePath, "branch", "--show-current"],
-      AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
-    )
-  ).trim();
-  if (!branch) return null;
-  const pulls = JSON.parse(
-    await spawnRead(
-      [
-        "gh",
-        "pr",
-        "list",
-        "--repo",
-        String(payload?.github),
-        "--head",
-        branch,
-        "--state",
-        "open",
-        "--json",
-        "number,url,headRefName,isDraft,state",
-      ],
-      AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
-    ),
+  return findWorkspacePullRequestDefault(payload);
+}
+
+/**
+ * The dispatch bag for serve's chain-approval pass.
+ *
+ * Before this existed the serve tick handed `autoApproveChains` the raw SQLite
+ * handle, which is not a dispatch bag at all: `withPassInFlightCache` saw no
+ * `fetchInFlight` and returned it unchanged (so #1064's per-pass in-flight
+ * cache was inert under serve), the eligibility gate found no injected readers
+ * and fell back to the uncached synchronous `*Default` fetchers, and
+ * `wrapLinearReads` — the ticket/viewer/in-flight memo *and* the rate-limit
+ * latch — never applied on this path at all. This wires all three together
+ * with awaited readers and a per-row read deadline.
+ *
+ * `resetReadBudget` is called by the async gate at the start of every row, so a
+ * stalled row cannot spend the next row's read time (the same rule
+ * `planAdmittedEvents` applies per event).
+ */
+export function createAutoApprovalDispatch({
+  now = Date.now,
+  configSnapshot = null,
+  cache = null,
+  readTimeoutMs = AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
+} = {}) {
+  const snapshot = configSnapshot ?? policySnapshot();
+  const readCache = cache ?? createLinearReadCache();
+  const newBudget = () =>
+    createLinearReadBudget({ now, timeoutMs: readTimeoutMs });
+  readCache.linearReadBudget = newBudget();
+  const readBudget = () => readCache.linearReadBudget;
+  return wrapLinearReads(
+    {
+      configSnapshot: snapshot,
+      resetReadBudget: () => {
+        readCache.linearReadBudget = newBudget();
+      },
+      fetchTicket: (ticketId, repo) =>
+        fetchTicketAsync(ticketId, repo, { readBudget: readBudget() }),
+      fetchViewer: (repoName, snap = snapshot) =>
+        fetchViewerAsync(repoName, snap, { readBudget: readBudget() }),
+      fetchInFlight: (repo) =>
+        fetchInFlightAsync(repo, { readBudget: readBudget() }),
+      fetchPullRequest: fetchPullRequestAsync,
+      findWorkspacePullRequest: findWorkspacePullRequestAsync,
+    },
+    readCache,
+    now,
+    snapshot,
   );
-  return Array.isArray(pulls) ? (pulls[0] ?? null) : null;
 }
 
 /**
@@ -1245,6 +1308,34 @@ function refusal(reason, evidence, decision = "noop", detail = null) {
  * The shared dispatch proof used at plan time and immediately before a chain
  * auto-approval. Its evidence captures every fact the latter needs to compare.
  */
+/**
+ * The tier-escalation continuation bindings, as a check map. Shared so the
+ * async wrapper can decide whether an escalation prefetch is worth a forge read
+ * using exactly the condition the gate itself will apply — an unauthorised
+ * continuation refuses before it ever looks at a pull request.
+ *
+ * @returns {Record<string, boolean>|null} null when there is no continuation.
+ */
+function escalationContinuationChecks(payload, escalatedContinuation) {
+  if (!escalatedContinuation) return null;
+  return {
+    ticket_escalation_failed_run_bound: Boolean(
+      escalatedContinuation.failedRunId,
+    ),
+    ticket_escalation_continuation_run_bound: Boolean(
+      escalatedContinuation.continuationRunId,
+    ),
+    ticket_escalation_root_run_bound: Boolean(escalatedContinuation.rootRunId),
+    ticket_escalation_projection_applied:
+      escalatedContinuation.projectionState === "applied",
+    ticket_escalation_repo_matches:
+      escalatedContinuation.repo === payload?.repo,
+    ticket_escalation_ticket_matches:
+      String(escalatedContinuation.ticket) === String(payload?.ticket),
+    ticket_escalation_model_tier_strong: payload?.modelTier === "strong",
+  };
+}
+
 export function worktreeDispatchAutoEligibility(
   payload,
   {
@@ -1336,26 +1427,10 @@ export function worktreeDispatchAutoEligibility(
   }
   evidence.checks.ticket_identifier_parseable = true;
 
-  const escalationChecks = escalatedContinuation
-    ? {
-        ticket_escalation_failed_run_bound: Boolean(
-          escalatedContinuation.failedRunId,
-        ),
-        ticket_escalation_continuation_run_bound: Boolean(
-          escalatedContinuation.continuationRunId,
-        ),
-        ticket_escalation_root_run_bound: Boolean(
-          escalatedContinuation.rootRunId,
-        ),
-        ticket_escalation_projection_applied:
-          escalatedContinuation.projectionState === "applied",
-        ticket_escalation_repo_matches:
-          escalatedContinuation.repo === payload?.repo,
-        ticket_escalation_ticket_matches:
-          String(escalatedContinuation.ticket) === String(payload?.ticket),
-        ticket_escalation_model_tier_strong: payload?.modelTier === "strong",
-      }
-    : null;
+  const escalationChecks = escalationContinuationChecks(
+    payload,
+    escalatedContinuation,
+  );
   if (escalationChecks) Object.assign(evidence.checks, escalationChecks);
   const canResumeEscalation = Boolean(
     escalationChecks && Object.values(escalationChecks).every(Boolean),
@@ -1739,16 +1814,43 @@ export function worktreeDispatchAutoEligibility(
   return { ok: true, evidence };
 }
 
+/** Thrown by the local-refusal prepass the first time the gate wants a read. */
+const CONTROL_PLANE_READ_REQUIRED = Symbol("control_plane_read_required");
+
 /**
  * Async counterpart for the serve-loop chain approval path. The historical
  * synchronous gate remains in place for planner and execute-time consumers
  * outside that loop; changing it would turn their established result contract
- * into Promises. All control-plane readers used here yield through Bun.spawn.
+ * into Promises. All control-plane readers used here yield.
+ *
+ * Shape of the pass, and why:
+ *
+ *  1. A *local-refusal prepass* runs the gate with readers that refuse to read.
+ *     Every zero-read refusal (`repo_registry_invalid`, `repo_unknown`,
+ *     `repo_report_only`, `no_worktree_scripts`, a malformed ticket id, the
+ *     budget refusal, `capacity_full`) is decided there, so a row that cannot
+ *     dispatch never spends a control-plane read. The prepass stops at the
+ *     gate's first read, well before `ownedPathsClosureDetails` walks the repo
+ *     for pin manifests, so it is cheap; the lease count it needs is memoised
+ *     and handed to the real pass.
+ *  2. The reads the gate will actually want are then resolved once, under the
+ *     gate's own conditions (viewer only for an assigned ticket, forge reads
+ *     only for an authorised escalation continuation).
+ *  3. The gate runs *once* more, with every reader resolved. The expensive tail
+ *     — owned-paths closure, pin-manifest freshness, escalate-path globs — is
+ *     therefore evaluated exactly one time per row, which is the whole point of
+ *     moving this pass off the synchronous path.
+ *
+ * A read that throws is not swallowed: it is replayed from the throwing reader
+ * inside the real pass, so the gate emits its own typed refusal with full
+ * evidence rather than the wrapper inventing one (or rejecting outright).
  */
 export async function worktreeDispatchAutoEligibilityAsync(
   payload,
   options = {},
 ) {
+  // Per-row deadline: a stalled row must not consume the next row's read time.
+  options.resetReadBudget?.();
   const readBudget = options.readBudget ?? null;
   const fetchTicket =
     options.fetchTicket ??
@@ -1763,6 +1865,60 @@ export async function worktreeDispatchAutoEligibilityAsync(
   const findWorkspacePullRequest =
     options.findWorkspacePullRequest ?? findWorkspacePullRequestAsync;
 
+  // Worker leases are a filesystem scan. Memoise them across the two gate
+  // passes so the prepass costs nothing the real pass then repeats.
+  const baseCountLeases =
+    options.countLeases ?? ((repoName) => liveWorkerLeases(repoName).length);
+  const baseHasTicketLease =
+    options.hasTicketLease ??
+    ((repoName, ticket) =>
+      liveWorkerLeases(repoName).some(
+        (lease) => String(lease.ticket) === String(ticket),
+      ));
+  const leaseCounts = new Map();
+  const ticketLeases = new Map();
+  const countLeases = (repoName) => {
+    const key = String(repoName ?? "");
+    if (!leaseCounts.has(key)) leaseCounts.set(key, baseCountLeases(repoName));
+    return leaseCounts.get(key);
+  };
+  const hasTicketLease = (repoName, ticket) => {
+    const key = `${repoName ?? ""}\u0000${ticket ?? ""}`;
+    if (!ticketLeases.has(key))
+      ticketLeases.set(key, baseHasTicketLease(repoName, ticket));
+    return ticketLeases.get(key);
+  };
+  // Same reason: the budget refusal reads policy and the ledger. The prepass
+  // and the real pass are one row's evaluation, so they see one answer.
+  const baseBudgetRefusal = options.budgetRefusal ?? defaultBudgetRefusal;
+  let budgetRefusalMemo;
+  const budgetRefusal = (...args) => {
+    if (budgetRefusalMemo === undefined)
+      budgetRefusalMemo = baseBudgetRefusal(...args);
+    return budgetRefusalMemo;
+  };
+  const base = { ...options, countLeases, hasTicketLease, budgetRefusal };
+
+  const readRefused = () => {
+    throw CONTROL_PLANE_READ_REQUIRED;
+  };
+  let localRefusal = null;
+  try {
+    localRefusal = worktreeDispatchAutoEligibility(payload, {
+      ...base,
+      fetchTicket: readRefused,
+      fetchViewer: readRefused,
+      fetchInFlight: readRefused,
+      fetchPullRequest: readRefused,
+      findWorkspacePullRequest: readRefused,
+    });
+  } catch (err) {
+    if (err !== CONTROL_PLANE_READ_REQUIRED) throw err;
+  }
+  // A verdict without a read is final either way: the gate reads nothing after
+  // it has decided.
+  if (localRefusal) return localRefusal;
+
   const ticket = await fetchTicket(payload?.ticket, payload?.repo);
   const viewer = ticket?.assignee
     ? await fetchViewer(payload?.repo, options.configSnapshot)
@@ -1771,42 +1927,65 @@ export async function worktreeDispatchAutoEligibilityAsync(
   try {
     repo = getRepo(snapshotRepos(options.configSnapshot), payload?.repo);
   } catch {
-    // The synchronous gate below owns the typed invalid-repo refusal.
+    // Unreachable after the prepass, which owns the typed unknown-repo
+    // refusal; stay defensive rather than turning it into a rejection.
   }
-  const escalation = options.escalatedContinuation;
-  const failedPullRequest = Number.isInteger(
-    escalation?.failedRunArtifact?.prNumber,
-  )
-    ? await fetchPullRequest({
+  const escalation = options.escalatedContinuation ?? null;
+  const escalationChecks = escalationContinuationChecks(payload, escalation);
+  // Only an escalation the gate will actually honour is worth a forge read;
+  // an unauthorised continuation refuses `ticket_assigned` before it looks.
+  const canResumeEscalation = Boolean(
+    escalationChecks && Object.values(escalationChecks).every(Boolean),
+  );
+  let failedPullRequest = null;
+  let failedPullRequestError = null;
+  if (
+    canResumeEscalation &&
+    Number.isInteger(escalation?.failedRunArtifact?.prNumber)
+  ) {
+    try {
+      failedPullRequest = await fetchPullRequest({
         github: repo?.github,
         pr: escalation.failedRunArtifact.prNumber,
-      })
-    : null;
-  const workspacePullRequest = escalation?.workspacePath
-    ? await findWorkspacePullRequest({
+      });
+    } catch (err) {
+      failedPullRequestError = err;
+    }
+  }
+  let workspacePullRequest = null;
+  let workspacePullRequestError = null;
+  if (canResumeEscalation && escalation?.workspacePath) {
+    try {
+      workspacePullRequest = await findWorkspacePullRequest({
         github: repo?.github,
         workspacePath: escalation.workspacePath,
-      })
-    : null;
-  const resolved = {
-    ...options,
+      });
+    } catch (err) {
+      workspacePullRequestError = err;
+    }
+  }
+  // The in-flight list is the gate's last read and sits behind every ticket,
+  // claim and owned-paths refusal — but the gate is synchronous, so resolving
+  // it lazily would cost a second full pass (and a second pin-manifest walk)
+  // for every healthy row. Resolve it here instead: the caller's dispatch bag
+  // memoises the query per repo for the pass (#1064) and per team+project for
+  // the cache TTL, so at most one query is issued for the whole pass however
+  // many rows reach this point.
+  const inFlight = await fetchInFlight(repo);
+
+  return worktreeDispatchAutoEligibility(payload, {
+    ...base,
     fetchTicket: () => ticket,
     fetchViewer: () => viewer,
-    fetchPullRequest: () => failedPullRequest,
-    findWorkspacePullRequest: () => workspacePullRequest,
-  };
-  // Keep the expensive in-flight query behind every local/ticket/claim/path
-  // refusal. A malformed or no-longer-ready ticket must not consume another
-  // scarce control-plane read merely because chain approval is asynchronous.
-  const beforeInFlight = worktreeDispatchAutoEligibility(payload, {
-    ...resolved,
-    fetchInFlight: () => [],
-  });
-  if (!beforeInFlight.ok || !repo || !ticket) return beforeInFlight;
-  const inFlight = await fetchInFlight(repo);
-  return worktreeDispatchAutoEligibility(payload, {
-    ...resolved,
     fetchInFlight: () => inFlight,
+    fetchPullRequest: () => {
+      if (failedPullRequestError) throw failedPullRequestError;
+      return failedPullRequest;
+    },
+    findWorkspacePullRequest: () => {
+      if (workspacePullRequestError) throw workspacePullRequestError;
+      return workspacePullRequest;
+    },
   });
 }
 
@@ -3247,11 +3426,21 @@ export function planAdmittedEvents(db, registry, opts = {}) {
   // candidate set, while every failed proof remains open with a typed reason.
   // This stays after planning so no approval happens inside a planner write
   // transaction or before the proposal has a persisted immutable RunSpec.
-  autoApproveChains(db, registry, {
-    now: opts.now ?? Date.now(),
-    policyVersion: opts.policyVersion ?? "unknown",
-    dispatchEligibility: worktreeDispatchAutoEligibility,
-    dispatch,
-  });
+  // Exactly one owner per process. `serve` runs this pass itself, on its own
+  // loop, with awaited readers and a per-row read deadline; letting the
+  // planner (inline here, or in its worker thread) run the same pass as well
+  // meant two concurrent passes over the same rows — the pass-serialising
+  // WeakMap in auto-approval is per-realm and does not cross the worker
+  // thread. Serve clears the flag for its process before starting the worker.
+  const chainApproval =
+    opts.autoApproveChains ??
+    process.env.FACTORY_PLANNER_AUTO_APPROVE_CHAINS !== "0";
+  if (chainApproval)
+    autoApproveChains(db, registry, {
+      now: opts.now ?? Date.now(),
+      policyVersion: opts.policyVersion ?? "unknown",
+      dispatchEligibility: worktreeDispatchAutoEligibility,
+      dispatch,
+    });
   return { planned, failed, deadLettered };
 }

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -742,6 +742,171 @@ function fetchInFlightDefault(repoConfig, { readBudget = null } = {}) {
   }
 }
 
+// The general planner and execute-time gate intentionally retain their
+// synchronous public contract (several non-serve callers rely on it). Chain
+// auto-approval runs on serve's event loop, so it uses this async reader set
+// instead. Keeping the boundary explicit prevents a Promise from silently
+// becoming a successful or failed synchronous eligibility verdict.
+export const AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS = (() => {
+  const value = Number(process.env.FACTORY_AUTO_APPROVAL_READ_TIMEOUT_MS);
+  return Number.isFinite(value) && value > 0 ? value : 5_000;
+})();
+
+async function spawnRead(args, timeoutMs) {
+  const proc = Bun.spawn(args, {
+    stdin: "ignore",
+    stdout: "pipe",
+    stderr: "pipe",
+    timeout: timeoutMs,
+  });
+  const [stdout, stderr, exitCode] = await Promise.all([
+    new Response(proc.stdout).text(),
+    new Response(proc.stderr).text(),
+    proc.exited,
+  ]);
+  if (exitCode !== 0) {
+    const err = new Error(stderr.trim() || `command exited ${exitCode}`);
+    err.stderr = stderr;
+    err.stdout = stdout;
+    err.status = exitCode;
+    throw err;
+  }
+  return stdout;
+}
+
+function autoApprovalReadTimeout(readBudget) {
+  return Math.min(
+    AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
+    linearReadTimeout(readBudget),
+  );
+}
+
+async function fetchTicketAsync(ticketId, repo, { readBudget = null } = {}) {
+  try {
+    const args = [linearCli(), "get", ticketId, "--json"];
+    if (repo) args.push("--repo", repo);
+    return JSON.parse(
+      await spawnRead(["bun", ...args], autoApprovalReadTimeout(readBudget)),
+    );
+  } catch (err) {
+    if (err instanceof LinearReadBudgetExceededError) throw err;
+    throwIfLinearCliRateLimited(err);
+    const stderr = String(err?.stderr ?? "");
+    if (stderr.includes("no such issue")) return null;
+    throwIfLinearReadBudgetExhausted(err, readBudget);
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
+  }
+}
+
+async function fetchViewerAsync(
+  repoName,
+  configSnapshot = null,
+  { readBudget = null } = {},
+) {
+  try {
+    const repo = repoName
+      ? getRepo(snapshotRepos(configSnapshot), repoName)
+      : null;
+    const query =
+      repo?.controlPlane === "github" ? "/user" : "query{ viewer{ id name } }";
+    const args = [linearCli(), "raw", query];
+    if (repoName) args.push("--repo", repoName);
+    const parsed = JSON.parse(
+      await spawnRead(["bun", ...args], autoApprovalReadTimeout(readBudget)),
+    );
+    return repo?.controlPlane === "github"
+      ? parsed?.id == null
+        ? null
+        : { id: String(parsed.id), name: parsed.login ?? parsed.name ?? null }
+      : (parsed?.viewer ?? null);
+  } catch (err) {
+    if (err instanceof LinearReadBudgetExceededError) throw err;
+    throwIfLinearCliRateLimited(err);
+    throwIfLinearReadBudgetExhausted(err, readBudget);
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
+  }
+}
+
+async function fetchInFlightAsync(repoConfig, { readBudget = null } = {}) {
+  try {
+    const args = [
+      linearCli(),
+      "inflight",
+      "--team",
+      String(repoConfig.team),
+      "--project",
+      String(repoConfig.project),
+      "--json",
+    ];
+    if (repoConfig.name) args.push("--repo", repoConfig.name);
+    const rows = JSON.parse(
+      await spawnRead(["bun", ...args], autoApprovalReadTimeout(readBudget)),
+    );
+    return Array.isArray(rows) ? rows : [];
+  } catch (err) {
+    if (err instanceof LinearReadBudgetExceededError) throw err;
+    throwIfLinearCliRateLimited(err);
+    throwIfLinearReadBudgetExhausted(err, readBudget);
+    throw new Error(`linear_read_failed: ${linearReadFailureReason(err)}`, {
+      cause: err,
+    });
+  }
+}
+
+async function fetchPullRequestAsync(payload) {
+  try {
+    const pull = JSON.parse(
+      await spawnRead(
+        ["gh", "api", `repos/${payload?.github}/pulls/${payload?.pr}`],
+        AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
+      ),
+    );
+    return { state: pull.state?.toUpperCase(), headRefOid: pull.head?.sha };
+  } catch (err) {
+    const stderr = String(err?.stderr ?? "");
+    if (/not found|no pull request/i.test(stderr)) return null;
+    throw new Error(
+      `github_read_failed: ${stderr.trim().split("\n").pop() || err.message}`,
+      { cause: err },
+    );
+  }
+}
+
+async function findWorkspacePullRequestAsync(payload) {
+  const workspacePath = payload?.workspacePath;
+  if (!workspacePath || !existsSync(workspacePath)) return null;
+  const branch = (
+    await spawnRead(
+      ["git", "-C", workspacePath, "branch", "--show-current"],
+      AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
+    )
+  ).trim();
+  if (!branch) return null;
+  const pulls = JSON.parse(
+    await spawnRead(
+      [
+        "gh",
+        "pr",
+        "list",
+        "--repo",
+        String(payload?.github),
+        "--head",
+        branch,
+        "--state",
+        "open",
+        "--json",
+        "number,url,headRefName,isDraft,state",
+      ],
+      AUTO_APPROVAL_CONTROL_PLANE_READ_TIMEOUT_MS,
+    ),
+  );
+  return Array.isArray(pulls) ? (pulls[0] ?? null) : null;
+}
+
 /**
  * The serve loop evaluates every admitted event in one tick. Keep the mutable
  * config view consistent within that tick and avoid re-parsing both YAML files
@@ -1572,6 +1737,77 @@ export function worktreeDispatchAutoEligibility(
     );
   }
   return { ok: true, evidence };
+}
+
+/**
+ * Async counterpart for the serve-loop chain approval path. The historical
+ * synchronous gate remains in place for planner and execute-time consumers
+ * outside that loop; changing it would turn their established result contract
+ * into Promises. All control-plane readers used here yield through Bun.spawn.
+ */
+export async function worktreeDispatchAutoEligibilityAsync(
+  payload,
+  options = {},
+) {
+  const readBudget = options.readBudget ?? null;
+  const fetchTicket =
+    options.fetchTicket ??
+    ((ticket, repo) => fetchTicketAsync(ticket, repo, { readBudget }));
+  const fetchViewer =
+    options.fetchViewer ??
+    ((repo, snapshot) => fetchViewerAsync(repo, snapshot, { readBudget }));
+  const fetchInFlight =
+    options.fetchInFlight ??
+    ((repo) => fetchInFlightAsync(repo, { readBudget }));
+  const fetchPullRequest = options.fetchPullRequest ?? fetchPullRequestAsync;
+  const findWorkspacePullRequest =
+    options.findWorkspacePullRequest ?? findWorkspacePullRequestAsync;
+
+  const ticket = await fetchTicket(payload?.ticket, payload?.repo);
+  const viewer = ticket?.assignee
+    ? await fetchViewer(payload?.repo, options.configSnapshot)
+    : null;
+  let repo = null;
+  try {
+    repo = getRepo(snapshotRepos(options.configSnapshot), payload?.repo);
+  } catch {
+    // The synchronous gate below owns the typed invalid-repo refusal.
+  }
+  const escalation = options.escalatedContinuation;
+  const failedPullRequest = Number.isInteger(
+    escalation?.failedRunArtifact?.prNumber,
+  )
+    ? await fetchPullRequest({
+        github: repo?.github,
+        pr: escalation.failedRunArtifact.prNumber,
+      })
+    : null;
+  const workspacePullRequest = escalation?.workspacePath
+    ? await findWorkspacePullRequest({
+        github: repo?.github,
+        workspacePath: escalation.workspacePath,
+      })
+    : null;
+  const resolved = {
+    ...options,
+    fetchTicket: () => ticket,
+    fetchViewer: () => viewer,
+    fetchPullRequest: () => failedPullRequest,
+    findWorkspacePullRequest: () => workspacePullRequest,
+  };
+  // Keep the expensive in-flight query behind every local/ticket/claim/path
+  // refusal. A malformed or no-longer-ready ticket must not consume another
+  // scarce control-plane read merely because chain approval is asynchronous.
+  const beforeInFlight = worktreeDispatchAutoEligibility(payload, {
+    ...resolved,
+    fetchInFlight: () => [],
+  });
+  if (!beforeInFlight.ok || !repo || !ticket) return beforeInFlight;
+  const inFlight = await fetchInFlight(repo);
+  return worktreeDispatchAutoEligibility(payload, {
+    ...resolved,
+    fetchInFlight: () => inFlight,
+  });
 }
 
 /**

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -33,6 +33,7 @@ import {
   policyDispatchPaused,
   policyMaxConcurrentMerges,
   policyMergeBatchSize,
+  createAutoApprovalDispatch,
   wrapLinearReads,
   worktreeDispatchAutoEligibility,
   worktreeDispatchAutoEligibilityAsync,
@@ -1168,7 +1169,33 @@ describe("planEvent worktree gate (WM-108)", () => {
     fetchInFlight: () => [],
   });
 
-  test("async dispatch eligibility awaits control-plane readers without changing the synchronous gate contract (#2123)", async () => {
+  async function withReposRootAsync(yaml, fn, policy = null) {
+    const root = tmpDir("evrt-plan-wt-");
+    mkdirSync(path.join(root, "config"), { recursive: true });
+    writeFileSync(path.join(root, "config", "repos.yaml"), yaml);
+    if (policy) writeFileSync(path.join(root, "config", "policy.yaml"), policy);
+    const previous = process.env.FACTORY_REPOS_ROOT;
+    process.env.FACTORY_REPOS_ROOT = root;
+    try {
+      return await fn(root);
+    } finally {
+      if (previous === undefined) delete process.env.FACTORY_REPOS_ROOT;
+      else process.env.FACTORY_REPOS_ROOT = previous;
+    }
+  }
+
+  const resumableEscalation = (overrides = {}) => ({
+    failedRunId: "run_failed",
+    continuationRunId: "run_continuation",
+    rootRunId: "run_root",
+    projectionState: "applied",
+    repo: "tiered",
+    ticket: "WM-694",
+    failedRunArtifact: { prNumber: 7 },
+    ...overrides,
+  });
+
+  test("a zero-read refusal costs no control-plane read at all (#2123)", async () => {
     let ticketReads = 0;
     const result = await worktreeDispatchAutoEligibilityAsync(
       { repo: "not-configured", ticket: "WM-2123" },
@@ -1179,8 +1206,100 @@ describe("planEvent worktree gate (WM-108)", () => {
         },
       },
     );
-    expect(ticketReads).toBe(1);
+    // The refusal is decidable from local config alone, so the ticket read is
+    // never issued — the read is gated behind the prepass, not before it.
+    expect(ticketReads).toBe(0);
     expect(result.refusal?.reason).toMatch(/^repo_unknown: /);
+  });
+
+  test("async dispatch eligibility awaits its readers and evaluates the gate once per row (#2123)", async () => {
+    await withReposRootAsync(tierRepo, async () => {
+      let ticketReads = 0;
+      let inFlightReads = 0;
+      let budgetChecks = 0;
+      const result = await worktreeDispatchAutoEligibilityAsync(
+        { repo: "tiered", ticket: "WM-694" },
+        {
+          countLeases: () => 0,
+          budgetRefusal: () => {
+            budgetChecks += 1;
+            return null;
+          },
+          fetchTicket: async () => {
+            ticketReads += 1;
+            return tierTicket();
+          },
+          fetchInFlight: async () => {
+            inFlightReads += 1;
+            return [];
+          },
+        },
+      );
+
+      expect(result.ok).toBe(true);
+      expect(ticketReads).toBe(1);
+      expect(inFlightReads).toBe(1);
+      // One evaluation of the row's local facts. The earlier shape ran the
+      // whole synchronous gate twice per row (once with an empty in-flight
+      // list), repeating the repo snapshot, the lease scan, the budget read
+      // and — worse — the owned-paths closure and its unbounded pin-manifest
+      // walk, which is the very per-row cost this pass exists to remove.
+      expect(budgetChecks).toBe(1);
+    });
+  });
+
+  test("an escalation forge read failure is the gate's typed refusal, not a rejected call (#2123)", async () => {
+    await withReposRootAsync(tierRepo, async () => {
+      const result = await worktreeDispatchAutoEligibilityAsync(
+        { repo: "tiered", ticket: "WM-694", modelTier: "strong" },
+        {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: async () => tierTicket(),
+          fetchInFlight: async () => [],
+          escalatedContinuation: resumableEscalation(),
+          fetchPullRequest: async () => {
+            throw new Error("github_read_failed: gh api timed out");
+          },
+        },
+      );
+
+      expect(result.ok).toBeFalsy();
+      expect(result.refusal?.reason).toBe("ticket_escalation_pr_read_failed");
+      expect(result.refusal?.decision).toBe("noop");
+    });
+  });
+
+  test("an unauthorised escalation continuation spends no forge read (#2123)", async () => {
+    await withReposRootAsync(tierRepo, async () => {
+      let pullRequestReads = 0;
+      const result = await worktreeDispatchAutoEligibilityAsync(
+        { repo: "tiered", ticket: "WM-694", modelTier: "strong" },
+        {
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          fetchTicket: async () => tierTicket(),
+          fetchInFlight: async () => [],
+          // Projection not applied: the gate refuses before it would ever look
+          // at the failed run's pull request.
+          escalatedContinuation: resumableEscalation({
+            projectionState: "pending",
+            workspacePath: "/tmp/nowhere",
+          }),
+          fetchPullRequest: async () => {
+            pullRequestReads += 1;
+            return { state: "OPEN" };
+          },
+          findWorkspacePullRequest: async () => {
+            pullRequestReads += 1;
+            return null;
+          },
+        },
+      );
+
+      expect(pullRequestReads).toBe(0);
+      expect(result.refusal?.reason).toBe("ticket_assigned");
+    });
   });
 
   test("ticket-scoped human-needed refusals deduplicate unchanged bodies and supersede changed ones", () => {
@@ -4581,6 +4700,42 @@ describe("Linear rate limit (WM-878)", () => {
       expect(error?.name).toBe("LinearReadBudgetExceededError");
       expect(error?.message).toBe("linear_read_budget_exhausted");
     });
+  });
+
+  test("an awaited read killed by its own deadline defers instead of failing hard (#2123)", async () => {
+    // Regression: the async reader must reproduce the killed-child error shape
+    // `linearReadTimedOut` recognises (code ETIMEDOUT / SIGTERM with a null
+    // status). Without it the timeout surfaced as `linear_read_failed`, which
+    // chain approval memoises as a hard refusal instead of retrying next tick.
+    const root = tmpDir("evrt-plan-async-cli-");
+    const cli = path.join(root, "linear.mjs");
+    writeFileSync(cli, "Bun.sleepSync(5000);");
+    const previousCli = process.env.FACTORY_LINEAR_CLI;
+    process.env.FACTORY_LINEAR_CLI = cli;
+    try {
+      const dispatch = createAutoApprovalDispatch({
+        readTimeoutMs: 50,
+        configSnapshot: {
+          root,
+          repos: new Map([
+            ["gated", { name: "gated", controlPlane: "linear" }],
+          ]),
+        },
+      });
+
+      let error;
+      try {
+        await dispatch.fetchTicket("WM-slow", "gated");
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error?.name).toBe("LinearReadBudgetExceededError");
+      expect(error?.message).toBe("linear_read_budget_exhausted");
+    } finally {
+      if (previousCli === undefined) delete process.env.FACTORY_LINEAR_CLI;
+      else process.env.FACTORY_LINEAR_CLI = previousCli;
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 
   test("a simulated Linear 400 rate-limit refuses linear_rate_limited, leaves the event admitted, and does not dead-letter", () => {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -35,6 +35,7 @@ import {
   policyMergeBatchSize,
   wrapLinearReads,
   worktreeDispatchAutoEligibility,
+  worktreeDispatchAutoEligibilityAsync,
   worktreeDispatchGate,
   worktreeMergeFixEligibility,
 } from "./planner.mjs";
@@ -1165,6 +1166,21 @@ describe("planEvent worktree gate (WM-108)", () => {
     budgetRefusal: () => null,
     fetchTicket: () => tierTicket(tierLabels),
     fetchInFlight: () => [],
+  });
+
+  test("async dispatch eligibility awaits control-plane readers without changing the synchronous gate contract (#2123)", async () => {
+    let ticketReads = 0;
+    const result = await worktreeDispatchAutoEligibilityAsync(
+      { repo: "not-configured", ticket: "WM-2123" },
+      {
+        fetchTicket: async () => {
+          ticketReads += 1;
+          return tierTicket();
+        },
+      },
+    );
+    expect(ticketReads).toBe(1);
+    expect(result.refusal?.reason).toMatch(/^repo_unknown: /);
   });
 
   test("ticket-scoped human-needed refusals deduplicate unchanged bodies and supersede changed ones", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2123

Deploy the bounded async chain-approval reads to keep the control API responsive under tracker latency.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli/serve.test.mjs event-runtime/lib/auto-approval.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/tick-guard.test.mjs` | pass | 196 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2382 passed, 10 skipped; lint warnings only |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend/control-plane responsiveness change; no user-completable flow

run:run_357e5875-71f0-430a-9cf4-2473131c646a
