### PR TITLE
fix(serve): watchdog main-loop stalls

### DIFF
--- a/event-runtime/cli/serve.mjs
+++ b/event-runtime/cli/serve.mjs
@@ -34,7 +34,11 @@ import {
 import { startApi } from "../lib/api.mjs";
 import { codeStamp, REGISTRY_STAMP_PATHS } from "../lib/worker.mjs";
 import { reapExpiredLeases } from "../lib/reaper.mjs";
-import { startPlannerWorker } from "../lib/planner-worker.mjs";
+import {
+  MAIN_LOOP_HARD_STALL_FLOOR_MS,
+  MAIN_LOOP_HEARTBEAT_INTERVAL_MS,
+  startPlannerWorker,
+} from "../lib/planner-worker.mjs";
 import { CLI_PATH, fail, flagValue, log } from "./shared.mjs";
 
 export const PRUNE_INTERVAL_MS = 60 * 60 * 1000;
@@ -57,6 +61,19 @@ export const INBOX_RECONCILE_DEADLINE_MS = 10_000;
 export const CONNECTOR_STOP_TIMEOUT_MS = 1_500;
 export const CLOSE_CONNECTIONS_AFTER_MS = 500;
 export const HARD_EXIT_MS = 2_500;
+
+/**
+ * The hard main-loop watchdog is intentionally disabled unless an operator
+ * opts in. An invalid value is equivalent to disabled rather than turning a
+ * typo into an unexpected serve restart, and an enabled one is clamped up to
+ * a floor of several soft stall windows so ordinary tick slowness can never
+ * be enough to restart serve.
+ */
+export function mainLoopHardStallAfterMs(env = process.env) {
+  const value = Number(env.FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS);
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return Math.max(value, MAIN_LOOP_HARD_STALL_FLOOR_MS);
+}
 
 /**
  * Mutable ownership seam for the validated registry.  Loading and validation
@@ -684,6 +701,7 @@ export default async function serve(args) {
   let currentTickStep = null;
   let tickStartedAt = null;
   let plannerWorker = null;
+  let plannerHeartbeatTimer = null;
   // Chain approval has exactly one owner in this process: the tick step below,
   // which runs it with awaited, memoised, per-row-bounded control-plane reads.
   // Without this the planner would run the same pass again — inline under
@@ -768,12 +786,30 @@ export default async function serve(args) {
   }
 
   if (!noPlanner) {
+    const hardStallAfterMs = mainLoopHardStallAfterMs();
     plannerWorker = startPlannerWorker({
       eventHome: home,
       policyVersion: pv,
       adapterOverride,
+      mainLoopHardStallAfterMs: hardStallAfterMs,
       log,
     });
+    if (hardStallAfterMs != null) {
+      const raw = Number(process.env.FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS);
+      log(
+        `planner: main-loop hard stall exit armed at ${hardStallAfterMs}ms` +
+          (raw !== hardStallAfterMs
+            ? ` (raised from ${raw}ms to the ${MAIN_LOOP_HARD_STALL_FLOOR_MS}ms floor)`
+            : ""),
+      );
+    }
+    // The worker owns the clock and can therefore observe a main event-loop
+    // wedge. Include the live step so its report says where the loop stopped.
+    plannerWorker.heartbeat(currentTickStep);
+    plannerHeartbeatTimer = setInterval(
+      () => plannerWorker?.heartbeat(currentTickStep),
+      MAIN_LOOP_HEARTBEAT_INTERVAL_MS,
+    );
   }
 
   const env = {
@@ -867,6 +903,12 @@ export default async function serve(args) {
     stopping = true;
     log(`shutting down (${signal})`);
     if (timer) clearInterval(timer);
+    if (plannerHeartbeatTimer) clearInterval(plannerHeartbeatTimer);
+    // We stop heartbeating on purpose from here on, and the bounded stops
+    // below can legitimately take CONNECTOR_STOP_TIMEOUT_MS. Disarm before
+    // any of that so an orderly shutdown cannot be turned into a SIGKILL
+    // that skips releaseServeLock.
+    plannerWorker?.disarmHardStall();
     // Arm this before any cleanup: a connector or the planner thread may
     // never settle. It sits inside the supervisor's SIGKILL grace so the lock
     // is released by us, not by a kernel kill; it is longer than the bounded

--- a/event-runtime/cli/serve.test.mjs
+++ b/event-runtime/cli/serve.test.mjs
@@ -18,9 +18,11 @@ import {
   CLOSE_CONNECTIONS_AFTER_MS,
   CONNECTOR_STOP_TIMEOUT_MS,
   HARD_EXIT_MS,
+  mainLoopHardStallAfterMs,
   serveLockPath,
   stopBounded,
 } from "./serve.mjs";
+import { MAIN_LOOP_HARD_STALL_FLOOR_MS } from "../lib/planner-worker.mjs";
 import { openDb } from "../lib/db.mjs";
 import { startPlannerWorker } from "../lib/planner-worker.mjs";
 import { freePort, until } from "../lib/test-helpers-timing.mjs";
@@ -66,6 +68,28 @@ test("planner worker exit is logged and exposed as dead", async () => {
   } finally {
     await planner.stop();
   }
+});
+
+test("main-loop hard stall recovery is inert until explicitly enabled", () => {
+  expect(mainLoopHardStallAfterMs({})).toBeNull();
+  expect(
+    mainLoopHardStallAfterMs({ FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS: "0" }),
+  ).toBeNull();
+  expect(
+    mainLoopHardStallAfterMs({ FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS: "bad" }),
+  ).toBeNull();
+  // An enabled-but-tiny threshold is raised to the floor: ordinary tick
+  // slowness must never be enough to restart serve.
+  expect(
+    mainLoopHardStallAfterMs({ FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS: "1234" }),
+  ).toBe(MAIN_LOOP_HARD_STALL_FLOOR_MS);
+  expect(
+    mainLoopHardStallAfterMs({
+      FACTORY_MAIN_LOOP_STALL_EXIT_AFTER_MS: String(
+        MAIN_LOOP_HARD_STALL_FLOOR_MS * 4,
+      ),
+    }),
+  ).toBe(MAIN_LOOP_HARD_STALL_FLOOR_MS * 4);
 });
 
 /**
@@ -300,15 +324,27 @@ describe("serve command", () => {
     let health;
     try {
       expect(out).toContain("control API on");
-      const res = await fetch(`http://127.0.0.1:${port}/health`);
-      expect(res.ok).toBe(true);
-      health = await res.json();
+      // The worker echoes its main-loop observation at ~1Hz, so poll until
+      // the first one has landed rather than racing the very first tick.
+      for (let attempt = 0; attempt < 30; attempt++) {
+        const res = await fetch(`http://127.0.0.1:${port}/health`);
+        expect(res.ok).toBe(true);
+        health = await res.json();
+        if (health.planner?.mainLoopHeartbeat) break;
+        await new Promise((resolve) => setTimeout(resolve, 150));
+      }
     } finally {
       child.kill("SIGTERM");
       await new Promise((resolve) => child.once("exit", resolve));
     }
     expect(health.ok).toBe(true);
     expect(health.tick.deadlineSkipped).toBe(0);
+    // The planner worker is serve's only observer of a wedged main loop, so
+    // /health must carry its report (#2129).
+    expect(health.planner.mainLoopHeartbeat).toMatchObject({
+      stalled: false,
+    });
+    expect(typeof health.planner.mainLoopHeartbeat.lastAt).toBe("string");
   });
 
   test("a stalled Linear ticket read cannot wedge /health past the tick budget (#1835 AC3)", async () => {

--- a/event-runtime/lib/planner-worker-thread.mjs
+++ b/event-runtime/lib/planner-worker-thread.mjs
@@ -8,6 +8,10 @@ import { parentPort, workerData } from "node:worker_threads";
 import path from "node:path";
 import { openDb } from "./db.mjs";
 import { loadRegistry } from "./registry.mjs";
+import {
+  evaluateMainLoopObservation,
+  MAIN_LOOP_HARD_STALL_OBSERVATIONS,
+} from "./planner-worker.mjs";
 import { planAdmittedEvents } from "./planner.mjs";
 
 const {
@@ -15,6 +19,9 @@ const {
   policyVersion,
   adapterOverride = null,
   pollMs = 250,
+  heartbeatIntervalMs = 250,
+  mainLoopStallAfterMs = 5_000,
+  mainLoopHardStallAfterMs = null,
 } = workerData || {};
 
 const targetDbPath = path.join(eventHome || process.cwd(), "runtime.db");
@@ -22,6 +29,83 @@ const db = openDb(targetDbPath);
 const registry = loadRegistry();
 
 let busy = false;
+// Age arithmetic runs on the monotonic clock; the wall clock is only ever used
+// for the human-readable `lastAt` field an operator reads in /health.
+let lastMainLoopHeartbeatMono = performance.now();
+let lastMainLoopHeartbeatWallMs = Date.now();
+let lastObservationMono = null;
+let lastMainLoopTickStep = null;
+let mainLoopStalled = false;
+let consecutiveStalledObservations = 0;
+let hardStallTriggered = false;
+let hardStallArmed = mainLoopHardStallAfterMs != null;
+// The stall/recovered transitions below are posted on their own; echoing every
+// observation as well would put four messages a second on the port for no new
+// information. Echo at ~1Hz, plus whenever something actually changed.
+const echoIntervalMs = Math.max(1_000, heartbeatIntervalMs);
+let lastEchoMono = null;
+let lastEchoedTickStep = null;
+
+function observationPayload(ageMs, stalled) {
+  return {
+    lastAt: new Date(lastMainLoopHeartbeatWallMs).toISOString(),
+    ageMs: Math.round(ageMs),
+    stalled,
+    staleAfterMs: mainLoopStallAfterMs,
+    lastTickStep: lastMainLoopTickStep,
+  };
+}
+
+function observeMainLoopHeartbeat() {
+  const now = performance.now();
+  const decision = evaluateMainLoopObservation({
+    nowMono: now,
+    lastHeartbeatMono: lastMainLoopHeartbeatMono,
+    lastObservationMono,
+    heartbeatIntervalMs,
+    mainLoopStallAfterMs,
+    mainLoopHardStallAfterMs: hardStallArmed ? mainLoopHardStallAfterMs : null,
+    consecutiveStalledObservations,
+    requiredStalledObservations: MAIN_LOOP_HARD_STALL_OBSERVATIONS,
+  });
+  lastObservationMono = now;
+  lastMainLoopHeartbeatMono = decision.lastHeartbeatMono;
+  consecutiveStalledObservations = decision.consecutiveStalledObservations;
+
+  // This round says nothing about the main loop — the worker itself was off
+  // CPU. Say nothing, and wait for the queued heartbeats to be delivered.
+  if (decision.workerDescheduled) return;
+
+  const observation = observationPayload(decision.ageMs, decision.stalled);
+  const transitioned = decision.stalled !== mainLoopStalled;
+  if (transitioned) {
+    parentPort?.postMessage({
+      type: decision.stalled ? "main-loop-stall" : "main-loop-recovered",
+      ...observation,
+    });
+  }
+  mainLoopStalled = decision.stalled;
+
+  if (
+    transitioned ||
+    lastEchoedTickStep !== lastMainLoopTickStep ||
+    lastEchoMono == null ||
+    now - lastEchoMono >= echoIntervalMs
+  ) {
+    lastEchoMono = now;
+    lastEchoedTickStep = lastMainLoopTickStep;
+    parentPort?.postMessage({ type: "main-loop-heartbeat", ...observation });
+  }
+
+  if (decision.hardStall && !hardStallTriggered) {
+    hardStallTriggered = true;
+    parentPort?.postMessage({ type: "main-loop-hard-stall", ...observation });
+    // A main-loop wedge cannot service its message queue or signal handlers.
+    // This is deliberately opt-in: SIGKILL gives a supervisor an unambiguous
+    // non-zero exit so it can restart a genuinely stuck serve process.
+    process.kill(process.pid, "SIGKILL");
+  }
+}
 
 async function tickPlanner() {
   if (busy) return;
@@ -47,13 +131,26 @@ async function tickPlanner() {
 }
 
 const interval = setInterval(tickPlanner, pollMs);
+const heartbeatInterval = setInterval(
+  observeMainLoopHeartbeat,
+  heartbeatIntervalMs,
+);
 tickPlanner();
 
 parentPort?.on("message", (msg) => {
   if (msg?.type === "wake" || msg?.type === "admitted") {
     tickPlanner();
+  } else if (msg?.type === "main-loop-heartbeat") {
+    lastMainLoopHeartbeatMono = performance.now();
+    lastMainLoopHeartbeatWallMs = Date.now();
+    lastMainLoopTickStep = msg.currentTickStep ?? null;
+    consecutiveStalledObservations = 0;
+    hardStallTriggered = false;
+  } else if (msg?.type === "main-loop-watchdog-disarm") {
+    hardStallArmed = false;
   } else if (msg?.type === "stop") {
     clearInterval(interval);
+    clearInterval(heartbeatInterval);
     process.exit(0);
   }
 });

--- a/event-runtime/lib/planner-worker.mjs
+++ b/event-runtime/lib/planner-worker.mjs
@@ -10,12 +10,88 @@ import { runtimeHome } from "./config.mjs";
 // minutes leaves room for tracker/API slowness while making a wedged planner
 // visible well before queued intake becomes operationally surprising.
 export const PLANNER_STALE_AFTER_MS = 5 * 60 * 1000;
+export const MAIN_LOOP_HEARTBEAT_INTERVAL_MS = 250;
+export const MAIN_LOOP_STALL_AFTER_MS = 5_000;
+// A hard threshold below a few soft windows would turn ordinary tick slowness
+// into a restart, so an operator's value is clamped up to this floor.
+export const MAIN_LOOP_HARD_STALL_FLOOR_MS = MAIN_LOOP_STALL_AFTER_MS * 3;
+// The hard branch kills the process, so one unlucky observation must never be
+// enough: require this many in a row, each spaced by the heartbeat interval.
+export const MAIN_LOOP_HARD_STALL_OBSERVATIONS = 3;
+// The worker and the main loop share a process. When the worker's own timer
+// slips by more than this multiple of its interval the worker — not the main
+// loop — is what stopped running, and heartbeats are still queued behind it.
+export const WORKER_DESCHEDULED_INTERVALS = 4;
+
+/**
+ * Decide what one heartbeat observation means. Pure so the awkward cases —
+ * a descheduled worker, a not-yet-repeated stall — are testable without a
+ * thread, and so the kill decision has exactly one implementation.
+ *
+ * All time inputs are monotonic (`performance.now()`): a wall-clock step from
+ * NTP or a suspend/resume must not synthesize a stall.
+ */
+export function evaluateMainLoopObservation({
+  nowMono,
+  lastHeartbeatMono,
+  lastObservationMono = null,
+  heartbeatIntervalMs = MAIN_LOOP_HEARTBEAT_INTERVAL_MS,
+  mainLoopStallAfterMs = MAIN_LOOP_STALL_AFTER_MS,
+  mainLoopHardStallAfterMs = null,
+  consecutiveStalledObservations = 0,
+  requiredStalledObservations = MAIN_LOOP_HARD_STALL_OBSERVATIONS,
+}) {
+  const observationGapMs =
+    lastObservationMono == null
+      ? 0
+      : Math.max(0, nowMono - lastObservationMono);
+
+  // The worker's own loop was blocked (a synchronous SQLite pass in
+  // tickPlanner, say). Heartbeats the main loop already posted are sitting
+  // undelivered in the port queue, and after a long block libuv runs timers
+  // before poll — so this observation sees an age the main loop never had.
+  // Credit the blocked window forward and skip the decision this round.
+  if (observationGapMs > heartbeatIntervalMs * WORKER_DESCHEDULED_INTERVALS) {
+    const creditedMono = Math.min(
+      nowMono,
+      lastHeartbeatMono + (observationGapMs - heartbeatIntervalMs),
+    );
+    return {
+      workerDescheduled: true,
+      observationGapMs,
+      lastHeartbeatMono: creditedMono,
+      ageMs: Math.max(0, nowMono - creditedMono),
+      stalled: false,
+      hardStall: false,
+      consecutiveStalledObservations: 0,
+    };
+  }
+
+  const ageMs = Math.max(0, nowMono - lastHeartbeatMono);
+  const stalled = ageMs >= mainLoopStallAfterMs;
+  const nextConsecutive = stalled ? consecutiveStalledObservations + 1 : 0;
+  return {
+    workerDescheduled: false,
+    observationGapMs,
+    lastHeartbeatMono,
+    ageMs,
+    stalled,
+    hardStall:
+      mainLoopHardStallAfterMs != null &&
+      ageMs >= mainLoopHardStallAfterMs &&
+      nextConsecutive >= requiredStalledObservations,
+    consecutiveStalledObservations: nextConsecutive,
+  };
+}
 
 export function startPlannerWorker({
   eventHome = runtimeHome(),
   policyVersion = "unknown",
   adapterOverride = null,
   pollMs = 250,
+  heartbeatIntervalMs = MAIN_LOOP_HEARTBEAT_INTERVAL_MS,
+  mainLoopStallAfterMs = MAIN_LOOP_STALL_AFTER_MS,
+  mainLoopHardStallAfterMs = null,
   log = console.log,
 } = {}) {
   const workerUrl = new URL("./planner-worker-thread.mjs", import.meta.url);
@@ -25,9 +101,13 @@ export function startPlannerWorker({
       policyVersion,
       adapterOverride,
       pollMs,
+      heartbeatIntervalMs,
+      mainLoopStallAfterMs,
+      mainLoopHardStallAfterMs,
     },
   });
   let lastPlannedAt = null;
+  let mainLoopHeartbeat = null;
   let alive = true;
   let stopping = false;
 
@@ -37,6 +117,34 @@ export function startPlannerWorker({
       log(`planner worker: planned ${msg.count} event(s)`);
     } else if (msg?.type === "error") {
       log(`planner worker error: ${msg.message}`);
+    } else if (msg?.type === "main-loop-heartbeat") {
+      mainLoopHeartbeat = {
+        lastAt: msg.lastAt,
+        ageMs: msg.ageMs,
+        stalled: msg.stalled,
+        staleAfterMs: msg.staleAfterMs,
+        lastTickStep: msg.lastTickStep,
+      };
+    } else if (msg?.type === "main-loop-stall") {
+      mainLoopHeartbeat = {
+        lastAt: msg.lastAt,
+        ageMs: msg.ageMs,
+        stalled: true,
+        staleAfterMs: msg.staleAfterMs,
+        lastTickStep: msg.lastTickStep,
+      };
+      log(
+        `planner worker: main-loop heartbeat stalled for ${msg.ageMs}ms at step ${msg.lastTickStep ?? "idle"}`,
+      );
+    } else if (msg?.type === "main-loop-recovered") {
+      mainLoopHeartbeat = {
+        lastAt: msg.lastAt,
+        ageMs: msg.ageMs,
+        stalled: false,
+        staleAfterMs: msg.staleAfterMs,
+        lastTickStep: msg.lastTickStep,
+      };
+      log("planner worker: main-loop heartbeat recovered");
     }
   });
 
