### PR TITLE
fix(verify): preserve tracked result files

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1794,6 +1794,15 @@ function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
   const nowMs = Date.now();
   const stalePaths = [];
   for (const candidatePath of [...new Set(candidates)]) {
+    // A checkout can legitimately own a root result.json. Never adopt or
+    // delete that repository file; only untracked checkout output is a stray.
+    if (
+      checkout &&
+      candidatePath === path.join(checkout, "result.json") &&
+      checkoutResultIsTracked(checkout)
+    ) {
+      continue;
+    }
     let stat;
     try {
       stat = statSync(candidatePath);
@@ -1832,6 +1841,19 @@ function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
   if (stalePaths.length > 0) err.missingResultPaths = stalePaths;
   if (candidates.length > 0) err.missingResultFallbacks = candidates;
   throw err;
+}
+
+function checkoutResultIsTracked(checkout) {
+  try {
+    execFileSync(
+      "git",
+      ["-C", checkout, "ls-files", "--error-unmatch", "result.json"],
+      { stdio: "ignore" },
+    );
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /**

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1794,19 +1794,22 @@ function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
   const nowMs = Date.now();
   const stalePaths = [];
   for (const candidatePath of [...new Set(candidates)]) {
+    let stat;
+    try {
+      stat = statSync(candidatePath);
+    } catch {
+      continue;
+    }
     // A checkout can legitimately own a root result.json. Never adopt or
     // delete that repository file; only untracked checkout output is a stray.
+    // Checked after the existence probe so git is not spawned for a candidate
+    // that does not exist.
     if (
       checkout &&
       candidatePath === path.join(checkout, "result.json") &&
       checkoutResultIsTracked(checkout)
     ) {
-      continue;
-    }
-    let stat;
-    try {
-      stat = statSync(candidatePath);
-    } catch {
+      stalePaths.push({ path: candidatePath, skipped: "tracked_in_checkout" });
       continue;
     }
     const mtimeMs = stat.mtimeMs;
@@ -1848,11 +1851,15 @@ function checkoutResultIsTracked(checkout) {
     execFileSync(
       "git",
       ["-C", checkout, "ls-files", "--error-unmatch", "result.json"],
-      { stdio: "ignore" },
+      { stdio: "ignore", timeout: 60_000 },
     );
     return true;
-  } catch {
-    return false;
+  } catch (err) {
+    // Exit 1 is the definitive "not tracked" answer. Anything else (not a
+    // repository, dubious ownership, a locked index, no git on PATH, timeout)
+    // is ambiguous — fail closed and treat the file as tracked so a stray
+    // git failure can never make us adopt and delete a repository file.
+    return err?.status !== 1;
   }
 }
 

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -529,6 +529,58 @@ describe("verifyResult", () => {
     );
   });
 
+  test("leaves a tracked checkout result in place and tries the next candidate", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const physicalParent = tmpDir("evrt-verify-checkout-parent-");
+    const checkout = path.join(physicalParent, "checkout");
+    mkdirSync(checkout);
+    symlinkSync(checkout, path.join(workspaceDir, "repo"), "dir");
+    const trackedPath = path.join(checkout, "result.json");
+    const trackedResult = JSON.stringify({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+    });
+    writeFileSync(trackedPath, trackedResult, "utf8");
+    execFileSync("git", ["init", "--quiet", checkout]);
+    execFileSync("git", ["-C", checkout, "add", "result.json"]);
+    const strayPath = path.join(physicalParent, "result.json");
+    const events = [];
+    writeFileSync(
+      strayPath,
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+      }),
+      "utf8",
+    );
+
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: { path: checkout },
+      attempt: 1,
+      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      onTrace: (kind, payload) => events.push({ kind, payload }),
+    });
+
+    expect(out.kind).toBe("completed");
+    expect(readFileSync(trackedPath, "utf8")).toBe(trackedResult);
+    expect(existsSync(strayPath)).toBe(false);
+    expect(events).toEqual([
+      {
+        kind: "lifecycle",
+        payload: {
+          note: "result_recovered_from_stray_path",
+          path: strayPath,
+        },
+      },
+    ]);
+  });
+
   test("probes the checkout handed over separately from the worktree record", () => {
     const workspaceDir = tmpDir("evrt-verify-workspace-");
     const checkout = tmpDir("evrt-verify-checkout-");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -499,6 +499,7 @@ describe("verifyResult", () => {
     symlinkSync(checkout, path.join(workspaceDir, "repo"), "dir");
     // The first candidate probed is <checkout>/result.json; a truncated file
     // there must not be destroyed, and must not stop the sibling lookup.
+    execFileSync("git", ["init", "--quiet", checkout]);
     const truncatedPath = path.join(checkout, "result.json");
     writeFileSync(truncatedPath, '{"schemaVersion": "factory.age', "utf8");
     const strayPath = path.join(physicalParent, "result.json");
@@ -581,9 +582,49 @@ describe("verifyResult", () => {
     ]);
   });
 
+  test("fails closed when the tracked check cannot answer (#2172)", () => {
+    // The checkout is not a git repository, so `git ls-files` exits 128
+    // rather than the definitive 1. An ambiguous git failure must never let
+    // the candidate be adopted and deleted: the file stays untouched.
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const physicalParent = tmpDir("evrt-verify-checkout-parent-");
+    const checkout = path.join(physicalParent, "checkout");
+    mkdirSync(checkout);
+    symlinkSync(checkout, path.join(workspaceDir, "repo"), "dir");
+    const candidatePath = path.join(checkout, "result.json");
+    const candidate = JSON.stringify({
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      artifact: VALID_ARTIFACT,
+    });
+    writeFileSync(candidatePath, candidate, "utf8");
+
+    try {
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        worktreeRecord: { path: checkout },
+        attempt: 1,
+        attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      });
+      throw new Error("expected ContractViolation");
+    } catch (err) {
+      expect(err).toBeInstanceOf(ContractViolation);
+      expect(err.violations).toEqual(["missing_result"]);
+      expect(err.missingResultPaths).toEqual([
+        { path: candidatePath, skipped: "tracked_in_checkout" },
+      ]);
+    }
+    expect(existsSync(candidatePath)).toBe(true);
+    expect(readFileSync(candidatePath, "utf8")).toBe(candidate);
+  });
+
   test("probes the checkout handed over separately from the worktree record", () => {
     const workspaceDir = tmpDir("evrt-verify-workspace-");
     const checkout = tmpDir("evrt-verify-checkout-");
+    execFileSync("git", ["init", "--quiet", checkout]);
     const strayPath = path.join(checkout, "result.json");
     writeFileSync(
       strayPath,
@@ -615,6 +656,7 @@ describe("verifyResult", () => {
   test("rejects a stale stray result from before this attempt", () => {
     const workspaceDir = tmpDir("evrt-verify-workspace-");
     const checkout = tmpDir("evrt-verify-checkout-");
+    execFileSync("git", ["init", "--quiet", checkout]);
     const strayPath = path.join(checkout, "result.json");
     writeFileSync(
       strayPath,


### PR DESCRIPTION
Fixes watt-mind/factory#2172

Preserve tracked checkout result files during stray-result recovery.

## Validation

| Check                | Command                                                                          | Result  | Notes                     |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------- |
| Verification Command | `bun test event-runtime/lib/verify.test.mjs --timeout 20000`                     | pass    | 113 tests, 0 failures     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 baseline warnings |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface    |

UX critique: skipped — no user-facing surface
run:run_6da41f46-7201-41e6-a0f3-4d1fadf22232
