### PR TITLE
docs(handoff): document run inspection, traces, and progress checks in factory-handoff skill

### DIFF
--- a/dist/codex/skills/factory-handoff/SKILL.md
+++ b/dist/codex/skills/factory-handoff/SKILL.md
@@ -36,21 +36,25 @@ Follow the existing capture and specification protocols before handoff:
 When an operator asks for the status of a handed-off ticket or wants to inspect execution:
 
 1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+
    ```sh
    factory handoff --request-id <requestId> [--repo <repo>] <ticket>
    ```
 
 2. **Check the ticket on the control plane**:
+
    ```sh
    factory ticket get [--repo <repo>] <ticket>
    ```
 
 3. **Inspect run details, token usage, and lifecycle history on the runner**:
+
    ```sh
    ssh runner "factory events inspect <runId>"
    ```
 
 4. **Stream or view the agent execution trace**:
+
    ```sh
    ssh runner "factory events trace <runId> | tail -n 50"
    ```
@@ -66,4 +70,3 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
-

--- a/dist/codex/skills/factory-handoff/SKILL.md
+++ b/dist/codex/skills/factory-handoff/SKILL.md
@@ -31,6 +31,32 @@ Follow the existing capture and specification protocols before handoff:
 3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
 4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
 
+## Checking run progress and traces
+
+When an operator asks for the status of a handed-off ticket or wants to inspect execution:
+
+1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+   ```sh
+   factory handoff --request-id <requestId> [--repo <repo>] <ticket>
+   ```
+
+2. **Check the ticket on the control plane**:
+   ```sh
+   factory ticket get [--repo <repo>] <ticket>
+   ```
+
+3. **Inspect run details, token usage, and lifecycle history on the runner**:
+   ```sh
+   ssh runner "factory events inspect <runId>"
+   ```
+
+4. **Stream or view the agent execution trace**:
+   ```sh
+   ssh runner "factory events trace <runId> | tail -n 50"
+   ```
+
+5. **Web dashboard**: `https://factory.whale-pike.ts.net`
+
 ## Retry rule
 
 The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
@@ -40,3 +66,4 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
+

--- a/dist/gemini/skills/factory-handoff/SKILL.md
+++ b/dist/gemini/skills/factory-handoff/SKILL.md
@@ -36,21 +36,25 @@ Follow the existing capture and specification protocols before handoff:
 When an operator asks for the status of a handed-off ticket or wants to inspect execution:
 
 1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+
    ```sh
    factory handoff --request-id <requestId> [--repo <repo>] <ticket>
    ```
 
 2. **Check the ticket on the control plane**:
+
    ```sh
    factory ticket get [--repo <repo>] <ticket>
    ```
 
 3. **Inspect run details, token usage, and lifecycle history on the runner**:
+
    ```sh
    ssh runner "factory events inspect <runId>"
    ```
 
 4. **Stream or view the agent execution trace**:
+
    ```sh
    ssh runner "factory events trace <runId> | tail -n 50"
    ```
@@ -66,4 +70,3 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
-

--- a/dist/gemini/skills/factory-handoff/SKILL.md
+++ b/dist/gemini/skills/factory-handoff/SKILL.md
@@ -31,6 +31,32 @@ Follow the existing capture and specification protocols before handoff:
 3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
 4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
 
+## Checking run progress and traces
+
+When an operator asks for the status of a handed-off ticket or wants to inspect execution:
+
+1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+   ```sh
+   factory handoff --request-id <requestId> [--repo <repo>] <ticket>
+   ```
+
+2. **Check the ticket on the control plane**:
+   ```sh
+   factory ticket get [--repo <repo>] <ticket>
+   ```
+
+3. **Inspect run details, token usage, and lifecycle history on the runner**:
+   ```sh
+   ssh runner "factory events inspect <runId>"
+   ```
+
+4. **Stream or view the agent execution trace**:
+   ```sh
+   ssh runner "factory events trace <runId> | tail -n 50"
+   ```
+
+5. **Web dashboard**: `https://factory.whale-pike.ts.net`
+
 ## Retry rule
 
 The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
@@ -40,3 +66,4 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
+

--- a/dist/pi/skills/factory-handoff/SKILL.md
+++ b/dist/pi/skills/factory-handoff/SKILL.md
@@ -36,21 +36,25 @@ Follow the existing capture and specification protocols before handoff:
 When an operator asks for the status of a handed-off ticket or wants to inspect execution:
 
 1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+
    ```sh
    factory handoff --request-id <requestId> [--repo <repo>] <ticket>
    ```
 
 2. **Check the ticket on the control plane**:
+
    ```sh
    factory ticket get [--repo <repo>] <ticket>
    ```
 
 3. **Inspect run details, token usage, and lifecycle history on the runner**:
+
    ```sh
    ssh runner "factory events inspect <runId>"
    ```
 
 4. **Stream or view the agent execution trace**:
+
    ```sh
    ssh runner "factory events trace <runId> | tail -n 50"
    ```
@@ -66,4 +70,3 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
-

