### PR TITLE
fix(repo): replace literal NUL bytes with \0 escapes (#2135)

### DIFF
--- a/event-runtime/web/src/lib/artifactView.ts
+++ b/event-runtime/web/src/lib/artifactView.ts
@@ -370,7 +370,7 @@ export function groupRows(
   for (const row of rows) {
     const value = resolveRelative(row.raw, groupBy);
     if (value === undefined || value === null || value === "") {
-      missing ??= { key: " missing", label: "—", rows: [] };
+      missing ??= { key: "\0missing", label: "—", rows: [] };
       missing.rows.push(row);
       continue;
     }

--- a/lib/control-plane/github.mjs
+++ b/lib/control-plane/github.mjs
@@ -1449,7 +1449,7 @@ export function githubControlPlane(options = {}) {
    */
   async function collaboratorAssociation(repo, login) {
     if (!login) return null;
-    const key = `${repo} ${login}`;
+    const key = `${repo}\0${login}`;
     if (collaboratorAssociationCache.has(key))
       return collaboratorAssociationCache.get(key);
     let resolved = null;

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -824,7 +824,7 @@ export async function reapDeadDispatchWorktrees(
     for (const { runId, repo: repoName, ticket } of db
       .query(DEAD_DISPATCH_WORKTREE_SQL)
       .all()) {
-      const key = `${repoName} ${ticket}`;
+      const key = `${repoName}\0${ticket}`;
       if (seen.has(key)) continue;
       seen.add(key);
 

--- a/tools/check-source-encoding.test.mjs
+++ b/tools/check-source-encoding.test.mjs
@@ -1,0 +1,65 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+const TEXT_GLOBS = [
+  "*.mjs",
+  "*.ts",
+  "*.tsx",
+  "*.js",
+  "*.md",
+  "*.sh",
+  "*.yaml",
+  "*.yml",
+];
+
+/** Locate NUL bytes in a buffer, reporting 1-based line numbers. */
+export function findNulHits(relPath, bytes) {
+  const hits = [];
+  let line = 1;
+  for (let i = 0; i < bytes.length; i++) {
+    if (bytes[i] === 0) hits.push({ path: relPath, line });
+    if (bytes[i] === 0x0a) line += 1;
+  }
+  return hits;
+}
+
+function formatHits(hits) {
+  return hits.map((hit) => `${hit.path}:${hit.line}`).join("\n");
+}
+
+function trackedTextSources(repoRoot) {
+  const proc = Bun.spawnSync({
+    cmd: ["git", "-C", repoRoot, "ls-files", "--", ...TEXT_GLOBS],
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  if (proc.exitCode !== 0) {
+    const detail = (proc.stderr.toString() || proc.stdout.toString()).trim();
+    throw new Error(`git ls-files failed${detail ? `: ${detail}` : ""}`);
+  }
+  return proc.stdout
+    .toString()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+test("NUL hits name the offending path and line", () => {
+  const bytes = Buffer.from("ok\nconst key = `a\x00b`;\n");
+  expect(formatHits(findNulHits("fixture.mjs", bytes))).toBe("fixture.mjs:2");
+});
+
+test("tracked text sources contain no NUL bytes", () => {
+  const files = trackedTextSources(ROOT);
+  expect(files.length).toBeGreaterThan(0);
+  const hits = [];
+  for (const rel of files) {
+    hits.push(...findNulHits(rel, readFileSync(path.join(ROOT, rel))));
+  }
+  if (hits.length > 0) {
+    throw new Error(`NUL byte in ${formatHits(hits).replaceAll("\n", ", ")}`);
+  }
+});


### PR DESCRIPTION
Fixes watt-mind/factory#2135

Replace literal NUL bytes in three sources with `\0` so grep treats them as text.

## Validation

| Check                | Command                                                                                          | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `bun test tools/check-source-encoding.test.mjs lib/control-plane/github.test.mjs`                | pass    | 139 tests, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2394 tests, format clean, lint 0 errors    |
| UX critique          | factory-ux-critic                                                                                | not run | encoding-only; runtime strings unchanged   |

UX critique: skipped — encoding-only; runtime strings unchanged

run:run_664d3d5b-8fbf-4e6c-859f-e894806645de
