### PR TITLE
feat(web): add semantic event envelope rendering

### DIFF
--- a/event-runtime/web/src/components/EventEnvelopeView.test.tsx
+++ b/event-runtime/web/src/components/EventEnvelopeView.test.tsx
@@ -1,0 +1,77 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { cleanup, fireEvent } from "@testing-library/react";
+import { EventEnvelopeView } from "./EventEnvelopeView";
+import { renderWithClient } from "../test-render";
+
+afterEach(() => {
+  cleanup();
+  localStorage.clear();
+});
+
+describe("EventEnvelopeView", () => {
+  test("formats operational identifiers as navigable semantic values", () => {
+    const r = renderWithClient(
+      <EventEnvelopeView
+        now={Date.now()}
+        envelope={{
+          payload: {
+            repo: "watt-mind/factory",
+            runId: 42,
+            ticket: "WM-2122",
+            prNumber: 81,
+            headSha: "0123456789abcdef",
+            receivedAt: "2025-01-01T00:00:00.000Z",
+          },
+        }}
+      />,
+    );
+
+    expect(
+      r.getByRole("link", { name: "watt-mind/factory" }).getAttribute("href"),
+    ).toBe("https://github.com/watt-mind/factory");
+    expect(r.getByRole("link", { name: "run #42" }).getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/actions/runs/42",
+    );
+    expect(r.getByRole("link", { name: "WM-2122" }).getAttribute("href")).toBe(
+      "#/tickets/WM-2122",
+    );
+    expect(r.getByRole("link", { name: "#81" }).getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/pull/81",
+    );
+    expect(r.getByRole("link", { name: "01234567" }).getAttribute("href")).toBe(
+      "https://github.com/watt-mind/factory/commit/0123456789abcdef",
+    );
+  });
+
+  test("persists the View / Raw choice", () => {
+    const r = renderWithClient(
+      <EventEnvelopeView
+        now={Date.now()}
+        envelope={{ payload: { repo: "watt-mind/factory" } }}
+      />,
+    );
+
+    fireEvent.click(r.getByRole("button", { name: "Raw" }));
+    expect(localStorage.getItem("evrt-artifact-raw")).toBe("1");
+    expect(r.getByText('"watt-mind/factory"')).toBeTruthy();
+  });
+
+  test("uses the routed agent input view with the envelope payload", () => {
+    const r = renderWithClient(
+      <EventEnvelopeView
+        now={Date.now()}
+        envelope={{ payload: { repo: "watt-mind/factory" } }}
+        inputView={{
+          schemaVersion: "factory.artifact-view/v1",
+          title: "Routed input",
+          summary: "/repo",
+          sections: [],
+        }}
+      />,
+    );
+
+    expect(r.getByText("Routed input")).toBeTruthy();
+    expect(r.getByText("watt-mind/factory")).toBeTruthy();
+  });
+});

