### PR TITLE
fix(dispatch): preserve result envelopes from symlinked worktrees

### DIFF
--- a/event-runtime/agents/dispatch.json
+++ b/event-runtime/agents/dispatch.json
@@ -31,7 +31,7 @@
     }
   ],
   "pins": {
-    "agents/dispatch.md": "sha256:38b1bb3499f85ad0522e8327597a5b341d9e71610c82413be1f76e25539e293c",
+    "agents/dispatch.md": "sha256:486fb6e7c4462df00b24773f227b61b807efcf63619c9a30fa7b9696b683c618",
     "schemas/dispatch.input.json": "sha256:2909f2898723c796669716a0f9c185ec262bdbea20a948754c6228384f88e6e6",
     "schemas/dispatch.output.json": "sha256:a8d8cd5816eb8d7da832da59120bc1f028623edf1a9a9e180348d897621dfff1"
   }

--- a/event-runtime/agents/dispatch.md
+++ b/event-runtime/agents/dispatch.md
@@ -9,10 +9,19 @@ You are a ticket agent. `./input.json` names one repo and one ticket:
 The repo's source is at `./repo` — a full worktree the repo's **own**
 `worktree_up` script built for this ticket, with its own branch, ports, and
 database. Do not create another worktree, do not touch any sibling worktree,
-and do not work anything except this one ticket. Write `./result.json` **before
-posting the final `## Handoff` comment**: a handoff without its result envelope
-fails the run after the PR is already open. Work only inside this directory
-(the `./repo` worktree included).
+and do not work anything except this one ticket. Write `"$FACTORY_RESULT_PATH"`
+**before posting the final `## Handoff` comment**: a handoff without its result
+envelope fails the run after the PR is already open. `./repo` is a symlink to
+the physical checkout, so `..` from inside it does **not** reach this workspace;
+never use `cd`/`mv ../result.json`. Write the envelope directly, for example:
+
+```
+cat > "$FACTORY_RESULT_PATH" <<'EOF'
+{ ...valid factory.agent-result/v1 JSON... }
+EOF
+```
+
+Work only inside this directory (the `./repo` worktree included).
 
 ## 1. Claim
 
@@ -24,7 +33,7 @@ bun "$FACTORY_ROOT/tools/ticket.mjs" claim <TICKET>
 ```
 
 The claim verb enforces the read-back — if it reports a lost race, or the
-ticket is no longer in a dispatchable state, **stop**: write `./result.json`
+ticket is no longer in a dispatchable state, **stop**: write `"$FACTORY_RESULT_PATH"`
 with `outcome: "NOT_CLAIMED"` and a summary naming who holds it. That is a
 good, typed outcome (docs/event-runtime-dispatch.md §2), not a failure. Never
 steal a claim, never queue behind the holder.
@@ -133,7 +142,7 @@ HTTP 200); <genuinely unassessable reason>` only after the authenticated
 
    Screenshot evidence must survive workspace cleanup. For every screenshot the
    critic creates, calculate its SHA-256 and declare it in the outer
-   `result.json` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`
+   `"$FACTORY_RESULT_PATH"` as `{ "kind": "ux-screenshot", "path": "ux-artifacts/<file>" }`
    only after confirming the file exists under `artifactDir`; if the critic
    produced no file there, omit the declaration entirely and record the
    ephemeral URL instead — a declared artifact whose file is missing hard-fails
@@ -251,7 +260,7 @@ shell` means the spawn prompt was defective: correct its path/launch details
    worker's `## Handoff verification (worker-observed)` comment is what
    settles the question.
 
-   After `./result.json` has been written, post the structured `## Handoff`
+   After `"$FACTORY_RESULT_PATH"` has been written, post the structured `## Handoff`
    comment on the ticket before transitioning. This ordering prevents a
    completed PR and Handoff from being discarded as `missing_result`:
 
@@ -324,7 +333,11 @@ report `outcome: "FAILED"`.
 
 ## Output
 
