### PR TITLE
fix(worker): scope ticket state mutations to repo

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3042,14 +3042,17 @@ export function defaultUnclaimTicket({
       Array.isArray(cur.labels) ? cur.labels : (cur.labels?.nodes ?? [])
     ).map((l) => l.name);
     const { add, remove } = releaseLabels(currentNames, { to: "Todo" });
-    runCli([
-      "state",
-      ticket,
-      "Todo",
-      "--unassign",
-      ...add.flatMap((n) => ["--add", n]),
-      ...remove.flatMap((n) => ["--remove", n]),
-    ]);
+    runCli(
+      [
+        "state",
+        ticket,
+        "Todo",
+        "--unassign",
+        ...add.flatMap((n) => ["--add", n]),
+        ...remove.flatMap((n) => ["--remove", n]),
+      ],
+      { repo },
+    );
     const body = `Dispatch run failed, claim released back to Todo + ai:agent-ready.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}`;
     runCli(["comment", ticket, body], { repo });
     return true;
@@ -3155,8 +3158,8 @@ export function defaultReturnHandoffTicket({
   try {
     const cur =
       typeof fetchTicket === "function"
-        ? fetchTicket(ticket)
-        : defaultFetchTicket(ticket);
+        ? fetchTicket(ticket, repo)
+        : defaultFetchTicket(ticket, repo);
     const state = cur?.state?.name;
     if (!cur || !["In Progress", "In Review"].includes(state)) return false;
     const args = [
@@ -3174,7 +3177,7 @@ export function defaultReturnHandoffTicket({
     let agentReadyRestored = true;
     let labelWarning = null;
     try {
-      runCli(args);
+      runCli(args, { repo });
     } catch {
       // `--add ai:agent-ready` can fail independently of the state move
       // (e.g. the Owned Paths closure check re-running on `--add`). Retry as
@@ -3184,6 +3187,7 @@ export function defaultReturnHandoffTicket({
       // dispatchable again.
       runCli(
         args.filter((a, i) => !(a === "--add" || args[i - 1] === "--add")),
+        { repo },
       );
       try {
         runCli(["labels", ticket, "--add", "ai:agent-ready"], { repo });
@@ -3547,13 +3551,15 @@ function hasRecordedBaselineFailureComment(ticket, signature, repo) {
   }
 }
 
-function defaultBlockBaselineTicket({
+export function defaultBlockBaselineTicket({
   repo,
   ticket,
   why,
   log = null,
   baseline = null,
   fetchTicket,
+  runCli = runLinearCli,
+  hasRecordedBaselineFailure = hasRecordedBaselineFailureComment,
 }) {
   try {
     let cur = null;
@@ -3571,22 +3577,25 @@ function defaultBlockBaselineTicket({
       return false;
 
     const signature = baselineFailureSignature({ why, log, baseline });
-    runLinearCli([
-      "state",
-      ticket,
-      "Blocked",
-      "--unassign",
-      "--add",
-      "ai:blocked",
-      "--remove",
-      "ai:in-progress",
-    ]);
+    runCli(
+      [
+        "state",
+        ticket,
+        "Blocked",
+        "--unassign",
+        "--add",
+        "ai:blocked",
+        "--remove",
+        "ai:in-progress",
+      ],
+      { repo },
+    );
 
-    if (!hasRecordedBaselineFailureComment(ticket, signature, repo)) {
+    if (!hasRecordedBaselineFailure(ticket, signature, repo)) {
       const marker = `${BASELINE_COMMENT_MARKER}${signature}`;
       const body = `Dispatch run blocked due pre-existing baseline red.\n\n**Why:** ${why}${log ? `\n**Log:** \`${log.replace(homedir(), "~")}\`` : ""}\n\n
 <!-- ${marker} -->`;
-      runLinearCli(["comment", ticket, body], { repo });
+      runCli(["comment", ticket, body], { repo });
     }
     return true;
   } catch {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -95,6 +95,7 @@ import {
   escalationHandoffFailure,
   createReloadWatcher,
   DEFAULT_MAX_ENVIRONMENT_RETRIES,
+  defaultBlockBaselineTicket,
   defaultFindWorkspacePullRequest,
   defaultLocksDir,
   defaultMarkHandoffPullRequestReady,
@@ -7103,6 +7104,108 @@ sh -c 'sleep 5 & wait'
     expect(capturedReadOnlyEnv.SSH_AUTH_SOCK).toBeUndefined();
     expect(capturedReadOnlyEnv.GITHUB_TOKEN).toBeUndefined();
     expect(capturedReadOnlyEnv.ANTHROPIC_API_KEY).toBeUndefined();
+  });
+
+  describe("Linear-plane tracker state mutations (#2165)", () => {
+    const repo = "linear-plane-repo";
+
+    test("unclaim sends its state transition to the injected repo", () => {
+      const calls = [];
+      expect(
+        defaultUnclaimTicket({
+          repo,
+          ticket: "WM-2165",
+          why: "test",
+          fetchTicket: () => ({
+            state: { name: "In Progress" },
+            labels: [{ name: "ai:in-progress" }],
+          }),
+          runCli: (args, options) => calls.push({ args, options }),
+        }),
+      ).toBe(true);
+
+      expect(calls.find(({ args }) => args[0] === "state")?.options).toEqual({
+        repo,
+      });
+    });
+
+    test("handoff return passes repo to its ticket read and state transition", () => {
+      const calls = [];
+      const fetchCalls = [];
+      expect(
+        defaultReturnHandoffTicket({
+          repo,
+          ticket: "WM-2165",
+          body: "returning ticket",
+          fetchTicket: (...args) => {
+            fetchCalls.push(args);
+            return { state: { name: "In Review" } };
+          },
+          runCli: (args, options) => calls.push({ args, options }),
+        }),
+      ).toMatchObject({ ok: true, agentReadyRestored: true });
+
+      expect(fetchCalls).toEqual([["WM-2165", repo]]);
+      expect(calls.find(({ args }) => args[0] === "state")?.options).toEqual({
+        repo,
+      });
+    });
+
+    test("handoff return preserves repo through its split state retry", () => {
+      const calls = [];
+      expect(
+        defaultReturnHandoffTicket({
+          repo,
+          ticket: "WM-2165",
+          body: "returning ticket",
+          fetchTicket: () => ({ state: { name: "In Review" } }),
+          runCli: (args, options) => {
+            calls.push({ args, options });
+            if (calls.length === 1) throw new Error("combined label failure");
+          },
+        }),
+      ).toMatchObject({ ok: true, agentReadyRestored: true });
+
+      expect(calls.filter(({ args }) => args[0] === "state")).toHaveLength(2);
+      expect(
+        calls
+          .filter(({ args }) => args[0] === "state")
+          .map(({ options }) => options),
+      ).toEqual([{ repo }, { repo }]);
+    });
+
+    test("baseline block sends its state transition to the injected repo", () => {
+      const calls = [];
+      expect(
+        defaultBlockBaselineTicket({
+          repo,
+          ticket: "WM-2165",
+          why: "baseline failed",
+          fetchTicket: () => ({
+            state: { name: "In Progress" },
+            labels: [{ name: "ai:in-progress" }],
+          }),
+          hasRecordedBaselineFailure: () => true,
+          runCli: (args, options) => calls.push({ args, options }),
+        }),
+      ).toBe(true);
+
+      expect(calls).toEqual([
+        {
+          args: [
+            "state",
+            "WM-2165",
+            "Blocked",
+            "--unassign",
+            "--add",
+            "ai:blocked",
+            "--remove",
+            "ai:in-progress",
+          ],
+          options: { repo },
+        },
+      ]);
+    });
   });
 
   describe("defaultReconcileVerifiedHandoffTicket (#1498)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2165

Scope every worker ticket state transition to its configured tracker repo.

## Validation

| Check                | Command                                                                                 | Result  | Notes                                      |
| -------------------- | --------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib --timeout 20000`                                            | pass    | 2422 pass, 0 failures                      |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | emit, format, and lint completed (warnings) |
| UX critique          | factory-ux-critic                                                                       | not run | no user-facing surface                     |

UX critique: skipped — backend worker tracker mutation only

run:run_180fe8b3-4a98-44a4-bb9b-3f1a04eadbd5