--- a/event-runtime/web/src/components/EventEnvelopeView.tsx
+++ b/event-runtime/web/src/components/EventEnvelopeView.tsx
@@ -1,0 +1,179 @@
+import { useState, type ReactNode } from "react";
+import {
+  ArtifactPanel,
+  RawToggle,
+  loadArtifactRaw,
+  saveArtifactRaw,
+} from "./ArtifactView";
+import { TicketHoverCard } from "./TicketHoverCard";
+import { Ago, JsonBlock } from "./ui";
+import type { ArtifactView } from "../types";
+
+type Envelope = Record<string, unknown>;
+
+function asRecord(value: unknown): Envelope | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Envelope)
+    : null;
+}
+
+function text(value: unknown): string | null {
+  return typeof value === "string" || typeof value === "number"
+    ? String(value)
+    : null;
+}
+
+function commitHref(repo: string | null, sha: string) {
+  return repo ? `https://github.com/${repo}/commit/${sha}` : null;
+}
+
+function ExternalLink({
+  href,
+  children,
+}: {
+  href: string;
+  children: ReactNode;
+}) {
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noreferrer"
+      className="mono text-(--accent) hover:underline"
+    >
+      {children}
+    </a>
+  );
+}
+
+/**
+ * Operator-facing rendering for an admitted event's input envelope. Routes
+ * with a declared input view keep the agent-authored presentation; all other
+ * events get a compact formatter for the identifiers operators follow most.
+ */
+export function EventEnvelopeView({
+  envelope,
+  inputView,
+  now,
+}: {
+  envelope: unknown;
+  inputView?: ArtifactView | null;
+  now: number;
+}) {
+  const [raw, setRawState] = useState(loadArtifactRaw);
+  const setRaw = (next: boolean) => {
+    saveArtifactRaw(next);
+    setRawState(next);
+  };
+  const payload = asRecord(envelope)?.payload ?? envelope;
+
+  if (inputView) {
+    return (
+      <ArtifactPanel
+        artifact={payload}
+        view={inputView}
+        raw={raw}
+        onRawChange={setRaw}
+      />
+    );
+  }
+
+  const fields = asRecord(payload);
+  if (!fields) return <JsonBlock value={envelope} />;
+  const repo = text(fields.repo);
+  const runId = text(fields.runId);
+
+  return (
+    <div>
+      <div className="mb-2 flex justify-end">
+        <RawToggle raw={raw} onChange={setRaw} />
+      </div>
+      {raw ? (
+        <JsonBlock value={envelope} />
+      ) : (
+        <dl className="space-y-1.5 text-[12px]">
+          {Object.entries(fields).map(([key, value]) => (
+            <div
+              key={key}
+              className="grid grid-cols-[minmax(0,9rem)_1fr] gap-x-3"
+            >
+              <dt className="truncate text-(--text-faint)" title={key}>
+                {key}
+              </dt>
+              <dd className="min-w-0 break-words text-(--text-dim)">
+                <FieldValue
+                  field={key}
+                  value={value}
+                  repo={repo}
+                  runId={runId}
+                  now={now}
+                />
+              </dd>
+            </div>
+          ))}
+        </dl>
+      )}
+    </div>
+  );
+}
+
+function FieldValue({
+  field,
+  value,
+  repo,
+  runId,
+  now,
+}: {
+  field: string;
+  value: unknown;
+  repo: string | null;
+  runId: string | null;
+  now: number;
+}) {
+  const valueText = text(value);
+  if (valueText === null) {
+    return (
+      <span className="mono whitespace-pre-wrap">{JSON.stringify(value)}</span>
+    );
+  }
+
+  if (field === "repo") {
+    return (
+      <span className="flex flex-wrap gap-x-2">
+        <ExternalLink href={`https://github.com/${valueText}`}>
+          {valueText}
+        </ExternalLink>
+        {runId && (
+          <ExternalLink
+            href={`https://github.com/${valueText}/actions/runs/${runId}`}
+          >
+            run #{runId}
+          </ExternalLink>
+        )}
+      </span>
+    );
+  }
+  if (["ticket", "issue", "issueId"].includes(field))
+    return <TicketHoverCard ticketId={valueText} />;
+  if (["pr", "pullRequest", "prNumber"].includes(field)) {
+    const number = valueText.replace(/^#/, "");
+    return repo ? (
+      <ExternalLink href={`https://github.com/${repo}/pull/${number}`}>
+        #{number}
+      </ExternalLink>
+    ) : (
+      valueText
+    );
+  }
+  if (["commit", "sha", "headSha"].includes(field)) {
+    const href = commitHref(repo, valueText);
+    const label = valueText.slice(0, 8);
+    return href ? <ExternalLink href={href}>{label}</ExternalLink> : label;
+  }
+  if (
+    (field.endsWith("At") || field.endsWith("Time")) &&
+    !Number.isNaN(Date.parse(valueText))
+  )
+    return <Ago iso={valueText} now={now} />;
+  return valueText;
+}

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -282,6 +282,35 @@ describe("Events component harness: selection & detail view", () => {
     );
   });
 
