### PR TITLE
test(web): seed Inbox detail fixture for UX review

### DIFF
--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -46,6 +46,7 @@
 import { apiClient } from "../lib/client.mjs";
 import { openDb } from "../lib/db.mjs";
 import { dbPath, runtimeHome } from "../lib/config.mjs";
+import { createInboxItem } from "../lib/inbox.mjs";
 import { createRun, transition } from "../lib/lifecycle.mjs";
 import { hashJson } from "../lib/canonical.mjs";
 
@@ -844,6 +845,53 @@ try {
   );
   log(
     `${dispatchRunId} → COMPLETED (dispatch@1, simulated working PR workflow with PR_OPEN)`,
+  );
+
+  // A hand-authored open item gives web UX review a stable, information-rich
+  // detail pane. Runtime-generated items cover decisions and expiry, while
+  // this fixture deliberately exercises structured message rendering and every
+  // jump target without requiring an operator action.
+  // Use a non-live PR reference so inbox reconciliation cannot auto-resolve the
+  // review fixture when the historical dispatch's real pull request is merged.
+  const inboxPrUrl = `https://github.com/watt-mind/${primaryProject}/pull/999999`;
+  createInboxItem(
+    db,
+    {
+      kind: "ESCALATED",
+      severity: "normal",
+      title: "Review seeded dispatch handoff",
+      body: [
+        "## Handoff",
+        "",
+        "**Dispatch completed** and opened a review-ready pull request.",
+        "",
+        "## References",
+        "",
+        `- [Pull request](${inboxPrUrl})`,
+        `- Ticket \`DEMO-100\` in repository \`${primaryProject}\``,
+        "",
+        "Warning: this is fixture data for UX review; do not merge it.",
+        "",
+        "```",
+        "bun test event-runtime/demo/seed.test.mjs",
+        "```",
+      ].join("\n"),
+      refs: {
+        runId: dispatchRunId,
+        proposalId: human.id,
+        eventSource: "demo-seed",
+        eventId: `${prefix}-human-needed`,
+        // Keep an explicit ticket reference without coupling fixture lifetime
+        // to a live tracker issue that reconciliation may close.
+        issue: "DEMO-100",
+        pr: inboxPrUrl,
+        repo: primaryProject,
+      },
+    },
+    { id: `inbox_${prefix}_dispatch_detail`, now: Date.parse(nowStr) },
+  );
+  log(
+    `inbox_${prefix}_dispatch_detail left open (structured dispatch handoff)`,
   );
 
   db.close();

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -307,6 +307,7 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
       );
       await expectSuccess("initial seed", seedRes, port);
       expect(seedRes.stdout).toContain("merge-apply@2 watched");
+      expect(seedRes.stdout).toContain("structured dispatch handoff");
       expect(seedRes.stdout).not.toContain(
         "merge-verify@1 exact landed lifecycle",
       );
@@ -331,6 +332,39 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
       );
       expect(verifyRes.stdout).toContain(
         "TTL-expired Inbox item offers approve/reject decision",
+      );
+
+      const inboxResponse = await fetch(
+        `http://127.0.0.1:${port}/inbox?status=open`,
+        { headers: controlAuthHeaders() },
+      );
+      expect(inboxResponse.ok).toBe(true);
+      const { items } = await inboxResponse.json();
+      const fixture = items.find(
+        (item) => item.id === "inbox_t1_dispatch_detail",
+      );
+      expect(
+        fixture,
+        `seeded inbox refs: ${JSON.stringify(items.map((item) => item.refs))}`,
+      ).toBeTruthy();
+      expect(fixture).toMatchObject({
+        title: "Review seeded dispatch handoff",
+        refs: {
+          runId: "run_t1_dispatch_wm100",
+          eventSource: "demo-seed",
+          eventId: "t1-human-needed",
+          issue: "DEMO-100",
+        },
+      });
+      expect(fixture.refs.proposalId).toStartWith("prop_");
+      expect(fixture.refs.pr).toMatch(
+        /^https:\/\/github\.com\/watt-mind\/.+\/pull\/999999$/,
+      );
+      expect(fixture.refs.repo).toBeTruthy();
+      expect(fixture.body).toContain("## Handoff");
+      expect(fixture.body).toContain("## References");
+      expect(fixture.body).toContain(
+        "```\nbun test event-runtime/demo/seed.test.mjs\n```",
       );
     },
     loadAdjustedTimeout(30_000),


### PR DESCRIPTION
Fixes watt-mind/factory#2126

Seed an Open Inbox handoff detail fixture so web UX review can exercise structured content and all reference targets.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/demo/seed.test.mjs` | pass | 5 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; baseline lint warnings only |
| UX critique | factory-ux-critic | pass | SHIP; authenticated fixture GET /api/runs HTTP 200 |

UX critique: required — SHIP

run:run_ece91c6a-b1a7-4b5d-ac86-19e41a038f75