--- a/dist/pi/skills/factory-handoff/SKILL.md
+++ b/dist/pi/skills/factory-handoff/SKILL.md
@@ -31,6 +31,32 @@ Follow the existing capture and specification protocols before handoff:
 3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
 4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
 
+## Checking run progress and traces
+
+When an operator asks for the status of a handed-off ticket or wants to inspect execution:
+
+1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+   ```sh
+   factory handoff --request-id <requestId> [--repo <repo>] <ticket>
+   ```
+
+2. **Check the ticket on the control plane**:
+   ```sh
+   factory ticket get [--repo <repo>] <ticket>
+   ```
+
+3. **Inspect run details, token usage, and lifecycle history on the runner**:
+   ```sh
+   ssh runner "factory events inspect <runId>"
+   ```
+
+4. **Stream or view the agent execution trace**:
+   ```sh
+   ssh runner "factory events trace <runId> | tail -n 50"
+   ```
+
+5. **Web dashboard**: `https://factory.whale-pike.ts.net`
+
 ## Retry rule
 
 The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
@@ -40,3 +66,4 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
+

--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -101,6 +101,22 @@ factory handoff --request-id handoff-original-id --repo factory watt-mind/factor
 
 A retry returns `duplicate: true` and the original event rather than dispatching a second run. Reusing that request ID for a different repo or ticket fails with `idempotency_conflict`; it never reports the original dispatch as if it covered the new request.
 
+## Inspecting runs and traces
+
+Once a ticket has been admitted and planned, its execution details, token costs, and live traces can be inspected on the runner:
+
+```sh
+# List recent runs across the fleet
+ssh runner "factory events runs --limit 10"
+
+# Inspect lifecycle history, duration, token usage, and failure reasons
+ssh runner "factory events inspect <runId>"
+
+# Stream or view the live agent trace
+ssh runner "factory events trace <runId> | tail -n 50"
+```
+
+
 ## Rollout
 
 1. Deploy code and regenerate/install the Factory CLI before installing any key.

--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -116,7 +116,6 @@ ssh runner "factory events inspect <runId>"
 ssh runner "factory events trace <runId> | tail -n 50"
 ```
 
-
 ## Rollout
 
 1. Deploy code and regenerate/install the Factory CLI before installing any key.

--- a/event-runtime/pins.json
+++ b/event-runtime/pins.json
@@ -22,7 +22,7 @@
       "commands/factory-unblock.md": "sha256:496bffc002afea8eca9d6c1b80f38c6732eb2163f3e41f6d04f0357c4e2905cb",
       "commands/factory-work.md": "sha256:c69095b7697fb4f0599ed6f2da40a4f6495e74bc5cfed90f41a4bc786d9cc72a",
       "floor.md": "sha256:d3658d5c8ce6090c57fc3ff89dccdf3050180adb2e041352de2ea4a327c71fe8",
-      "skills/factory-handoff/SKILL.md": "sha256:004e6327b8ac9c60b2d79f2ce0aec2726f36fa21cd41ceb29afa6586965b7e2e",
+      "skills/factory-handoff/SKILL.md": "sha256:139b10c02c9425ce9fbd415d215f5d28042bb76e59850cf70b62242637e1a4c4",
       "skills/ticket-spec/SKILL.md": "sha256:6cd7e613072a1f4bd360389b62f3482432cbeb167b1e34b27b4a6099d4685b23"
     }
   }

--- a/event-runtime/pins.json
+++ b/event-runtime/pins.json
@@ -22,7 +22,7 @@
       "commands/factory-unblock.md": "sha256:496bffc002afea8eca9d6c1b80f38c6732eb2163f3e41f6d04f0357c4e2905cb",
       "commands/factory-work.md": "sha256:c69095b7697fb4f0599ed6f2da40a4f6495e74bc5cfed90f41a4bc786d9cc72a",
       "floor.md": "sha256:d3658d5c8ce6090c57fc3ff89dccdf3050180adb2e041352de2ea4a327c71fe8",
-      "skills/factory-handoff/SKILL.md": "sha256:c6e452e33a8101cd4fdca70f650c52b626688a5555826039ebfac26847de8fd9",
+      "skills/factory-handoff/SKILL.md": "sha256:004e6327b8ac9c60b2d79f2ce0aec2726f36fa21cd41ceb29afa6586965b7e2e",
       "skills/ticket-spec/SKILL.md": "sha256:6cd7e613072a1f4bd360389b62f3482432cbeb167b1e34b27b4a6099d4685b23"
     }
   }

--- a/plugins/core/skills/factory-handoff/SKILL.md
+++ b/plugins/core/skills/factory-handoff/SKILL.md
@@ -36,21 +36,25 @@ Follow the existing capture and specification protocols before handoff:
 When an operator asks for the status of a handed-off ticket or wants to inspect execution:
 
 1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+
    ```sh
    factory handoff --request-id <requestId> [--repo <repo>] <ticket>
    ```
 
 2. **Check the ticket on the control plane**:
+
    ```sh
    factory ticket get [--repo <repo>] <ticket>
    ```
 
 3. **Inspect run details, token usage, and lifecycle history on the runner**:
+
    ```sh
    ssh runner "factory events inspect <runId>"
    ```
 
 4. **Stream or view the agent execution trace**:
+
    ```sh
    ssh runner "factory events trace <runId> | tail -n 50"
    ```
@@ -66,4 +70,3 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
-

--- a/plugins/core/skills/factory-handoff/SKILL.md
+++ b/plugins/core/skills/factory-handoff/SKILL.md
@@ -31,6 +31,32 @@ Follow the existing capture and specification protocols before handoff:
 3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
 4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
 
+## Checking run progress and traces
+
+When an operator asks for the status of a handed-off ticket or wants to inspect execution:
+
+1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+   ```sh
+   factory handoff --request-id <requestId> [--repo <repo>] <ticket>
+   ```
+
+2. **Check the ticket on the control plane**:
+   ```sh
+   factory ticket get [--repo <repo>] <ticket>
+   ```
+
+3. **Inspect run details, token usage, and lifecycle history on the runner**:
+   ```sh
+   ssh runner "factory events inspect <runId>"
+   ```
+
+4. **Stream or view the agent execution trace**:
+   ```sh
+   ssh runner "factory events trace <runId> | tail -n 50"
+   ```
+
+5. **Web dashboard**: `https://factory.whale-pike.ts.net`
+
 ## Retry rule
 
 The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
