### PR TITLE
fix(verify): absorb unchanged repo test baselines

### DIFF
--- a/bin/worktree-up.sh
+++ b/bin/worktree-up.sh
@@ -417,6 +417,52 @@ else
   fi
 fi
 
+# ------------------------------------------------- repo verify baseline ---
+# gh-2167: the handoff gate's red-baseline absorber is keyed on a recorded
+# baseline, but web_build was the only check that ever recorded one — so a
+# repo-verify suite that is already red (or flaky under host load) at the base
+# commit was charged to whichever branch happened to be in flight. Recording
+# the repo verify command's result here gives the absorber a real baseline
+# instead of only the on-failure merge-base re-run.
+#
+# Off by default: the command is the full local gate (~70-90s on this host) and
+# every dispatch pays it. Set FACTORY_WORKTREE_BASELINE_VERIFY=1 to record it.
+# Only a tree that still sits exactly at the base commit is a valid baseline —
+# a resumed branch with its own commits is not the base, and its failures are
+# the branch's to answer for.
+if [[ "${FACTORY_WORKTREE_BASELINE_VERIFY:-0}" == "1" && ! -f "$BASELINE_REPORT" ]]; then
+  VERIFY_COMMAND="${FACTORY_WORKTREE_VERIFY_COMMAND:-$(
+    bun -e '
+      const [repoPath] = process.argv.slice(1);
+      try {
+        const { findRepoForPath, loadRepos } = await import(
+          `${repoPath}/event-runtime/lib/repos.mjs`
+        );
+        const repo = findRepoForPath(loadRepos(), repoPath);
+        process.stdout.write(repo?.verify ?? "");
+      } catch {
+        process.stdout.write("");
+      }
+    ' -- "$REPO" 2>/dev/null || true
+  )}"
+  AHEAD_OF_BASE="$(git -C "$WT" rev-list --count "origin/$BASE_BRANCH..HEAD" 2>/dev/null || echo 1)"
+  if [[ -z "$VERIFY_COMMAND" ]]; then
+    warn "no repo verify command resolved — skipping the repo_verify baseline"
+  elif [[ "$AHEAD_OF_BASE" != "0" ]]; then
+    info "worktree is ahead of origin/$BASE_BRANCH — skipping the repo_verify baseline"
+  else
+    info "recording the repo_verify baseline at origin/$BASE_BRANCH"
+    VERIFY_BASELINE_OUTPUT="$RUN_DIR/baseline-repo-verify.log"
+    if (cd "$WT" && eval "$VERIFY_COMMAND" >"$VERIFY_BASELINE_OUTPUT" 2>&1); then
+      rm -f "$VERIFY_BASELINE_OUTPUT"
+    else
+      verify_status=$?
+      warn "baseline is red: repo_verify failed (exit $verify_status) — continuing with the usable worktree"
+      record_red_baseline "repo_verify" "$VERIFY_COMMAND" "$verify_status" "$VERIFY_BASELINE_OUTPUT"
+    fi
+  fi
+fi
+
 WEB_AVAILABLE=1
 if [[ -f "$BASELINE_REPORT" && ! -f "$WEB_DIR/dist/index.html" ]]; then
   WEB_AVAILABLE=0

