### PR TITLE
fix(tools): scan JSON, CSS, and HTML for NUL bytes

### DIFF
--- a/tools/check-source-encoding.test.mjs
+++ b/tools/check-source-encoding.test.mjs
@@ -5,18 +5,21 @@ import { expect, test } from "bun:test";
 const ROOT = path.resolve(import.meta.dir, "..");
 
 const TEXT_GLOBS = [
+  "*.css",
+  "*.html",
+  "*.js",
+  "*.json",
+  "*.md",
   "*.mjs",
   "*.ts",
   "*.tsx",
-  "*.js",
-  "*.md",
   "*.sh",
   "*.yaml",
   "*.yml",
 ];
 
 /** Locate NUL bytes in a buffer, reporting 1-based line numbers. */
-export function findNulHits(relPath, bytes) {
+function findNulHits(relPath, bytes) {
   const hits = [];
   let line = 1;
   for (let i = 0; i < bytes.length; i++) {


### PR DESCRIPTION
Fixes watt-mind/factory#2142

Extend the repository NUL guard to cover JSON, CSS, and HTML files.

## Validation

| Check                | Command                                                                                              | Result  | Notes                          |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------ |
| Verification Command | `bun test tools/check-source-encoding.test.mjs`                                                      | pass    | 2 tests, 0 failures            |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | completed; 616 lint warnings |
| UX critique          | `factory-ux-critic`                                                                                  | not run | isolated CI test change         |

UX critique: skipped — no user-facing surface

run:run_e2fcb4ee-73ad-40cf-be1e-088ba60e6d61