@@ -40,3 +66,4 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
+

--- a/shared/skills/factory-handoff/SKILL.md
+++ b/shared/skills/factory-handoff/SKILL.md
@@ -36,21 +36,25 @@ Follow the existing capture and specification protocols before handoff:
 When an operator asks for the status of a handed-off ticket or wants to inspect execution:
 
 1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+
    ```sh
    factory handoff --request-id <requestId> [--repo <repo>] <ticket>
    ```
 
 2. **Check the ticket on the control plane**:
+
    ```sh
    factory ticket get [--repo <repo>] <ticket>
    ```
 
 3. **Inspect run details, token usage, and lifecycle history on the runner**:
+
    ```sh
    ssh runner "factory events inspect <runId>"
    ```
 
 4. **Stream or view the agent execution trace**:
+
    ```sh
    ssh runner "factory events trace <runId> | tail -n 50"
    ```
@@ -66,4 +70,3 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
-

--- a/shared/skills/factory-handoff/SKILL.md
+++ b/shared/skills/factory-handoff/SKILL.md
@@ -31,6 +31,32 @@ Follow the existing capture and specification protocols before handoff:
 3. Use `ticket-spec` to fill derivable gaps. If intent or credentials are missing, leave it in Triage and report what is needed; do not hand it off yet.
 4. Once the ticket is `Todo` + `ai:agent-ready` + unassigned, invoke `factory handoff` as above.
 
+## Checking run progress and traces
+
+When an operator asks for the status of a handed-off ticket or wants to inspect execution:
+
+1. **Query receipt state via request ID** (idempotent; returns event, proposal, and run status):
+   ```sh
+   factory handoff --request-id <requestId> [--repo <repo>] <ticket>
+   ```
+
+2. **Check the ticket on the control plane**:
+   ```sh
+   factory ticket get [--repo <repo>] <ticket>
+   ```
+
+3. **Inspect run details, token usage, and lifecycle history on the runner**:
+   ```sh
+   ssh runner "factory events inspect <runId>"
+   ```
+
+4. **Stream or view the agent execution trace**:
+   ```sh
+   ssh runner "factory events trace <runId> | tail -n 50"
+   ```
+
+5. **Web dashboard**: `https://factory.whale-pike.ts.net`
+
 ## Retry rule
 
 The client creates a unique request ID. If transport failed after the request may have reached the server, retry with the **same** ID so admission deduplicates:
@@ -40,3 +66,4 @@ factory handoff --request-id <original-id> --repo <repo> <ticket>
 ```
 
 Never use `factory dispatch`, `/replay`, direct HTTP, a caller-selected `source`, or a local implementation agent as a substitute. The client sends only `{schemaVersion, requestId, repo, ticket}` and does not possess the runtime signing secret.
+


### PR DESCRIPTION
Fixes #2186

## Summary of Changes
- Updated `shared/skills/factory-handoff/SKILL.md` to add a dedicated section: **"Checking run progress and traces"**.
- Documented idempotent request ID status queries (`factory handoff --request-id <id>`), control-plane status lookups (`factory ticket get`), runner run inspections (`factory events inspect <runId>`), and live agent trace streaming (`factory events trace <runId>`).
- Re-emitted derived skill files across all harness targets (`dist/codex/`, `dist/gemini/`, `dist/pi/`, and `plugins/core/`) using `bun build/emit.mjs`.
- Updated `docs/remote-handoff.md` with CLI examples for inspecting runs and streaming traces.

## Verification
- `bun build/emit.mjs --check` — pass (94 files synced)
- `bun test tools/handoff.test.mjs` — pass (19/19 tests pass)