### PR TITLE
fix(web): sort Needs You groups newest-first in Inbox

### DIFF
--- a/event-runtime/web/src/views/Inbox.test.tsx
+++ b/event-runtime/web/src/views/Inbox.test.tsx
@@ -62,7 +62,7 @@ const T1 = "2026-08-17T11:00:00.000Z";
 const T2 = "2026-08-17T12:00:00.000Z";
 
 describe("inbox pure helpers", () => {
-  test("groups by triage kind and drops empty groups, oldest first inside a group", () => {
+  test("groups by triage kind and drops empty groups, newest first inside a group", () => {
     const rows = [
       item({ id: "i-ci", kind: "CI RED", createdAt: T2 }),
       item({ id: "i-blocked-new", kind: "BLOCKED", createdAt: T2 }),
@@ -72,9 +72,9 @@ describe("inbox pure helpers", () => {
     const groups = groupItems(rows);
     expect(groups.map((g) => g.group.id)).toEqual(["decide", "red"]);
     expect(groups[0].items.map((i) => i.id)).toEqual([
-      "i-blocked-old",
-      "i-decision",
       "i-blocked-new",
+      "i-decision",
+      "i-blocked-old",
     ]);
     expect(groups[1].items.map((i) => i.id)).toEqual(["i-ci"]);
   });

--- a/event-runtime/web/src/views/Inbox.tsx
+++ b/event-runtime/web/src/views/Inbox.tsx
@@ -297,7 +297,7 @@ function InboxDetailFallback({
   );
 }
 
-/** Group in triage order, oldest first inside a group; empty groups are dropped. */
+/** Group in triage order, newest first inside a group; empty groups are dropped. */
 export function groupItems(
   items: InboxItem[],
 ): { group: InboxGroup; items: InboxItem[] }[] {
@@ -314,7 +314,7 @@ export function groupItems(
     .map((g) => ({
       group: g,
       items: [...byGroup.get(g.id)!].sort((a, b) =>
-        a.createdAt.localeCompare(b.createdAt),
+        b.createdAt.localeCompare(a.createdAt),
       ),
     }));
 }

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -72,16 +72,9 @@ const OverviewNeedsYou = lazy(async () => {
     onAck,
     onMore,
   }: OverviewNeedsYouProps) {
-    // The ledger defaults to oldest-first, but Overview is a live attention
-    // surface: preserve its shared triage groups while leading with fresh work.
-    const groups = useMemo(
-      () =>
-        groupItems(items).map(({ group, items: groupItems }) => ({
-          group,
-          items: [...groupItems].reverse(),
-        })),
-      [items],
-    );
+    // groupItems() already orders each group newest-first, which is what this
+    // live attention surface wants: lead with fresh work.
+    const groups = useMemo(() => groupItems(items), [items]);
     const navigable = useMemo(
       () => [
         ...groups.flatMap(({ items: groupItems }) =>


### PR DESCRIPTION
Fixes watt-mind/factory#2132

Sort Inbox groupItems newest-first so Needs You and Inbox groups share one order.

## Validation

| Check                | Command                          | Result        | Notes                  |
| -------------------- | -------------------------------- | ------------- | ---------------------- |
| Verification Command | `bun test event-runtime/web/src/views/Inbox.test.tsx` | pass | 48 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2405 tests, format clean, lint 0 errors |
| UX critique          | factory-ux-critic                | not assessed | GET /api/runs HTTP 200; Needs You/Inbox empty |

UX critique: required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); Needs You / Inbox queues empty so newest-first order could not be observed

run:run_b3a0eb4f-6b06-42de-a0ae-d2bc09c64749
