### PR TITLE
build: run prettier from bun run check

### DIFF
--- a/package.json
+++ b/package.json
@@ -72,7 +72,7 @@
     "merge": "bun orchestrator/run.mjs --only merge --once --apply --repo",
     "janitor": "bun orchestrator/run.mjs --only janitor --once --apply --repo",
     "emit": "bun build/emit.mjs",
-    "check": "bun build/emit.mjs --check && bun run check:web",
+    "check": "bun build/emit.mjs --check && bun run check:web && bun run format:check",
     "check:web": "cd event-runtime/web && if [ -d node_modules ]; then bun run typecheck; else echo \"check:web: skipped (run 'bun install' in event-runtime/web to enable the TypeScript check)\"; fi",
     "link": "bun build/emit.mjs --link",
     "link-bin": "bun build/emit.mjs --link-bin",

--- a/tools/package-scripts.test.mjs
+++ b/tools/package-scripts.test.mjs
@@ -1,0 +1,13 @@
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { expect, test } from "bun:test";
+
+const ROOT = path.resolve(import.meta.dir, "..");
+
+test("check runs the formatting gate", () => {
+  const manifest = JSON.parse(
+    readFileSync(path.join(ROOT, "package.json"), "utf8"),
+  );
+
+  expect(manifest.scripts.check).toContain("bun run format:check");
+});


### PR DESCRIPTION
Fixes watt-mind/factory#2175

Review the check script now runs Prettier before a branch can pass the local gate.

## Validation

| Check                | Command                                                                                                  | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test tools/package-scripts.test.mjs --timeout 20000`                                               | pass    | 1 test, 0 failures                 |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | all gates passed; existing warnings |
| UX critique          | factory-ux-critic                                                                                        | not run | package-script wiring; no user flow |

UX critique: skipped — package-script wiring only; no user-facing surface

run:run_18f6a048-6f03-4129-a17c-a9c8cbc7f786