@@ -54,6 +162,19 @@ export function startPlannerWorker({
   return {
     worker,
     wake: () => worker.postMessage({ type: "wake" }),
+    heartbeat: (currentTickStep = null) =>
+      worker.postMessage({ type: "main-loop-heartbeat", currentTickStep }),
+    // A graceful shutdown stops heartbeating on purpose, and the bounded stops
+    // it then waits on can legitimately take seconds. Disarm first so an
+    // orderly exit can never be converted into a SIGKILL before the serve lock
+    // is released.
+    disarmHardStall: () => {
+      try {
+        worker.postMessage({ type: "main-loop-watchdog-disarm" });
+      } catch {
+        /* the thread is already gone; nothing left to disarm */
+      }
+    },
     state: ({ nowMs = Date.now(), queued = false } = {}) => {
       const plannedMs = lastPlannedAt ? Date.parse(lastPlannedAt) : Number.NaN;
       const ageMs = Number.isNaN(plannedMs)
@@ -67,11 +188,13 @@ export function startPlannerWorker({
           (queued && (ageMs === null || ageMs >= PLANNER_STALE_AFTER_MS)),
         staleAfterMs: PLANNER_STALE_AFTER_MS,
         alive,
+        mainLoopHeartbeat,
       };
     },
     stop: async () => {
       stopping = true;
       try {
+        worker.postMessage({ type: "main-loop-watchdog-disarm" });
         worker.postMessage({ type: "stop" });
         await worker.terminate();
       } catch {

--- a/event-runtime/lib/planner-worker.test.mjs
+++ b/event-runtime/lib/planner-worker.test.mjs
@@ -1,0 +1,175 @@
+import { expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { writeFileSync } from "node:fs";
+import {
+  evaluateMainLoopObservation,
+  MAIN_LOOP_HARD_STALL_OBSERVATIONS,
+  startPlannerWorker,
+} from "./planner-worker.mjs";
+import { until } from "./test-helpers-timing.mjs";
+import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-planner-worker-test-mjs";
+
+test("planner worker reports an aged main-loop heartbeat and clears it on recovery", async () => {
+  const logs = [];
+  const planner = startPlannerWorker({
+    eventHome: tmpDir("planner-heartbeat-"),
+    heartbeatIntervalMs: 50,
+    mainLoopStallAfterMs: 200,
+    log: (line) => logs.push(line),
+  });
+  try {
+    planner.heartbeat("reconcile-inbox");
+    await until(
+      "the worker to receive the main-loop heartbeat",
+      () =>
+        planner.state().mainLoopHeartbeat?.lastTickStep === "reconcile-inbox",
+      { timeoutMs: 5_000 },
+    );
+    await until(
+      "the worker to observe the missing heartbeat",
+      () => planner.state().mainLoopHeartbeat?.stalled === true,
+      { timeoutMs: 5_000 },
+    );
+    expect(planner.state().mainLoopHeartbeat).toMatchObject({
+      stalled: true,
+      staleAfterMs: 200,
+      lastTickStep: "reconcile-inbox",
+    });
+    expect(logs.some((line) => line.includes("heartbeat stalled"))).toBe(true);
+
+    planner.heartbeat("announce-transitions");
+    await until(
+      "the worker to clear its heartbeat stall",
+      () =>
+        planner.state().mainLoopHeartbeat?.stalled === false &&
+        planner.state().mainLoopHeartbeat?.lastTickStep ===
+          "announce-transitions",
+      { timeoutMs: 5_000 },
+    );
+    expect(logs.some((line) => line.includes("heartbeat recovered"))).toBe(
+      true,
+    );
+  } finally {
+    await planner.stop();
+  }
+});
+
+test("an explicitly enabled hard heartbeat threshold terminates the wedged serve process", () => {
+  const home = tmpDir("planner-hard-heartbeat-");
+  const result = runStarvedWorker(home, {
+    heartbeatIntervalMs: 50,
+    mainLoopStallAfterMs: 100,
+    mainLoopHardStallAfterMs: 200,
+    exitAfterMs: 5_000,
+  });
+  expect(result.error).toBeUndefined();
+  // The kill is the contract: a supervisor restarts on the signal, and a
+  // clean non-zero exit would be indistinguishable from an ordinary crash.
+  expect(result.signal).toBe("SIGKILL");
+});
+
+test("the default hard threshold leaves a stalled main loop reported but alive", () => {
+  const home = tmpDir("planner-soft-heartbeat-");
+  // No mainLoopHardStallAfterMs: the default. 1s is ten soft windows.
+  const result = runStarvedWorker(home, {
+    heartbeatIntervalMs: 50,
+    mainLoopStallAfterMs: 100,
+    exitAfterMs: 1_000,
+  });
+  expect(result.error).toBeUndefined();
+  expect(result.signal).toBeNull();
+  // 0 = stalled and alive; 3 = alive but never observed the stall.
+  expect(result.status).toBe(0);
+});
+
+test("an observation that follows a descheduled worker cannot report a stall", () => {
+  const heartbeatIntervalMs = 250;
+  // The worker's own timer slipped 9s: heartbeats the main loop posted during
+  // that window are still queued, so the raw age is meaningless this round.
+  const decision = evaluateMainLoopObservation({
+    nowMono: 10_000,
+    lastHeartbeatMono: 1_000,
+    lastObservationMono: 1_000,
+    heartbeatIntervalMs,
+    mainLoopStallAfterMs: 5_000,
+    mainLoopHardStallAfterMs: 8_000,
+    consecutiveStalledObservations: 2,
+  });
+  expect(decision.workerDescheduled).toBe(true);
+  expect(decision.stalled).toBe(false);
+  expect(decision.hardStall).toBe(false);
+  expect(decision.consecutiveStalledObservations).toBe(0);
+  // The blocked window is credited forward, so the next round starts from a
+  // fresh age rather than inheriting the worker's own outage.
+  expect(decision.ageMs).toBe(heartbeatIntervalMs);
+});
+
+test("a hard stall needs consecutive stalled observations, not one unlucky round", () => {
+  const base = {
+    nowMono: 20_000,
+    lastHeartbeatMono: 0,
+    lastObservationMono: 19_800,
+    heartbeatIntervalMs: 250,
+    mainLoopStallAfterMs: 5_000,
+    mainLoopHardStallAfterMs: 15_000,
+  };
+  const first = evaluateMainLoopObservation({
+    ...base,
+    consecutiveStalledObservations: 0,
+  });
+  expect(first.stalled).toBe(true);
+  expect(first.hardStall).toBe(false);
+  expect(first.consecutiveStalledObservations).toBe(1);
+
+  expect(
+    evaluateMainLoopObservation({ ...base, consecutiveStalledObservations: 1 })
+      .hardStall,
+  ).toBe(false);
+  expect(
+    evaluateMainLoopObservation({
+      ...base,
+      consecutiveStalledObservations: MAIN_LOOP_HARD_STALL_OBSERVATIONS - 1,
+    }).hardStall,
+  ).toBe(true);
+});
+
+test("a heartbeat within the stall window clears the consecutive count", () => {
+  const decision = evaluateMainLoopObservation({
+    nowMono: 1_000,
+    lastHeartbeatMono: 900,
+    lastObservationMono: 750,
+    heartbeatIntervalMs: 250,
+    mainLoopStallAfterMs: 5_000,
+    mainLoopHardStallAfterMs: 15_000,
+    consecutiveStalledObservations: 2,
+  });
+  expect(decision.stalled).toBe(false);
+  expect(decision.hardStall).toBe(false);
+  expect(decision.consecutiveStalledObservations).toBe(0);
+});
+
+/**
+ * Run a planner worker in its own process that never sends a main-loop
+ * heartbeat, and let it exit on its own after `exitAfterMs`. A hard-stall
+ * SIGKILL therefore shows up as a signal, and its absence as status 0/3.
+ */
+function runStarvedWorker(home, { exitAfterMs, ...options }) {
+  const script = `${home}/starved-worker.mjs`;
+  writeFileSync(
+    script,
+    [
+      `import { startPlannerWorker } from ${JSON.stringify(new URL("./planner-worker.mjs", import.meta.url).href)};`,
+      `const planner = startPlannerWorker({ eventHome: ${JSON.stringify(home)}, ...${JSON.stringify(options)} });`,
+      `setTimeout(() => {`,
+      `  const stalled = planner.state().mainLoopHeartbeat?.stalled === true;`,
+      `  process.exit(stalled ? 0 : 3);`,
+      `}, ${exitAfterMs});`,
+      "",
+    ].join("\n"),
+  );
+
+  return spawnSync(process.execPath, [script], {
+    encoding: "utf8",
+    timeout: 20_000,
+  });
+}


### PR DESCRIPTION
Fixes watt-mind/factory#2129

Worker-observed heartbeat stalls now surface in serve health and can opt into supervisor recovery.

## Validation

| Check | Command | Result | Notes |
| ----- | ------- | ------ | ----- |
| Verification Command | `bun test event-runtime/lib/planner-worker.test.mjs event-runtime/cli/serve.test.mjs` | pass | 28 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 615 baseline lint warnings |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend worker-thread watchdog only

run:run_bde6b807-4467-4658-aad7-2fbb4dc82e25