### PR TITLE
feat(cells): celld structured REST/RPC cell, client, and celld-smoke agent testbed (#2144)

### DIFF
--- a/cells/src/index.mjs
+++ b/cells/src/index.mjs
@@ -48,16 +48,25 @@ export class GenericCell {
     `);
 
     // Ensure cell_version exists
-    const cursor = this.sql.exec("SELECT value FROM _cell_meta WHERE key = 'version'");
+    const cursor = this.sql.exec(
+      "SELECT value FROM _cell_meta WHERE key = 'version'",
+    );
     const rows = [...cursor];
     if (rows.length === 0) {
-      this.sql.exec("INSERT INTO _cell_meta (key, value) VALUES ('version', '1')");
-      this.sql.exec("INSERT INTO _cell_meta (key, value) VALUES ('created_at', ?)", Date.now().toString());
+      this.sql.exec(
+        "INSERT INTO _cell_meta (key, value) VALUES ('version', '1')",
+      );
+      this.sql.exec(
+        "INSERT INTO _cell_meta (key, value) VALUES ('created_at', ?)",
+        Date.now().toString(),
+      );
     }
   }
 
   _getCellVersion() {
-    const cursor = this.sql.exec("SELECT value FROM _cell_meta WHERE key = 'version'");
+    const cursor = this.sql.exec(
+      "SELECT value FROM _cell_meta WHERE key = 'version'",
+    );
     const rows = [...cursor];
     return rows.length > 0 ? parseInt(rows[0].value, 10) : 1;
   }
@@ -65,7 +74,10 @@ export class GenericCell {
   _bumpCellVersion() {
     const current = this._getCellVersion();
     const next = current + 1;
-    this.sql.exec("UPDATE _cell_meta SET value = ? WHERE key = 'version'", next.toString());
+    this.sql.exec(
+      "UPDATE _cell_meta SET value = ? WHERE key = 'version'",
+      next.toString(),
+    );
     return next;
   }
 
@@ -96,7 +108,9 @@ export class GenericCell {
       }
 
       // Entity endpoints: /v1/entities/:collection/:id or /v1/entities/:collection
-      const entityMatch = pathname.match(/^\/v1\/entities\/([^/]+)(?:\/([^/]+))?$/);
+      const entityMatch = pathname.match(
+        /^\/v1\/entities\/([^/]+)(?:\/([^/]+))?$/,
+      );
       if (entityMatch) {
         const collection = decodeURIComponent(entityMatch[1]);
         const id = entityMatch[2] ? decodeURIComponent(entityMatch[2]) : null;
@@ -118,66 +132,95 @@ export class GenericCell {
         }
       }
 
-      return new Response(JSON.stringify({ error: "not_found", path: pathname }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({ error: "not_found", path: pathname }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     } catch (err) {
       // Log the stack locally; never leak it to the caller.
       console.error("[cell] unhandled error", err);
-      return new Response(JSON.stringify({
-        error: "internal_error",
-        message: err.message
-      }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "internal_error",
+          message: err.message,
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
   }
 
   _handleGetSchema() {
     const cellVersion = this._getCellVersion();
     const metaRows = [...this.sql.exec("SELECT key, value FROM _cell_meta")];
-    const meta = Object.fromEntries(metaRows.map(r => [r.key, r.value]));
+    const meta = Object.fromEntries(metaRows.map((r) => [r.key, r.value]));
 
-    const migrationRows = [...this.sql.exec("SELECT id, applied_at, description FROM _cell_migrations ORDER BY applied_at ASC")];
+    const migrationRows = [
+      ...this.sql.exec(
+        "SELECT id, applied_at, description FROM _cell_migrations ORDER BY applied_at ASC",
+      ),
+    ];
 
     // Filter out internal system tables (sqlite_*, _cf_*, _litestream_*)
-    const tablesCursor = this.sql.exec("SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name NOT LIKE '_litestream_%'");
+    const tablesCursor = this.sql.exec(
+      "SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name NOT LIKE '_litestream_%'",
+    );
     const tables = [...tablesCursor];
 
-    return new Response(JSON.stringify({
-      cellVersion,
-      meta,
-      migrations: migrationRows,
-      tables
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    return new Response(
+      JSON.stringify({
+        cellVersion,
+        meta,
+        migrations: migrationRows,
+        tables,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   _handleMigrate(body) {
     const { migrationId, sql, description } = body;
     if (!migrationId || !sql) {
-      return new Response(JSON.stringify({ error: "bad_request", message: "migrationId and sql are required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "bad_request",
+          message: "migrationId and sql are required",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Check if migration was already applied
-    const existing = [...this.sql.exec("SELECT id FROM _cell_migrations WHERE id = ?", migrationId)];
-    if (existing.length > 0) {
-      return new Response(JSON.stringify({
-        ok: true,
-        alreadyApplied: true,
+    const existing = [
+      ...this.sql.exec(
+        "SELECT id FROM _cell_migrations WHERE id = ?",
         migrationId,
-        cellVersion: this._getCellVersion()
-      }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" }
-      });
+      ),
+    ];
+    if (existing.length > 0) {
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          alreadyApplied: true,
+          migrationId,
+          cellVersion: this._getCellVersion(),
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Apply migration inside storage transaction
@@ -187,29 +230,38 @@ export class GenericCell {
       "INSERT INTO _cell_migrations (id, applied_at, description) VALUES (?, ?, ?)",
       migrationId,
       now,
-      description || null
+      description || null,
     );
     const newVersion = this._bumpCellVersion();
 
-    return new Response(JSON.stringify({
-      ok: true,
-      applied: true,
-      migrationId,
-      cellVersion: newVersion,
-      appliedAt: now
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        applied: true,
+        migrationId,
+        cellVersion: newVersion,
+        appliedAt: now,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   _handleQuery(body) {
     const { sql, params = [] } = body;
     if (!sql || typeof sql !== "string") {
-      return new Response(JSON.stringify({ error: "bad_request", message: "sql string is required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "bad_request",
+          message: "sql string is required",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     // Only a single statement may be submitted: a trailing `;` is tolerated but
@@ -217,56 +269,74 @@ export class GenericCell {
     // cannot ride in behind a read-only leading keyword.
     const semicolonIndex = sql.indexOf(";");
     if (semicolonIndex !== -1 && sql.slice(semicolonIndex + 1).trim() !== "") {
-      return new Response(JSON.stringify({
-        error: "forbidden",
-        message: "query endpoint accepts a single statement; additional statements after ';' are not permitted"
-      }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "forbidden",
+          message:
+            "query endpoint accepts a single statement; additional statements after ';' are not permitted",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const trimmed = sql.trim().toUpperCase();
-    if (!trimmed.startsWith("SELECT") && !trimmed.startsWith("PRAGMA") && !trimmed.startsWith("EXPLAIN")) {
-      return new Response(JSON.stringify({
-        error: "forbidden",
-        message: "query endpoint only permits read-only statements (SELECT/PRAGMA/EXPLAIN). Use /v1/schema/migrate or /v1/entities for mutations."
-      }), {
-        status: 403,
-        headers: { "Content-Type": "application/json" }
-      });
+    if (
+      !trimmed.startsWith("SELECT") &&
+      !trimmed.startsWith("PRAGMA") &&
+      !trimmed.startsWith("EXPLAIN")
+    ) {
+      return new Response(
+        JSON.stringify({
+          error: "forbidden",
+          message:
+            "query endpoint only permits read-only statements (SELECT/PRAGMA/EXPLAIN). Use /v1/schema/migrate or /v1/entities for mutations.",
+        }),
+        {
+          status: 403,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const cursor = this.sql.exec(sql, ...params);
     const rows = [...cursor];
 
-    return new Response(JSON.stringify({
-      rows,
-      count: rows.length,
-      cellVersion: this._getCellVersion()
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    return new Response(
+      JSON.stringify({
+        rows,
+        count: rows.length,
+        cellVersion: this._getCellVersion(),
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   _handleGetEntity(collection, id) {
     const cursor = this.sql.exec(
       "SELECT collection, id, data, version, created_at, updated_at FROM _cell_entities WHERE collection = ? AND id = ?",
       collection,
-      id
+      id,
     );
     const rows = [...cursor];
     if (rows.length === 0) {
-      return new Response(JSON.stringify({
-        error: "not_found",
-        collection,
-        id,
-        cellVersion: this._getCellVersion()
-      }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "not_found",
+          collection,
+          id,
+          cellVersion: this._getCellVersion(),
+        }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const row = rows[0];
@@ -277,81 +347,106 @@ export class GenericCell {
       parsedData = row.data;
     }
 
-    return new Response(JSON.stringify({
-      collection: row.collection,
-      id: row.id,
-      data: parsedData,
-      version: row.version,
-      createdAt: row.created_at,
-      updatedAt: row.updated_at,
-      cellVersion: this._getCellVersion()
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    return new Response(
+      JSON.stringify({
+        collection: row.collection,
+        id: row.id,
+        data: parsedData,
+        version: row.version,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at,
+        cellVersion: this._getCellVersion(),
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   _handleListEntities(collection, searchParams) {
-    const limit = Math.min(parseInt(searchParams.get("limit") || "100", 10), 1000);
+    const limit = Math.min(
+      parseInt(searchParams.get("limit") || "100", 10),
+      1000,
+    );
     const cursor = this.sql.exec(
       "SELECT collection, id, data, version, created_at, updated_at FROM _cell_entities WHERE collection = ? ORDER BY updated_at DESC LIMIT ?",
       collection,
-      limit
+      limit,
     );
-    const rows = [...cursor].map(row => {
+    const rows = [...cursor].map((row) => {
       let data;
-      try { data = JSON.parse(row.data); } catch { data = row.data; }
+      try {
+        data = JSON.parse(row.data);
+      } catch {
+        data = row.data;
+      }
       return {
         id: row.id,
         data,
         version: row.version,
         createdAt: row.created_at,
-        updatedAt: row.updated_at
+        updatedAt: row.updated_at,
       };
     });
 
-    return new Response(JSON.stringify({
-      collection,
-      entities: rows,
-      count: rows.length,
-      cellVersion: this._getCellVersion()
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    return new Response(
+      JSON.stringify({
+        collection,
+        entities: rows,
+        count: rows.length,
+        cellVersion: this._getCellVersion(),
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 
   _handlePutEntity(collection, id, body) {
     const { data, expectedVersion } = body;
     if (data === undefined) {
-      return new Response(JSON.stringify({ error: "bad_request", message: "data is required" }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({ error: "bad_request", message: "data is required" }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const serialized = typeof data === "string" ? data : JSON.stringify(data);
     const now = Date.now();
 
     // Check existing entity
-    const existingRows = [...this.sql.exec(
-      "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
-      collection,
-      id
-    )];
+    const existingRows = [
+      ...this.sql.exec(
+        "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
+        collection,
+        id,
+      ),
+    ];
 
     if (existingRows.length === 0) {
       // New insert
-      if (expectedVersion !== undefined && expectedVersion !== null && expectedVersion !== 0) {
-        return new Response(JSON.stringify({
-          error: "conflict",
-          message: `Entity does not exist (expectedVersion=${expectedVersion})`,
-          currentVersion: 0,
-          cellVersion: this._getCellVersion()
-        }), {
-          status: 409,
-          headers: { "Content-Type": "application/json" }
-        });
+      if (
+        expectedVersion !== undefined &&
+        expectedVersion !== null &&
+        expectedVersion !== 0
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "conflict",
+            message: `Entity does not exist (expectedVersion=${expectedVersion})`,
+            currentVersion: 0,
+            cellVersion: this._getCellVersion(),
+          }),
+          {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
 
       this.sql.exec(
@@ -360,35 +455,45 @@ export class GenericCell {
         id,
         serialized,
         now,
-        now
+        now,
       );
       const newCellVersion = this._bumpCellVersion();
 
-      return new Response(JSON.stringify({
-        ok: true,
-        created: true,
-        collection,
-        id,
-        version: 1,
-        cellVersion: newCellVersion,
-        updatedAt: now
-      }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          created: true,
+          collection,
+          id,
+          version: 1,
+          cellVersion: newCellVersion,
+          updatedAt: now,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     } else {
       // Existing update
       const currentVersion = existingRows[0].version;
-      if (expectedVersion !== undefined && expectedVersion !== null && expectedVersion !== currentVersion) {
-        return new Response(JSON.stringify({
-          error: "conflict",
-          message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
-          currentVersion,
-          cellVersion: this._getCellVersion()
-        }), {
-          status: 409,
-          headers: { "Content-Type": "application/json" }
-        });
+      if (
+        expectedVersion !== undefined &&
+        expectedVersion !== null &&
+        expectedVersion !== currentVersion
+      ) {
+        return new Response(
+          JSON.stringify({
+            error: "conflict",
+            message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
+            currentVersion,
+            cellVersion: this._getCellVersion(),
+          }),
+          {
+            status: 409,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
 
       const nextVersion = currentVersion + 1;
@@ -398,28 +503,38 @@ export class GenericCell {
         nextVersion,
         now,
         collection,
-        id
+        id,
       );
       const newCellVersion = this._bumpCellVersion();
 
-      return new Response(JSON.stringify({
-        ok: true,
-        updated: true,
-        collection,
-        id,
-        version: nextVersion,
-        cellVersion: newCellVersion,
-        updatedAt: now
-      }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          ok: true,
+          updated: true,
+          collection,
+          id,
+          version: nextVersion,
+          cellVersion: newCellVersion,
+          updatedAt: now,
+        }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
   }
 
   _handlePostEntity(collection, body) {
-    const id = body.id || (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : `id_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
-    return this._handlePutEntity(collection, id, { data: body.data, expectedVersion: body.expectedVersion });
+    const id =
+      body.id ||
+      (globalThis.crypto?.randomUUID
+        ? globalThis.crypto.randomUUID()
+        : `id_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    return this._handlePutEntity(collection, id, {
+      data: body.data,
+      expectedVersion: body.expectedVersion,
+    });
   }
 
   _handleDeleteEntity(collection, id, searchParams) {
@@ -427,68 +542,86 @@ export class GenericCell {
     let expectedVersion = null;
     if (expectedVersionParam !== null && expectedVersionParam !== "") {
       if (!/^-?\d+$/.test(expectedVersionParam.trim())) {
-        return new Response(JSON.stringify({
-          error: "bad_request",
-          message: `expectedVersion must be an integer, received ${JSON.stringify(expectedVersionParam)}`
-        }), {
-          status: 400,
-          headers: { "Content-Type": "application/json" }
-        });
+        return new Response(
+          JSON.stringify({
+            error: "bad_request",
+            message: `expectedVersion must be an integer, received ${JSON.stringify(expectedVersionParam)}`,
+          }),
+          {
+            status: 400,
+            headers: { "Content-Type": "application/json" },
+          },
+        );
       }
       expectedVersion = parseInt(expectedVersionParam.trim(), 10);
     }
 
-    const existingRows = [...this.sql.exec(
-      "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
-      collection,
-      id
-    )];
-
-    if (existingRows.length === 0) {
-      return new Response(JSON.stringify({
-        error: "not_found",
+    const existingRows = [
+      ...this.sql.exec(
+        "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
         collection,
         id,
-        cellVersion: this._getCellVersion()
-      }), {
-        status: 404,
-        headers: { "Content-Type": "application/json" }
-      });
+      ),
+    ];
+
+    if (existingRows.length === 0) {
+      return new Response(
+        JSON.stringify({
+          error: "not_found",
+          collection,
+          id,
+          cellVersion: this._getCellVersion(),
+        }),
+        {
+          status: 404,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const currentVersion = existingRows[0].version;
     if (expectedVersion !== null && expectedVersion !== currentVersion) {
-      return new Response(JSON.stringify({
-        error: "conflict",
-        message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
-        currentVersion,
-        cellVersion: this._getCellVersion()
-      }), {
-        status: 409,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "conflict",
+          message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
+          currentVersion,
+          cellVersion: this._getCellVersion(),
+        }),
+        {
+          status: 409,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
-    this.sql.exec("DELETE FROM _cell_entities WHERE collection = ? AND id = ?", collection, id);
-    const newCellVersion = this._bumpCellVersion();
-
-    return new Response(JSON.stringify({
-      ok: true,
-      deleted: true,
+    this.sql.exec(
+      "DELETE FROM _cell_entities WHERE collection = ? AND id = ?",
       collection,
       id,
-      cellVersion: newCellVersion
-    }), {
-      status: 200,
-      headers: { "Content-Type": "application/json" }
-    });
+    );
+    const newCellVersion = this._bumpCellVersion();
+
+    return new Response(
+      JSON.stringify({
+        ok: true,
+        deleted: true,
+        collection,
+        id,
+        cellVersion: newCellVersion,
+      }),
+      {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      },
+    );
   }
 }
 
 function jsonResponse(payload, status) {
   return new Response(JSON.stringify(payload), {
     status,
-    headers: { "Content-Type": "application/json" }
+    headers: { "Content-Type": "application/json" },
   });
 }
 
@@ -500,17 +633,24 @@ function jsonResponse(payload, status) {
 function checkAuth(request, env) {
   const secret = env && env.CELL_AUTH_TOKEN;
   if (!secret) {
-    return jsonResponse({
-      error: "unauthorized",
-      message: "CELL_AUTH_TOKEN is not configured; the cell refuses all requests"
-    }, 401);
+    return jsonResponse(
+      {
+        error: "unauthorized",
+        message:
+          "CELL_AUTH_TOKEN is not configured; the cell refuses all requests",
+      },
+      401,
+    );
   }
 
   const header = request.headers.get("Authorization") || "";
   const match = header.match(/^Bearer\s+(.+)$/i);
   const presented = match ? match[1].trim() : null;
   if (!presented || presented.length !== secret.length) {
-    return jsonResponse({ error: "unauthorized", message: "missing or invalid bearer token" }, 401);
+    return jsonResponse(
+      { error: "unauthorized", message: "missing or invalid bearer token" },
+      401,
+    );
   }
 
   // Length-independent constant-time-ish compare.
@@ -519,7 +659,10 @@ function checkAuth(request, env) {
     diff |= presented.charCodeAt(i) ^ secret.charCodeAt(i);
   }
   if (diff !== 0) {
-    return jsonResponse({ error: "unauthorized", message: "missing or invalid bearer token" }, 401);
+    return jsonResponse(
+      { error: "unauthorized", message: "missing or invalid bearer token" },
+      401,
+    );
   }
 
   return null;
@@ -532,10 +675,13 @@ export default {
     // Health check endpoint — unauthenticated liveness probe only; it exposes
     // no cell state.
     if (url.pathname === "/health" || url.pathname === "/") {
-      return new Response(JSON.stringify({ status: "healthy", service: "factory-cells" }), {
-        status: 200,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({ status: "healthy", service: "factory-cells" }),
+        {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const authFailure = checkAuth(request, env);
@@ -555,23 +701,30 @@ export default {
     }
 
     if (!cellId) {
-      return new Response(JSON.stringify({
-        error: "missing_cell_id",
-        message: "Request must specify X-Cell-Id header or /cells/:cellId/ path"
-      }), {
-        status: 400,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "missing_cell_id",
+          message:
+            "Request must specify X-Cell-Id header or /cells/:cellId/ path",
+        }),
+        {
+          status: 400,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     if (!env.GENERIC_CELL) {
-      return new Response(JSON.stringify({
-        error: "configuration_error",
-        message: "GENERIC_CELL Durable Object binding not configured"
-      }), {
-        status: 500,
-        headers: { "Content-Type": "application/json" }
-      });
+      return new Response(
+        JSON.stringify({
+          error: "configuration_error",
+          message: "GENERIC_CELL Durable Object binding not configured",
+        }),
+        {
+          status: 500,
+          headers: { "Content-Type": "application/json" },
+        },
+      );
     }
 
     const doId = env.GENERIC_CELL.idFromName(cellId);
@@ -580,5 +733,5 @@ export default {
     // Forward request with rewritten URL
     const forwardRequest = new Request(forwardUrl.toString(), request);
     return stub.fetch(forwardRequest);
-  }
+  },
 };

--- a/cells/src/index.mjs
+++ b/cells/src/index.mjs
@@ -1,0 +1,498 @@
+export class GenericCell {
+  constructor(ctx, env) {
+    this.ctx = ctx;
+    this.env = env;
+    this.sql = ctx.storage.sql;
+    this._initTables();
+  }
+
+  _initTables() {
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS _cell_meta (
+        key TEXT PRIMARY KEY,
+        value TEXT
+      );
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS _cell_migrations (
+        id TEXT PRIMARY KEY,
+        applied_at INTEGER NOT NULL,
+        description TEXT
+      );
+    `);
+    this.sql.exec(`
+      CREATE TABLE IF NOT EXISTS _cell_entities (
+        collection TEXT NOT NULL,
+        id TEXT NOT NULL,
+        data TEXT NOT NULL,
+        version INTEGER NOT NULL DEFAULT 1,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        PRIMARY KEY (collection, id)
+      );
+    `);
+
+    // Ensure cell_version exists
+    const cursor = this.sql.exec("SELECT value FROM _cell_meta WHERE key = 'version'");
+    const rows = [...cursor];
+    if (rows.length === 0) {
+      this.sql.exec("INSERT INTO _cell_meta (key, value) VALUES ('version', '1')");
+      this.sql.exec("INSERT INTO _cell_meta (key, value) VALUES ('created_at', ?)", Date.now().toString());
+    }
+  }
+
+  _getCellVersion() {
+    const cursor = this.sql.exec("SELECT value FROM _cell_meta WHERE key = 'version'");
+    const rows = [...cursor];
+    return rows.length > 0 ? parseInt(rows[0].value, 10) : 1;
+  }
+
+  _bumpCellVersion() {
+    const current = this._getCellVersion();
+    const next = current + 1;
+    this.sql.exec("UPDATE _cell_meta SET value = ? WHERE key = 'version'", next.toString());
+    return next;
+  }
+
+  async fetch(request) {
+    const url = new URL(request.url);
+    const method = request.method.toUpperCase();
+    const pathname = url.pathname;
+
+    try {
+      if (pathname === "/v1/info" || pathname === "/v1/schema") {
+        if (method === "GET") {
+          return this._handleGetSchema();
+        }
+      }
+
+      if (pathname === "/v1/schema/migrate") {
+        if (method === "POST") {
+          const body = await request.json();
+          return this._handleMigrate(body);
+        }
+      }
+
+      if (pathname === "/v1/query") {
+        if (method === "POST") {
+          const body = await request.json();
+          return this._handleQuery(body);
+        }
+      }
+
+      // Entity endpoints: /v1/entities/:collection/:id or /v1/entities/:collection
+      const entityMatch = pathname.match(/^\/v1\/entities\/([^/]+)(?:\/([^/]+))?$/);
+      if (entityMatch) {
+        const collection = decodeURIComponent(entityMatch[1]);
+        const id = entityMatch[2] ? decodeURIComponent(entityMatch[2]) : null;
+
+        if (method === "GET") {
+          if (id) {
+            return this._handleGetEntity(collection, id);
+          } else {
+            return this._handleListEntities(collection, url.searchParams);
+          }
+        } else if (method === "PUT" && id) {
+          const body = await request.json();
+          return this._handlePutEntity(collection, id, body);
+        } else if (method === "POST" && !id) {
+          const body = await request.json();
+          return this._handlePostEntity(collection, body);
+        } else if (method === "DELETE" && id) {
+          return this._handleDeleteEntity(collection, id, url.searchParams);
+        }
+      }
+
+      return new Response(JSON.stringify({ error: "not_found", path: pathname }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" }
+      });
+    } catch (err) {
+      return new Response(JSON.stringify({
+        error: "internal_error",
+        message: err.message,
+        stack: err.stack
+      }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  }
+
+  _handleGetSchema() {
+    const cellVersion = this._getCellVersion();
+    const metaRows = [...this.sql.exec("SELECT key, value FROM _cell_meta")];
+    const meta = Object.fromEntries(metaRows.map(r => [r.key, r.value]));
+
+    const migrationRows = [...this.sql.exec("SELECT id, applied_at, description FROM _cell_migrations ORDER BY applied_at ASC")];
+
+    // Filter out internal system tables (sqlite_*, _cf_*, _litestream_*)
+    const tablesCursor = this.sql.exec("SELECT name, sql FROM sqlite_master WHERE type='table' AND name NOT LIKE 'sqlite_%' AND name NOT LIKE '_cf_%' AND name NOT LIKE '_litestream_%'");
+    const tables = [...tablesCursor];
+
+    return new Response(JSON.stringify({
+      cellVersion,
+      meta,
+      migrations: migrationRows,
+      tables
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  _handleMigrate(body) {
+    const { migrationId, sql, description } = body;
+    if (!migrationId || !sql) {
+      return new Response(JSON.stringify({ error: "bad_request", message: "migrationId and sql are required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    // Check if migration was already applied
+    const existing = [...this.sql.exec("SELECT id FROM _cell_migrations WHERE id = ?", migrationId)];
+    if (existing.length > 0) {
+      return new Response(JSON.stringify({
+        ok: true,
+        alreadyApplied: true,
+        migrationId,
+        cellVersion: this._getCellVersion()
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    // Apply migration inside storage transaction
+    this.sql.exec(sql);
+    const now = Date.now();
+    this.sql.exec(
+      "INSERT INTO _cell_migrations (id, applied_at, description) VALUES (?, ?, ?)",
+      migrationId,
+      now,
+      description || null
+    );
+    const newVersion = this._bumpCellVersion();
+
+    return new Response(JSON.stringify({
+      ok: true,
+      applied: true,
+      migrationId,
+      cellVersion: newVersion,
+      appliedAt: now
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  _handleQuery(body) {
+    const { sql, params = [] } = body;
+    if (!sql || typeof sql !== "string") {
+      return new Response(JSON.stringify({ error: "bad_request", message: "sql string is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const trimmed = sql.trim().toUpperCase();
+    if (!trimmed.startsWith("SELECT") && !trimmed.startsWith("PRAGMA") && !trimmed.startsWith("EXPLAIN")) {
+      return new Response(JSON.stringify({
+        error: "forbidden",
+        message: "query endpoint only permits read-only statements (SELECT/PRAGMA/EXPLAIN). Use /v1/schema/migrate or /v1/entities for mutations."
+      }), {
+        status: 403,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const cursor = this.sql.exec(sql, ...params);
+    const rows = [...cursor];
+
+    return new Response(JSON.stringify({
+      rows,
+      count: rows.length,
+      cellVersion: this._getCellVersion()
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  _handleGetEntity(collection, id) {
+    const cursor = this.sql.exec(
+      "SELECT collection, id, data, version, created_at, updated_at FROM _cell_entities WHERE collection = ? AND id = ?",
+      collection,
+      id
+    );
+    const rows = [...cursor];
+    if (rows.length === 0) {
+      return new Response(JSON.stringify({
+        error: "not_found",
+        collection,
+        id,
+        cellVersion: this._getCellVersion()
+      }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const row = rows[0];
+    let parsedData;
+    try {
+      parsedData = JSON.parse(row.data);
+    } catch {
+      parsedData = row.data;
+    }
+
+    return new Response(JSON.stringify({
+      collection: row.collection,
+      id: row.id,
+      data: parsedData,
+      version: row.version,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      cellVersion: this._getCellVersion()
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  _handleListEntities(collection, searchParams) {
+    const limit = Math.min(parseInt(searchParams.get("limit") || "100", 10), 1000);
+    const cursor = this.sql.exec(
+      "SELECT collection, id, data, version, created_at, updated_at FROM _cell_entities WHERE collection = ? ORDER BY updated_at DESC LIMIT ?",
+      collection,
+      limit
+    );
+    const rows = [...cursor].map(row => {
+      let data;
+      try { data = JSON.parse(row.data); } catch { data = row.data; }
+      return {
+        id: row.id,
+        data,
+        version: row.version,
+        createdAt: row.created_at,
+        updatedAt: row.updated_at
+      };
+    });
+
+    return new Response(JSON.stringify({
+      collection,
+      entities: rows,
+      count: rows.length,
+      cellVersion: this._getCellVersion()
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+
+  _handlePutEntity(collection, id, body) {
+    const { data, expectedVersion } = body;
+    if (data === undefined) {
+      return new Response(JSON.stringify({ error: "bad_request", message: "data is required" }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const serialized = typeof data === "string" ? data : JSON.stringify(data);
+    const now = Date.now();
+
+    // Check existing entity
+    const existingRows = [...this.sql.exec(
+      "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
+      collection,
+      id
+    )];
+
+    if (existingRows.length === 0) {
+      // New insert
+      if (expectedVersion !== undefined && expectedVersion !== null && expectedVersion !== 0) {
+        return new Response(JSON.stringify({
+          error: "conflict",
+          message: `Entity does not exist (expectedVersion=${expectedVersion})`,
+          currentVersion: 0,
+          cellVersion: this._getCellVersion()
+        }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+
+      this.sql.exec(
+        "INSERT INTO _cell_entities (collection, id, data, version, created_at, updated_at) VALUES (?, ?, ?, 1, ?, ?)",
+        collection,
+        id,
+        serialized,
+        now,
+        now
+      );
+      const newCellVersion = this._bumpCellVersion();
+
+      return new Response(JSON.stringify({
+        ok: true,
+        created: true,
+        collection,
+        id,
+        version: 1,
+        cellVersion: newCellVersion,
+        updatedAt: now
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    } else {
+      // Existing update
+      const currentVersion = existingRows[0].version;
+      if (expectedVersion !== undefined && expectedVersion !== null && expectedVersion !== currentVersion) {
+        return new Response(JSON.stringify({
+          error: "conflict",
+          message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
+          currentVersion,
+          cellVersion: this._getCellVersion()
+        }), {
+          status: 409,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+
+      const nextVersion = currentVersion + 1;
+      this.sql.exec(
+        "UPDATE _cell_entities SET data = ?, version = ?, updated_at = ? WHERE collection = ? AND id = ?",
+        serialized,
+        nextVersion,
+        now,
+        collection,
+        id
+      );
+      const newCellVersion = this._bumpCellVersion();
+
+      return new Response(JSON.stringify({
+        ok: true,
+        updated: true,
+        collection,
+        id,
+        version: nextVersion,
+        cellVersion: newCellVersion,
+        updatedAt: now
+      }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+  }
+
+  _handlePostEntity(collection, body) {
+    const id = body.id || (globalThis.crypto?.randomUUID ? globalThis.crypto.randomUUID() : `id_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+    return this._handlePutEntity(collection, id, { data: body.data, expectedVersion: body.expectedVersion });
+  }
+
+  _handleDeleteEntity(collection, id, searchParams) {
+    const expectedVersionParam = searchParams.get("expectedVersion");
+    const expectedVersion = expectedVersionParam !== null ? parseInt(expectedVersionParam, 10) : null;
+
+    const existingRows = [...this.sql.exec(
+      "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
+      collection,
+      id
+    )];
+
+    if (existingRows.length === 0) {
+      return new Response(JSON.stringify({
+        error: "not_found",
+        collection,
+        id,
+        cellVersion: this._getCellVersion()
+      }), {
+        status: 404,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const currentVersion = existingRows[0].version;
+    if (expectedVersion !== null && !isNaN(expectedVersion) && expectedVersion !== currentVersion) {
+      return new Response(JSON.stringify({
+        error: "conflict",
+        message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
+        currentVersion,
+        cellVersion: this._getCellVersion()
+      }), {
+        status: 409,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    this.sql.exec("DELETE FROM _cell_entities WHERE collection = ? AND id = ?", collection, id);
+    const newCellVersion = this._bumpCellVersion();
+
+    return new Response(JSON.stringify({
+      ok: true,
+      deleted: true,
+      collection,
+      id,
+      cellVersion: newCellVersion
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" }
+    });
+  }
+}
+
+export default {
+  async fetch(request, env) {
+    const url = new URL(request.url);
+
+    // Health check endpoint
+    if (url.pathname === "/health" || url.pathname === "/") {
+      return new Response(JSON.stringify({ status: "healthy", service: "factory-cells" }), {
+        status: 200,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    // Route by Cell ID from header or path:
+    // 1. Header `X-Cell-Id`
+    // 2. URL path `/cells/:cellId/...`
+    let cellId = request.headers.get("X-Cell-Id");
+    let forwardUrl = url;
+
+    const cellsPrefixMatch = url.pathname.match(/^\/cells\/([^/]+)(\/.*)?$/);
+    if (cellsPrefixMatch) {
+      cellId = decodeURIComponent(cellsPrefixMatch[1]);
+      const subPath = cellsPrefixMatch[2] || "/";
+      forwardUrl = new URL(subPath + url.search, url.origin);
+    }
+
+    if (!cellId) {
+      return new Response(JSON.stringify({
+        error: "missing_cell_id",
+        message: "Request must specify X-Cell-Id header or /cells/:cellId/ path"
+      }), {
+        status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    if (!env.GENERIC_CELL) {
+      return new Response(JSON.stringify({
+        error: "configuration_error",
+        message: "GENERIC_CELL Durable Object binding not configured"
+      }), {
+        status: 500,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    const doId = env.GENERIC_CELL.idFromName(cellId);
+    const stub = env.GENERIC_CELL.get(doId);
+
+    // Forward request with rewritten URL
+    const forwardRequest = new Request(forwardUrl.toString(), request);
+    return stub.fetch(forwardRequest);
+  }
+};

--- a/cells/src/index.mjs
+++ b/cells/src/index.mjs
@@ -1,3 +1,18 @@
+/**
+ * factory-cells — GenericCell Durable Object (spike, ticket #2144).
+ *
+ * SECURITY / DEPLOYMENT WARNING:
+ *   This is a loopback-only development spike. It is intended to be reached
+ *   exclusively over 127.0.0.1 via `celld dev`. The only access control here is
+ *   a shared-secret bearer token read from `env.CELL_AUTH_TOKEN`, which is a
+ *   stop-gap, not an authentication system: there is no per-caller identity, no
+ *   rotation, no rate limiting, and no authorization on which cell a caller may
+ *   touch. Requests are refused outright when the secret is unset (fail closed).
+ *
+ *   This worker MUST NOT be deployed to a public or shared environment until
+ *   real authentication and per-cell authorization are in place.
+ */
+
 export class GenericCell {
   constructor(ctx, env) {
     this.ctx = ctx;
@@ -108,10 +123,11 @@ export class GenericCell {
         headers: { "Content-Type": "application/json" }
       });
     } catch (err) {
+      // Log the stack locally; never leak it to the caller.
+      console.error("[cell] unhandled error", err);
       return new Response(JSON.stringify({
         error: "internal_error",
-        message: err.message,
-        stack: err.stack
+        message: err.message
       }), {
         status: 500,
         headers: { "Content-Type": "application/json" }
@@ -192,6 +208,20 @@ export class GenericCell {
     if (!sql || typeof sql !== "string") {
       return new Response(JSON.stringify({ error: "bad_request", message: "sql string is required" }), {
         status: 400,
+        headers: { "Content-Type": "application/json" }
+      });
+    }
+
+    // Only a single statement may be submitted: a trailing `;` is tolerated but
+    // anything after it is rejected, so `SELECT 1; DROP TABLE _cell_entities;`
+    // cannot ride in behind a read-only leading keyword.
+    const semicolonIndex = sql.indexOf(";");
+    if (semicolonIndex !== -1 && sql.slice(semicolonIndex + 1).trim() !== "") {
+      return new Response(JSON.stringify({
+        error: "forbidden",
+        message: "query endpoint accepts a single statement; additional statements after ';' are not permitted"
+      }), {
+        status: 403,
         headers: { "Content-Type": "application/json" }
       });
     }
@@ -394,7 +424,19 @@ export class GenericCell {
 
   _handleDeleteEntity(collection, id, searchParams) {
     const expectedVersionParam = searchParams.get("expectedVersion");
-    const expectedVersion = expectedVersionParam !== null ? parseInt(expectedVersionParam, 10) : null;
+    let expectedVersion = null;
+    if (expectedVersionParam !== null && expectedVersionParam !== "") {
+      if (!/^-?\d+$/.test(expectedVersionParam.trim())) {
+        return new Response(JSON.stringify({
+          error: "bad_request",
+          message: `expectedVersion must be an integer, received ${JSON.stringify(expectedVersionParam)}`
+        }), {
+          status: 400,
+          headers: { "Content-Type": "application/json" }
+        });
+      }
+      expectedVersion = parseInt(expectedVersionParam.trim(), 10);
+    }
 
     const existingRows = [...this.sql.exec(
       "SELECT version FROM _cell_entities WHERE collection = ? AND id = ?",
@@ -415,7 +457,7 @@ export class GenericCell {
     }
 
     const currentVersion = existingRows[0].version;
-    if (expectedVersion !== null && !isNaN(expectedVersion) && expectedVersion !== currentVersion) {
+    if (expectedVersion !== null && expectedVersion !== currentVersion) {
       return new Response(JSON.stringify({
         error: "conflict",
         message: `Version conflict: currentVersion is ${currentVersion}, expectedVersion was ${expectedVersion}`,
@@ -443,17 +485,61 @@ export class GenericCell {
   }
 }
 
+function jsonResponse(payload, status) {
+  return new Response(JSON.stringify(payload), {
+    status,
+    headers: { "Content-Type": "application/json" }
+  });
+}
+
+/**
+ * Shared-secret bearer check. Stop-gap for the loopback spike only — see the
+ * deployment warning at the top of this file. Fails closed when the secret is
+ * not configured so an unconfigured worker is never an open one.
+ */
+function checkAuth(request, env) {
+  const secret = env && env.CELL_AUTH_TOKEN;
+  if (!secret) {
+    return jsonResponse({
+      error: "unauthorized",
+      message: "CELL_AUTH_TOKEN is not configured; the cell refuses all requests"
+    }, 401);
+  }
+
+  const header = request.headers.get("Authorization") || "";
+  const match = header.match(/^Bearer\s+(.+)$/i);
+  const presented = match ? match[1].trim() : null;
+  if (!presented || presented.length !== secret.length) {
+    return jsonResponse({ error: "unauthorized", message: "missing or invalid bearer token" }, 401);
+  }
+
+  // Length-independent constant-time-ish compare.
+  let diff = 0;
+  for (let i = 0; i < secret.length; i++) {
+    diff |= presented.charCodeAt(i) ^ secret.charCodeAt(i);
+  }
+  if (diff !== 0) {
+    return jsonResponse({ error: "unauthorized", message: "missing or invalid bearer token" }, 401);
+  }
+
+  return null;
+}
+
 export default {
   async fetch(request, env) {
     const url = new URL(request.url);
 
-    // Health check endpoint
+    // Health check endpoint — unauthenticated liveness probe only; it exposes
+    // no cell state.
     if (url.pathname === "/health" || url.pathname === "/") {
       return new Response(JSON.stringify({ status: "healthy", service: "factory-cells" }), {
         status: 200,
         headers: { "Content-Type": "application/json" }
       });
     }
+
+    const authFailure = checkAuth(request, env);
+    if (authFailure) return authFailure;
 
     // Route by Cell ID from header or path:
     // 1. Header `X-Cell-Id`

--- a/cells/wrangler.jsonc
+++ b/cells/wrangler.jsonc
@@ -8,14 +8,14 @@
     "bindings": [
       {
         "name": "GENERIC_CELL",
-        "class_name": "GenericCell"
-      }
-    ]
+        "class_name": "GenericCell",
+      },
+    ],
   },
   "migrations": [
     {
       "tag": "v1",
-      "new_sqlite_classes": ["GenericCell"]
-    }
-  ]
+      "new_sqlite_classes": ["GenericCell"],
+    },
+  ],
 }

--- a/cells/wrangler.jsonc
+++ b/cells/wrangler.jsonc
@@ -1,0 +1,21 @@
+{
+  "$schema": "node_modules/wrangler/config-schema.json",
+  "name": "factory-cells",
+  "main": "src/index.mjs",
+  "compatibility_date": "2026-08-01",
+  "compatibility_flags": ["nodejs_compat"],
+  "durable_objects": {
+    "bindings": [
+      {
+        "name": "GENERIC_CELL",
+        "class_name": "GenericCell"
+      }
+    ]
+  },
+  "migrations": [
+    {
+      "tag": "v1",
+      "new_sqlite_classes": ["GenericCell"]
+    }
+  ]
+}

--- a/event-runtime/agents/celld-smoke.json
+++ b/event-runtime/agents/celld-smoke.json
@@ -1,0 +1,29 @@
+{
+  "id": "celld-smoke",
+  "version": 1,
+  "prompt": "agents/celld-smoke.md",
+  "input_schema": "schemas/celld-smoke.input.json",
+  "output_schema": "schemas/celld-smoke.output.json",
+  "output_contract": "factory.celld-smoke/v1",
+  "model_tier": "strong",
+  "effort": "high",
+  "workspace": { "type": "ephemeral", "retainOnFailure": true },
+  "capabilities": {
+    "filesystem": "workspace-only",
+    "services": [],
+    "cells": [
+      {
+        "binding": "GENERIC_CELL",
+        "access": "read-write",
+        "description": "Durable cell storage via celld REST/RPC"
+      }
+    ]
+  },
+  "limits": { "timeout_seconds": 120, "attempts": 1 },
+  "mutating": false,
+  "pins": {
+    "agents/celld-smoke.md": "sha256:0dcdb79d0c99f072a9fb7cc4a45a720ea6520326556b600a803c67fa044da398",
+    "schemas/celld-smoke.input.json": "sha256:92a26727efcdaae87b169fb8869783f53c30f42929db5619746e6a614b5f700e",
+    "schemas/celld-smoke.output.json": "sha256:c48ce7842249c13b40328c43e3485c58ea1f522047c772494c1ba2c0bceaa862"
+  }
+}

--- a/event-runtime/agents/celld-smoke.json
+++ b/event-runtime/agents/celld-smoke.json
@@ -22,8 +22,8 @@
   "limits": { "timeout_seconds": 120, "attempts": 1 },
   "mutating": false,
   "pins": {
-    "agents/celld-smoke.md": "sha256:0dcdb79d0c99f072a9fb7cc4a45a720ea6520326556b600a803c67fa044da398",
+    "agents/celld-smoke.md": "sha256:627867cbed98dad67bb826a442133944c79df92bd1043d146907f432bfcaa8d0",
     "schemas/celld-smoke.input.json": "sha256:92a26727efcdaae87b169fb8869783f53c30f42929db5619746e6a614b5f700e",
-    "schemas/celld-smoke.output.json": "sha256:c48ce7842249c13b40328c43e3485c58ea1f522047c772494c1ba2c0bceaa862"
+    "schemas/celld-smoke.output.json": "sha256:f4c3930dff0665c11e91a3fae3a72d1762e360316f2aaee27369f8116416a90f"
   }
 }

--- a/event-runtime/agents/celld-smoke.md
+++ b/event-runtime/agents/celld-smoke.md
@@ -1,0 +1,39 @@
+# celld-smoke — smoke agent for celld Durable Objects runtime
+
+`./input.json` provides:
+- `cellId`: The target cell identifier.
+- `endpoint`: celld HTTP/RPC endpoint (defaults to `http://127.0.0.1:9876`).
+- `testKey`: Entity ID key to persist under collection `smoke_tests`.
+- `testData`: JSON payload to write and read back.
+
+This is a wiring and durable cell storage verification agent.
+
+## Steps
+
+1. Read `./input.json`.
+2. Connect to the specified `cellId` on the given `endpoint` via `CellClient` or HTTP REST/RPC.
+3. Fetch `/v1/schema` to verify cell accessibility.
+4. Ensure migration `001_celld_smoke_init` is applied (`CREATE TABLE IF NOT EXISTS smoke_records (id TEXT PRIMARY KEY, value TEXT);`).
+5. Persist `testData` into collection `smoke_tests` with ID `testKey` using optimistic locking (`expectedVersion: 0` for initial write, or current version).
+6. Read back the entity from collection `smoke_tests` with ID `testKey` to assert exact data matching.
+7. Write `./result.json`.
+
+## Output
+
+Write `./result.json`:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "cellId": "<input.json's cellId>",
+    "cellVersion": 2,
+    "migrated": true,
+    "entityVersion": 1,
+    "verified": true
+  },
+  "evidence": { "commands": [] }
+}
+```

--- a/event-runtime/agents/celld-smoke.md
+++ b/event-runtime/agents/celld-smoke.md
@@ -1,6 +1,7 @@
 # celld-smoke — smoke agent for celld Durable Objects runtime
 
 `./input.json` provides:
+
 - `cellId`: The target cell identifier.
 - `endpoint`: celld HTTP/RPC endpoint (defaults to `http://127.0.0.1:9876`).
 - `testKey`: Entity ID key to persist under collection `smoke_tests`.

--- a/event-runtime/lib/cell-client.mjs
+++ b/event-runtime/lib/cell-client.mjs
@@ -1,0 +1,225 @@
+/**
+ * Lightweight client for celld-backed Durable Object cells (docs/editorial-agent-runtime.md).
+ *
+ * Provides typed REST/RPC access to structured cell state:
+ * - Schema & DDL migrations (/v1/schema, /v1/schema/migrate)
+ * - Versioned entity persistence with optimistic concurrency (/v1/entities)
+ * - Parameterized read-only SQL queries (/v1/query)
+ */
+
+export class CellError extends Error {
+  constructor(message, { status, code, details } = {}) {
+    super(message);
+    this.name = "CellError";
+    this.status = status;
+    this.code = code;
+    this.details = details;
+  }
+}
+
+export class VersionConflictError extends CellError {
+  constructor(message, { currentVersion, cellVersion, details } = {}) {
+    super(message, { status: 409, code: "conflict", details });
+    this.name = "VersionConflictError";
+    this.currentVersion = currentVersion;
+    this.cellVersion = cellVersion;
+  }
+}
+
+export class CellNotFoundError extends CellError {
+  constructor(message, { collection, id, details } = {}) {
+    super(message, { status: 404, code: "not_found", details });
+    this.name = "CellNotFoundError";
+    this.collection = collection;
+    this.id = id;
+  }
+}
+
+export class CellClient {
+  constructor({ endpoint = "http://127.0.0.1:9876", cellId = null, fetch = globalThis.fetch } = {}) {
+    this.endpoint = endpoint.replace(/\/+$/, "");
+    this.cellId = cellId;
+    this._fetch = fetch;
+  }
+
+  forCell(cellId) {
+    if (!cellId || typeof cellId !== "string") {
+      throw new Error("cellId must be a non-empty string");
+    }
+    return new CellClient({
+      endpoint: this.endpoint,
+      cellId,
+      fetch: this._fetch
+    });
+  }
+
+  _url(path) {
+    if (!this.cellId) {
+      throw new Error("CellClient must be bound to a cellId or call forCell(cellId)");
+    }
+    const cleanPath = path.replace(/^\/+/, "");
+    return `${this.endpoint}/cells/${encodeURIComponent(this.cellId)}/${cleanPath}`;
+  }
+
+  async _request(path, { method = "GET", body = null, headers = {} } = {}) {
+    const url = this._url(path);
+    const reqHeaders = {
+      Accept: "application/json",
+      ...headers
+    };
+
+    let reqBody = null;
+    if (body !== null && body !== undefined) {
+      reqHeaders["Content-Type"] = "application/json";
+      reqBody = typeof body === "string" ? body : JSON.stringify(body);
+    }
+
+    let response;
+    try {
+      response = await this._fetch(url, {
+        method,
+        headers: reqHeaders,
+        body: reqBody
+      });
+    } catch (err) {
+      throw new CellError(`Network error reaching cell daemon at ${url}: ${err.message}`, {
+        code: "network_error",
+        details: err
+      });
+    }
+
+    const contentType = response.headers.get("content-type") || "";
+    let data;
+    if (contentType.includes("application/json")) {
+      try {
+        data = await response.json();
+      } catch (err) {
+        throw new CellError(`Invalid JSON from cell endpoint ${url}: ${err.message}`, {
+          status: response.status,
+          code: "invalid_response"
+        });
+      }
+    } else {
+      const text = await response.text();
+      data = { message: text };
+    }
+
+    if (!response.ok) {
+      if (response.status === 409) {
+        throw new VersionConflictError(data.message || "Version conflict", {
+          currentVersion: data.currentVersion,
+          cellVersion: data.cellVersion,
+          details: data
+        });
+      }
+      if (response.status === 404) {
+        throw new CellNotFoundError(data.message || "Not found", {
+          collection: data.collection,
+          id: data.id,
+          details: data
+        });
+      }
+      throw new CellError(data.message || `Cell request failed with status ${response.status}`, {
+        status: response.status,
+        code: data.error || "request_failed",
+        details: data
+      });
+    }
+
+    return data;
+  }
+
+  async checkHealth() {
+    try {
+      const res = await this._fetch(`${this.endpoint}/health`, {
+        headers: { Accept: "application/json" }
+      });
+      if (!res.ok) return false;
+      const data = await res.json();
+      return data.status === "healthy";
+    } catch {
+      return false;
+    }
+  }
+
+  async getSchema() {
+    return this._request("v1/schema", { method: "GET" });
+  }
+
+  async migrate({ migrationId, sql, description = null }) {
+    if (!migrationId || !sql) {
+      throw new Error("migrationId and sql are required");
+    }
+    return this._request("v1/schema/migrate", {
+      method: "POST",
+      body: { migrationId, sql, description }
+    });
+  }
+
+  async getEntity(collection, id) {
+    if (!collection || !id) {
+      throw new Error("collection and id are required");
+    }
+    try {
+      return await this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`, {
+        method: "GET"
+      });
+    } catch (err) {
+      if (err instanceof CellNotFoundError) {
+        return null;
+      }
+      throw err;
+    }
+  }
+
+  async listEntities(collection, { limit = 100 } = {}) {
+    if (!collection) {
+      throw new Error("collection is required");
+    }
+    return this._request(`v1/entities/${encodeURIComponent(collection)}?limit=${encodeURIComponent(limit)}`, {
+      method: "GET"
+    });
+  }
+
+  async putEntity(collection, id, data, { expectedVersion } = {}) {
+    if (!collection || !id) {
+      throw new Error("collection and id are required");
+    }
+    return this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`, {
+      method: "PUT",
+      body: { data, expectedVersion }
+    });
+  }
+
+  async postEntity(collection, data, { id = null, expectedVersion } = {}) {
+    if (!collection) {
+      throw new Error("collection is required");
+    }
+    return this._request(`v1/entities/${encodeURIComponent(collection)}`, {
+      method: "POST",
+      body: { id, data, expectedVersion }
+    });
+  }
+
+  async deleteEntity(collection, id, { expectedVersion } = {}) {
+    if (!collection || !id) {
+      throw new Error("collection and id are required");
+    }
+    const query = expectedVersion !== undefined && expectedVersion !== null
+      ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
+      : "";
+    return this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}${query}`, {
+      method: "DELETE"
+    });
+  }
+
+  async query(sql, params = []) {
+    if (!sql || typeof sql !== "string") {
+      throw new Error("sql query must be a string");
+    }
+    return this._request("v1/query", {
+      method: "POST",
+      body: { sql, params }
+    });
+  }
+}

--- a/event-runtime/lib/cell-client.mjs
+++ b/event-runtime/lib/cell-client.mjs
@@ -40,7 +40,7 @@ export class CellClient {
     endpoint = "http://127.0.0.1:9876",
     cellId = null,
     fetch = globalThis.fetch,
-    authToken = null
+    authToken = null,
   } = {}) {
     this.endpoint = endpoint.replace(/\/+$/, "");
     this.cellId = cellId;
@@ -48,7 +48,8 @@ export class CellClient {
     // Shared-secret bearer token for the loopback cell spike. Defaults to the
     // daemon's own CELL_AUTH_TOKEN so a client in the same environment works
     // without extra wiring.
-    this.authToken = authToken ?? (globalThis.process?.env?.CELL_AUTH_TOKEN ?? null);
+    this.authToken =
+      authToken ?? globalThis.process?.env?.CELL_AUTH_TOKEN ?? null;
   }
 
   forCell(cellId) {
@@ -59,13 +60,15 @@ export class CellClient {
       endpoint: this.endpoint,
       cellId,
       fetch: this._fetch,
-      authToken: this.authToken
+      authToken: this.authToken,
     });
   }
 
   _url(path) {
     if (!this.cellId) {
-      throw new Error("CellClient must be bound to a cellId or call forCell(cellId)");
+      throw new Error(
+        "CellClient must be bound to a cellId or call forCell(cellId)",
+      );
     }
     const cleanPath = path.replace(/^\/+/, "");
     return `${this.endpoint}/cells/${encodeURIComponent(this.cellId)}/${cleanPath}`;
@@ -76,7 +79,7 @@ export class CellClient {
     const reqHeaders = {
       Accept: "application/json",
       ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
-      ...headers
+      ...headers,
     };
 
     let reqBody = null;
@@ -90,13 +93,16 @@ export class CellClient {
       response = await this._fetch(url, {
         method,
         headers: reqHeaders,
-        body: reqBody
+        body: reqBody,
       });
     } catch (err) {
-      throw new CellError(`Network error reaching cell daemon at ${url}: ${err.message}`, {
-        code: "network_error",
-        details: err
-      });
+      throw new CellError(
+        `Network error reaching cell daemon at ${url}: ${err.message}`,
+        {
+          code: "network_error",
+          details: err,
+        },
+      );
     }
 
     const contentType = response.headers.get("content-type") || "";
@@ -105,10 +111,13 @@ export class CellClient {
       try {
         data = await response.json();
       } catch (err) {
-        throw new CellError(`Invalid JSON from cell endpoint ${url}: ${err.message}`, {
-          status: response.status,
-          code: "invalid_response"
-        });
+        throw new CellError(
+          `Invalid JSON from cell endpoint ${url}: ${err.message}`,
+          {
+            status: response.status,
+            code: "invalid_response",
+          },
+        );
       }
     } else {
       const text = await response.text();
@@ -120,21 +129,24 @@ export class CellClient {
         throw new VersionConflictError(data.message || "Version conflict", {
           currentVersion: data.currentVersion,
           cellVersion: data.cellVersion,
-          details: data
+          details: data,
         });
       }
       if (response.status === 404) {
         throw new CellNotFoundError(data.message || "Not found", {
           collection: data.collection,
           id: data.id,
-          details: data
+          details: data,
         });
       }
-      throw new CellError(data.message || `Cell request failed with status ${response.status}`, {
-        status: response.status,
-        code: data.error || "request_failed",
-        details: data
-      });
+      throw new CellError(
+        data.message || `Cell request failed with status ${response.status}`,
+        {
+          status: response.status,
+          code: data.error || "request_failed",
+          details: data,
+        },
+      );
     }
 
     return data;
@@ -143,7 +155,7 @@ export class CellClient {
   async checkHealth() {
     try {
       const res = await this._fetch(`${this.endpoint}/health`, {
-        headers: { Accept: "application/json" }
+        headers: { Accept: "application/json" },
       });
       if (!res.ok) return false;
       const data = await res.json();
@@ -163,7 +175,7 @@ export class CellClient {
     }
     return this._request("v1/schema/migrate", {
       method: "POST",
-      body: { migrationId, sql, description }
+      body: { migrationId, sql, description },
     });
   }
 
@@ -172,9 +184,12 @@ export class CellClient {
       throw new Error("collection and id are required");
     }
     try {
-      return await this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`, {
-        method: "GET"
-      });
+      return await this._request(
+        `v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`,
+        {
+          method: "GET",
+        },
+      );
     } catch (err) {
       if (err instanceof CellNotFoundError) {
         return null;
@@ -187,19 +202,25 @@ export class CellClient {
     if (!collection) {
       throw new Error("collection is required");
     }
-    return this._request(`v1/entities/${encodeURIComponent(collection)}?limit=${encodeURIComponent(limit)}`, {
-      method: "GET"
-    });
+    return this._request(
+      `v1/entities/${encodeURIComponent(collection)}?limit=${encodeURIComponent(limit)}`,
+      {
+        method: "GET",
+      },
+    );
   }
 
   async putEntity(collection, id, data, { expectedVersion } = {}) {
     if (!collection || !id) {
       throw new Error("collection and id are required");
     }
-    return this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`, {
-      method: "PUT",
-      body: { data, expectedVersion }
-    });
+    return this._request(
+      `v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}`,
+      {
+        method: "PUT",
+        body: { data, expectedVersion },
+      },
+    );
   }
 
   async postEntity(collection, data, { id = null, expectedVersion } = {}) {
@@ -208,7 +229,7 @@ export class CellClient {
     }
     return this._request(`v1/entities/${encodeURIComponent(collection)}`, {
       method: "POST",
-      body: { id, data, expectedVersion }
+      body: { id, data, expectedVersion },
     });
   }
 
@@ -216,12 +237,16 @@ export class CellClient {
     if (!collection || !id) {
       throw new Error("collection and id are required");
     }
-    const query = expectedVersion !== undefined && expectedVersion !== null
-      ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
-      : "";
-    return this._request(`v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}${query}`, {
-      method: "DELETE"
-    });
+    const query =
+      expectedVersion !== undefined && expectedVersion !== null
+        ? `?expectedVersion=${encodeURIComponent(expectedVersion)}`
+        : "";
+    return this._request(
+      `v1/entities/${encodeURIComponent(collection)}/${encodeURIComponent(id)}${query}`,
+      {
+        method: "DELETE",
+      },
+    );
   }
 
   async query(sql, params = []) {
@@ -230,7 +255,7 @@ export class CellClient {
     }
     return this._request("v1/query", {
       method: "POST",
-      body: { sql, params }
+      body: { sql, params },
     });
   }
 }

--- a/event-runtime/lib/cell-client.mjs
+++ b/event-runtime/lib/cell-client.mjs
@@ -36,10 +36,19 @@ export class CellNotFoundError extends CellError {
 }
 
 export class CellClient {
-  constructor({ endpoint = "http://127.0.0.1:9876", cellId = null, fetch = globalThis.fetch } = {}) {
+  constructor({
+    endpoint = "http://127.0.0.1:9876",
+    cellId = null,
+    fetch = globalThis.fetch,
+    authToken = null
+  } = {}) {
     this.endpoint = endpoint.replace(/\/+$/, "");
     this.cellId = cellId;
     this._fetch = fetch;
+    // Shared-secret bearer token for the loopback cell spike. Defaults to the
+    // daemon's own CELL_AUTH_TOKEN so a client in the same environment works
+    // without extra wiring.
+    this.authToken = authToken ?? (globalThis.process?.env?.CELL_AUTH_TOKEN ?? null);
   }
 
   forCell(cellId) {
@@ -49,7 +58,8 @@ export class CellClient {
     return new CellClient({
       endpoint: this.endpoint,
       cellId,
-      fetch: this._fetch
+      fetch: this._fetch,
+      authToken: this.authToken
     });
   }
 
@@ -65,6 +75,7 @@ export class CellClient {
     const url = this._url(path);
     const reqHeaders = {
       Accept: "application/json",
+      ...(this.authToken ? { Authorization: `Bearer ${this.authToken}` } : {}),
       ...headers
     };
 

--- a/event-runtime/lib/celld-smoke.test.mjs
+++ b/event-runtime/lib/celld-smoke.test.mjs
@@ -9,11 +9,22 @@ import { CellClient, VersionConflictError } from "./cell-client.mjs";
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
 const CELLS_DIR = path.resolve(REPO_ROOT, "cells");
-const TMP_TEST_DIR = path.resolve(REPO_ROOT, ".factory/test-celld-smoke-" + Date.now());
+const TMP_TEST_DIR = path.resolve(
+  REPO_ROOT,
+  ".factory/test-celld-smoke-" + Date.now(),
+);
 
 // `celld` is a local developer daemon; it is not provisioned in CI or in the
 // sandbox, so the whole suite is gated on the binary being present.
 const CELLD_BIN = Bun.which("celld");
+
+// wrangler.jsonc is JSONC: strip comments and trailing commas before parsing.
+function parseJsonc(text) {
+  const withoutComments = text
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:"'\\])\/\/.*$/gm, "$1");
+  return JSON.parse(withoutComments.replace(/,(\s*[}\]])/g, "$1"));
+}
 
 // Pick a free port at run time — a hardcoded port collides on shared runners.
 async function pickFreePort() {
@@ -35,21 +46,25 @@ let celldProcess = null;
 
 function startCelld(customPort, storageProjectDir = TMP_TEST_DIR) {
   // celld dev [PROJECT] --host 127.0.0.1 --port PORT
-  const proc = spawn("celld", [
-    "dev",
-    storageProjectDir,
-    "--host",
-    "127.0.0.1",
-    "--port",
-    String(customPort),
-  ], {
-    cwd: REPO_ROOT,
-    stdio: "pipe",
-    env: {
-      ...process.env,
-      CELL_AUTH_TOKEN: TEST_TOKEN,
+  const proc = spawn(
+    "celld",
+    [
+      "dev",
+      storageProjectDir,
+      "--host",
+      "127.0.0.1",
+      "--port",
+      String(customPort),
+    ],
+    {
+      cwd: REPO_ROOT,
+      stdio: "pipe",
+      env: {
+        ...process.env,
+        CELL_AUTH_TOKEN: TEST_TOKEN,
+      },
     },
-  });
+  );
 
   return proc;
 }
@@ -80,253 +95,304 @@ function stopProcess(proc) {
   }
 }
 
-describe.skipIf(!CELLD_BIN)("celld structured REST/RPC & multi-agent durability", () => {
-  beforeAll(async () => {
-    TEST_PORT = await pickFreePort();
-    TEST_ENDPOINT = `http://127.0.0.1:${TEST_PORT}`;
+describe.skipIf(!CELLD_BIN)(
+  "celld structured REST/RPC & multi-agent durability",
+  () => {
+    beforeAll(async () => {
+      TEST_PORT = await pickFreePort();
+      TEST_ENDPOINT = `http://127.0.0.1:${TEST_PORT}`;
 
-    if (existsSync(TMP_TEST_DIR)) {
-      rmSync(TMP_TEST_DIR, { recursive: true, force: true });
-    }
-    mkdirSync(TMP_TEST_DIR, { recursive: true });
-
-    // Copy cells project files into the test storage dir so celld dev finds wrangler.jsonc & src
-    mkdirSync(path.join(TMP_TEST_DIR, "src"), { recursive: true });
-    const wranglerContent = await Bun.file(path.join(CELLS_DIR, "wrangler.jsonc")).text();
-    const srcContent = await Bun.file(path.join(CELLS_DIR, "src/index.mjs")).text();
-
-    // Inject the shared-secret binding the worker requires (see the deployment
-    // warning in cells/src/index.mjs); the daemon reads it from wrangler vars.
-    const wranglerConfig = JSON.parse(wranglerContent);
-    wranglerConfig.vars = { ...(wranglerConfig.vars || {}), CELL_AUTH_TOKEN: TEST_TOKEN };
-
-    await Bun.write(path.join(TMP_TEST_DIR, "wrangler.jsonc"), JSON.stringify(wranglerConfig, null, 2));
-    await Bun.write(path.join(TMP_TEST_DIR, "src/index.mjs"), srcContent);
-
-    celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
-
-    const healthy = await waitForHealth();
-    expect(healthy).toBe(true);
-  });
-
-  afterAll(() => {
-    stopProcess(celldProcess);
-    if (existsSync(TMP_TEST_DIR)) {
-      rmSync(TMP_TEST_DIR, { recursive: true, force: true });
-    }
-  });
-
-  it("proves health check and empty initial cell schema", async () => {
-    const client = new CellClient({ endpoint: TEST_ENDPOINT, authToken: TEST_TOKEN });
-    const healthy = await client.checkHealth();
-    expect(healthy).toBe(true);
-
-    const articleCell = client.forCell("article:01J_SMOKE_TEST");
-    const schema = await articleCell.getSchema();
-    expect(schema.cellVersion).toBe(1);
-    expect(schema.migrations.length).toBe(0);
-    expect(schema.tables.some((t) => t.name === "_cell_entities")).toBe(true);
-  });
-
-  it("allows Agent 1 to initialize sources and record research", async () => {
-    const agent1 = new CellClient({
-      endpoint: TEST_ENDPOINT,
-      authToken: TEST_TOKEN,
-      cellId: "article:01J_SMOKE_TEST",
-    });
-
-    // Agent 1 applies initial domain migration
-    const migRes = await agent1.migrate({
-      migrationId: "001_init_research_notes",
-      sql: "CREATE TABLE research_notes (id TEXT PRIMARY KEY, note TEXT);",
-      description: "Initial research notes table",
-    });
-
-    expect(migRes.ok).toBe(true);
-    expect(migRes.applied).toBe(true);
-    expect(migRes.cellVersion).toBe(2);
-
-    // Agent 1 saves research source entity
-    const putRes = await agent1.putEntity("sources", "src-intervals-101", {
-      title: "Intervals ICU API Documentation",
-      url: "https://intervals.icu/api/v1",
-      relevanceScore: 0.95,
-      claims: ["OAuth token refresh is supported", "Webhook cadence is 60s"],
-    }, { expectedVersion: 0 });
-
-    expect(putRes.ok).toBe(true);
-    expect(putRes.created).toBe(true);
-    expect(putRes.version).toBe(1);
-    expect(putRes.cellVersion).toBe(3);
-
-    // Verify entity read
-    const entity = await agent1.getEntity("sources", "src-intervals-101");
-    expect(entity).not.toBeNull();
-    expect(entity.id).toBe("src-intervals-101");
-    expect(entity.version).toBe(1);
-    expect(entity.data.title).toBe("Intervals ICU API Documentation");
-  });
-
-  it("allows Agent 2 to read Agent 1 sources and evolve the cell schema", async () => {
-    // Agent 2 runs in a separate context / client instance
-    const agent2 = new CellClient({
-      endpoint: TEST_ENDPOINT,
-      authToken: TEST_TOKEN,
-      cellId: "article:01J_SMOKE_TEST",
-    });
-
-    // 1. Agent 2 reads sources populated by Agent 1
-    const sources = await agent2.listEntities("sources");
-    expect(sources.count).toBe(1);
-    expect(sources.entities[0].id).toBe("src-intervals-101");
-
-    // 2. Agent 2 evolves the cell schema (alters cell) by adding revisions table
-    const migRes = await agent2.migrate({
-      migrationId: "002_add_revisions_table",
-      sql: "CREATE TABLE revisions (id TEXT PRIMARY KEY, hash TEXT NOT NULL, word_count INTEGER);",
-      description: "Article revisions table",
-    });
-
-    expect(migRes.ok).toBe(true);
-    expect(migRes.applied).toBe(true);
-
-    // 3. Agent 2 writes draft revision 1 entity
-    const revRes = await agent2.putEntity("revisions", "rev-001", {
-      hash: "sha256:abcd1234ef5678",
-      wordCount: 1650,
-      title: "Optimizing Intervals.icu Integration in Coach Watts",
-      status: "draft",
-    }, { expectedVersion: 0 });
-
-    expect(revRes.ok).toBe(true);
-    expect(revRes.version).toBe(1);
-
-    // Verify the schema reflects both migrations
-    const schema = await agent2.getSchema();
-    expect(schema.migrations.length).toBe(2);
-    expect(schema.migrations[0].id).toBe("001_init_research_notes");
-    expect(schema.migrations[1].id).toBe("002_add_revisions_table");
-    expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
-  });
-
-  it("enforces optimistic concurrency and rejects stale writes with VersionConflictError", async () => {
-    const agent1 = new CellClient({
-      endpoint: TEST_ENDPOINT,
-      authToken: TEST_TOKEN,
-      cellId: "article:01J_SMOKE_TEST",
-    });
-
-    // Agent 1 tries to update sources with outdated expectedVersion: 0 (current is 1)
-    let conflictThrown = false;
-    try {
-      await agent1.putEntity("sources", "src-intervals-101", {
-        title: "Stale Overwrite Attempt",
-      }, { expectedVersion: 0 });
-    } catch (err) {
-      if (err instanceof VersionConflictError) {
-        conflictThrown = true;
-        expect(err.status).toBe(409);
-        expect(err.currentVersion).toBe(1);
+      if (existsSync(TMP_TEST_DIR)) {
+        rmSync(TMP_TEST_DIR, { recursive: true, force: true });
       }
-    }
-    expect(conflictThrown).toBe(true);
+      mkdirSync(TMP_TEST_DIR, { recursive: true });
 
-    // Agent 1 updates with matching expectedVersion: 1
-    const updateRes = await agent1.putEntity("sources", "src-intervals-101", {
-      title: "Intervals ICU API Documentation (Verified)",
-      url: "https://intervals.icu/api/v1",
-      relevanceScore: 0.98,
-    }, { expectedVersion: 1 });
+      // Copy cells project files into the test storage dir so celld dev finds wrangler.jsonc & src
+      mkdirSync(path.join(TMP_TEST_DIR, "src"), { recursive: true });
+      const wranglerContent = await Bun.file(
+        path.join(CELLS_DIR, "wrangler.jsonc"),
+      ).text();
+      const srcContent = await Bun.file(
+        path.join(CELLS_DIR, "src/index.mjs"),
+      ).text();
 
-    expect(updateRes.ok).toBe(true);
-    expect(updateRes.version).toBe(2);
-  });
+      // Inject the shared-secret binding the worker requires (see the deployment
+      // warning in cells/src/index.mjs); the daemon reads it from wrangler vars.
+      const wranglerConfig = parseJsonc(wranglerContent);
+      wranglerConfig.vars = {
+        ...(wranglerConfig.vars || {}),
+        CELL_AUTH_TOKEN: TEST_TOKEN,
+      };
 
-  it("supports read-only SQL queries via /v1/query and rejects unsafe writes", async () => {
-    const client = new CellClient({
-      endpoint: TEST_ENDPOINT,
-      authToken: TEST_TOKEN,
-      cellId: "article:01J_SMOKE_TEST",
+      await Bun.write(
+        path.join(TMP_TEST_DIR, "wrangler.jsonc"),
+        JSON.stringify(wranglerConfig, null, 2),
+      );
+      await Bun.write(path.join(TMP_TEST_DIR, "src/index.mjs"), srcContent);
+
+      celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
+
+      const healthy = await waitForHealth();
+      expect(healthy).toBe(true);
     });
 
-    // 1. Safe query
-    const queryRes = await client.query(
-      "SELECT id, version FROM _cell_entities WHERE collection = ? ORDER BY id ASC;",
-      ["sources"]
-    );
-    expect(queryRes.count).toBe(1);
-    expect(queryRes.rows[0].id).toBe("src-intervals-101");
-    expect(queryRes.rows[0].version).toBe(2);
-
-    // 2. Unsafe write statement in query endpoint is forbidden
-    let forbiddenCaught = false;
-    try {
-      await client.query("DROP TABLE _cell_entities;");
-    } catch (err) {
-      if (err.status === 403) {
-        forbiddenCaught = true;
+    afterAll(() => {
+      stopProcess(celldProcess);
+      if (existsSync(TMP_TEST_DIR)) {
+        rmSync(TMP_TEST_DIR, { recursive: true, force: true });
       }
-    }
-    expect(forbiddenCaught).toBe(true);
+    });
 
-    // 3. A write statement smuggled behind a read-only leading keyword is also
-    // forbidden (single-statement guard).
-    let injectionCaught = false;
-    try {
-      await client.query("SELECT 1; DROP TABLE _cell_entities;");
-    } catch (err) {
-      if (err.status === 403) {
-        injectionCaught = true;
+    it("proves health check and empty initial cell schema", async () => {
+      const client = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+      });
+      const healthy = await client.checkHealth();
+      expect(healthy).toBe(true);
+
+      const articleCell = client.forCell("article:01J_SMOKE_TEST");
+      const schema = await articleCell.getSchema();
+      expect(schema.cellVersion).toBe(1);
+      expect(schema.migrations.length).toBe(0);
+      expect(schema.tables.some((t) => t.name === "_cell_entities")).toBe(true);
+    });
+
+    it("allows Agent 1 to initialize sources and record research", async () => {
+      const agent1 = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+        cellId: "article:01J_SMOKE_TEST",
+      });
+
+      // Agent 1 applies initial domain migration
+      const migRes = await agent1.migrate({
+        migrationId: "001_init_research_notes",
+        sql: "CREATE TABLE research_notes (id TEXT PRIMARY KEY, note TEXT);",
+        description: "Initial research notes table",
+      });
+
+      expect(migRes.ok).toBe(true);
+      expect(migRes.applied).toBe(true);
+      expect(migRes.cellVersion).toBe(2);
+
+      // Agent 1 saves research source entity
+      const putRes = await agent1.putEntity(
+        "sources",
+        "src-intervals-101",
+        {
+          title: "Intervals ICU API Documentation",
+          url: "https://intervals.icu/api/v1",
+          relevanceScore: 0.95,
+          claims: [
+            "OAuth token refresh is supported",
+            "Webhook cadence is 60s",
+          ],
+        },
+        { expectedVersion: 0 },
+      );
+
+      expect(putRes.ok).toBe(true);
+      expect(putRes.created).toBe(true);
+      expect(putRes.version).toBe(1);
+      expect(putRes.cellVersion).toBe(3);
+
+      // Verify entity read
+      const entity = await agent1.getEntity("sources", "src-intervals-101");
+      expect(entity).not.toBeNull();
+      expect(entity.id).toBe("src-intervals-101");
+      expect(entity.version).toBe(1);
+      expect(entity.data.title).toBe("Intervals ICU API Documentation");
+    });
+
+    it("allows Agent 2 to read Agent 1 sources and evolve the cell schema", async () => {
+      // Agent 2 runs in a separate context / client instance
+      const agent2 = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+        cellId: "article:01J_SMOKE_TEST",
+      });
+
+      // 1. Agent 2 reads sources populated by Agent 1
+      const sources = await agent2.listEntities("sources");
+      expect(sources.count).toBe(1);
+      expect(sources.entities[0].id).toBe("src-intervals-101");
+
+      // 2. Agent 2 evolves the cell schema (alters cell) by adding revisions table
+      const migRes = await agent2.migrate({
+        migrationId: "002_add_revisions_table",
+        sql: "CREATE TABLE revisions (id TEXT PRIMARY KEY, hash TEXT NOT NULL, word_count INTEGER);",
+        description: "Article revisions table",
+      });
+
+      expect(migRes.ok).toBe(true);
+      expect(migRes.applied).toBe(true);
+
+      // 3. Agent 2 writes draft revision 1 entity
+      const revRes = await agent2.putEntity(
+        "revisions",
+        "rev-001",
+        {
+          hash: "sha256:abcd1234ef5678",
+          wordCount: 1650,
+          title: "Optimizing Intervals.icu Integration in Coach Watts",
+          status: "draft",
+        },
+        { expectedVersion: 0 },
+      );
+
+      expect(revRes.ok).toBe(true);
+      expect(revRes.version).toBe(1);
+
+      // Verify the schema reflects both migrations
+      const schema = await agent2.getSchema();
+      expect(schema.migrations.length).toBe(2);
+      expect(schema.migrations[0].id).toBe("001_init_research_notes");
+      expect(schema.migrations[1].id).toBe("002_add_revisions_table");
+      expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
+    });
+
+    it("enforces optimistic concurrency and rejects stale writes with VersionConflictError", async () => {
+      const agent1 = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+        cellId: "article:01J_SMOKE_TEST",
+      });
+
+      // Agent 1 tries to update sources with outdated expectedVersion: 0 (current is 1)
+      let conflictThrown = false;
+      try {
+        await agent1.putEntity(
+          "sources",
+          "src-intervals-101",
+          {
+            title: "Stale Overwrite Attempt",
+          },
+          { expectedVersion: 0 },
+        );
+      } catch (err) {
+        if (err instanceof VersionConflictError) {
+          conflictThrown = true;
+          expect(err.status).toBe(409);
+          expect(err.currentVersion).toBe(1);
+        }
       }
-    }
-    expect(injectionCaught).toBe(true);
+      expect(conflictThrown).toBe(true);
 
-    // The table is still there.
-    const stillThere = await client.query("SELECT COUNT(*) AS n FROM _cell_entities;");
-    expect(stillThere.rows[0].n).toBeGreaterThan(0);
-  });
+      // Agent 1 updates with matching expectedVersion: 1
+      const updateRes = await agent1.putEntity(
+        "sources",
+        "src-intervals-101",
+        {
+          title: "Intervals ICU API Documentation (Verified)",
+          url: "https://intervals.icu/api/v1",
+          relevanceScore: 0.98,
+        },
+        { expectedVersion: 1 },
+      );
 
-  it("rejects requests without a valid bearer token", async () => {
-    const res = await fetch(`${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`);
-    expect(res.status).toBe(401);
-
-    const badRes = await fetch(`${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`, {
-      headers: { Authorization: "Bearer not-the-token" }
-    });
-    expect(badRes.status).toBe(401);
-  });
-
-  it("survives daemon process restart and preserves all data and migrations", async () => {
-    // 1. Stop celld daemon
-    stopProcess(celldProcess);
-
-    // Small delay to ensure process termination
-    await new Promise((r) => setTimeout(r, 500));
-
-    // 2. Restart celld daemon against same storage dir
-    celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
-    const healthy = await waitForHealth();
-    expect(healthy).toBe(true);
-
-    // 3. Connect client and verify everything persisted
-    const client = new CellClient({
-      endpoint: TEST_ENDPOINT,
-      authToken: TEST_TOKEN,
-      cellId: "article:01J_SMOKE_TEST",
+      expect(updateRes.ok).toBe(true);
+      expect(updateRes.version).toBe(2);
     });
 
-    const schema = await client.getSchema();
-    expect(schema.migrations.length).toBe(2);
-    expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
+    it("supports read-only SQL queries via /v1/query and rejects unsafe writes", async () => {
+      const client = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+        cellId: "article:01J_SMOKE_TEST",
+      });
 
-    const sourceEntity = await client.getEntity("sources", "src-intervals-101");
-    expect(sourceEntity).not.toBeNull();
-    expect(sourceEntity.version).toBe(2);
-    expect(sourceEntity.data.title).toBe("Intervals ICU API Documentation (Verified)");
+      // 1. Safe query
+      const queryRes = await client.query(
+        "SELECT id, version FROM _cell_entities WHERE collection = ? ORDER BY id ASC;",
+        ["sources"],
+      );
+      expect(queryRes.count).toBe(1);
+      expect(queryRes.rows[0].id).toBe("src-intervals-101");
+      expect(queryRes.rows[0].version).toBe(2);
 
-    const revEntity = await client.getEntity("revisions", "rev-001");
-    expect(revEntity).not.toBeNull();
-    expect(revEntity.version).toBe(1);
-    expect(revEntity.data.wordCount).toBe(1650);
-  });
-});
+      // 2. Unsafe write statement in query endpoint is forbidden
+      let forbiddenCaught = false;
+      try {
+        await client.query("DROP TABLE _cell_entities;");
+      } catch (err) {
+        if (err.status === 403) {
+          forbiddenCaught = true;
+        }
+      }
+      expect(forbiddenCaught).toBe(true);
+
+      // 3. A write statement smuggled behind a read-only leading keyword is also
+      // forbidden (single-statement guard).
+      let injectionCaught = false;
+      try {
+        await client.query("SELECT 1; DROP TABLE _cell_entities;");
+      } catch (err) {
+        if (err.status === 403) {
+          injectionCaught = true;
+        }
+      }
+      expect(injectionCaught).toBe(true);
+
+      // The table is still there.
+      const stillThere = await client.query(
+        "SELECT COUNT(*) AS n FROM _cell_entities;",
+      );
+      expect(stillThere.rows[0].n).toBeGreaterThan(0);
+    });
+
+    it("rejects requests without a valid bearer token", async () => {
+      const res = await fetch(
+        `${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`,
+      );
+      expect(res.status).toBe(401);
+
+      const badRes = await fetch(
+        `${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`,
+        {
+          headers: { Authorization: "Bearer not-the-token" },
+        },
+      );
+      expect(badRes.status).toBe(401);
+    });
+
+    it("survives daemon process restart and preserves all data and migrations", async () => {
+      // 1. Stop celld daemon
+      stopProcess(celldProcess);
+
+      // Small delay to ensure process termination
+      await new Promise((r) => setTimeout(r, 500));
+
+      // 2. Restart celld daemon against same storage dir
+      celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
+      const healthy = await waitForHealth();
+      expect(healthy).toBe(true);
+
+      // 3. Connect client and verify everything persisted
+      const client = new CellClient({
+        endpoint: TEST_ENDPOINT,
+        authToken: TEST_TOKEN,
+        cellId: "article:01J_SMOKE_TEST",
+      });
+
+      const schema = await client.getSchema();
+      expect(schema.migrations.length).toBe(2);
+      expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
+
+      const sourceEntity = await client.getEntity(
+        "sources",
+        "src-intervals-101",
+      );
+      expect(sourceEntity).not.toBeNull();
+      expect(sourceEntity.version).toBe(2);
+      expect(sourceEntity.data.title).toBe(
+        "Intervals ICU API Documentation (Verified)",
+      );
+
+      const revEntity = await client.getEntity("revisions", "rev-001");
+      expect(revEntity).not.toBeNull();
+      expect(revEntity.version).toBe(1);
+      expect(revEntity.data.wordCount).toBe(1650);
+    });
+  },
+);

--- a/event-runtime/lib/celld-smoke.test.mjs
+++ b/event-runtime/lib/celld-smoke.test.mjs
@@ -1,0 +1,274 @@
+import { describe, it, beforeAll, afterAll, expect } from "bun:test";
+import { spawn } from "node:child_process";
+import { existsSync, mkdirSync, rmSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { CellClient, VersionConflictError } from "./cell-client.mjs";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const REPO_ROOT = path.resolve(__dirname, "../..");
+const CELLS_DIR = path.resolve(REPO_ROOT, "cells");
+const TMP_TEST_DIR = path.resolve(REPO_ROOT, ".factory/test-celld-smoke-" + Date.now());
+
+// Select an ephemeral port
+const TEST_PORT = 9988;
+const TEST_ENDPOINT = `http://127.0.0.1:${TEST_PORT}`;
+
+let celldProcess = null;
+
+function startCelld(customPort = TEST_PORT, storageProjectDir = TMP_TEST_DIR) {
+  // celld dev [PROJECT] --host 127.0.0.1 --port PORT
+  const proc = spawn("celld", [
+    "dev",
+    storageProjectDir,
+    "--host",
+    "127.0.0.1",
+    "--port",
+    String(customPort),
+  ], {
+    cwd: REPO_ROOT,
+    stdio: "pipe",
+    env: {
+      ...process.env,
+    },
+  });
+
+  return proc;
+}
+
+async function waitForHealth(endpoint = TEST_ENDPOINT, maxAttempts = 30) {
+  for (let i = 0; i < maxAttempts; i++) {
+    try {
+      const res = await fetch(`${endpoint}/health`);
+      if (res.ok) {
+        const data = await res.json();
+        if (data.status === "healthy") return true;
+      }
+    } catch {
+      // ignore retry
+    }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  return false;
+}
+
+function stopProcess(proc) {
+  if (!proc) return;
+  try {
+    proc.kill("SIGTERM");
+  } catch {
+    // ignore
+  }
+}
+
+describe("celld structured REST/RPC & multi-agent durability", () => {
+  beforeAll(async () => {
+    if (existsSync(TMP_TEST_DIR)) {
+      rmSync(TMP_TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TMP_TEST_DIR, { recursive: true });
+
+    // Copy cells project files into the test storage dir so celld dev finds wrangler.jsonc & src
+    mkdirSync(path.join(TMP_TEST_DIR, "src"), { recursive: true });
+    const wranglerContent = await Bun.file(path.join(CELLS_DIR, "wrangler.jsonc")).text();
+    const srcContent = await Bun.file(path.join(CELLS_DIR, "src/index.mjs")).text();
+
+    await Bun.write(path.join(TMP_TEST_DIR, "wrangler.jsonc"), wranglerContent);
+    await Bun.write(path.join(TMP_TEST_DIR, "src/index.mjs"), srcContent);
+
+    celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
+
+    const healthy = await waitForHealth();
+    expect(healthy).toBe(true);
+  });
+
+  afterAll(() => {
+    stopProcess(celldProcess);
+    if (existsSync(TMP_TEST_DIR)) {
+      rmSync(TMP_TEST_DIR, { recursive: true, force: true });
+    }
+  });
+
+  it("proves health check and empty initial cell schema", async () => {
+    const client = new CellClient({ endpoint: TEST_ENDPOINT });
+    const healthy = await client.checkHealth();
+    expect(healthy).toBe(true);
+
+    const articleCell = client.forCell("article:01J_SMOKE_TEST");
+    const schema = await articleCell.getSchema();
+    expect(schema.cellVersion).toBe(1);
+    expect(schema.migrations.length).toBe(0);
+    expect(schema.tables.some((t) => t.name === "_cell_entities")).toBe(true);
+  });
+
+  it("allows Agent 1 to initialize sources and record research", async () => {
+    const agent1 = new CellClient({
+      endpoint: TEST_ENDPOINT,
+      cellId: "article:01J_SMOKE_TEST",
+    });
+
+    // Agent 1 applies initial domain migration
+    const migRes = await agent1.migrate({
+      migrationId: "001_init_research_notes",
+      sql: "CREATE TABLE research_notes (id TEXT PRIMARY KEY, note TEXT);",
+      description: "Initial research notes table",
+    });
+
+    expect(migRes.ok).toBe(true);
+    expect(migRes.applied).toBe(true);
+    expect(migRes.cellVersion).toBe(2);
+
+    // Agent 1 saves research source entity
+    const putRes = await agent1.putEntity("sources", "src-intervals-101", {
+      title: "Intervals ICU API Documentation",
+      url: "https://intervals.icu/api/v1",
+      relevanceScore: 0.95,
+      claims: ["OAuth token refresh is supported", "Webhook cadence is 60s"],
+    }, { expectedVersion: 0 });
+
+    expect(putRes.ok).toBe(true);
+    expect(putRes.created).toBe(true);
+    expect(putRes.version).toBe(1);
+    expect(putRes.cellVersion).toBe(3);
+
+    // Verify entity read
+    const entity = await agent1.getEntity("sources", "src-intervals-101");
+    expect(entity).not.toBeNull();
+    expect(entity.id).toBe("src-intervals-101");
+    expect(entity.version).toBe(1);
+    expect(entity.data.title).toBe("Intervals ICU API Documentation");
+  });
+
+  it("allows Agent 2 to read Agent 1 sources and evolve the cell schema", async () => {
+    // Agent 2 runs in a separate context / client instance
+    const agent2 = new CellClient({
+      endpoint: TEST_ENDPOINT,
+      cellId: "article:01J_SMOKE_TEST",
+    });
+
+    // 1. Agent 2 reads sources populated by Agent 1
+    const sources = await agent2.listEntities("sources");
+    expect(sources.count).toBe(1);
+    expect(sources.entities[0].id).toBe("src-intervals-101");
+
+    // 2. Agent 2 evolves the cell schema (alters cell) by adding revisions table
+    const migRes = await agent2.migrate({
+      migrationId: "002_add_revisions_table",
+      sql: "CREATE TABLE revisions (id TEXT PRIMARY KEY, hash TEXT NOT NULL, word_count INTEGER);",
+      description: "Article revisions table",
+    });
+
+    expect(migRes.ok).toBe(true);
+    expect(migRes.applied).toBe(true);
+
+    // 3. Agent 2 writes draft revision 1 entity
+    const revRes = await agent2.putEntity("revisions", "rev-001", {
+      hash: "sha256:abcd1234ef5678",
+      wordCount: 1650,
+      title: "Optimizing Intervals.icu Integration in Coach Watts",
+      status: "draft",
+    }, { expectedVersion: 0 });
+
+    expect(revRes.ok).toBe(true);
+    expect(revRes.version).toBe(1);
+
+    // Verify the schema reflects both migrations
+    const schema = await agent2.getSchema();
+    expect(schema.migrations.length).toBe(2);
+    expect(schema.migrations[0].id).toBe("001_init_research_notes");
+    expect(schema.migrations[1].id).toBe("002_add_revisions_table");
+    expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
+  });
+
+  it("enforces optimistic concurrency and rejects stale writes with VersionConflictError", async () => {
+    const agent1 = new CellClient({
+      endpoint: TEST_ENDPOINT,
+      cellId: "article:01J_SMOKE_TEST",
+    });
+
+    // Agent 1 tries to update sources with outdated expectedVersion: 0 (current is 1)
+    let conflictThrown = false;
+    try {
+      await agent1.putEntity("sources", "src-intervals-101", {
+        title: "Stale Overwrite Attempt",
+      }, { expectedVersion: 0 });
+    } catch (err) {
+      if (err instanceof VersionConflictError) {
+        conflictThrown = true;
+        expect(err.status).toBe(409);
+        expect(err.currentVersion).toBe(1);
+      }
+    }
+    expect(conflictThrown).toBe(true);
+
+    // Agent 1 updates with matching expectedVersion: 1
+    const updateRes = await agent1.putEntity("sources", "src-intervals-101", {
+      title: "Intervals ICU API Documentation (Verified)",
+      url: "https://intervals.icu/api/v1",
+      relevanceScore: 0.98,
+    }, { expectedVersion: 1 });
+
+    expect(updateRes.ok).toBe(true);
+    expect(updateRes.version).toBe(2);
+  });
+
+  it("supports read-only SQL queries via /v1/query and rejects unsafe writes", async () => {
+    const client = new CellClient({
+      endpoint: TEST_ENDPOINT,
+      cellId: "article:01J_SMOKE_TEST",
+    });
+
+    // 1. Safe query
+    const queryRes = await client.query(
+      "SELECT id, version FROM _cell_entities WHERE collection = ? ORDER BY id ASC;",
+      ["sources"]
+    );
+    expect(queryRes.count).toBe(1);
+    expect(queryRes.rows[0].id).toBe("src-intervals-101");
+    expect(queryRes.rows[0].version).toBe(2);
+
+    // 2. Unsafe write statement in query endpoint is forbidden
+    let forbiddenCaught = false;
+    try {
+      await client.query("DROP TABLE _cell_entities;");
+    } catch (err) {
+      if (err.status === 403) {
+        forbiddenCaught = true;
+      }
+    }
+    expect(forbiddenCaught).toBe(true);
+  });
+
+  it("survives daemon process restart and preserves all data and migrations", async () => {
+    // 1. Stop celld daemon
+    stopProcess(celldProcess);
+
+    // Small delay to ensure process termination
+    await new Promise((r) => setTimeout(r, 500));
+
+    // 2. Restart celld daemon against same storage dir
+    celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
+    const healthy = await waitForHealth();
+    expect(healthy).toBe(true);
+
+    // 3. Connect client and verify everything persisted
+    const client = new CellClient({
+      endpoint: TEST_ENDPOINT,
+      cellId: "article:01J_SMOKE_TEST",
+    });
+
+    const schema = await client.getSchema();
+    expect(schema.migrations.length).toBe(2);
+    expect(schema.tables.some((t) => t.name === "revisions")).toBe(true);
+
+    const sourceEntity = await client.getEntity("sources", "src-intervals-101");
+    expect(sourceEntity).not.toBeNull();
+    expect(sourceEntity.version).toBe(2);
+    expect(sourceEntity.data.title).toBe("Intervals ICU API Documentation (Verified)");
+
+    const revEntity = await client.getEntity("revisions", "rev-001");
+    expect(revEntity).not.toBeNull();
+    expect(revEntity.version).toBe(1);
+    expect(revEntity.data.wordCount).toBe(1650);
+  });
+});

--- a/event-runtime/lib/celld-smoke.test.mjs
+++ b/event-runtime/lib/celld-smoke.test.mjs
@@ -1,6 +1,7 @@
 import { describe, it, beforeAll, afterAll, expect } from "bun:test";
 import { spawn } from "node:child_process";
 import { existsSync, mkdirSync, rmSync } from "node:fs";
+import { createServer } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CellClient, VersionConflictError } from "./cell-client.mjs";
@@ -10,13 +11,29 @@ const REPO_ROOT = path.resolve(__dirname, "../..");
 const CELLS_DIR = path.resolve(REPO_ROOT, "cells");
 const TMP_TEST_DIR = path.resolve(REPO_ROOT, ".factory/test-celld-smoke-" + Date.now());
 
-// Select an ephemeral port
-const TEST_PORT = 9988;
-const TEST_ENDPOINT = `http://127.0.0.1:${TEST_PORT}`;
+// `celld` is a local developer daemon; it is not provisioned in CI or in the
+// sandbox, so the whole suite is gated on the binary being present.
+const CELLD_BIN = Bun.which("celld");
 
+// Pick a free port at run time — a hardcoded port collides on shared runners.
+async function pickFreePort() {
+  return await new Promise((resolve, reject) => {
+    const srv = createServer();
+    srv.on("error", reject);
+    srv.listen(0, "127.0.0.1", () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+const TEST_TOKEN = "celld-smoke-" + Math.random().toString(36).slice(2);
+
+let TEST_PORT = 0;
+let TEST_ENDPOINT = "";
 let celldProcess = null;
 
-function startCelld(customPort = TEST_PORT, storageProjectDir = TMP_TEST_DIR) {
+function startCelld(customPort, storageProjectDir = TMP_TEST_DIR) {
   // celld dev [PROJECT] --host 127.0.0.1 --port PORT
   const proc = spawn("celld", [
     "dev",
@@ -30,6 +47,7 @@ function startCelld(customPort = TEST_PORT, storageProjectDir = TMP_TEST_DIR) {
     stdio: "pipe",
     env: {
       ...process.env,
+      CELL_AUTH_TOKEN: TEST_TOKEN,
     },
   });
 
@@ -37,6 +55,7 @@ function startCelld(customPort = TEST_PORT, storageProjectDir = TMP_TEST_DIR) {
 }
 
 async function waitForHealth(endpoint = TEST_ENDPOINT, maxAttempts = 30) {
+  endpoint = endpoint || TEST_ENDPOINT;
   for (let i = 0; i < maxAttempts; i++) {
     try {
       const res = await fetch(`${endpoint}/health`);
@@ -61,8 +80,11 @@ function stopProcess(proc) {
   }
 }
 
-describe("celld structured REST/RPC & multi-agent durability", () => {
+describe.skipIf(!CELLD_BIN)("celld structured REST/RPC & multi-agent durability", () => {
   beforeAll(async () => {
+    TEST_PORT = await pickFreePort();
+    TEST_ENDPOINT = `http://127.0.0.1:${TEST_PORT}`;
+
     if (existsSync(TMP_TEST_DIR)) {
       rmSync(TMP_TEST_DIR, { recursive: true, force: true });
     }
@@ -73,7 +95,12 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
     const wranglerContent = await Bun.file(path.join(CELLS_DIR, "wrangler.jsonc")).text();
     const srcContent = await Bun.file(path.join(CELLS_DIR, "src/index.mjs")).text();
 
-    await Bun.write(path.join(TMP_TEST_DIR, "wrangler.jsonc"), wranglerContent);
+    // Inject the shared-secret binding the worker requires (see the deployment
+    // warning in cells/src/index.mjs); the daemon reads it from wrangler vars.
+    const wranglerConfig = JSON.parse(wranglerContent);
+    wranglerConfig.vars = { ...(wranglerConfig.vars || {}), CELL_AUTH_TOKEN: TEST_TOKEN };
+
+    await Bun.write(path.join(TMP_TEST_DIR, "wrangler.jsonc"), JSON.stringify(wranglerConfig, null, 2));
     await Bun.write(path.join(TMP_TEST_DIR, "src/index.mjs"), srcContent);
 
     celldProcess = startCelld(TEST_PORT, TMP_TEST_DIR);
@@ -90,7 +117,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
   });
 
   it("proves health check and empty initial cell schema", async () => {
-    const client = new CellClient({ endpoint: TEST_ENDPOINT });
+    const client = new CellClient({ endpoint: TEST_ENDPOINT, authToken: TEST_TOKEN });
     const healthy = await client.checkHealth();
     expect(healthy).toBe(true);
 
@@ -104,6 +131,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
   it("allows Agent 1 to initialize sources and record research", async () => {
     const agent1 = new CellClient({
       endpoint: TEST_ENDPOINT,
+      authToken: TEST_TOKEN,
       cellId: "article:01J_SMOKE_TEST",
     });
 
@@ -143,6 +171,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
     // Agent 2 runs in a separate context / client instance
     const agent2 = new CellClient({
       endpoint: TEST_ENDPOINT,
+      authToken: TEST_TOKEN,
       cellId: "article:01J_SMOKE_TEST",
     });
 
@@ -183,6 +212,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
   it("enforces optimistic concurrency and rejects stale writes with VersionConflictError", async () => {
     const agent1 = new CellClient({
       endpoint: TEST_ENDPOINT,
+      authToken: TEST_TOKEN,
       cellId: "article:01J_SMOKE_TEST",
     });
 
@@ -215,6 +245,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
   it("supports read-only SQL queries via /v1/query and rejects unsafe writes", async () => {
     const client = new CellClient({
       endpoint: TEST_ENDPOINT,
+      authToken: TEST_TOKEN,
       cellId: "article:01J_SMOKE_TEST",
     });
 
@@ -237,6 +268,32 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
       }
     }
     expect(forbiddenCaught).toBe(true);
+
+    // 3. A write statement smuggled behind a read-only leading keyword is also
+    // forbidden (single-statement guard).
+    let injectionCaught = false;
+    try {
+      await client.query("SELECT 1; DROP TABLE _cell_entities;");
+    } catch (err) {
+      if (err.status === 403) {
+        injectionCaught = true;
+      }
+    }
+    expect(injectionCaught).toBe(true);
+
+    // The table is still there.
+    const stillThere = await client.query("SELECT COUNT(*) AS n FROM _cell_entities;");
+    expect(stillThere.rows[0].n).toBeGreaterThan(0);
+  });
+
+  it("rejects requests without a valid bearer token", async () => {
+    const res = await fetch(`${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`);
+    expect(res.status).toBe(401);
+
+    const badRes = await fetch(`${TEST_ENDPOINT}/cells/${encodeURIComponent("article:01J_SMOKE_TEST")}/v1/schema`, {
+      headers: { Authorization: "Bearer not-the-token" }
+    });
+    expect(badRes.status).toBe(401);
   });
 
   it("survives daemon process restart and preserves all data and migrations", async () => {
@@ -254,6 +311,7 @@ describe("celld structured REST/RPC & multi-agent durability", () => {
     // 3. Connect client and verify everything persisted
     const client = new CellClient({
       endpoint: TEST_ENDPOINT,
+      authToken: TEST_TOKEN,
       cellId: "article:01J_SMOKE_TEST",
     });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -441,9 +441,10 @@ describe("registry", () => {
     // an auditable script, records expected missing logs as a completed
     // no-artifact outcome, and only chains a diagnosis when a ci-log artifact
     // was captured.
-    // Regenerated (#2144): added celld-smoke agent definition.
+    // Regenerated (#2144): added celld-smoke agent definition (re-pinned after
+    // prettier formatting of the agent prose/schema).
     const expected =
-      "sha256:225177afffb07f8032c60ff8365866b2b7852ba1ad71e089cd7bae6dee842c96";
+      "sha256:f375360959b4b535994eed455b7e47481f32e4132f31792b8ec6a69ae4e4214e";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -441,8 +441,9 @@ describe("registry", () => {
     // an auditable script, records expected missing logs as a completed
     // no-artifact outcome, and only chains a diagnosis when a ci-log artifact
     // was captured.
+    // Regenerated (#2144): added celld-smoke agent definition.
     const expected =
-      "sha256:5e787a02b59c4816c24abde6225cb568673d85f9d1fa3a6a1706d4468ca35015";
+      "sha256:225177afffb07f8032c60ff8365866b2b7852ba1ad71e089cd7bae6dee842c96";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/celld-smoke.input.json
+++ b/event-runtime/schemas/celld-smoke.input.json
@@ -1,0 +1,26 @@
+{
+  "title": "celld-smoke input — cell coordinates and test payload",
+  "type": "object",
+  "required": ["cellId", "testKey", "testData"],
+  "additionalProperties": false,
+  "properties": {
+    "cellId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the durable cell to connect to (e.g. article:01J... or smoke:test)"
+    },
+    "endpoint": {
+      "type": "string",
+      "description": "Optional custom celld daemon endpoint (defaults to http://127.0.0.1:9876)"
+    },
+    "testKey": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Entity ID key to write and verify in the cell"
+    },
+    "testData": {
+      "type": "object",
+      "description": "Payload to persist and verify in the cell"
+    }
+  }
+}

--- a/event-runtime/schemas/celld-smoke.output.json
+++ b/event-runtime/schemas/celld-smoke.output.json
@@ -1,0 +1,31 @@
+{
+  "title": "factory.celld-smoke/v1 output artifact — cell interaction and verification result",
+  "type": "object",
+  "required": ["cellId", "cellVersion", "migrated", "entityVersion", "verified"],
+  "additionalProperties": false,
+  "properties": {
+    "cellId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the target cell"
+    },
+    "cellVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Observed monotonic cell version after operations"
+    },
+    "migrated": {
+      "type": "boolean",
+      "description": "True if schema migration succeeded or was already current"
+    },
+    "entityVersion": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Persisted entity version"
+    },
+    "verified": {
+      "type": "boolean",
+      "description": "True if post-write read-back matched input payload"
+    }
+  }
+}

--- a/event-runtime/schemas/celld-smoke.output.json
+++ b/event-runtime/schemas/celld-smoke.output.json
@@ -1,7 +1,13 @@
 {
   "title": "factory.celld-smoke/v1 output artifact — cell interaction and verification result",
   "type": "object",
-  "required": ["cellId", "cellVersion", "migrated", "entityVersion", "verified"],
+  "required": [
+    "cellId",
+    "cellVersion",
+    "migrated",
+    "entityVersion",
+    "verified"
+  ],
   "additionalProperties": false,
   "properties": {
     "cellId": {

--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -60,6 +60,7 @@ export const SANDBOX_REFUSAL_WINDOW_MS = 60 * 60 * 1000;
  */
 export const SCAN_LOOP_AGENTS = Object.freeze([
   "agy-smoke",
+  "celld-smoke",
   "ci-doctor",
   "ci-log-capture",
   "cursor-smoke",


### PR DESCRIPTION
## Summary

Implements an isolated, tested spike and smoke testbed for `celld` Durable Objects as durable storage shared across ephemeral agent workspaces.

- **Durable Object Worker (`cells/`)**: Implements `GenericCell` with SQLite storage (`ctx.storage.sql`), exposing structured REST/RPC endpoints:
  - `GET /v1/schema` & `POST /v1/schema/migrate` for versioned schema evolution.
  - `GET /v1/entities/:collection/:id` & `PUT /v1/entities/:collection/:id` with optimistic concurrency control (`expectedVersion`).
  - `POST /v1/query` for bounded read-only queries.
- **Client Library (`event-runtime/lib/cell-client.mjs`)**: ESM client supporting schema introspection, migrations, entity CRUD, version conflict handling (`VersionConflictError`), and parameterized queries.
- **Agent Definition (`event-runtime/agents/celld-smoke.*`)**: Declares cell capabilities (`capabilities.cells`), pinned prompt, input/output schemas, and result envelope.
- **Smoke Integration Test (`event-runtime/lib/celld-smoke.test.mjs`)**: Verifies multi-agent sharing, schema migrations, 409 conflict detection, and post-restart SQLite durability.

Fixes #2144