### PR TITLE
api: classify since durations for ticket-index caching

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -1073,14 +1073,17 @@ const RELATIVE_SINCE_PATTERN =
 
 export function parseSinceDuration(since, nowMs = Date.now()) {
   if (since == null || since === "") {
-    return nowMs - 14 * 24 * 60 * 60 * 1000;
+    const durationMs = 14 * 24 * 60 * 60 * 1000;
+    return { sinceMs: nowMs - durationMs, kind: "relative", durationMs };
   }
   if (typeof since === "number") {
     if (!Number.isFinite(since) || since <= 0) {
       throw new ListQueryError("invalid_since", { since });
     }
-    if (since > 1e11) return since;
-    return nowMs - since;
+    if (since > 1e11) {
+      return { sinceMs: since, kind: "absolute", durationMs: null };
+    }
+    return { sinceMs: nowMs - since, kind: "relative", durationMs: since };
   }
   if (typeof since !== "string") {
     throw new ListQueryError("invalid_since", { since });
@@ -1099,11 +1102,11 @@ export function parseSinceDuration(since, nowMs = Date.now()) {
     else if (unit.startsWith("h")) ms = count * 60 * 60 * 1000;
     else if (unit.startsWith("m")) ms = count * 60 * 1000;
     else if (unit.startsWith("s")) ms = count * 1000;
-    return nowMs - ms;
+    return { sinceMs: nowMs - ms, kind: "relative", durationMs: ms };
   }
   const parsedDate = Date.parse(trimmed);
   if (Number.isFinite(parsedDate) && !/^\d+$/.test(trimmed)) {
-    return parsedDate;
+    return { sinceMs: parsedDate, kind: "absolute", durationMs: null };
   }
   throw new ListQueryError("invalid_since", { since });
 }
@@ -1159,14 +1162,8 @@ function ticketIndexCacheDatabaseId(db) {
   return id;
 }
 
-function ticketIndexCacheSinceKey(since, sinceMs, nowMs) {
-  if (since == null || since === "") return `relative:${nowMs - sinceMs}`;
-  if (typeof since === "number") {
-    return since > 1e11 ? `absolute:${sinceMs}` : `relative:${nowMs - sinceMs}`;
-  }
-  return RELATIVE_SINCE_PATTERN.test(since.trim())
-    ? `relative:${nowMs - sinceMs}`
-    : `absolute:${sinceMs}`;
+function ticketIndexCacheSinceKey({ sinceMs, kind, durationMs }) {
+  return kind === "relative" ? `relative:${durationMs}` : `absolute:${sinceMs}`;
 }
 
 /**
@@ -1175,7 +1172,8 @@ function ticketIndexCacheSinceKey(since, sinceMs, nowMs) {
  */
 export function ticketIndexView(db, options = {}) {
   const nowMs = options.nowMs ?? Date.now();
-  const sinceMs = parseSinceDuration(options.since, nowMs);
+  const parsedSince = parseSinceDuration(options.since, nowMs);
+  const { sinceMs } = parsedSince;
   const sinceIso = new Date(sinceMs).toISOString();
   const limit = options.limit
     ? Math.min(Math.max(1, Number(options.limit) || 50), 200)
@@ -1187,7 +1185,7 @@ export function ticketIndexView(db, options = {}) {
 
   const cacheKey = JSON.stringify([
     ticketIndexCacheDatabaseId(db),
-    ticketIndexCacheSinceKey(options.since, sinceMs, nowMs),
+    ticketIndexCacheSinceKey(parsedSince),
     limit,
     repoFilter,
   ]);

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -26,6 +26,7 @@ import {
   clearRunSubjectCache,
   clearTicketDetailCache,
   clearTicketIndexCache,
+  parseSinceDuration,
   mergeTicketSupply,
   scanTicketSupply,
   setTicketDetailControlPlane,
@@ -1878,6 +1879,48 @@ describe("recent-ticket index (WM-821)", () => {
         since: "2w",
       });
       expect(refreshed.map((ticket) => ticket.id)).toEqual(["WM-2158"]);
+    } finally {
+      clearTicketIndexCache();
+      s.close();
+    }
+  });
+
+  test("classifies since values and keeps relative and absolute cache entries separate", async () => {
+    const nowMs = Date.parse("2026-08-18T12:00:00.000Z");
+    const relativeDurationMs = 14 * 24 * 60 * 60 * 1000;
+    const absoluteSinceMs = nowMs - relativeDurationMs;
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      expect(parseSinceDuration("14d", nowMs)).toEqual({
+        sinceMs: absoluteSinceMs,
+        kind: "relative",
+        durationMs: relativeDurationMs,
+      });
+      expect(parseSinceDuration(relativeDurationMs, nowMs)).toEqual({
+        sinceMs: absoluteSinceMs,
+        kind: "relative",
+        durationMs: relativeDurationMs,
+      });
+      expect(parseSinceDuration(absoluteSinceMs, nowMs)).toEqual({
+        sinceMs: absoluteSinceMs,
+        kind: "absolute",
+        durationMs: null,
+      });
+
+      clearTicketIndexCache();
+      const relative = ticketIndexView(s.db, { nowMs, since: "14d" });
+      const numericRelative = ticketIndexView(s.db, {
+        nowMs,
+        since: relativeDurationMs,
+      });
+      const absolute = ticketIndexView(s.db, { nowMs, since: absoluteSinceMs });
+      const isoAbsolute = ticketIndexView(s.db, {
+        nowMs,
+        since: new Date(absoluteSinceMs).toISOString(),
+      });
+      expect(numericRelative).toBe(relative);
+      expect(absolute).not.toBe(relative);
+      expect(isoAbsolute).toBe(absolute);
     } finally {
       clearTicketIndexCache();
       s.close();


### PR DESCRIPTION
Fixes watt-mind/factory#2182

Make ticket-index cache keys consume parsed since classifications, preventing relative and absolute windows from colliding.

## Validation

| Check                | Command                                                                              | Result  | Notes                              |
| -------------------- | ------------------------------------------------------------------------------------ | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-runs.test.mjs --timeout 20000`                       | pass    | 55 tests, 0 failures               |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; lint emitted 615 warnings |
| UX critique          | `factory-ux-critic`                                                                  | not run | no user-facing surface             |

UX critique: skipped — backend cache parsing and test coverage only
run:run_c99f1a88-936e-47a1-868f-f11ce7a22c4f
