### PR TITLE
fix(api): normalize ticket cache since keys (#2174)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1068,6 +1068,9 @@ function collectionPage(url) {
   }
 }
 
+const RELATIVE_SINCE_PATTERN =
+  /^(\d+)\s*(d|day|days|h|hour|hours|m|min|mins|minute|minutes|s|sec|secs|second|seconds|w|week|weeks)$/i;
+
 export function parseSinceDuration(since, nowMs = Date.now()) {
   if (since == null || since === "") {
     return nowMs - 14 * 24 * 60 * 60 * 1000;
@@ -1083,9 +1086,7 @@ export function parseSinceDuration(since, nowMs = Date.now()) {
     throw new ListQueryError("invalid_since", { since });
   }
   const trimmed = since.trim();
-  const match = trimmed.match(
-    /^(\d+)\s*(d|day|days|h|hour|hours|m|min|mins|minute|minutes|s|sec|secs|second|seconds|w|week|weeks)$/i,
-  );
+  const match = trimmed.match(RELATIVE_SINCE_PATTERN);
   if (match) {
     const count = Number(match[1]);
     if (!Number.isFinite(count) || count <= 0) {
@@ -1158,9 +1159,14 @@ function ticketIndexCacheDatabaseId(db) {
   return id;
 }
 
-function ticketIndexCacheSinceKey(since) {
-  if (since == null || since === "") return "";
-  return typeof since === "string" ? since.trim() : String(since);
+function ticketIndexCacheSinceKey(since, sinceMs, nowMs) {
+  if (since == null || since === "") return `relative:${nowMs - sinceMs}`;
+  if (typeof since === "number") {
+    return since > 1e11 ? `absolute:${sinceMs}` : `relative:${nowMs - sinceMs}`;
+  }
+  return RELATIVE_SINCE_PATTERN.test(since.trim())
+    ? `relative:${nowMs - sinceMs}`
+    : `absolute:${sinceMs}`;
 }
 
 /**
@@ -1181,7 +1187,7 @@ export function ticketIndexView(db, options = {}) {
 
   const cacheKey = JSON.stringify([
     ticketIndexCacheDatabaseId(db),
-    ticketIndexCacheSinceKey(options.since),
+    ticketIndexCacheSinceKey(options.since, sinceMs, nowMs),
     limit,
     repoFilter,
   ]);

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -1823,7 +1823,33 @@ describe("recent-ticket index (WM-821)", () => {
     }
   });
 
-  test("caches ticket index requests across advancing clocks until its TTL expires", async () => {
+  test("normalizes equivalent absolute since values to one ticket-index cache entry", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      clearTicketIndexCache();
+      const utc = ticketIndexView(s.db, {
+        nowMs,
+        since: "2026-08-01T00:00:00Z",
+      });
+      const offset = ticketIndexView(s.db, {
+        nowMs,
+        since: "2026-08-01T00:00:00+00:00",
+      });
+      const milliseconds = ticketIndexView(s.db, {
+        nowMs,
+        since: "2026-08-01T00:00:00.000Z",
+      });
+
+      expect(offset).toBe(utc);
+      expect(milliseconds).toBe(utc);
+    } finally {
+      clearTicketIndexCache();
+      s.close();
+    }
+  });
+
+  test("normalizes equivalent duration cache entries and reanchors them after TTL expiry", async () => {
     const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
     const s = await makeServer({ now: () => nowMs });
     try {
@@ -1842,14 +1868,14 @@ describe("recent-ticket index (WM-821)", () => {
 
       const cached = ticketIndexView(s.db, {
         nowMs: nowMs + 10,
-        since: "14d",
+        since: "336h",
       });
       expect(cached).toBe(initial);
       expect(cached).toEqual([]);
 
       const refreshed = ticketIndexView(s.db, {
         nowMs: nowMs + 5001,
-        since: "14d",
+        since: "2w",
       });
       expect(refreshed.map((ticket) => ticket.id)).toEqual(["WM-2158"]);
     } finally {


### PR DESCRIPTION
Fixes watt-mind/factory#2174

Normalize equivalent absolute and relative since values to reuse ticket-index cache entries.

## Validation

| Check                | Command                                                                          | Result  | Notes                                 |
| -------------------- | -------------------------------------------------------------------------------- | ------- | ------------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs --timeout 20000`                | pass    | 54 tests, 0 failures                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 pre-existing lint warnings |
| UX critique          | factory-ux-critic                                                                | skipped | no user-facing surface                |

UX critique: skipped — backend cache behavior has no user-facing surface.

run:run_500bd9fb-cba1-426f-870d-9fa3b3dda94b