### PR TITLE
fix(inbox): bound asynchronous PR referent sweep

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -50,6 +50,7 @@ const USAGE = BASE_USAGE.replace(
 
 // Preserve the small programmatic surface used by runtime tests and tooling.
 export {
+  INBOX_RECONCILE_DEADLINE_MS,
   PRUNE_INTERVAL_MS,
   TICK_SUBSYSTEMS,
   acquireServeLock,

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -232,6 +232,7 @@ export async function tick({
   subsystems = {},
   skipPlan = false,
   proposalSweepLimit,
+  reconcile = reconcileInbox,
   onStep = () => {},
 } = {}) {
   const tickStart = Date.now();
@@ -317,9 +318,7 @@ export async function tick({
 
   // Referent state is authoritative: acknowledged or untouched items both
   // resolve automatically once the proposal/event no longer needs a human.
-  await runStep("inbox", () => {
-    reconcileInbox(db, { now });
-  });
+  await runStep("inbox", () => reconcile(db, { now }));
 
   await runStep("proposals", () => {
     const { expired, remaining } = sweepOrphanedNonRunProposals(db, {

--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -39,6 +39,13 @@ import { CLI_PATH, fail, flagValue, log } from "./shared.mjs";
 
 export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
 /**
+ * Cap on the inbox step (#2147). Reconciliation reads live GitHub and Linear
+ * state, so an unbounded await lets one slow forge stall every other tick
+ * step. Past the deadline the tick continues and the sweep finishes in the
+ * background; its result lands on the next poll.
+ */
+export const INBOX_RECONCILE_DEADLINE_MS = 10_000;
+/**
  * Shutdown budget (#1585). The supervisor (`await_daemon` in
  * bin/worktree-common.sh) SIGKILLs a serve that has not exited 3 s after
  * SIGTERM. Everything below must fit inside that window with margin, or the
@@ -233,6 +240,7 @@ export async function tick({
   skipPlan = false,
   proposalSweepLimit,
   reconcile = reconcileInbox,
+  inboxDeadlineMs = INBOX_RECONCILE_DEADLINE_MS,
   onStep = () => {},
 } = {}) {
   const tickStart = Date.now();
@@ -318,7 +326,26 @@ export async function tick({
 
   // Referent state is authoritative: acknowledged or untouched items both
   // resolve automatically once the proposal/event no longer needs a human.
-  await runStep("inbox", () => reconcile(db, { now }));
+  // Reconciliation now reads live GitHub/Linear state, so the step is capped:
+  // the tick moves on when the deadline passes and the in-flight sweep is left
+  // attributed, so a late failure logs instead of rejecting unhandled.
+  await runStep("inbox", async () => {
+    const sweep = Promise.resolve(reconcile(db, { now })).catch((err) => {
+      logLine(`tick inbox: ${err?.message ?? err}`);
+    });
+    if (!(inboxDeadlineMs > 0)) return sweep;
+    let timer;
+    const overran = new Promise((resolve) => {
+      timer = setTimeout(() => resolve("overran"), inboxDeadlineMs);
+      timer.unref?.();
+    });
+    const outcome = await Promise.race([sweep.then(() => "done"), overran]);
+    clearTimeout(timer);
+    if (outcome === "overran")
+      logLine(
+        `inbox reconcile overran ${inboxDeadlineMs}ms; continuing tick (sweep still running)`,
+      );
+  });
 
   await runStep("proposals", () => {
     const { expired, remaining } = sweepOrphanedNonRunProposals(db, {

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -814,6 +814,44 @@ export default async function start() {
     db.close();
   });
 
+  test("tick awaits asynchronous inbox reconciliation", async () => {
+    const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
+    const db = openDb(":memory:");
+    let release;
+    let entered;
+    const reconciled = new Promise((resolve) => {
+      release = resolve;
+    });
+    const enteredInbox = new Promise((resolve) => {
+      entered = resolve;
+    });
+    const subsystems = Object.fromEntries(
+      TICK_SUBSYSTEMS.filter((name) => name !== "inbox").map((name) => [
+        name,
+        () => {},
+      ]),
+    );
+    let finished = false;
+    const running = tick({
+      db,
+      now: 9000,
+      skipPlan: true,
+      subsystems,
+      reconcile: () => {
+        entered();
+        return reconciled;
+      },
+    }).then(() => {
+      finished = true;
+    });
+
+    await enteredInbox;
+    expect(finished).toBe(false);
+    release();
+    await running;
+    db.close();
+  });
+
   test("tick bounds orphaned non-run proposal sweeps and logs the remainder", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -852,6 +852,38 @@ export default async function start() {
     db.close();
   });
 
+  test("tick abandons an overrunning inbox reconcile and logs late failures", async () => {
+    const { tick, TICK_SUBSYSTEMS } = await import("../cli.mjs");
+    const db = openDb(":memory:");
+    const subsystems = Object.fromEntries(
+      TICK_SUBSYSTEMS.filter((name) => name !== "inbox").map((name) => [
+        name,
+        () => {},
+      ]),
+    );
+    let rejectSweep;
+    const sweep = new Promise((_, reject) => {
+      rejectSweep = reject;
+    });
+    const lines = [];
+    await tick({
+      db,
+      now: 9000,
+      skipPlan: true,
+      subsystems,
+      inboxDeadlineMs: 5,
+      log: (line) => lines.push(String(line)),
+      reconcile: () => sweep,
+    });
+    expect(lines.some((l) => l.includes("inbox reconcile overran"))).toBe(true);
+    // The abandoned sweep stays attributed: a late failure logs rather than
+    // surfacing as an unhandled rejection.
+    rejectSweep(new Error("late forge failure"));
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(lines.some((l) => l.includes("late forge failure"))).toBe(true);
+    db.close();
+  });
+
   test("tick bounds orphaned non-run proposal sweeps and logs the remainder", async () => {
     const { tick } = await import("../cli.mjs");
     const { loadRegistry } = await import("../lib/registry.mjs");

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -1547,10 +1547,13 @@ const RUN_PROGRESS_KINDS = new Set(["CI RED", "SMOKE RED", "CIRCUIT BREAKER"]);
 // automatically when the ticket moves on; an ESCALATED ask or any other kind
 // names something an operator still has to look at.
 const PARKED_KINDS = new Set(["BLOCKED", "human_needed"]);
-// A busy inbox must not read every distinct PR on every poll. The offset is
-// kept per database so deferred, oldest-first referents are reached next poll.
+// A busy inbox must not read every distinct PR on every poll. The cursor is
+// kept per database and holds the last `owner/repo#pr` key actually read, so
+// the next poll resumes after it in sorted key order. Keying on the referent
+// rather than a numeric offset keeps the rotation stable when the pending set
+// grows, shrinks or reorders between polls.
 const PR_FETCH_LIMIT = 8;
-const prFetchOffset = new WeakMap();
+const prFetchCursor = new WeakMap();
 
 /** An ask the operator has been handed and has not answered yet. */
 function hasPendingDecision(row) {
@@ -1582,11 +1585,23 @@ function githubRepoFor(refs) {
   }
 }
 
-async function defaultFetchPullRequest({ github, pr }) {
+/**
+ * REST reports `state` as "open"/"closed" and flags a merge only via
+ * `merged_at`; the reconciler speaks the GraphQL vocabulary. Normalise here so
+ * a merged pull request is never mistaken for a still-open one.
+ */
+export function normalizePullRequestState(pull) {
+  if (pull?.merged_at || pull?.merged === true) return "MERGED";
+  const state = typeof pull?.state === "string" ? pull.state.toUpperCase() : "";
+  if (state === "CLOSED" || state === "MERGED") return state;
+  return "OPEN";
+}
+
+export async function defaultFetchPullRequest({ github, pr, api }) {
   // makeGhApi uses ghSpawn, rather than the forge's spawnSync transport, so
   // the serve loop yields while GitHub answers this read.
-  const pull = await makeGhApi()("GET", `repos/${github}/pulls/${pr}`);
-  return { state: pull.state };
+  const pull = await (api ?? makeGhApi())("GET", `repos/${github}/pulls/${pr}`);
+  return { state: normalizePullRequestState(pull) };
 }
 
 async function fetchReferencedInboxPullRequests(rows, fetchPullRequest, db) {
@@ -1605,15 +1620,22 @@ async function fetchReferencedInboxPullRequests(rows, fetchPullRequest, db) {
       return [key, null];
     }
   };
-  const entries = [...unique.entries()];
+  const entries = [...unique.entries()].sort(([a], [b]) =>
+    a < b ? -1 : a > b ? 1 : 0,
+  );
   if (entries.length === 0) return new Map();
-  const offset = prFetchOffset.get(db) ?? 0;
-  const start = offset % entries.length;
+  const cursor = prFetchCursor.get(db);
+  // Resume after the last key actually read. A key that has since disappeared
+  // still orders the remainder correctly, and an unseen list simply starts at
+  // the beginning.
+  const resumeAt =
+    typeof cursor === "string" ? entries.findIndex(([key]) => key > cursor) : 0;
+  const start = resumeAt === -1 ? 0 : resumeAt;
   const selected = Array.from(
     { length: Math.min(PR_FETCH_LIMIT, entries.length) },
     (_, index) => entries[(start + index) % entries.length],
   );
-  prFetchOffset.set(db, (start + selected.length) % entries.length);
+  prFetchCursor.set(db, selected[selected.length - 1][0]);
   const fetched = await Promise.all(selected.map(fetchOne));
   return new Map(fetched.filter(([, pull]) => pull));
 }

--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -10,7 +10,7 @@ import { readFileSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { loadControlPlane } from "../../lib/control-plane/index.mjs";
-import { loadForge } from "../../lib/forge/index.mjs";
+import { makeGhApi } from "../../lib/control-plane/github.mjs";
 import { hashJson } from "./canonical.mjs";
 import { ApiParameterError } from "./api-params.mjs";
 import {
@@ -1547,9 +1547,10 @@ const RUN_PROGRESS_KINDS = new Set(["CI RED", "SMOKE RED", "CIRCUIT BREAKER"]);
 // automatically when the ticket moves on; an ESCALATED ask or any other kind
 // names something an operator still has to look at.
 const PARKED_KINDS = new Set(["BLOCKED", "human_needed"]);
-// Bounded fan-out for the per-tick PR referent sweep (#1069): a busy inbox
-// must not open one forge request per distinct PR all at once.
-const PR_FETCH_CONCURRENCY = 4;
+// A busy inbox must not read every distinct PR on every poll. The offset is
+// kept per database so deferred, oldest-first referents are reached next poll.
+const PR_FETCH_LIMIT = 8;
+const prFetchOffset = new WeakMap();
 
 /** An ask the operator has been handed and has not answered yet. */
 function hasPendingDecision(row) {
@@ -1581,11 +1582,14 @@ function githubRepoFor(refs) {
   }
 }
 
-function defaultFetchPullRequest({ github, pr }) {
-  return loadForge().prView(github, pr, { fields: ["state"] });
+async function defaultFetchPullRequest({ github, pr }) {
+  // makeGhApi uses ghSpawn, rather than the forge's spawnSync transport, so
+  // the serve loop yields while GitHub answers this read.
+  const pull = await makeGhApi()("GET", `repos/${github}/pulls/${pr}`);
+  return { state: pull.state };
 }
 
-async function fetchReferencedInboxPullRequests(rows, fetchPullRequest) {
+async function fetchReferencedInboxPullRequests(rows, fetchPullRequest, db) {
   const unique = new Map();
   for (const { refs } of rows) {
     const pr = prNumber(refs.pr);
@@ -1601,17 +1605,16 @@ async function fetchReferencedInboxPullRequests(rows, fetchPullRequest) {
       return [key, null];
     }
   };
-  // Chunked loop: at most PR_FETCH_CONCURRENCY forge reads in flight at once,
-  // so a wide inbox cannot burst a request per distinct PR every tick.
   const entries = [...unique.entries()];
-  const fetched = [];
-  for (let i = 0; i < entries.length; i += PR_FETCH_CONCURRENCY) {
-    fetched.push(
-      ...(await Promise.all(
-        entries.slice(i, i + PR_FETCH_CONCURRENCY).map(fetchOne),
-      )),
-    );
-  }
+  if (entries.length === 0) return new Map();
+  const offset = prFetchOffset.get(db) ?? 0;
+  const start = offset % entries.length;
+  const selected = Array.from(
+    { length: Math.min(PR_FETCH_LIMIT, entries.length) },
+    (_, index) => entries[(start + index) % entries.length],
+  );
+  prFetchOffset.set(db, (start + selected.length) % entries.length);
+  const fetched = await Promise.all(selected.map(fetchOne));
   return new Map(fetched.filter(([, pull]) => pull));
 }
 
@@ -1966,7 +1969,7 @@ export function reconcileInbox(
       ? fetchReferencedInboxIssues(linearRows, linearIssues, controlPlane)
       : [],
     prRows.length
-      ? fetchReferencedInboxPullRequests(prRows, fetchPullRequest)
+      ? fetchReferencedInboxPullRequests(prRows, fetchPullRequest, db)
       : new Map(),
   ])
     .then(([issues, pulls]) => {

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -1564,6 +1564,38 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
+  test("bounds PR referent reads and rotates deferred oldest rows to the next poll", async () => {
+    const db = openDb(":memory:");
+    for (let pr = 1; pr <= 10; pr += 1) {
+      createInboxItem(
+        db,
+        {
+          kind: "BLOCKED",
+          title: `PR ${pr}`,
+          refs: { repo: "factory", pr: String(pr) },
+        },
+        { id: `pr-${pr}`, now: pr * 1000 },
+      );
+    }
+    const fetched = [];
+    const fetchPullRequest = async ({ pr }) => {
+      fetched.push(pr);
+      return { state: pr > 8 ? "MERGED" : "OPEN" };
+    };
+
+    await reconcileInbox(db, { now: 60_000, fetchPullRequest });
+    expect(fetched).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+
+    await expect(
+      reconcileInbox(db, { now: 120_000, fetchPullRequest }),
+    ).resolves.toEqual([
+      { id: "pr-9", resolvedBy: "auto:pr_merged" },
+      { id: "pr-10", resolvedBy: "auto:pr_merged" },
+    ]);
+    expect(fetched).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6]);
+    db.close();
+  });
+
   test("supersedes an older parked item when a newer run owns its ticket", () => {
     const db = openDb(":memory:");
     createInboxItem(

--- a/event-runtime/lib/inbox.test.mjs
+++ b/event-runtime/lib/inbox.test.mjs
@@ -17,6 +17,8 @@ import {
   markInboxDelivered,
   MAX_PARKED_INBOX_AGE_MS,
   reconcileInbox,
+  normalizePullRequestState,
+  defaultFetchPullRequest,
   retryInboxDecision,
   resolveInboxItem,
   fetchLinearInboxIssues,
@@ -1564,9 +1566,89 @@ describe("human inbox ledger (WM-285)", () => {
     ]);
   });
 
-  test("bounds PR referent reads and rotates deferred oldest rows to the next poll", async () => {
+  test("normalizes the REST pull request shape into referent states", async () => {
+    expect(
+      normalizePullRequestState({ state: "closed", merged_at: null }),
+    ).toBe("CLOSED");
+    expect(
+      normalizePullRequestState({
+        state: "closed",
+        merged_at: "2026-09-01T00:00:00Z",
+      }),
+    ).toBe("MERGED");
+    expect(normalizePullRequestState({ state: "open", merged_at: null })).toBe(
+      "OPEN",
+    );
+
+    // The default fetcher is what serve actually installs: drive it with the
+    // real REST payload shape rather than a hand-written {state:"MERGED"} stub.
+    const rest = {
+      "repos/watt-mind/factory/pulls/17": {
+        state: "closed",
+        merged_at: "2026-09-01T00:00:00Z",
+      },
+      "repos/watt-mind/factory/pulls/18": { state: "closed", merged_at: null },
+      "repos/watt-mind/factory/pulls/19": { state: "open", merged_at: null },
+    };
+    const api = async (method, route) => {
+      expect(method).toBe("GET");
+      return rest[route];
+    };
+    await expect(
+      defaultFetchPullRequest({ github: "watt-mind/factory", pr: 17, api }),
+    ).resolves.toEqual({ state: "MERGED" });
+    await expect(
+      defaultFetchPullRequest({ github: "watt-mind/factory", pr: 19, api }),
+    ).resolves.toEqual({ state: "OPEN" });
+
     const db = openDb(":memory:");
-    for (let pr = 1; pr <= 10; pr += 1) {
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "merged",
+        refs: { repo: "factory", pr: "PR#17" },
+      },
+      { id: "rest-merged", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "ESCALATED",
+        title: "closed",
+        refs: { repo: "factory", pr: "PR#18" },
+      },
+      { id: "rest-closed", now: 1000 },
+    );
+    createInboxItem(
+      db,
+      {
+        kind: "BLOCKED",
+        title: "open",
+        refs: { repo: "factory", pr: "PR#19" },
+      },
+      { id: "rest-open", now: 1000 },
+    );
+
+    await expect(
+      reconcileInbox(db, {
+        now: 60_000,
+        fetchPullRequest: (request) =>
+          defaultFetchPullRequest({ ...request, api }),
+      }),
+    ).resolves.toEqual([
+      { id: "rest-merged", resolvedBy: "auto:pr_merged" },
+      { id: "rest-closed", resolvedBy: "auto:pr_closed" },
+    ]);
+    expect(listInboxItems(db, { status: "open" }).map((i) => i.id)).toEqual([
+      "rest-open",
+    ]);
+    db.close();
+  });
+
+  test("bounds PR referent reads and resumes after the last key read", async () => {
+    const db = openDb(":memory:");
+    for (let pr = 101; pr <= 110; pr += 1) {
       createInboxItem(
         db,
         {
@@ -1580,19 +1662,54 @@ describe("human inbox ledger (WM-285)", () => {
     const fetched = [];
     const fetchPullRequest = async ({ pr }) => {
       fetched.push(pr);
-      return { state: pr > 8 ? "MERGED" : "OPEN" };
+      return { state: pr > 108 ? "MERGED" : "OPEN" };
     };
 
     await reconcileInbox(db, { now: 60_000, fetchPullRequest });
-    expect(fetched).toEqual([1, 2, 3, 4, 5, 6, 7, 8]);
+    expect(fetched).toEqual([101, 102, 103, 104, 105, 106, 107, 108]);
 
     await expect(
       reconcileInbox(db, { now: 120_000, fetchPullRequest }),
     ).resolves.toEqual([
-      { id: "pr-9", resolvedBy: "auto:pr_merged" },
-      { id: "pr-10", resolvedBy: "auto:pr_merged" },
+      { id: "pr-109", resolvedBy: "auto:pr_merged" },
+      { id: "pr-110", resolvedBy: "auto:pr_merged" },
     ]);
-    expect(fetched).toEqual([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 6]);
+    // Resumed after watt-mind/factory#108 and wrapped, rather than replaying a
+    // numeric offset into a list that has since changed length.
+    expect(fetched.slice(8)).toEqual([109, 110, 101, 102, 103, 104, 105, 106]);
+    db.close();
+  });
+
+  test("keeps the PR rotation cursor stable when the pending set shrinks", async () => {
+    const db = openDb(":memory:");
+    for (let pr = 101; pr <= 112; pr += 1) {
+      createInboxItem(
+        db,
+        {
+          kind: "BLOCKED",
+          title: `PR ${pr}`,
+          refs: { repo: "factory", pr: String(pr) },
+        },
+        { id: `pr-${pr}`, now: pr * 1000 },
+      );
+    }
+    const fetched = [];
+    const fetchPullRequest = async ({ pr }) => {
+      fetched.push(pr);
+      return { state: "OPEN" };
+    };
+
+    await reconcileInbox(db, { now: 60_000, fetchPullRequest });
+    expect(fetched).toEqual([101, 102, 103, 104, 105, 106, 107, 108]);
+
+    // Two already-read referents vanish before the next poll. A numeric offset
+    // would skip past unread rows; the key cursor still resumes at #109.
+    resolveInboxItem(db, "pr-101", { now: 90_000, resolvedBy: "operator" });
+    resolveInboxItem(db, "pr-102", { now: 90_000, resolvedBy: "operator" });
+
+    fetched.length = 0;
+    await reconcileInbox(db, { now: 120_000, fetchPullRequest });
+    expect(fetched).toEqual([109, 110, 111, 112, 103, 104, 105, 106]);
     db.close();
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2147

Review the bounded asynchronous PR sweep and inbox-step timing.

## Validation
| Check                | Command                                                                                                   | Result  | Notes                                  |
| -------------------- | --------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib/inbox.test.mjs event-runtime/cli/serve.test.mjs`                             | pass    | 82 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2396 pass, 10 skipped; lint clean      |
| UX critique          | factory-ux-critic                                                                                         | not run | no user-facing surface                 |

UX critique: skipped — no user-facing surface

run:run_b61c9033-703c-4063-a26d-68286152410e