### PR TITLE
Suppress benign artifact download abort warnings

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -80,10 +80,15 @@ export function artifactHead(
 
 /** Stream an artifact while closing both ends when either side fails or aborts. */
 export async function streamArtifact(source, response) {
+  const responseAlreadyClosed = response.destroyed || response.closed;
   try {
     await pipeline(source, response);
   } catch (err) {
-    console.warn(`artifact download stream failed: ${err.message}`);
+    const clientAborted =
+      err?.code === "ERR_STREAM_PREMATURE_CLOSE" || responseAlreadyClosed;
+    if (!clientAborted) {
+      console.warn(`artifact download stream failed: ${err.message}`);
+    }
     response.destroy();
   }
 }

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -611,6 +611,61 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
     expect(response.destroyed).toBe(true);
   });
 
+  test("artifact stream client aborts are silent while source failures warn", async () => {
+    const warnings = [];
+    const warn = console.warn;
+    console.warn = (message) => warnings.push(message);
+    try {
+      const clientAbort = new Readable({
+        read() {
+          const error = new Error("client closed download");
+          error.code = "ERR_STREAM_PREMATURE_CLOSE";
+          this.destroy(error);
+        },
+      });
+      const clientResponse = new Writable({
+        write(_chunk, _encoding, done) {
+          done();
+        },
+      });
+      await streamArtifact(clientAbort, clientResponse);
+      expect(clientResponse.destroyed).toBe(true);
+      expect(warnings).toEqual([]);
+
+      const alreadyClosedSource = new Readable({
+        read() {
+          this.destroy(new Error("client closed download"));
+        },
+      });
+      const alreadyClosedResponse = new Writable({
+        write(_chunk, _encoding, done) {
+          done();
+        },
+      });
+      alreadyClosedResponse.destroy();
+      await streamArtifact(alreadyClosedSource, alreadyClosedResponse);
+      expect(warnings).toEqual([]);
+
+      const failedSource = new Readable({
+        read() {
+          this.destroy(new Error("artifact blob was pruned"));
+        },
+      });
+      const failedResponse = new Writable({
+        write(_chunk, _encoding, done) {
+          done();
+        },
+      });
+      await streamArtifact(failedSource, failedResponse);
+      expect(failedResponse.destroyed).toBe(true);
+      expect(warnings).toEqual([
+        "artifact download stream failed: artifact blob was pruned",
+      ]);
+    } finally {
+      console.warn = warn;
+    }
+  });
+
   test("GET /artifacts/:hash streams large text and binary artifacts with bounded sniffing", async () => {
     const home = tmpDir("evrt-large-artifacts-api-");
     const store = path.join(home, "artifacts");


### PR DESCRIPTION
Fixes watt-mind/factory#2173

Suppresses routine client-abort noise while retaining warnings for artifact source failures.

## Validation

| Check                | Command                                                        | Result  | Notes                             |
| -------------------- | -------------------------------------------------------------- | ------- | --------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-artifacts.test.mjs --timeout 20000` | pass    | 8 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,437 pass, 0 failures            |
| UX critique          | factory-ux-critic                                              | not run | no user-facing surface            |

UX critique: skipped — backend stream handling has no user-facing surface
run:run_7f6eb1df-8b9d-4d37-8dac-dc5d5131b19a
