### PR TITLE
fix(api-artifacts): handle corrupt artifact stream races

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -12,6 +12,7 @@ import {
   readSync,
   rmSync,
 } from "node:fs";
+import { pipeline } from "node:stream/promises";
 import { findArtifact, hashFileAsync, pruneArtifacts } from "./artifacts.mjs";
 import { artifactsRoot } from "./config.mjs";
 import { ApiParameterError, parseListLimit } from "./api-params.mjs";
@@ -74,6 +75,16 @@ export function artifactHead(
     return null;
   } finally {
     if (fd !== undefined) closeSync(fd);
+  }
+}
+
+/** Stream an artifact while closing both ends when either side fails or aborts. */
+export async function streamArtifact(source, response) {
+  try {
+    await pipeline(source, response);
+  } catch (err) {
+    console.warn(`artifact download stream failed: ${err.message}`);
+    response.destroy();
   }
 }
 
@@ -188,6 +199,8 @@ export async function handleArtifactApiRoute({
     if (!found) return send(404, { error: `no artifact ${artifactGet[1]}` });
     if ((await hashFileAsync(found.file)) !== artifactGet[1]) {
       rmSync(found.file, { force: true });
+      clearStoreStats();
+      clearArtifactPage();
       return send(404, { error: `no artifact ${artifactGet[1]}` });
     }
     const rawName = url.searchParams.get("name");
@@ -205,7 +218,7 @@ export async function handleArtifactApiRoute({
           }
         : {}),
     });
-    createReadStream(found.file).pipe(res);
+    await streamArtifact(createReadStream(found.file), res);
     return;
   }
 

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -4,6 +4,8 @@ import {
 } from "../test-support/tmp.mjs?file=event-runtime-lib-api-artifacts-test-mjs";
 import { afterAll, beforeAll, describe, expect, test } from "bun:test";
 import { symlinkSync } from "node:fs";
+import { Readable, Writable } from "node:stream";
+import { streamArtifact } from "./api-artifacts.mjs";
 import { artifactReferenceIndex } from "./artifacts.mjs";
 import { canonicalJson, sha256Hex } from "./canonical.mjs";
 import {
@@ -519,6 +521,8 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
         canonicalJson(view.result.artifact),
       );
 
+      const corruptHash = sha256Hex("expected bytes");
+      writeFileSync(path.join(home, "artifacts", corruptHash), "corrupt");
       const inventory = await (
         await fetch(`http://127.0.0.1:${port}/artifacts`)
       ).json();
@@ -571,16 +575,40 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
         (await fetch(`http://127.0.0.1:${port}/artifacts/not-a-hash`)).status,
       ).toBe(404);
 
-      const corruptHash = sha256Hex("expected bytes");
-      writeFileSync(path.join(home, "artifacts", corruptHash), "corrupt");
       expect(
         (await fetch(`http://127.0.0.1:${port}/artifacts/${corruptHash}`))
           .status,
       ).toBe(404);
       expect(existsSync(path.join(home, "artifacts", corruptHash))).toBe(false);
+      expect(
+        (
+          await (await fetch(`http://127.0.0.1:${port}/artifacts`)).json()
+        ).artifacts.map((artifact) => artifact.sha256),
+      ).not.toContain(corruptHash);
     } finally {
       server.close();
     }
+  });
+
+  test("artifact stream failures destroy the response without leaking an error", async () => {
+    const source = new Readable({
+      read() {
+        this.destroy(new Error("simulated read failure"));
+      },
+    });
+    const response = new Writable({
+      write(_chunk, _encoding, done) {
+        done();
+      },
+    });
+    const warn = console.warn;
+    console.warn = () => {};
+    try {
+      await expect(streamArtifact(source, response)).resolves.toBeUndefined();
+    } finally {
+      console.warn = warn;
+    }
+    expect(response.destroyed).toBe(true);
   });
 
   test("GET /artifacts/:hash streams large text and binary artifacts with bounded sniffing", async () => {


### PR DESCRIPTION
Fixes #2159

Corrupt artifact downloads now invalidate cached inventory and cannot crash the API on stream failures.

## Validation

| Check                | Command                                                                                                    | Result  | Notes                      |
| -------------------- | ---------------------------------------------------------------------------------------------------------- | ------- | -------------------------- |
| Verification Command | `bun test event-runtime/lib/api-artifacts.test.mjs`                                                        | pass    | 7 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2415 pass, 10 skip, 0 fail |
| UX critique          | factory-ux-critic                                                                                          | not run | backend API; no user flow  |

UX critique: skipped — backend API change with no user-facing surface

run:run_56527ef5-8cd0-44be-bf66-4e573709f1bc
