### PR TITLE
fix(serve): report deadline-truncated chain skips

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -314,7 +314,7 @@ export async function tick({
       logLine(`chain approval error: ${e.proposalId}:${e.reason}`);
     if (auto.skipped > 0 || expiredScheduledProposals > 0) {
       logLine(
-        `proposal staleness: skipped ${auto.skipped} pending chain row(s) (${auto.memoised ?? 0} memoised registry-stale); expired ${expiredScheduledProposals} unreplannable scheduler row(s)`,
+        `proposal staleness: skipped ${auto.skipped} pending chain row(s) (${auto.memoised ?? 0} memoised registry-stale; ${auto.deadlineSkipped ?? 0} deadline-truncated); expired ${expiredScheduledProposals} unreplannable scheduler row(s)`,
       );
     }
   });

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -759,7 +759,7 @@ export default async function start() {
 
     expect(logs).toEqual(
       expect.arrayContaining([
-        "proposal staleness: skipped 0 pending chain row(s) (0 memoised registry-stale); expired 1 unreplannable scheduler row(s)",
+        "proposal staleness: skipped 0 pending chain row(s) (0 memoised registry-stale; 0 deadline-truncated); expired 1 unreplannable scheduler row(s)",
       ]),
     );
     db.close();


### PR DESCRIPTION
Fixes watt-mind/factory#2150

Operators can distinguish deadline-truncated chain approval backlog from other staleness skips.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli/serve.test.mjs` | pass | 25 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, lint passed |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface
run:run_5d150a2b-9639-4788-a812-150ace67efba
