### PR TITLE
fix(serve): publish deadline skipped tick stats

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -242,10 +242,12 @@ export async function tick({
   reconcile = reconcileInbox,
   inboxDeadlineMs = INBOX_RECONCILE_DEADLINE_MS,
   onStep = () => {},
+  autoApproveChainsFn = autoApproveChains,
 } = {}) {
   const tickStart = Date.now();
   const stepMs = {};
   let expiredScheduledProposals = 0;
+  let deadlineSkipped = 0;
   const runStep = async (name, fn) => {
     const start = Date.now();
     onStep({ name, startedAt: start });
@@ -300,12 +302,13 @@ export async function tick({
     // `wrapLinearReads` (ticket/viewer/in-flight plus the rate-limit latch) and
     // by `withPassInFlightCache` for the pass (#1064), each read bounded well
     // under the tracker's own 15s request timeout.
-    const auto = await autoApproveChains(db, registry, {
+    const auto = await autoApproveChainsFn(db, registry, {
       now,
       policyVersion: pv,
       dispatchEligibility: worktreeDispatchAutoEligibilityAsync,
       dispatch: createAutoApprovalDispatch(),
     });
+    deadlineSkipped = auto.deadlineSkipped ?? 0;
     for (const a of auto.approved)
       logLine(
         `chain proposal approved ${a.proposalId} → run ${a.runId} (actor: chain auto)`,
@@ -448,6 +451,7 @@ export async function tick({
     lastPrune: nextPrune,
     durationMs: Date.now() - tickStart,
     stepMs,
+    deadlineSkipped,
   };
 }
 
@@ -673,6 +677,7 @@ export default async function serve(args) {
   let lastPrune = Date.now();
   let busy = false;
   let tickOverruns = 0;
+  let lastDeadlineSkipped = 0;
   let lastTickMs = 0;
   let lastOverrunAt = null;
   let lastTickAt = null;
@@ -696,6 +701,7 @@ export default async function serve(args) {
       // watchdog and the web dashboard read them) — keep exactly one spelling.
       lastMs: lastTickMs,
       overruns: tickOverruns,
+      deadlineSkipped: lastDeadlineSkipped,
       lastTickAt,
       currentStep: currentTickStep,
       // How long the in-progress tick has been running. Non-zero here with a
@@ -720,6 +726,7 @@ export default async function serve(args) {
     busy = true;
     const start = Date.now();
     tickStartedAt = start;
+    lastDeadlineSkipped = 0;
     try {
       registryRef.poll();
       const result = await tick({
@@ -740,6 +747,7 @@ export default async function serve(args) {
         },
       });
       lastPrune = result.lastPrune;
+      lastDeadlineSkipped = result.deadlineSkipped;
       const duration = Date.now() - start;
       lastTickMs = duration;
       lastTickAt = new Date().toISOString();

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -308,6 +308,7 @@ describe("serve command", () => {
       await new Promise((resolve) => child.once("exit", resolve));
     }
     expect(health.ok).toBe(true);
+    expect(health.tick.deadlineSkipped).toBe(0);
   });
 
   test("a stalled Linear ticket read cannot wedge /health past the tick budget (#1835 AC3)", async () => {

--- a/event-runtime/lib/api-intake.mjs
+++ b/event-runtime/lib/api-intake.mjs
@@ -431,6 +431,7 @@ export async function handleIntakeApiRoute({
       tick: {
         lastMs: tickStats?.lastMs ?? 0,
         overruns: tickStats?.overruns ?? 0,
+        deadlineSkipped: tickStats?.deadlineSkipped ?? 0,
       },
       planner: tickStats?.planner ?? null,
     });

--- a/event-runtime/lib/tick-guard.test.mjs
+++ b/event-runtime/lib/tick-guard.test.mjs
@@ -29,15 +29,22 @@ test("tick measures durationMs and per-step timings stepMs (WM-1208)", async () 
         await Bun.sleep(10);
       },
     },
+    autoApproveChainsFn: async () => ({
+      approved: [],
+      errors: [],
+      skipped: 2,
+      deadlineSkipped: 2,
+    }),
   });
 
   expect(result.durationMs).toBeGreaterThanOrEqual(9);
   expect(result.stepMs).toBeDefined();
   expect(result.stepMs["tick emit"]).toBeGreaterThanOrEqual(9);
   expect(result.stepMs["plan"]).toBe(0);
+  expect(result.deadlineSkipped).toBe(2);
 });
 
-test("GET /health exposes tick stats with lastMs and overruns (WM-1208)", async () => {
+test("GET /health exposes tick stats including deadline-truncated approvals", async () => {
   const dbFile = path.join(
     tmpdir(),
     `health-tick-${Date.now()}-${Math.random().toString(36).slice(2)}.db`,
@@ -48,6 +55,7 @@ test("GET /health exposes tick stats with lastMs and overruns (WM-1208)", async 
   let tickStats = {
     lastMs: 42,
     overruns: 2,
+    deadlineSkipped: 2,
   };
 
   const probe = Bun.serve({
@@ -76,15 +84,17 @@ test("GET /health exposes tick stats with lastMs and overruns (WM-1208)", async 
     expect(body.tick).toEqual({
       lastMs: 42,
       overruns: 2,
+      deadlineSkipped: 2,
     });
 
     // Update stats and verify live reflection
-    tickStats = { lastMs: 1500, overruns: 3 };
+    tickStats = { lastMs: 1500, overruns: 3, deadlineSkipped: 0 };
     const res2 = await fetch(`http://127.0.0.1:${port}/health`);
     const body2 = await res2.json();
     expect(body2.tick).toEqual({
       lastMs: 1500,
       overruns: 3,
+      deadlineSkipped: 0,
     });
   } finally {
     await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
Fixes watt-mind/factory#2155

Expose deadline-truncated chain auto-approval counts through runtime health stats.

## Validation

| Check                | Command                                                                                     | Result  | Notes                            |
| -------------------- | ------------------------------------------------------------------------------------------- | ------- | -------------------------------- |
| Verification Command | `bun test event-runtime/cli/serve.test.mjs event-runtime/lib/api-intake.test.mjs`          | pass    | 69 tests, 0 failures             |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | unit, emit, format, lint clean   |
| UX critique          | factory-ux-critic                                                                           | not run | backend /health observability only |

UX critique: skipped — backend /health observability only

run:run_0137b49b-7cb7-403d-bc6b-08890b2a7a0f
