### PR TITLE
perf(api): stabilize ticket index cache key

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1140,9 +1140,27 @@ function collectTicketIds(value, targetSet = new Set()) {
 
 const TICKET_INDEX_CACHE_TTL_MS = 5000;
 const ticketIndexCache = new Map();
+let ticketIndexCacheDatabaseIds = new WeakMap();
+let nextTicketIndexCacheDatabaseId = 0;
 
 export function clearTicketIndexCache() {
   ticketIndexCache.clear();
+  ticketIndexCacheDatabaseIds = new WeakMap();
+  nextTicketIndexCacheDatabaseId = 0;
+}
+
+function ticketIndexCacheDatabaseId(db) {
+  let id = ticketIndexCacheDatabaseIds.get(db);
+  if (id == null) {
+    id = ++nextTicketIndexCacheDatabaseId;
+    ticketIndexCacheDatabaseIds.set(db, id);
+  }
+  return id;
+}
+
+function ticketIndexCacheSinceKey(since) {
+  if (since == null || since === "") return "";
+  return typeof since === "string" ? since.trim() : String(since);
 }
 
 /**
@@ -1161,7 +1179,12 @@ export function ticketIndexView(db, options = {}) {
       ? options.repo.trim().toLowerCase()
       : null;
 
-  const cacheKey = `${db.filename ?? "mem"}:${sinceMs}:${limit}:${repoFilter ?? ""}`;
+  const cacheKey = JSON.stringify([
+    ticketIndexCacheDatabaseId(db),
+    ticketIndexCacheSinceKey(options.since),
+    limit,
+    repoFilter,
+  ]);
   if (options.noCache !== true) {
     const cached = ticketIndexCache.get(cacheKey);
     if (cached && nowMs - cached.timestamp < TICKET_INDEX_CACHE_TTL_MS) {

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -25,6 +25,7 @@ import {
   clearObservedModelCache,
   clearRunSubjectCache,
   clearTicketDetailCache,
+  clearTicketIndexCache,
   mergeTicketSupply,
   scanTicketSupply,
   setTicketDetailControlPlane,
@@ -1818,6 +1819,41 @@ describe("recent-ticket index (WM-821)", () => {
       const direct = ticketIndexView(s.db, { since: "14d", nowMs });
       expect(direct.length).toBe(5);
     } finally {
+      s.close();
+    }
+  });
+
+  test("caches ticket index requests across advancing clocks until its TTL expires", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      clearTicketIndexCache();
+      const initial = ticketIndexView(s.db, { nowMs, since: "14d" });
+      expect(initial).toEqual([]);
+
+      const observedAt = new Date(nowMs - 1000).toISOString();
+      s.db
+        .query(
+          `INSERT INTO events
+           (source, event_id, type, subject, occurred_at, received_at, envelope_json, payload_hash, admitted_at)
+           VALUES ('test', 'ticket-index-cache', 'ticket.updated', 'WM-2158', ?, ?, '{}', 'sha256:test', ?)`,
+        )
+        .run(observedAt, observedAt, observedAt);
+
+      const cached = ticketIndexView(s.db, {
+        nowMs: nowMs + 10,
+        since: "14d",
+      });
+      expect(cached).toBe(initial);
+      expect(cached).toEqual([]);
+
+      const refreshed = ticketIndexView(s.db, {
+        nowMs: nowMs + 5001,
+        since: "14d",
+      });
+      expect(refreshed.map((ticket) => ticket.id)).toEqual(["WM-2158"]);
+    } finally {
+      clearTicketIndexCache();
       s.close();
     }
   });


### PR DESCRIPTION
Fixes watt-mind/factory#2158

Ticket index requests now reuse each database's cache entry throughout the five-second TTL.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs` | pass | 53 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, and lint passed |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend cache and regression-test change only
run:run_dd0c8373-8c90-430a-87e1-921e152ddcc6
