### PR TITLE
fix(web): align envelope Raw scope and input-view attribution (#2136)

### DIFF
--- a/event-runtime/web/src/components/EventEnvelopeView.test.tsx
+++ b/event-runtime/web/src/components/EventEnvelopeView.test.tsx
@@ -74,4 +74,73 @@ describe("EventEnvelopeView", () => {
     expect(r.getByText("Routed input")).toBeTruthy();
     expect(r.getByText("watt-mind/factory")).toBeTruthy();
   });
+
+  test("Raw prints the envelope in both the semantic and input-view branches", () => {
+    const envelope = {
+      schemaVersion: "factory.event/v1",
+      eventId: "evt_raw_scope",
+      type: "demo.type",
+      payload: { repo: "watt-mind/factory" },
+    };
+    const inputView = {
+      schemaVersion: "factory.artifact-view/v1" as const,
+      title: "Routed input",
+      summary: "/repo",
+      sections: [],
+    };
+
+    for (const view of [undefined, inputView]) {
+      const r = renderWithClient(
+        <EventEnvelopeView
+          now={Date.now()}
+          envelope={envelope}
+          inputView={view}
+        />,
+      );
+      fireEvent.click(r.getByRole("button", { name: "Raw" }));
+      const rawJson =
+        Array.from(r.container.querySelectorAll("pre"))
+          .map((el) => el.textContent ?? "")
+          .find((text) => text.includes("evt_raw_scope")) ?? "";
+      expect(rawJson).toContain('"schemaVersion"');
+      expect(rawJson).toContain('"evt_raw_scope"');
+      expect(rawJson).toContain('"demo.type"');
+      cleanup();
+      localStorage.clear();
+    }
+  });
+
+  test("a payload-less envelope is JSON, not a field list of envelope metadata", () => {
+    const r = renderWithClient(
+      <EventEnvelopeView
+        now={Date.now()}
+        envelope={{
+          schemaVersion: "factory.event/v1",
+          eventId: "evt_no_payload",
+          type: "demo.type",
+        }}
+      />,
+    );
+
+    expect(r.container.querySelector("dl")).toBeNull();
+    expect(r.queryByRole("button", { name: "Raw" })).toBeNull();
+    expect(r.container.querySelector("pre")?.textContent).toContain(
+      "evt_no_payload",
+    );
+  });
+
+  test("undefined payload fields render an em dash rather than an empty cell", () => {
+    const r = renderWithClient(
+      <EventEnvelopeView
+        now={Date.now()}
+        envelope={{
+          payload: { repo: "watt-mind/factory", optional: undefined },
+        }}
+      />,
+    );
+
+    const row = r.getByText("optional").closest("div");
+    expect(row?.textContent).toContain("—");
+    expect(row?.querySelector("dd")?.textContent).toBe("—");
+  });
 });