--- a/docs/event-runtime-worker-protocol.md
+++ b/docs/event-runtime-worker-protocol.md
@@ -387,6 +387,36 @@ default 600 s) and its full output lands in the workspace (`.verify.log`,
 | no ticket command parses **and** the repo has no `verify:` | `handoff_verification_unspecified` |
 | deviations under `owned_paths_conformance: strict`         | `handoff_owned_paths_violation`    |
 
+#### The `baseline_red` route (gh-2167)
+
+A repo-verify failure is charged to the branch only once the worker has
+evidence the branch caused it. Two routes lead to `baseline_red` instead —
+still a refusal, still blocking the ticket, but named so triage reads it as
+"the tree was already red", and the ticket goes back to Todo without the
+branch being blamed:
+
+- **Recorded baseline.** `bin/worktree-up.sh` writes a red-baseline record for
+  a check that was already failing at the base commit. `web_build` has always
+  recorded one; with `FACTORY_WORKTREE_BASELINE_VERIFY=1` the script also runs
+  the repo's `verify:` command at the base commit and records that (off by
+  default — it is the full local gate, and every dispatch would pay it; a
+  worktree already ahead of `origin/<base>` is not a baseline and is skipped).
+  Matching is fail-closed: for a test failure, **every** test failing on the
+  branch must also have failed at the baseline. A branch that adds a failure is
+  never absorbed; a branch that fixes some of the baseline's failures still is.
+  Non-test failures keep exact normalized-signature matching.
+- **Merge-base re-run.** With no recorded baseline, the worker re-runs the same
+  verify command once at `merge-base(origin/<base>, HEAD)` in a disposable
+  detached checkout (never the shared repo, never a stash) — but only when the
+  runner attributed every failing test to a file the branch did not change. If
+  the identical failing-test set reproduces at the base, the result is
+  `baseline_red`; if the base is green, `handoff_verification_failed` stands.
+
+Ambiguity is always fail-closed: a timeout, output the runner-format parser
+cannot tie to a file, a failing test in a changed file, or a failing-test list
+long enough to be truncated (`…and N more`) all keep
+`handoff_verification_failed`.
+
 These are agent errors (bounded by `maxAttempts`, never an environment retry).
 The run is FAILED with no accepted result — nothing downstream chains a review
 — and the journal reason carries the last lines of the failing output. Because

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -13,6 +13,7 @@
 import { execFileSync, spawnSync } from "node:child_process";
 import {
   closeSync,
+  cpSync,
   existsSync,
   mkdtempSync,
   openSync,
@@ -1194,8 +1195,6 @@ function normalizeFailureOutput(output) {
 
 /**
  * Deterministic normalized signature of a failure payload.
- * Exact equality is intentionally strict: any new signal (even a single
- * additional line) proves the failure signature changed.
  */
 function failureSignature(output) {
   return normalizeFailureOutput(output).join("\n");
@@ -1203,11 +1202,21 @@ function failureSignature(output) {
 
 /**
  * Conservative evidence that post-agent verification hit the recorded red baseline.
- * Unlike partial line overlap, this compares full normalized signatures and fails
- * closed on ambiguous signal drift.
+ * Test failures are compared by name, so an unchanged red suite remains absorbed
+ * when the branch adds another test to its output. Non-test failures retain exact
+ * normalized-signature matching because there is no narrower stable identity.
  */
 function matchesRedBaseline(baseline, verifyOutput) {
   if (baseline?.status !== "red") return false;
+  const baselineTests = repoVerifyFailingTests(baseline.output);
+  const verifyTests = repoVerifyFailingTests(verifyOutput);
+  if (baselineTests.length > 0 || verifyTests.length > 0) {
+    return (
+      baselineTests.length > 0 &&
+      verifyTests.length > 0 &&
+      baselineTests.every((testName) => verifyTests.includes(testName))
+    );
+  }
   const baselineSig = failureSignature(baseline.output);
   const verifySig = failureSignature(verifyOutput);
   if (!baselineSig || !verifySig) return false;
@@ -1254,6 +1263,123 @@ export function repoVerifyFailingTests(output) {
   const shown = names.slice(0, REPO_VERIFY_FAILING_TESTS_MAX);
   shown.push(`…and ${names.length - REPO_VERIFY_FAILING_TESTS_MAX} more`);
   return shown;
+}
+
+// Bun prints a source-file heading before the tests it reports from that file.
+// Keep this deliberately narrow: an unrecognised runner format is ambiguous and
+// must not trigger the branch-external baseline retry.
+const REPO_VERIFY_TEST_FILE_LINE =
+  /^\s*(?<path>(?:\.?\/?[\w@.-]+\/)*[\w@.-]+\.(?:test|spec)\.[cm]?[jt]sx?)\s*:\s*$/i;
+
+/**
+ * Return the runner-reported source files for failing tests, or null when a
+ * failure cannot be tied to a file. The null result is the fail-closed path.
+ */
+export function repoVerifyFailingTestFiles(output) {
+  const files = new Set();
+  let currentFile = null;
+  let failures = 0;
+  for (const rawLine of stripAnsi(output).split("\n")) {
+    const line = rawLine.trim();
+    const match = REPO_VERIFY_TEST_FILE_LINE.exec(line);
+    if (match) {
+      currentFile = match.groups.path.replace(/^\.\//, "");
+      continue;
+    }
+    if (!REPO_VERIFY_TEST_FAILURE_LINE.test(line)) continue;
+    failures += 1;
+    if (!currentFile) return null;
+    files.add(currentFile);
+  }
+  return failures > 0 ? [...files] : null;
+}
+
+function sameFailingTestSet(left, right) {
+  return (
+    left.length > 0 &&
+    left.length === right.length &&
+    left.every((testName) => right.includes(testName))
+  );
+}
+
+function failingTestsAreOutsideChangedFiles(obs, changedFiles) {
+  const failingFiles = repoVerifyFailingTestFiles(obs.output);
+  return (
+    Array.isArray(changedFiles) &&
+    obs.failingTests.length > 0 &&
+    Array.isArray(failingFiles) &&
+    failingFiles.length > 0 &&
+    failingFiles.every((file) => !changedFiles.includes(file))
+  );
+}
+
+/**
+ * Execute a second repo verify at the branch's merge-base without mutating the
+ * dispatched checkout. Dependencies are copied only into the disposable
+ * checkout; a linked worktree otherwise has no ignored node_modules tree.
+ */
+function runRepoVerifyBaseline({
+  command,
+  worktreePath,
+  workspaceDir,
+  baseCommit,
+  timeoutMs,
+  runHandoffStep,
+}) {
+  const scratchPath = mkdtempSync(
+    path.join(workspaceDir, ".repo-verify-baseline-"),
+  );
+  rmSync(scratchPath, { recursive: true, force: true });
+  try {
+    try {
+      execFileSync(
+        "git",
+        ["worktree", "add", "--detach", "--force", scratchPath, baseCommit],
+        {
+          cwd: worktreePath,
+          stdio: ["ignore", "pipe", "pipe"],
+          timeout: 60_000,
+        },
+      );
+      const dependencies = path.join(worktreePath, "node_modules");
+      if (existsSync(dependencies)) {
+        cpSync(dependencies, path.join(scratchPath, "node_modules"), {
+          recursive: true,
+          verbatimSymlinks: true,
+        });
+      }
+    } catch (err) {
+      return {
+        passed: false,
+        timedOut: false,
+        setupFailed: true,
+        output: String(err?.stderr ?? err?.message ?? err),
+      };
+    }
+    const obs = runHandoffStep({
+      command,
+      cwd: scratchPath,
+      worktreePath: scratchPath,
+      logPath: path.join(workspaceDir, ".verify.baseline.log"),
+      timeoutMs,
+    });
+    obs.source = "repo_verify_baseline";
+    obs.executionContext = "merge_base_scratch";
+    obs.failingTests = repoVerifyFailingTests(obs.output);
+    obs.failingTestFiles = repoVerifyFailingTestFiles(obs.output);
+    return obs;
+  } finally {
+    try {
+      execFileSync("git", ["worktree", "remove", "--force", scratchPath], {
+        cwd: worktreePath,
+        stdio: "ignore",
+        timeout: 60_000,
+      });
+    } catch {
+      // The directory is disposable even if Git has already pruned its entry.
+    }
+    rmSync(scratchPath, { recursive: true, force: true });
+  }
 }
 
 function boundedDiagnostic(lines) {
@@ -2165,9 +2291,39 @@ function verifyCompleted({
         // clean-checkout reproduction at the same commit.
         obs.executionContext = "dispatch_worktree";
         obs.failingTests = repoVerifyFailingTests(obs.output);
+        obs.failingTestFiles = repoVerifyFailingTestFiles(obs.output);
         const baselineStillRed =
           !obs.timedOut &&
           matchesRedBaseline(worktreeRecord.baseline, obs.output);
+        const shouldRecheckBase =
+          !obs.timedOut &&
+          !baselineStillRed &&
+          handoff.diff.ok &&
+          failingTestsAreOutsideChangedFiles(obs, handoff.diff.files) &&
+          typeof handoff.diff.mergeBase === "string";
+        if (shouldRecheckBase) {
+          const baselineObs = runRepoVerifyBaseline({
+            command: worktreeRecord.verify,
+            worktreePath,
+            workspaceDir,
+            baseCommit: handoff.diff.mergeBase,
+            timeoutMs: verifyTimeoutMs,
+            runHandoffStep,
+          });
+          handoff.repoVerifyBaseline = baselineObs;
+          if (
+            !baselineObs.setupFailed &&
+            !baselineObs.timedOut &&
+            !baselineObs.passed &&
+            sameFailingTestSet(obs.failingTests, baselineObs.failingTests)
+          ) {
+            handoff.reasonCode = "baseline_red";
+            throw new ContractViolation(
+              [`repo_verify_failed: ${failureWhy(obs)}`],
+              { reasonCode: handoff.reasonCode, handoff },
+            );
+          }
+        }
         handoff.reasonCode = baselineStillRed
           ? "baseline_red"
           : "handoff_verification_failed";

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -21,6 +21,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  symlinkSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
@@ -1202,19 +1203,26 @@ function failureSignature(output) {
 
 /**
  * Conservative evidence that post-agent verification hit the recorded red baseline.
- * Test failures are compared by name, so an unchanged red suite remains absorbed
- * when the branch adds another test to its output. Non-test failures retain exact
- * normalized-signature matching because there is no narrower stable identity.
+ * Test failures are compared by name in the fail-closed direction: every failure
+ * observed on the branch must also have failed at the recorded baseline, so a
+ * branch that *adds* a failure is never absorbed. A branch that fixes some of the
+ * baseline's failures still lands, because absorption only needs its remaining
+ * failures to be a subset. Non-test failures retain exact normalized-signature
+ * matching because there is no narrower stable identity.
  */
 function matchesRedBaseline(baseline, verifyOutput) {
   if (baseline?.status !== "red") return false;
   const baselineTests = repoVerifyFailingTests(baseline.output);
   const verifyTests = repoVerifyFailingTests(verifyOutput);
   if (baselineTests.length > 0 || verifyTests.length > 0) {
+    // A truncated list is not a complete failure set; containment over it could
+    // absorb a branch-introduced failure that fell past the cap.
+    if (isTruncatedTestList(baselineTests) || isTruncatedTestList(verifyTests))
+      return false;
     return (
       baselineTests.length > 0 &&
       verifyTests.length > 0 &&
-      baselineTests.every((testName) => verifyTests.includes(testName))
+      verifyTests.every((testName) => baselineTests.includes(testName))
     );
   }
   const baselineSig = failureSignature(baseline.output);
@@ -1265,11 +1273,30 @@ export function repoVerifyFailingTests(output) {
   return shown;
 }
 
+// The sentinel repoVerifyFailingTests appends once it caps the list. Any set
+// comparison over a truncated list is unsound in both directions, so both
+// absorption paths refuse rather than guess at the names they cannot see.
+const REPO_VERIFY_TRUNCATION_SENTINEL = /^…and \d+ more$/;
+
+/** True when a failing-test list was capped and is therefore incomplete. */
+export function isTruncatedTestList(names) {
+  return (
+    Array.isArray(names) &&
+    names.some(
+      (name) =>
+        typeof name === "string" && REPO_VERIFY_TRUNCATION_SENTINEL.test(name),
+    )
+  );
+}
+
 // Bun prints a source-file heading before the tests it reports from that file.
 // Keep this deliberately narrow: an unrecognised runner format is ambiguous and
 // must not trigger the branch-external baseline retry.
+// The path is one flat character class (no nested quantifier over a group) so
+// the match stays linear on adversarial input — CodeQL flags the grouped form
+// as polynomial-backtracking ReDoS.
 const REPO_VERIFY_TEST_FILE_LINE =
-  /^\s*(?<path>(?:\.?\/?[\w@.-]+\/)*[\w@.-]+\.(?:test|spec)\.[cm]?[jt]sx?)\s*:\s*$/i;
+  /^\s*(?<path>[\w@./-]+\.(?:test|spec)\.[cm]?[jt]sx?)\s*:\s*$/i;
 
 /**
  * Return the runner-reported source files for failing tests, or null when a
@@ -1295,6 +1322,9 @@ export function repoVerifyFailingTestFiles(output) {
 }
 
 function sameFailingTestSet(left, right) {
+  // A capped list hides names, so equality over it would absorb a branch
+  // failure the cap swallowed. Truncation is ambiguous; ambiguous is fail-closed.
+  if (isTruncatedTestList(left) || isTruncatedTestList(right)) return false;
   return (
     left.length > 0 &&
     left.length === right.length &&
@@ -1343,10 +1373,17 @@ function runRepoVerifyBaseline({
       );
       const dependencies = path.join(worktreePath, "node_modules");
       if (existsSync(dependencies)) {
-        cpSync(dependencies, path.join(scratchPath, "node_modules"), {
-          recursive: true,
-          verbatimSymlinks: true,
-        });
+        const scratchDependencies = path.join(scratchPath, "node_modules");
+        // node_modules is multi-GB here; a symlink makes the scratch checkout
+        // free. Copy only where a link is not usable (e.g. no symlink support).
+        try {
+          symlinkSync(dependencies, scratchDependencies, "dir");
+        } catch {
+          cpSync(dependencies, scratchDependencies, {
+            recursive: true,
+            verbatimSymlinks: true,
+          });
+        }
       }
     } catch (err) {
       return {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -1006,7 +1006,7 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
-  test("a recorded test baseline survives additional branch test output", () => {
+  test("a recorded test baseline does not absorb an additional branch-only failure", () => {
     const baselineOutput = [
       "event-runtime/lib/worker.test.mjs:",
       "(fail) worker > pre-existing flaky probe",
@@ -1027,7 +1027,58 @@ describe("worktree baseline verification (WM-334)", () => {
       throw new Error("expected ContractViolation");
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+    }
+  });
+
+  test("a recorded test baseline still absorbs a branch that fixed some of its failures", () => {
+    const baselineOutput = [
+      "event-runtime/lib/worker.test.mjs:",
+      "(fail) worker > pre-existing flaky probe",
+      "(fail) worker > second pre-existing probe",
+    ].join("\n");
+    const { dir, record } = worktreeWorkspace(
+      `printf '%s\\n' 'event-runtime/lib/worker.test.mjs:' '(fail) worker > pre-existing flaky probe' >&2; exit 9`,
+      { status: "red", check: "repo_verify", output: baselineOutput },
+    );
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
       expect(err.reasonCode).toBe("baseline_red");
+    }
+  });
+
+  test("a truncated failing-test list is never absorbed by a recorded baseline", () => {
+    const names = Array.from({ length: 25 }, (_, i) => `probe ${i}`);
+    const lines = ["event-runtime/lib/worker.test.mjs:"].concat(
+      names.map((name) => `(fail) worker > ${name}`),
+    );
+    const { dir, record } = worktreeWorkspace(
+      `printf '%s\\n' ${lines.map((line) => `'${line}'`).join(" ")} >&2; exit 9`,
+      { status: "red", check: "repo_verify", output: lines.join("\n") },
+    );
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
     }
   });
 
@@ -1133,6 +1184,38 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(calls).toHaveLength(2);
     expect(calls[0].cwd).toBe(record.path);
     expect(calls[1].cwd).not.toBe(record.path);
+  });
+
+  test("a truncated merge-base failing-test list is not absorbed as baseline_red", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "docs/note.md");
+    const output = ["event-runtime/lib/worker.test.mjs:"]
+      .concat(
+        Array.from({ length: 25 }, (_, i) => `(fail) worker > probe ${i}`),
+      )
+      .join("\n");
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: () => ({
+          passed: false,
+          exitCode: 1,
+          output,
+          sandbox: { tmpfsMb: 1024 },
+        }),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+    }
   });
 
   test("does not retry a repo verify failure from a changed test file", () => {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -46,6 +46,7 @@ import {
   handoffSandboxFacts,
   policyHandoffSandboxTmpfsMb,
   policyOwnedPathsConformance,
+  repoVerifyFailingTestFiles,
   repoVerifyFailingTests,
   runHandoffCommand,
   runHandoffVerifySmoke,
@@ -1005,6 +1006,31 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
+  test("a recorded test baseline survives additional branch test output", () => {
+    const baselineOutput = [
+      "event-runtime/lib/worker.test.mjs:",
+      "(fail) worker > pre-existing flaky probe",
+    ].join("\n");
+    const { dir, record } = worktreeWorkspace(
+      `printf '%s\\n' '${baselineOutput}' 'event-runtime/lib/new.test.mjs:' '(fail) new suite > branch-only failure' >&2; exit 9`,
+      { status: "red", check: "repo_verify", output: baselineOutput },
+    );
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("baseline_red");
+    }
+  });
+
   // WM-718: a post-agent repo verify failure at handoff is the handoff gate
   // refusing (`handoff_verification_failed`), no longer a generic
   // `contract_violation` — same FAILED path, but named so the ticket goes back
@@ -1060,6 +1086,86 @@ describe("worktree baseline verification (WM-334)", () => {
       expect(err.reasonCode).toBe("handoff_verification_failed");
       expect(err.violations[0]).toStartWith("repo_verify_failed:");
     }
+  });
+
+  test("rechecks an unchanged failing test file at the merge base before charging the branch", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "docs/note.md");
+    const output = [
+      "event-runtime/lib/worker.test.mjs:",
+      "(fail) worker > drains a worktree adapter notification",
+    ].join("\n");
+    const calls = [];
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: ({ cwd, command }) => {
+          calls.push({ cwd, command });
+          return {
+            passed: false,
+            exitCode: 1,
+            output,
+            sandbox: { tmpfsMb: 1024 },
+          };
+        },
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("baseline_red");
+      expect(err.handoff.repoVerify.failingTestFiles).toEqual([
+        "event-runtime/lib/worker.test.mjs",
+      ]);
+      expect(err.handoff.repoVerifyBaseline.executionContext).toBe(
+        "merge_base_scratch",
+      );
+      expect(err.handoff.repoVerifyBaseline.failingTests).toEqual(
+        err.handoff.repoVerify.failingTests,
+      );
+    }
+    expect(calls).toHaveLength(2);
+    expect(calls[0].cwd).toBe(record.path);
+    expect(calls[1].cwd).not.toBe(record.path);
+  });
+
+  test("does not retry a repo verify failure from a changed test file", () => {
+    const { dir, record } = worktreeWorkspace("repo-verify", null);
+    record.handoff = { verificationCommand: "ticket-narrow" };
+    commitHandoffDiff(record, "event-runtime/lib/worker.test.mjs");
+    const calls = [];
+
+    try {
+      verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+        runHandoffCommandFn: ({ command }) => {
+          calls.push(command);
+          return {
+            passed: false,
+            exitCode: 1,
+            output:
+              "event-runtime/lib/worker.test.mjs:\n(fail) worker > branch regression",
+            sandbox: { tmpfsMb: 1024 },
+          };
+        },
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.reasonCode).toBe("handoff_verification_failed");
+    }
+    expect(calls).toEqual(["repo-verify"]);
   });
 
   test("a multi-line verification failure retains the failing test name and full log", () => {
@@ -1980,6 +2086,28 @@ describe("repoVerifyFailingTests", () => {
     const result = repoVerifyFailingTests(lines.join("\n"));
     expect(result).toHaveLength(20);
     expect(result.at(-1)).toBe("suite > case 19");
+  });
+
+  test("associates failures with Bun's source-file heading", () => {
+    expect(
+      repoVerifyFailingTestFiles(
+        [
+          "event-runtime/lib/worker.test.mjs:",
+          "(fail) worker > drains the queue [1ms]",
+          "event-runtime/lib/verify.test.mjs:",
+          "✗ verify > fails closed [2ms]",
+        ].join("\n"),
+      ),
+    ).toEqual([
+      "event-runtime/lib/worker.test.mjs",
+      "event-runtime/lib/verify.test.mjs",
+    ]);
+  });
+
+  test("fails closed when a runner failure lacks a source-file heading", () => {
+    expect(repoVerifyFailingTestFiles("(fail) worker > unknown source")).toBe(
+      null,
+    );
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2167

Review the fail-closed baseline rerun that prevents unrelated flaky repo-verify failures from charging a branch.

## Validation

| Check                | Command                                                                          | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs`                                     | pass    | 105 tests, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | lib suite, emit, format, lint; warnings only |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface                     |

UX critique: skipped — backend verification gate; no user-facing surface
run:run_58ccd80d-80b8-4316-b58b-09dc171cb053
