### PR TITLE
fix(janitor): discover GitHub ticket worktrees

### DIFF
--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -212,6 +212,42 @@ function emptySurvey(repo, apply) {
   };
 }
 
+/** A github-plane worktree directory, and nothing else. */
+const GH_SLUG = /^gh-\d+$/;
+/** A tracker-key worktree for a linear-plane repo with no team configured. */
+const LINEAR_SLUG = /^[A-Z]+-\d+$/;
+
+/** Tracker reads issued at once; bounds control-plane fan-out. */
+export const TICKET_QUERY_CONCURRENCY = 5;
+
+/**
+ * Resolve every ticket through the control plane a few at a time.
+ *
+ * `Promise.all` over the whole list turned a checkout with hundreds of
+ * worktrees into a burst of hundreds of concurrent GraphQL reads, which is a
+ * quota storm rather than a survey. Each read settles independently: a ticket
+ * that fails to resolve is simply absent from the result, which puts it in
+ * `unknown` and therefore out of reach of --apply.
+ */
+export async function getTicketsBounded(
+  identifiers,
+  controlPlane,
+  concurrency = TICKET_QUERY_CONCURRENCY,
+) {
+  const width = Math.max(1, concurrency | 0);
+  const nodes = [];
+  for (let start = 0; start < identifiers.length; start += width) {
+    const settled = await Promise.allSettled(
+      identifiers
+        .slice(start, start + width)
+        .map((identifier) => controlPlane.getTicket(identifier)),
+    );
+    for (const r of settled)
+      if (r.status === "fulfilled" && r.value) nodes.push(r.value);
+  }
+  return nodes;
+}
+
 export async function survey(
   repo,
   { apply },
@@ -237,38 +273,58 @@ export async function survey(
   // GitHub tickets are gh-<number>, while Linear tickets retain ABC-<number>.
   // Named worktrees (a release branch, a scratch checkout) are somebody's
   // deliberate workspace and are not this tool's business.
+  //
+  // The match must be exact for the repo's own plane. `isSluggableTicket` is
+  // deliberately permissive — it slugs `PR-516` and `WM-87` just as happily as
+  // `gh-2160` — so trusting it here would send a github-plane repo off to look
+  // up issues #516 and #87, find them long closed, and offer somebody's
+  // deliberate `PR-516` checkout up for deletion. A directory only counts as a
+  // ticket when its shape is the one this plane actually names worktrees with;
+  // everything else is `named` and is never reclaimed.
   const all = readdir(root);
-  const tickets = all.filter(isSluggableTicket);
-  result.named = all.filter((d) => !isSluggableTicket(d) && !d.startsWith("."));
+  const visible = all.filter((d) => !d.startsWith("."));
+  const sluggable = visible.filter(isSluggableTicket);
+
+  const controlPlane =
+    sluggable.length && !queryIssues
+      ? resolveControlPlane({ repoName: repo.name })
+      : null;
+  const planeKind = controlPlane?.kind ?? repo.control_plane;
+  // A linear-plane repo keeps its own team's keys and must never accept a
+  // gh-<n> directory, exactly as a github-plane repo accepts nothing else.
+  const ticketPattern =
+    planeKind === "github"
+      ? GH_SLUG
+      : repo.team
+        ? new RegExp(`^${repo.team}-\\d+$`)
+        : LINEAR_SLUG;
+  const tickets = sluggable.filter((d) => ticketPattern.test(d));
+  const ticketSet = new Set(tickets);
+  result.named = visible.filter((d) => !ticketSet.has(d));
 
   let states = {};
   if (tickets.length) {
-    const controlPlane = queryIssues
-      ? null
-      : resolveControlPlane({ repoName: repo.name });
-    const planeKind = controlPlane?.kind ?? repo.control_plane;
     const identifiers = tickets.map((slug) =>
       planeKind === "github"
         ? `${repo.github}#${slug.slice("gh-".length)}`
         : slug,
     );
     const queryBatch =
-      queryIssues ??
-      (async (batch) =>
-        Promise.all(
-          batch.map((identifier) => controlPlane.getTicket(identifier)),
-        ));
+      queryIssues ?? ((batch) => getTicketsBounded(batch, controlPlane));
 
-    // Keep bounded batches and run independent reads together so a large
-    // checkout is resolved without a serial API crawl.
-    const batches = [];
-    for (let i = 0; i < identifiers.length; i += 250)
-      batches.push(identifiers.slice(i, i + 250));
-    const nodes = (
-      await Promise.all(batches.map((batch) => queryBatch(batch)))
-    ).flat();
+    // One tracker read per worktree, run a few at a time: a large checkout is
+    // resolved without a serial crawl and without opening hundreds of
+    // simultaneous API requests. A ticket that cannot be resolved settles on
+    // its own and lands in `unknown` (never reclaimable) rather than sinking
+    // the whole survey.
+    const nodes =
+      (await Promise.resolve()
+        .then(() => queryBatch(identifiers))
+        .catch(() => [])) ?? [];
     states = Object.fromEntries(
-      nodes.map((n) => [ticketSlug(n.identifier), n.state]),
+      nodes
+        .filter((n) => n?.identifier && n.state)
+        .map((n) => [ticketSlug(n.identifier), n.state]),
     );
   }
 

--- a/orchestrator/janitor.mjs
+++ b/orchestrator/janitor.mjs
@@ -48,6 +48,7 @@ import { loadConfigYaml, ROOT } from "../lib/schedule.mjs";
 import { loadControlPlane } from "../lib/control-plane/index.mjs";
 import { emitFactoryEvent } from "../lib/emit-event.mjs";
 import { githubForge, loadForge } from "../lib/forge/index.mjs";
+import { isSluggableTicket, ticketSlug } from "../lib/ticket-slug.mjs";
 
 export function parseArgs(argv) {
   const val = (f) => {
@@ -218,6 +219,7 @@ export async function survey(
     readdir = readdirSync,
     exists = existsSync,
     queryIssues,
+    resolveControlPlane = loadControlPlane,
     getBranches = ticketBranches,
     getOpenPrs = listOpenPrs,
     doReclaim = reclaim,
@@ -231,36 +233,43 @@ export async function survey(
     return result;
   }
 
-  // Only ever consider <TEAM>-<number> directories. Named worktrees (a release
-  // branch, a scratch checkout) are somebody's deliberate workspace and are not
-  // this tool's business.
-  const pattern = new RegExp(`^${repo.team}-\\d+$`);
+  // Ticket worktrees are named by ticketSlug(), not by their tracker team.
+  // GitHub tickets are gh-<number>, while Linear tickets retain ABC-<number>.
+  // Named worktrees (a release branch, a scratch checkout) are somebody's
+  // deliberate workspace and are not this tool's business.
   const all = readdir(root);
-  const tickets = all.filter((d) => pattern.test(d));
-  result.named = all.filter((d) => !pattern.test(d) && !d.startsWith("."));
+  const tickets = all.filter(isSluggableTicket);
+  result.named = all.filter((d) => !isSluggableTicket(d) && !d.startsWith("."));
 
   let states = {};
   if (tickets.length) {
-    const nums = tickets.map((t) => Number(t.split("-")[1]));
+    const controlPlane = queryIssues
+      ? null
+      : resolveControlPlane({ repoName: repo.name });
+    const planeKind = controlPlane?.kind ?? repo.control_plane;
+    const identifiers = tickets.map((slug) =>
+      planeKind === "github"
+        ? `${repo.github}#${slug.slice("gh-".length)}`
+        : slug,
+    );
     const queryBatch =
       queryIssues ??
-      (async (team, batch) => {
-        const q = `query($n:[Float!]){ issues(first:250, filter:{ number:{in:$n}, team:{key:{eq:"${team}"}} }){ nodes{ identifier state{name type} } } }`;
-        return (
-          (await loadControlPlane().raw(q, { n: batch }))?.issues?.nodes ?? []
-        );
-      });
+      (async (batch) =>
+        Promise.all(
+          batch.map((identifier) => controlPlane.getTicket(identifier)),
+        ));
 
-    // Linear caps this connection at 250 nodes. Keep each filter at or below
-    // that cap and run the independent requests together so every worktree is
-    // resolved without turning a large checkout into a serial API crawl.
+    // Keep bounded batches and run independent reads together so a large
+    // checkout is resolved without a serial API crawl.
     const batches = [];
-    for (let i = 0; i < nums.length; i += 250)
-      batches.push(nums.slice(i, i + 250));
+    for (let i = 0; i < identifiers.length; i += 250)
+      batches.push(identifiers.slice(i, i + 250));
     const nodes = (
-      await Promise.all(batches.map((batch) => queryBatch(repo.team, batch)))
+      await Promise.all(batches.map((batch) => queryBatch(batch)))
     ).flat();
-    states = Object.fromEntries(nodes.map((n) => [n.identifier, n.state]));
+    states = Object.fromEntries(
+      nodes.map((n) => [ticketSlug(n.identifier), n.state]),
+    );
   }
 
   const allFinished = tickets.filter((t) =>

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -320,51 +320,74 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
     getOpenPrs: () => [{ number: 261, headRefName: "feat/CLNT-520" }],
   };
 
-  test("batches more than 250 ticket numbers and categorizes every worktree", async () => {
+  test("resolves hundreds of worktrees with a bounded tracker fan-out", async () => {
     const worktrees = Array.from({ length: 501 }, (_, i) => `CLNT-${i + 1}`);
-    const calls = [];
+    const asked = [];
     let active = 0;
     let maxActive = 0;
-    const queryIssues = async (identifiers) => {
-      calls.push(identifiers);
-      active += 1;
-      maxActive = Math.max(maxActive, active);
-      await Promise.resolve();
-      active -= 1;
-      // Match Linear's `issues(first: 250)` response limit. Passing all numbers
-      // in one request silently omits every worktree after the first 250.
-      return identifiers.slice(0, 250).map((identifier) => {
-        const number = Number(identifier.split("-")[1]);
-        return {
-          identifier,
-          state:
-            number % 2 === 0
-              ? { name: "Done", type: "completed" }
-              : { name: "In Progress", type: "started" },
-        };
-      });
-    };
-
     const res = await survey(
       repo,
       { apply: false },
       {
         readdir: () => worktrees,
         exists: () => true,
-        queryIssues,
+        resolveControlPlane: () => ({
+          kind: "linear",
+          getTicket: async (identifier) => {
+            asked.push(identifier);
+            active += 1;
+            maxActive = Math.max(maxActive, active);
+            await Promise.resolve();
+            active -= 1;
+            const number = Number(identifier.split("-")[1]);
+            return {
+              identifier,
+              state:
+                number % 2 === 0
+                  ? { name: "Done", type: "completed" }
+                  : { name: "In Progress", type: "started" },
+            };
+          },
+        }),
         getBranches: () => ({}),
         getOpenPrs: () => [],
       },
     );
 
-    expect(calls.map((identifiers) => identifiers.length)).toEqual([
-      250, 250, 1,
-    ]);
-    expect(maxActive).toBe(3);
+    expect(asked).toHaveLength(501);
+    // Every worktree is resolved, but never as one 501-wide request burst.
+    expect(maxActive).toBeLessThanOrEqual(5);
+    expect(maxActive).toBeGreaterThan(1);
     expect(res.unknown).toEqual([]);
     expect(res.reclaimable).toHaveLength(250);
     expect(res.kept).toHaveLength(251);
     expect(res.kept.at(-1)).toEqual({ id: "CLNT-501", state: "In Progress" });
+  });
+
+  test("one unresolvable ticket lands in unknown without sinking the survey", async () => {
+    const res = await survey(
+      repo,
+      { apply: false },
+      {
+        readdir: () => ["CLNT-520", "CLNT-600"],
+        exists: () => true,
+        resolveControlPlane: () => ({
+          kind: "linear",
+          getTicket: async (identifier) => {
+            if (identifier === "CLNT-600") throw new Error("tracker 502");
+            return {
+              identifier,
+              state: { name: "Done", type: "completed" },
+            };
+          },
+        }),
+        getBranches: () => ({ "CLNT-520": "feat/CLNT-520" }),
+        getOpenPrs: () => [],
+      },
+    );
+
+    expect(res.unknown).toEqual(["CLNT-600"]);
+    expect(res.reclaimable).toEqual([{ id: "CLNT-520", state: "Done" }]);
   });
 
   test("uses the repository's GitHub control plane for gh worktrees", async () => {
@@ -410,6 +433,77 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
     expect(res.named).toEqual(["release-scratch"]);
     expect(res.reclaimable).toEqual([{ id: "gh-2160", state: "Done" }]);
     expect(res.removed).toEqual(["gh-2160"]);
+  });
+
+  test("a github-plane repo never treats a tracker-key worktree as a ticket", async () => {
+    // `PR-516` and `WM-87` are deliberate human checkouts. They slug cleanly,
+    // so a loose match would look up issues #516 and #87 in this repo, find
+    // them closed years ago, and offer both directories up for deletion.
+    const githubRepo = {
+      ...repo,
+      name: "factory",
+      control_plane: "github",
+      github: "watt-mind/factory",
+    };
+    const ticketCalls = [];
+    const res = await survey(
+      githubRepo,
+      { apply: true },
+      {
+        readdir: () => ["gh-2160", "PR-516", "WM-87", "release-scratch"],
+        exists: () => true,
+        resolveControlPlane: () => ({
+          kind: "github",
+          getTicket: async (identifier) => {
+            ticketCalls.push(identifier);
+            return { identifier, state: { name: "Done", type: "completed" } };
+          },
+        }),
+        getBranches: () => ({ "gh-2160": "fix/gh-2160" }),
+        getOpenPrs: () => [],
+        doReclaim: (finished) => ({
+          removed: finished,
+          refused: [],
+          held: [],
+        }),
+      },
+    );
+
+    expect(ticketCalls).toEqual(["watt-mind/factory#2160"]);
+    expect(res.named).toEqual(["PR-516", "WM-87", "release-scratch"]);
+    expect(res.reclaimable).toEqual([{ id: "gh-2160", state: "Done" }]);
+    expect(res.removed).toEqual(["gh-2160"]);
+    for (const dir of ["PR-516", "WM-87"]) {
+      expect(res.reclaimable.map((r) => r.id)).not.toContain(dir);
+      expect(res.removed).not.toContain(dir);
+      expect(res.unknown).not.toContain(dir);
+      expect(res.kept.map((k) => k.id)).not.toContain(dir);
+    }
+  });
+
+  test("a linear-plane repo never treats a gh-<n> worktree as a ticket", async () => {
+    const ticketCalls = [];
+    const res = await survey(
+      repo,
+      { apply: false },
+      {
+        readdir: () => ["CLNT-520", "gh-2160"],
+        exists: () => true,
+        resolveControlPlane: () => ({
+          kind: "linear",
+          getTicket: async (identifier) => {
+            ticketCalls.push(identifier);
+            return { identifier, state: { name: "Done", type: "completed" } };
+          },
+        }),
+        getBranches: () => ({ "CLNT-520": "feat/CLNT-520" }),
+        getOpenPrs: () => [],
+      },
+    );
+
+    expect(ticketCalls).toEqual(["CLNT-520"]);
+    expect(res.named).toEqual(["gh-2160"]);
+    expect(res.reclaimable).toEqual([{ id: "CLNT-520", state: "Done" }]);
   });
 
   test("an open-PR hold populates the held array and is excluded from reclaimable (dry run)", () => {

--- a/orchestrator/janitor.test.mjs
+++ b/orchestrator/janitor.test.mjs
@@ -325,21 +325,24 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
     const calls = [];
     let active = 0;
     let maxActive = 0;
-    const queryIssues = async (_team, nums) => {
-      calls.push(nums);
+    const queryIssues = async (identifiers) => {
+      calls.push(identifiers);
       active += 1;
       maxActive = Math.max(maxActive, active);
       await Promise.resolve();
       active -= 1;
       // Match Linear's `issues(first: 250)` response limit. Passing all numbers
       // in one request silently omits every worktree after the first 250.
-      return nums.slice(0, 250).map((number) => ({
-        identifier: `CLNT-${number}`,
-        state:
-          number % 2 === 0
-            ? { name: "Done", type: "completed" }
-            : { name: "In Progress", type: "started" },
-      }));
+      return identifiers.slice(0, 250).map((identifier) => {
+        const number = Number(identifier.split("-")[1]);
+        return {
+          identifier,
+          state:
+            number % 2 === 0
+              ? { name: "Done", type: "completed" }
+              : { name: "In Progress", type: "started" },
+        };
+      });
     };
 
     const res = await survey(
@@ -354,12 +357,59 @@ describe("survey (WM-55: hold wiring and cannot-tell exclusion)", () => {
       },
     );
 
-    expect(calls.map((nums) => nums.length)).toEqual([250, 250, 1]);
+    expect(calls.map((identifiers) => identifiers.length)).toEqual([
+      250, 250, 1,
+    ]);
     expect(maxActive).toBe(3);
     expect(res.unknown).toEqual([]);
     expect(res.reclaimable).toHaveLength(250);
     expect(res.kept).toHaveLength(251);
     expect(res.kept.at(-1)).toEqual({ id: "CLNT-501", state: "In Progress" });
+  });
+
+  test("uses the repository's GitHub control plane for gh worktrees", async () => {
+    const githubRepo = {
+      ...repo,
+      name: "factory",
+      control_plane: "github",
+      github: "watt-mind/factory",
+    };
+    const controlPlaneCalls = [];
+    const ticketCalls = [];
+    const res = await survey(
+      githubRepo,
+      { apply: true },
+      {
+        readdir: () => ["gh-2160", "release-scratch"],
+        exists: () => true,
+        resolveControlPlane: (opts) => {
+          controlPlaneCalls.push(opts);
+          return {
+            kind: "github",
+            getTicket: async (identifier) => {
+              ticketCalls.push(identifier);
+              return {
+                identifier,
+                state: { name: "Done", type: "completed" },
+              };
+            },
+          };
+        },
+        getBranches: () => ({ "gh-2160": "fix/gh-2160" }),
+        getOpenPrs: () => [],
+        doReclaim: (finished) => ({
+          removed: finished,
+          refused: [],
+          held: [],
+        }),
+      },
+    );
+
+    expect(controlPlaneCalls).toEqual([{ repoName: "factory" }]);
+    expect(ticketCalls).toEqual(["watt-mind/factory#2160"]);
+    expect(res.named).toEqual(["release-scratch"]);
+    expect(res.reclaimable).toEqual([{ id: "gh-2160", state: "Done" }]);
+    expect(res.removed).toEqual(["gh-2160"]);
   });
 
   test("an open-PR hold populates the held array and is excluded from reclaimable (dry run)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2160

Janitor now discovers and reclaims closed GitHub ticket worktrees.

## Validation

| Check                | Command                                                                                              | Result  | Notes                         |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ----------------------------- |
| Verification Command | `bun test orchestrator/janitor.test.mjs`                                                            | pass    | 26 tests, 0 failures          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 616 existing warnings  |
| UX critique          | factory-ux-critic                                                                                    | not run | no user-facing surface        |

UX critique: skipped — no user-facing surface

run:run_03e0fef3-4906-4345-b9d5-ccf64140ef23