--- a/event-runtime/web/src/components/EventEnvelopeView.tsx
+++ b/event-runtime/web/src/components/EventEnvelopeView.tsx
@@ -65,21 +65,26 @@ export function EventEnvelopeView({
     saveArtifactRaw(next);
     setRawState(next);
   };
-  const payload = asRecord(envelope)?.payload ?? envelope;
+  // Payload is only a nested record. Falling back to the envelope itself
+  // would print schemaVersion / eventId / type as if they were payload fields.
+  const payload = asRecord(asRecord(envelope)?.payload);
 
-  if (inputView) {
+  if (inputView && payload) {
     return (
       <ArtifactPanel
         artifact={payload}
         view={inputView}
         raw={raw}
         onRawChange={setRaw}
+        rawFallback={<JsonBlock value={envelope} />}
       />
     );
   }
 
-  const fields = asRecord(payload);
-  if (!fields) return <JsonBlock value={envelope} />;
+  // No payload record: the envelope is the thing to read, not a field list
+  // that relabels metadata as payload.
+  if (!payload) return <JsonBlock value={envelope} />;
+  const fields = payload;
   const repo = text(fields.repo);
   const runId = text(fields.runId);
 
@@ -91,7 +96,7 @@ export function EventEnvelopeView({
       {raw ? (
         <JsonBlock value={envelope} />
       ) : (
-        <dl className="space-y-1.5 text-[12px]">
+        <dl className="space-y-1.5 text-[12px]" aria-label="Payload">
           {Object.entries(fields).map(([key, value]) => (
             <div
               key={key}
@@ -130,6 +135,9 @@ function FieldValue({
   runId: string | null;
   now: number;
 }) {
+  if (value === undefined) {
+    return <span className="text-(--text-faint)">—</span>;
+  }
   const valueText = text(value);
   if (valueText === null) {
     return (

--- a/event-runtime/web/src/views/Events.test.tsx
+++ b/event-runtime/web/src/views/Events.test.tsx
@@ -93,6 +93,36 @@ function ticketSchemaRegistry(eventType: string): AgentsView {
   });
 }
 
+/**
+ * Two agents declare the same event type. The top-level route names the
+ * agent with no input view; the other agent ships one. The fallback must
+ * not steal the type.
+ */
+function twoAgentsOneEventTypeRegistry(): AgentsView {
+  return createAgentsFixture({
+    agents: [
+      {
+        ref: "routed-agent@1",
+        eventTypes: [{ type: "shared.event" }],
+      },
+      {
+        ref: "other-agent@1",
+        eventTypes: [{ type: "shared.event" }],
+        outputView: {
+          schemaVersion: "factory.artifact-view/v1",
+          title: "Wrong agent output",
+          input: {
+            title: "Stolen input view",
+            summary: "/repo",
+            sections: [],
+          },
+        },
+      },
+    ] as unknown as AgentsView["agents"],
+    eventTypes: [{ type: "shared.event", agent: "routed-agent@1" }],
+  });
+}
+
 describe("Events component harness: selection & detail view", () => {
   test("successful detail replay is one-shot until a different event is selected", async () => {
     const replay = mock(async (_envelope: unknown) => ({
@@ -278,6 +308,40 @@ describe("Events component harness: selection & detail view", () => {
             r.getByRole("link", { name: "FOO-12" }).getAttribute("href"),
           ).toBe("#/tickets/FOO-12"),
         );
+      },
+    );
+  });
+
+  test("does not attach another agent's input view to a type already claimed by a top-level route", async () => {
+    const event = stubEvent("evt_claimed_type", "admitted", {
+      type: "shared.event",
+      envelope: {
+        schemaVersion: "factory.event/v1",
+        eventId: "evt_claimed_type",
+        type: "shared.event",
+        source: "github",
+        payload: { repo: "watt-mind/factory" },
+      },
+    });
+
+    await withApi(
+      {
+        events: async () => ({ events: [event] }),
+        status: async () => createStatusFixture(),
+        agents: async () => twoAgentsOneEventTypeRegistry(),
+      },
+      async () => {
+        const r = renderEvents({
+          focusEvent: { source: "github", eventId: event.eventId },
+        });
+        await waitFor(() =>
+          expect(
+            r
+              .getByRole("link", { name: "watt-mind/factory" })
+              .getAttribute("href"),
+          ).toBe("https://github.com/watt-mind/factory"),
+        );
+        expect(r.queryByText("Stolen input view")).toBeNull();
       },
     );
   });

--- a/event-runtime/web/src/views/Events.tsx
+++ b/event-runtime/web/src/views/Events.tsx
@@ -541,6 +541,7 @@ export function Events({
     const registry = agentsQ.data;
     const byRef = new Map(registry?.agents.map((agent) => [agent.ref, agent]));
     const views = new Map<string, ArtifactView>();
+    const claimed = new Set<string>();
     const add = (type: string, agent: AgentDef | undefined) => {
       const input = agent?.outputView?.input;
       if (input && agent?.outputView) {
@@ -551,11 +552,16 @@ export function Events({
         });
       }
     };
-    for (const route of registry?.eventTypes ?? [])
+    // A top-level route claims the type even when the named agent has no
+    // input view. The per-agent fallback must not then attach a different
+    // agent's presentation to a type the index already assigned.
+    for (const route of registry?.eventTypes ?? []) {
+      claimed.add(route.type);
       add(route.type, route.agent ? byRef.get(route.agent) : undefined);
+    }
     for (const agent of registry?.agents ?? []) {
       for (const route of agent.eventTypes) {
-        if (!views.has(route.type)) add(route.type, agent);
+        if (!claimed.has(route.type)) add(route.type, agent);
       }
     }
     return views;


### PR DESCRIPTION
Fixes watt-mind/factory#2136

Raw on Events is always the admitted envelope; claimed routes no longer inherit another agent's input view; payload-less envelopes stop looking like payload fields.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/web/src/components/EventEnvelopeView.test.tsx event-runtime/web/src/views/Events.test.tsx` | pass    | 44 tests, 0 failures   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 0 lint errors          |
| UX critique          | factory-ux-critic                | pass    | required — SHIP, 1 round |

UX critique: required — SHIP

run:run_f61f92ef-e0ac-4257-a54b-fa6c2e8eedf9