-`./result.json`, per factory.agent-result/v1:
+`"$FACTORY_RESULT_PATH"`, per factory.agent-result/v1. The top level is
+exactly the `factory.agent-result/v1` envelope and the payload belongs under
+`artifact`; `verification` is exactly `{ "command", "passed", "output" }`,
+where `passed` is a boolean. Do not add `ticketGate`/`repoGate` sub-objects or
+extra top-level properties: the schema rejects them.
 
 ```json
 {

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -35,6 +35,7 @@ export const DISPATCH_IDENTITY_ENV = [
   "FACTORY_RUN_ID",
   "FACTORY_TICKET",
   "FACTORY_REPO",
+  "FACTORY_RESULT_PATH",
 ];
 
 export const PUSH_CREDENTIAL_ENV = [
@@ -84,7 +85,7 @@ export const HARNESS_LAYOUT = Object.freeze({
 export const KILL_GRACE_MS = 30_000;
 
 export const PROMPT_SUFFIX =
-  "\n\n---\nInput is at ./input.json. Write ./result.json per the factory.agent-result/v1 contract. Work only inside this directory.";
+  "\n\n---\nInput is at ./input.json. Write the factory.agent-result/v1 envelope to $FACTORY_RESULT_PATH. Work only inside this directory.";
 
 /**
  * Prompt bytes are verified by the registry before they reach an adapter.

--- a/event-runtime/lib/adapters/child-env.mjs
+++ b/event-runtime/lib/adapters/child-env.mjs
@@ -85,7 +85,7 @@ export const HARNESS_LAYOUT = Object.freeze({
 export const KILL_GRACE_MS = 30_000;
 
 export const PROMPT_SUFFIX =
-  "\n\n---\nInput is at ./input.json. Write the factory.agent-result/v1 envelope to $FACTORY_RESULT_PATH. Work only inside this directory.";
+  "\n\n---\nInput is at ./input.json. Write the factory.agent-result/v1 envelope to ./result.json (or $FACTORY_RESULT_PATH when set). Work only inside this directory.";
 
 /**
  * Prompt bytes are verified by the registry before they reach an adapter.

--- a/event-runtime/lib/adapters/child-env.test.mjs
+++ b/event-runtime/lib/adapters/child-env.test.mjs
@@ -16,6 +16,7 @@ import {
   PROMPT_SUFFIX as acpPromptSuffix,
   verifiedPrompt as acpVerifiedPrompt,
 } from "./acp.mjs";
+import { dispatchIdentityEnv } from "../worker.mjs";
 import { safeChildEnvironment as claudeEnvironment } from "./claude.mjs";
 import {
   HARNESS_LAYOUT as claudeHarnessLayout,
@@ -134,6 +135,58 @@ describe("shared child environment", () => {
       keySet(outputs.claude).filter((key) => key !== "CURSOR_API_ENDPOINT"),
     );
     expect(keySet(outputs.pi)).toEqual(keySet(outputs.claude));
+  });
+
+  test("states a result location every agent can honour, dispatched or not", () => {
+    // The suffix is appended to EVERY agent's prompt, but FACTORY_RESULT_PATH
+    // is only exported for dispatch@ agents. It must therefore name the
+    // workspace-relative path unconditionally and the variable only as an
+    // override, or a non-dispatch agent is told to write to an empty string.
+    expect(PROMPT_SUFFIX).toContain("./result.json");
+    expect(PROMPT_SUFFIX).toContain("$FACTORY_RESULT_PATH when set");
+
+    const def = { ref: "review@1", promptText: "You are a test agent." };
+    const prompt = verifiedPrompt(def, "claude");
+    const resultPath = "/workspace/result.json";
+
+    for (const agent of ["review@1", "dispatch@1"]) {
+      const env = dispatchIdentityEnv({
+        spec: { agent },
+        env: { FACTORY_ROOT: "/factory-root" },
+        resultPath,
+      });
+      const dispatched = agent.startsWith("dispatch@");
+      expect(env.FACTORY_RESULT_PATH).toBe(dispatched ? resultPath : undefined);
+      // Whichever half of the instruction applies, the agent can resolve it.
+      const referenced = env.FACTORY_RESULT_PATH ?? "./result.json";
+      expect(referenced.length).toBeGreaterThan(0);
+      expect(prompt).toContain(
+        dispatched ? "$FACTORY_RESULT_PATH" : "./result.json",
+      );
+    }
+  });
+
+  test("carries FACTORY_RESULT_PATH through the child environment", () => {
+    expect(DISPATCH_IDENTITY_ENV).toContain("FACTORY_RESULT_PATH");
+    const supplied = { FACTORY_RESULT_PATH: "/workspace/result.json" };
+    for (const environment of [
+      claudeEnvironment,
+      commandEnvironment,
+      agyEnvironment,
+      cursorEnvironment,
+      piEnvironment,
+    ]) {
+      expect(
+        environment(supplied, { mutating: false }).FACTORY_RESULT_PATH,
+      ).toBe("/workspace/result.json");
+    }
+    // Even under the aggressive FACTORY_ prefix strip the adapters apply.
+    expect(
+      safeChildEnvironment(supplied, false, {
+        extraStrip: ["FACTORY_RESULT_PATH"],
+        stripPrefixes: ["FACTORY_"],
+      }).FACTORY_RESULT_PATH,
+    ).toBe("/workspace/result.json");
   });
 
   test("dispatch identity survives extraStrip and FACTORY_ prefix stripping", () => {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -3423,9 +3423,10 @@ describe("buildRunSpec", () => {
       runId: "run_baseline",
       policyVersion: "git:test",
     });
-    // Regenerated (#2071): unavailable worktree web UIs now block UX critique.
+    // Regenerated (#2170): dispatch's absolute result-path contract changes
+    // the pinned definition hash carried by planned specs.
     expect(canonicalJson(spec)).toBe(
-      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:1843e0a20438d74a3ec58d766c020a13c4677da3da00b72e907fd02e4f3dfe00","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
+      '{"adapter":"cursor","agent":"dispatch@1","capabilities":["tracker:write","repo:write","github:write"],"defHash":"sha256:8e8b4b99c6cd953977ed193d22b682b93bf7efd921ea514ae866d729d7442ab9","idempotencyKey":"dispatch@1:factory.dispatch-result/v1:sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59:dispatch-baseline","input":{"repo":"factory","ticket":"WM-694"},"inputHash":"sha256:4381f987d301384843e8cf651c969e06c3d9dba79b947f3c07b5c3852926cf59","maxAttempts":1,"model":"cursor-grok-4.6-high","modelTier":"strong","outputContract":"factory.dispatch-result/v1","policyVersion":"git:test","promptVersion":"git:test","runId":"run_baseline","schemaVersion":"factory.run-spec/v1","timeoutSeconds":5400,"workspace":{"checkoutDir":"repo","retainOnFailure":true,"type":"worktree"}}',
     );
   });
 

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -443,10 +443,10 @@ describe("registry", () => {
     // was captured.
     // Regenerated (#2144): added celld-smoke agent definition (re-pinned after
     // prettier formatting of the agent prose/schema).
-    // Regenerated (#2149): added the editorial agent definitions, their event
-    // types, and the editorial lifecycle edges.
+    // Regenerated (#2170): dispatch writes to FACTORY_RESULT_PATH and the
+    // pinned prompt/definition digest changes with that recovery contract.
     const expected =
-      "sha256:4935065888a9ef13e0a7aee5e528d5366c190f94874b90a3274074eda7520640";
+      "sha256:f39e83489b66ae02295fbedf030a830733693b7d1956cbbe401aef8dc7fdd49c";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 
@@ -747,10 +747,10 @@ describe("registry", () => {
     // prompt pin only, `pack` remains non-enumerable.
     // Regenerated (#2013): dispatch documents draft PR readiness; prompt pin
     // only, `pack` remains non-enumerable.
-    // Regenerated (#2071): dispatch blocks an unavailable web UI before UX
-    // critique, then re-pins the prompt definition.
+    // Regenerated (#2170): dispatch writes result envelopes through the
+    // worker-supplied absolute result path.
     expect(computeDefHash(def)).toBe(
-      "sha256:1843e0a20438d74a3ec58d766c020a13c4677da3da00b72e907fd02e4f3dfe00",
+      "sha256:8e8b4b99c6cd953977ed193d22b682b93bf7efd921ea514ae866d729d7442ab9",
     );
   });
 

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1721,6 +1721,7 @@ export function verifyResult({
   journalHead = null,
   extraArtifacts = [],
   worktreeRecord = null,
+  checkoutPath = null,
   onTrace = null,
   verifyTimeoutMs = repoVerifyTimeoutMs(),
   runHandoffCommandFn = runHandoffCommand,
@@ -1728,7 +1729,9 @@ export function verifyResult({
 }) {
   const raw = readResultFile({
     workspaceDir,
-    worktreeRecord,
+    // The stray probe only needs the physical checkout. Callers that suppress
+    // worktree command verification still pass it explicitly.
+    checkout: checkoutPath ?? worktreeRecord?.path ?? null,
     attemptStartedAt,
     onTrace,
   });
@@ -1769,12 +1772,7 @@ export function verifyResult({
  * their mtime proves they belong to this attempt; an old sibling ticket's
  * envelope is never a valid substitute for this run's result.
  */
-function readResultFile({
-  workspaceDir,
-  worktreeRecord,
-  attemptStartedAt,
-  onTrace,
-}) {
+function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
   const resultPath = path.join(workspaceDir, "result.json");
   try {
     return readFileSync(resultPath, "utf8");
@@ -1782,7 +1780,6 @@ function readResultFile({
     // The workspace result is deliberately the only unconditional location.
   }
 
-  const checkout = worktreeRecord?.path;
   const candidates = [];
   if (checkout) {
     candidates.push(path.join(checkout, "result.json"));
@@ -1808,17 +1805,27 @@ function readResultFile({
       stalePaths.push({ path: candidatePath, mtime: stat.mtime.toISOString() });
       continue;
     }
+    let raw;
     try {
-      const raw = readFileSync(candidatePath, "utf8");
-      rmSync(candidatePath, { force: true });
-      onTrace?.("lifecycle", {
-        note: "result_recovered_from_stray_path",
-        path: candidatePath,
-      });
-      return raw;
+      raw = readFileSync(candidatePath, "utf8");
     } catch {
       // A concurrent cleanup can remove a candidate between stat and read.
+      continue;
     }
+    try {
+      JSON.parse(raw);
+    } catch {
+      // Adoption destroys the candidate, so only well-formed JSON is adopted:
+      // a truncated or foreign file is left in place for the next candidate
+      // (and for the operator) rather than deleted unread.
+      continue;
+    }
+    rmSync(candidatePath, { force: true });
+    onTrace?.("lifecycle", {
+      note: "result_recovered_from_stray_path",
+      path: candidatePath,
+    });
+    return raw;
   }
 
   const err = new ContractViolation(["missing_result"]);

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -21,6 +21,7 @@ import {
   readFileSync,
   realpathSync,
   rmSync,
+  statSync,
   symlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -1716,19 +1717,21 @@ export function verifyResult({
   registry,
   workspaceDir,
   attempt,
+  attemptStartedAt = null,
   journalHead = null,
   extraArtifacts = [],
   worktreeRecord = null,
+  onTrace = null,
   verifyTimeoutMs = repoVerifyTimeoutMs(),
   runHandoffCommandFn = runHandoffCommand,
   dependencyInstaller = defaultDependencyInstaller,
 }) {
-  let raw;
-  try {
-    raw = readFileSync(path.join(workspaceDir, "result.json"), "utf8");
-  } catch {
-    throw new ContractViolation(["missing_result"]);
-  }
+  const raw = readResultFile({
+    workspaceDir,
+    worktreeRecord,
+    attemptStartedAt,
+    onTrace,
+  });
 
   let candidate;
   try {
@@ -1758,6 +1761,70 @@ export function verifyResult({
     runHandoffCommandFn,
     dependencyInstaller,
   });
+}
+
+/**
+ * Result authors work in `workspaceDir/repo`, which may be a symlink to the
+ * physical checkout. Recover the two historical stray locations only when
+ * their mtime proves they belong to this attempt; an old sibling ticket's
+ * envelope is never a valid substitute for this run's result.
+ */
+function readResultFile({
+  workspaceDir,
+  worktreeRecord,
+  attemptStartedAt,
+  onTrace,
+}) {
+  const resultPath = path.join(workspaceDir, "result.json");
+  try {
+    return readFileSync(resultPath, "utf8");
+  } catch {
+    // The workspace result is deliberately the only unconditional location.
+  }
+
+  const checkout = worktreeRecord?.path;
+  const candidates = [];
+  if (checkout) {
+    candidates.push(path.join(checkout, "result.json"));
+    try {
+      candidates.push(path.join(realpathSync(checkout), "..", "result.json"));
+    } catch {
+      // The normal missing-result path will report the primary result path.
+    }
+  }
+
+  const startMs = Date.parse(attemptStartedAt);
+  const nowMs = Date.now();
+  const stalePaths = [];
+  for (const candidatePath of [...new Set(candidates)]) {
+    let stat;
+    try {
+      stat = statSync(candidatePath);
+    } catch {
+      continue;
+    }
+    const mtimeMs = stat.mtimeMs;
+    if (!Number.isFinite(startMs) || mtimeMs < startMs || mtimeMs > nowMs) {
+      stalePaths.push({ path: candidatePath, mtime: stat.mtime.toISOString() });
+      continue;
+    }
+    try {
+      const raw = readFileSync(candidatePath, "utf8");
+      rmSync(candidatePath, { force: true });
+      onTrace?.("lifecycle", {
+        note: "result_recovered_from_stray_path",
+        path: candidatePath,
+      });
+      return raw;
+    } catch {
+      // A concurrent cleanup can remove a candidate between stat and read.
+    }
+  }
+
+  const err = new ContractViolation(["missing_result"]);
+  if (stalePaths.length > 0) err.missingResultPaths = stalePaths;
+  if (candidates.length > 0) err.missingResultFallbacks = candidates;
+  throw err;
 }
 
 /**

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -491,6 +491,75 @@ describe("verifyResult", () => {
     ]);
   });
 
+  test("leaves an unparseable stray in place and tries the next candidate", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const physicalParent = tmpDir("evrt-verify-checkout-parent-");
+    const checkout = path.join(physicalParent, "checkout");
+    mkdirSync(checkout);
+    symlinkSync(checkout, path.join(workspaceDir, "repo"), "dir");
+    // The first candidate probed is <checkout>/result.json; a truncated file
+    // there must not be destroyed, and must not stop the sibling lookup.
+    const truncatedPath = path.join(checkout, "result.json");
+    writeFileSync(truncatedPath, '{"schemaVersion": "factory.age', "utf8");
+    const strayPath = path.join(physicalParent, "result.json");
+    writeFileSync(
+      strayPath,
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+      }),
+      "utf8",
+    );
+
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: { path: checkout },
+      attempt: 1,
+      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(existsSync(strayPath)).toBe(false);
+    expect(readFileSync(truncatedPath, "utf8")).toBe(
+      '{"schemaVersion": "factory.age',
+    );
+  });
+
+  test("probes the checkout handed over separately from the worktree record", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const checkout = tmpDir("evrt-verify-checkout-");
+    const strayPath = path.join(checkout, "result.json");
+    writeFileSync(
+      strayPath,
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+      }),
+      "utf8",
+    );
+
+    // The timed-out preflight suppresses worktree command verification with an
+    // empty record while still naming the checkout for the stray probe.
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: {},
+      checkoutPath: checkout,
+      attempt: 1,
+      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(existsSync(strayPath)).toBe(false);
+  });
+
   test("rejects a stale stray result from before this attempt", () => {
     const workspaceDir = tmpDir("evrt-verify-workspace-");
     const checkout = tmpDir("evrt-verify-checkout-");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -6,6 +6,7 @@ import {
   readFileSync,
   realpathSync,
   symlinkSync,
+  utimesSync,
   writeSync,
   writeFileSync,
 } from "node:fs";
@@ -445,6 +446,85 @@ describe("verifyResult", () => {
     } catch (err) {
       expect(err).toBeInstanceOf(ContractViolation);
       expect(err.violations).toEqual(["missing_result"]);
+    }
+  });
+
+  test("recovers a current stray result from the physical checkout and removes it", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const physicalParent = tmpDir("evrt-verify-checkout-parent-");
+    const checkout = path.join(physicalParent, "checkout");
+    mkdirSync(checkout);
+    symlinkSync(checkout, path.join(workspaceDir, "repo"), "dir");
+    const strayPath = path.join(physicalParent, "result.json");
+    const events = [];
+    writeFileSync(
+      strayPath,
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+      }),
+      "utf8",
+    );
+
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: { path: checkout },
+      attempt: 1,
+      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      onTrace: (kind, payload) => events.push({ kind, payload }),
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(existsSync(strayPath)).toBe(false);
+    expect(events).toEqual([
+      {
+        kind: "lifecycle",
+        payload: {
+          note: "result_recovered_from_stray_path",
+          path: strayPath,
+        },
+      },
+    ]);
+  });
+
+  test("rejects a stale stray result from before this attempt", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const checkout = tmpDir("evrt-verify-checkout-");
+    const strayPath = path.join(checkout, "result.json");
+    writeFileSync(
+      strayPath,
+      JSON.stringify({ artifact: VALID_ARTIFACT }),
+      "utf8",
+    );
+    const attemptStartedAt = new Date(Date.now() - 5_000);
+    utimesSync(
+      strayPath,
+      new Date(attemptStartedAt.getTime() - 1_000),
+      new Date(attemptStartedAt.getTime() - 1_000),
+    );
+
+    try {
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        worktreeRecord: { path: checkout },
+        attempt: 1,
+        attemptStartedAt: attemptStartedAt.toISOString(),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toEqual(["missing_result"]);
+      expect(err.missingResultPaths).toEqual([
+        { path: strayPath, mtime: expect.any(String) },
+      ]);
+      expect(existsSync(strayPath)).toBe(true);
     }
   });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1094,6 +1094,7 @@ export function dispatchIdentityEnv({
   runId = null,
   ticketId = null,
   repoName = null,
+  resultPath = null,
 }) {
   if (!String(spec?.agent ?? "").startsWith("dispatch@")) return env;
   // A dispatched agent must never inherit the worker's control bearer. It can
@@ -1106,6 +1107,8 @@ export function dispatchIdentityEnv({
     identity.FACTORY_TICKET = String(ticketId);
   if (repoName != null && repoName !== "")
     identity.FACTORY_REPO = String(repoName);
+  if (resultPath != null && resultPath !== "")
+    identity.FACTORY_RESULT_PATH = String(resultPath);
   // A dispatched agent needs the location of its isolated runtime to retain
   // notifications, but never the worker's control bearer. The caller supplies
   // these two non-secret values explicitly rather than copying process.env.
@@ -1910,8 +1913,10 @@ export function defaultFindWorkspacePullRequest({ workspacePath, forge }) {
 
 const MISSING_RESULT_OUTPUT_CHARS = 2 * 1024;
 
-function missingResultFailure(workspaceDir) {
+function missingResultFailure(workspaceDir, error = null) {
   const resultPath = path.resolve(workspaceDir, "result.json");
+  const fallbackPaths = error?.missingResultFallbacks ?? [];
+  const stalePaths = error?.missingResultPaths ?? [];
   const output = [
     ["stdout", ".transcript.json"],
     ["stderr", ".stderr.txt"],
@@ -1930,7 +1935,13 @@ function missingResultFailure(workspaceDir) {
     .join("\n");
   const normalized = normalizeFailureOutput(output).join("\n");
   const tail = normalized.slice(-MISSING_RESULT_OUTPUT_CHARS);
-  return `missing_result: expected ${resultPath}; agent stdout/stderr (last 2 KB): ${tail || "(no captured output)"}`;
+  const fallbackDetail = fallbackPaths.length
+    ? `; probed fallbacks ${fallbackPaths.join(", ")}`
+    : "";
+  const staleDetail = stalePaths.length
+    ? `; stale result.json found at ${stalePaths.map(({ path: candidatePath, mtime }) => `${candidatePath} (mtime ${mtime}, before this attempt started)`).join(", ")}`
+    : "";
+  return `missing_result: expected ${resultPath}${fallbackDetail}${staleDetail}; agent stdout/stderr (last 2 KB): ${tail || "(no captured output)"}`;
 }
 
 /**
@@ -4198,7 +4209,7 @@ export async function executeClaimed(
       db.query(
         `UPDATE attempts SET started_at = ? WHERE run_id = ? AND attempt = ?`,
       ).run(iso(currentNow), runId, attempt);
-      return { ok: true };
+      return { ok: true, startedAt: iso(currentNow) };
     });
     if (started?.fenced) {
       return { fenced: true };
@@ -4964,6 +4975,7 @@ export async function executeClaimed(
         runId,
         ticketId,
         repoName,
+        resultPath: path.join(workspaceDir, "result.json"),
       });
       outcome = await adapter.execute({
         spec:
@@ -5107,8 +5119,10 @@ export async function executeClaimed(
           registry,
           workspaceDir,
           attempt,
+          attemptStartedAt: started.startedAt,
           extraArtifacts: RUNTIME_ARTIFACTS,
           worktreeRecord: {},
+          onTrace,
         });
         lateCompletion = true;
       } catch (err) {
@@ -5260,8 +5274,10 @@ export async function executeClaimed(
         registry,
         workspaceDir,
         attempt,
+        attemptStartedAt: started.startedAt,
         extraArtifacts: RUNTIME_ARTIFACTS,
         worktreeRecord,
+        onTrace,
       });
       // `prNumber` was optional on pre-WM-576 dispatch artifacts. Preserve
       // their accepted handoffs; current dispatch prompts require it, and all
@@ -5306,8 +5322,10 @@ export async function executeClaimed(
             registry,
             workspaceDir,
             attempt,
+            attemptStartedAt: started.startedAt,
             extraArtifacts: RUNTIME_ARTIFACTS,
             worktreeRecord,
+            onTrace,
           });
           if (verified.handoff && handoffPrNumber(verified.handoff)) {
             assertHandoffPullRequestBase({
@@ -5371,7 +5389,7 @@ export async function executeClaimed(
       let failureReason =
         activeError.violations.length === 1 &&
         activeError.violations[0] === "missing_result"
-          ? `${reasonCode}: ${missingResultFailure(workspaceDir)}`
+          ? `${reasonCode}: ${missingResultFailure(workspaceDir, activeError)}`
           : `${reasonCode}: ${activeError.violations.join(", ")}`;
       const continuationFailure = escalationHandoffFailure(
         activeError,

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -5121,7 +5121,11 @@ export async function executeClaimed(
           attempt,
           attemptStartedAt: started.startedAt,
           extraArtifacts: RUNTIME_ARTIFACTS,
+          // The empty record keeps worktree command verification suppressed;
+          // the checkout path is handed over separately so the stray-result
+          // probe still looks beside the worktree on this branch.
           worktreeRecord: {},
+          checkoutPath: worktreeRecord?.path ?? null,
           onTrace,
         });
         lateCompletion = true;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6411,6 +6411,7 @@ sh -c 'sleep 5 & wait'
       runId: "run-1",
       ticketId: 1497,
       repoName: "factory",
+      resultPath: "/workspace/result.json",
     });
     expect(full).toEqual({
       PATH: "/bin",
@@ -6420,6 +6421,7 @@ sh -c 'sleep 5 & wait'
       FACTORY_RUN_ID: "run-1",
       FACTORY_TICKET: "1497",
       FACTORY_REPO: "factory",
+      FACTORY_RESULT_PATH: "/workspace/result.json",
     });
     expect(full.FACTORY_CONTROL_API_TOKEN).toBeUndefined();
 


### PR DESCRIPTION
Fixes watt-mind/factory#2170

Dispatch agents now receive an absolute result path and verifier recovery safely handles fresh stray envelopes.

## Validation

| Check                | Command                                                                                                            | Result  | Notes                    |
| -------------------- | ------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------ |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs event-runtime/lib/worker.test.mjs event-runtime/lib/adapters/child-env.test.mjs --timeout 20000` | pass | 285 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (615 baseline warnings) |
| UX critique          | factory-ux-critic                                                                                                  | not run | no user-facing surface   |

UX critique: skipped — backend/runtime contract only

run:run_5522dd14-218d-439e-81aa-0d8da9e791a0