+  test("renders the selected envelope with semantic workflow links", async () => {
+    const event = stubEvent("evt_workflow_failure", "admitted", {
+      type: "github.workflow-run.failed",
+      envelope: {
+        schemaVersion: "factory.event/v1",
+        eventId: "evt_workflow_failure",
+        type: "github.workflow-run.failed",
+        source: "github",
+        payload: { repo: "watt-mind/factory", runId: 42 },
+      },
+    });
+    await withApi(
+      {
+        events: async () => ({ events: [event] }),
+        status: async () => createStatusFixture(),
+      },
+      async () => {
+        const r = renderEvents({
+          focusEvent: { source: "github", eventId: event.eventId },
+        });
+        await waitFor(() =>
+          expect(
+            r.getByRole("link", { name: "run #42" }).getAttribute("href"),
+          ).toBe("https://github.com/watt-mind/factory/actions/runs/42"),
+        );
+      },
+    );
+  });
+
   test("clicking a row selects the event via onSelectEvent", async () => {
     const onSelectEvent = mock(() => {});
     const e1 = stubEvent("evt_click_test", "admitted");

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -4,7 +4,7 @@ import {
   useQuery,
   useQueryClient,
 } from "@tanstack/react-query";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { Suspense, lazy, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../api";
 import { retriggerEnvelope } from "../templates";
 import {
@@ -32,7 +32,6 @@ import {
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
-import { EventEnvelopeView } from "../components/EventEnvelopeView";
 import {
   CausationGlyphs,
   EventHoverCard,
@@ -75,6 +74,7 @@ import {
   ListToolbar,
   ListPane,
   DetailPane,
+  JsonBlock,
   JumpLink,
   KV,
   ListEmpty,
@@ -91,6 +91,19 @@ import {
   shortId,
 } from "../components/ui";
 import { Button as PrimitiveButton } from "../components/ui";
+
+/**
+ * The envelope renderer pulls in the schema-derived ArtifactView (WM-455) for
+ * routes that declare an input view, and Events is an eager view with a
+ * budgeted entry chunk (vite.config.ts). Fetch it on demand, exactly as
+ * RunDetailBlocks does for the same renderer; until the chunk lands the raw
+ * JSON block stands in, which is what the detail pane showed before.
+ */
+const EventEnvelopeView = lazy(() =>
+  import("../components/EventEnvelopeView").then((m) => ({
+    default: m.EventEnvelopeView,
+  })),
+);
 
 function removeTokensFromQuery(
   filter: string,
@@ -1757,11 +1770,13 @@ export function Events({
           })()}
 
           <Section title="Envelope">
-            <EventEnvelopeView
-              envelope={sel.envelope}
-              inputView={inputViewByEventType.get(sel.type)}
-              now={now}
-            />
+            <Suspense fallback={<JsonBlock value={sel.envelope} />}>
+              <EventEnvelopeView
+                envelope={sel.envelope}
+                inputView={inputViewByEventType.get(sel.type)}
+                now={now}
+              />
+            </Suspense>
           </Section>
 
           <VerbError error={requeue.error ?? replay.error} />

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -32,6 +32,7 @@ import {
 } from "../displayOptions";
 import { DisplayOptions, exportJson } from "../components/DisplayOptions";
 import { CustomCell } from "../components/CustomCell";
+import { EventEnvelopeView } from "../components/EventEnvelopeView";
 import {
   CausationGlyphs,
   EventHoverCard,
@@ -40,7 +41,14 @@ import {
 import { chainKeyOfEvent, eventNodeId } from "../graph/chainModel";
 import { setContextActions } from "../palette";
 import { ScopeCaption } from "../components/ContextTabs";
-import type { AdmittedEvent, EventFocus, Proposal, RunSummary } from "../types";
+import type {
+  AdmittedEvent,
+  AgentDef,
+  ArtifactView,
+  EventFocus,
+  Proposal,
+  RunSummary,
+} from "../types";
 import type { OperatorContext } from "../context";
 import { matchesRepo } from "../context";
 import {
@@ -62,13 +70,11 @@ import {
   Button,
   CopyActions,
   Dialog,
-  Disclosure,
   EVENT_STATUS_HUES,
   FilterInput,
   ListToolbar,
   ListPane,
   DetailPane,
-  JsonBlock,
   JumpLink,
   KV,
   ListEmpty,
@@ -514,6 +520,32 @@ export function Events({
       }
     }
     return schemas;
+  }, [agentsQ.data]);
+  // Event routes identify the producer whose output view owns the matching
+  // input presentation. Keep this alongside the schema lookup above so both
+  // registry shapes (top-level routes and per-agent routes) remain useful.
+  const inputViewByEventType = useMemo(() => {
+    const registry = agentsQ.data;
+    const byRef = new Map(registry?.agents.map((agent) => [agent.ref, agent]));
+    const views = new Map<string, ArtifactView>();
+    const add = (type: string, agent: AgentDef | undefined) => {
+      const input = agent?.outputView?.input;
+      if (input && agent?.outputView) {
+        views.set(type, {
+          schemaVersion: agent.outputView.schemaVersion,
+          ...input,
+          sections: input.sections ?? [],
+        });
+      }
+    };
+    for (const route of registry?.eventTypes ?? [])
+      add(route.type, route.agent ? byRef.get(route.agent) : undefined);
+    for (const agent of registry?.agents ?? []) {
+      for (const route of agent.eventTypes) {
+        if (!views.has(route.type)) add(route.type, agent);
+      }
+    }
+    return views;
   }, [agentsQ.data]);
   const decisions = useMemo(() => {
     const byId = new Map<string, Proposal>();
@@ -1725,9 +1757,11 @@ export function Events({
           })()}
 
           <Section title="Envelope">
-            <Disclosure label="payload JSON">
-              <JsonBlock value={sel.envelope} />
-            </Disclosure>
+            <EventEnvelopeView
+              envelope={sel.envelope}
+              inputView={inputViewByEventType.get(sel.type)}
+              now={now}
+            />
           </Section>
 
           <VerbError error={requeue.error ?? replay.error} />


### PR DESCRIPTION
Fixes watt-mind/factory#2122

Review the Events detail envelope renderer for semantic operational links and routed agent input views.

## Validation

| Check                | Command                                                                                                                | Result | Notes                                  |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------- | ------ | -------------------------------------- |
| Verification Command | `bun test event-runtime/web/src/views/Events.test.tsx`                                                               | pass   | 37 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass   | clean; 616 existing lint warnings      |
| UX critique          | `factory-ux-critic`                                                                                                    | pass   | required — SHIP; GET /api/runs HTTP 200 |

UX critique: required — SHIP

run:run_1d87d966-290e-4e22-95f7-6cf11e94473a
