### PR TITLE
fix(api): classify artifact client aborts

### DIFF
--- a/event-runtime/lib/api-artifacts.mjs
+++ b/event-runtime/lib/api-artifacts.mjs
@@ -85,8 +85,17 @@ export async function streamArtifact(source, response) {
     await pipeline(source, response);
   } catch (err) {
     const clientAborted =
-      err?.code === "ERR_STREAM_PREMATURE_CLOSE" || responseAlreadyClosed;
-    if (!clientAborted) {
+      [
+        "ERR_STREAM_PREMATURE_CLOSE",
+        "ECONNRESET",
+        "EPIPE",
+        "ERR_STREAM_DESTROYED",
+      ].includes(err?.code) ||
+      err?.message === "aborted" ||
+      responseAlreadyClosed;
+    if (clientAborted) {
+      console.debug("artifact download client aborted");
+    } else {
       console.warn(`artifact download stream failed: ${err.message}`);
     }
     response.destroy();

--- a/event-runtime/lib/api-artifacts.test.mjs
+++ b/event-runtime/lib/api-artifacts.test.mjs
@@ -611,26 +611,50 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
     expect(response.destroyed).toBe(true);
   });
 
-  test("artifact stream client aborts are silent while source failures warn", async () => {
+  test("artifact stream client aborts log debug while source failures warn", async () => {
     const warnings = [];
+    const debugLogs = [];
     const warn = console.warn;
+    const debug = console.debug;
     console.warn = (message) => warnings.push(message);
+    console.debug = (message) => debugLogs.push(message);
     try {
-      const clientAbort = new Readable({
-        read() {
-          const error = new Error("client closed download");
-          error.code = "ERR_STREAM_PREMATURE_CLOSE";
-          this.destroy(error);
-        },
-      });
-      const clientResponse = new Writable({
-        write(_chunk, _encoding, done) {
-          done();
-        },
-      });
-      await streamArtifact(clientAbort, clientResponse);
-      expect(clientResponse.destroyed).toBe(true);
+      const clientAbort = async (
+        error,
+        response = new Writable({
+          write(_chunk, _encoding, done) {
+            done();
+          },
+        }),
+      ) => {
+        const source = new Readable({
+          read() {
+            this.destroy(error);
+          },
+        });
+        await streamArtifact(source, response);
+        expect(response.destroyed).toBe(true);
+      };
+
+      for (const code of [
+        "ERR_STREAM_PREMATURE_CLOSE",
+        "ECONNRESET",
+        "EPIPE",
+        "ERR_STREAM_DESTROYED",
+      ]) {
+        const error = new Error("client closed download");
+        error.code = code;
+        await clientAbort(error);
+      }
+      await clientAbort(new Error("aborted"));
       expect(warnings).toEqual([]);
+      expect(debugLogs).toEqual([
+        "artifact download client aborted",
+        "artifact download client aborted",
+        "artifact download client aborted",
+        "artifact download client aborted",
+        "artifact download client aborted",
+      ]);
 
       const alreadyClosedSource = new Readable({
         read() {
@@ -645,6 +669,7 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       alreadyClosedResponse.destroy();
       await streamArtifact(alreadyClosedSource, alreadyClosedResponse);
       expect(warnings).toEqual([]);
+      expect(debugLogs).toHaveLength(6);
 
       const failedSource = new Readable({
         read() {
@@ -661,8 +686,10 @@ describe("artifact store and agent registry surfacing (OPS-212)", () => {
       expect(warnings).toEqual([
         "artifact download stream failed: artifact blob was pruned",
       ]);
+      expect(debugLogs).toHaveLength(6);
     } finally {
       console.warn = warn;
+      console.debug = debug;
     }
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2181

Classify routine artifact-download socket aborts as debug-only diagnostics.

## Validation

| Check                | Command                                                        | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/api-artifacts.test.mjs --timeout 20000` | pass    | 8 tests, 0 failures                |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; existing lint warnings only |
| UX critique          | factory-ux-critic                                              | not run | no user-facing surface             |

UX critique: skipped — backend stream-error handling only

run:run_42cb1e4d-dbe9-4a4b-8dfe-8dc7cd37b8f5