### PR TITLE
feat(handoff): resolve default SSH host

### DIFF
--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -56,6 +56,27 @@ factory handoff --repo factory watt-mind/factory#1153
 # equivalent: factory handoff --host factory-runner --repo factory watt-mind/factory#1153
 ```
 
+When `--host` is omitted, the client resolves the SSH alias in this order:
+
+1. `--host <alias>`
+2. `FACTORY_HANDOFF_SSH_HOST`, then `FACTORY_HANDOFF_HOST`
+3. `handoff.host` (or `handoff_host`) in `~/.factory/config.json` or
+   `~/.factory/handoff.json`, then the matching environment variable in
+   `~/.factory/secrets.env`
+4. `handoff_host` for the selected repository in `config/repos.yaml`
+5. `handoff.host` or `handoff_host` in `config/policy.yaml`
+6. the canonical `factory-runner` SSH alias
+
+For example, an operator can set a repository-wide default without changing
+client shells:
+
+```yaml
+# config/repos.yaml
+repos:
+  - name: factory
+    handoff_host: factory-runner
+```
+
 When cwd is under a configured repo `path` or `worktree_root`, `--repo` may be omitted. The client supplies no remote command, so the server's forced command is the only executable path.
 
 ## Server forced command

--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -7,10 +7,13 @@
  */
 import { createHmac, randomUUID } from "node:crypto";
 import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
 import path from "node:path";
 import { parseArgs } from "node:util";
 
-import { loadRepos } from "../event-runtime/lib/repos.mjs";
+import { resolveConfigPath } from "../event-runtime/lib/config.mjs";
+import { loadRepos, reposRoot } from "../event-runtime/lib/repos.mjs";
 
 export const HANDOFF_SCHEMA_VERSION = "factory.handoff/v1";
 export const HANDOFF_RECEIPT_VERSION = "factory.handoff-receipt/v1";
@@ -125,6 +128,125 @@ export function resolveHandoffRepo({ repos, cwd = process.cwd(), repo } = {}) {
       "cwd is not inside a configured repository; pass --repo <short-name>",
     );
   return best.name;
+}
+
+function nonemptyString(value) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function handoffHostFromConfig(config, { directHost = false } = {}) {
+  if (!config || typeof config !== "object" || Array.isArray(config)) {
+    return null;
+  }
+  return (
+    nonemptyString(config.handoff?.host) ??
+    nonemptyString(config.handoff_host) ??
+    (directHost ? nonemptyString(config.host) : null)
+  );
+}
+
+function parseJsonFile(file, readFile) {
+  try {
+    return JSON.parse(readFile(file, "utf8"));
+  } catch {
+    return null;
+  }
+}
+
+function parseDotenvFile(file, readFile) {
+  let text;
+  try {
+    text = readFile(file, "utf8");
+  } catch {
+    return {};
+  }
+  const values = {};
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith("#")) continue;
+    const entry = line.replace(/^export\s+/, "");
+    const equals = entry.indexOf("=");
+    if (equals <= 0) continue;
+    const key = entry.slice(0, equals).trim();
+    let value = entry.slice(equals + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    values[key] = value;
+  }
+  return values;
+}
+
+function loadHandoffConfig({ root, readFile }) {
+  let repos = null;
+  let policy = null;
+  try {
+    repos = Bun.YAML.parse(
+      readFile(resolveConfigPath("repos", { root }), "utf8"),
+    );
+  } catch {
+    // An unavailable optional source must not prevent lower-precedence defaults.
+  }
+  try {
+    policy = Bun.YAML.parse(
+      readFile(resolveConfigPath("policy", { root }), "utf8"),
+    );
+  } catch {
+    // An unavailable optional source must not prevent lower-precedence defaults.
+  }
+  return { repos, policy };
+}
+
+/**
+ * Resolve the SSH destination without exposing configuration contents in errors.
+ * The result is validated by sendHandoff immediately before spawning ssh.
+ */
+export function resolveHandoffHost({
+  host,
+  env = process.env,
+  repo,
+  home = homedir(),
+  root = reposRoot(),
+  readFile = readFileSync,
+  repoConfig,
+  policy,
+} = {}) {
+  const configured =
+    repoConfig === undefined || policy === undefined
+      ? loadHandoffConfig({ root, readFile })
+      : null;
+  const configuredRepo =
+    repoConfig ??
+    configured?.repos?.repos?.find((entry) => entry?.name === repo);
+  const configuredPolicy = policy ?? configured?.policy;
+  const localConfig = parseJsonFile(
+    path.join(home, ".factory", "config.json"),
+    readFile,
+  );
+  const localHandoff = parseJsonFile(
+    path.join(home, ".factory", "handoff.json"),
+    readFile,
+  );
+  const localSecrets = parseDotenvFile(
+    path.join(home, ".factory", "secrets.env"),
+    readFile,
+  );
+
+  return (
+    nonemptyString(host) ??
+    nonemptyString(env.FACTORY_HANDOFF_SSH_HOST) ??
+    nonemptyString(env.FACTORY_HANDOFF_HOST) ??
+    handoffHostFromConfig(localConfig) ??
+    handoffHostFromConfig(localHandoff, { directHost: true }) ??
+    nonemptyString(localSecrets.FACTORY_HANDOFF_SSH_HOST) ??
+    nonemptyString(localSecrets.FACTORY_HANDOFF_HOST) ??
+    nonemptyString(configuredRepo?.handoff_host) ??
+    handoffHostFromConfig(configuredPolicy) ??
+    "factory-runner"
+  );
 }
 
 function validateTicketForRepo(ticket, repo) {
@@ -425,7 +547,6 @@ export function sshProcess(host, input) {
 
 /** Send one strict request. No remote command is supplied: sshd forces accept. */
 export async function sendHandoff(request, { host, ssh = sshProcess } = {}) {
-  if (!host) fail("ssh_host_missing", "set --host or FACTORY_HANDOFF_SSH_HOST");
   validateSshHost(host);
   const validation = validateHandoffRequest(JSON.stringify(request));
   if (!validation.ok) fail(validation.error, validation.error);
@@ -470,6 +591,11 @@ Usage:
 The client sends only factory.handoff/v1 JSON through SSH. The accept form is
 for a dedicated authorized_keys forced command and reads one bounded document
 from stdin.
+
+SSH host resolution (highest precedence first): --host, FACTORY_HANDOFF_SSH_HOST,
+FACTORY_HANDOFF_HOST, ~/.factory/config.json or handoff.json, ~/.factory/secrets.env,
+config/repos.yaml handoff_host, config/policy.yaml handoff.host or handoff_host,
+then the factory-runner alias.
 `;
 
 export function assertForcedCommandEnvironment(env = process.env) {
@@ -533,7 +659,7 @@ async function main(argv = process.argv.slice(2)) {
     ticket: positionals[0],
   });
   const receipt = await sendHandoff(request, {
-    host: values.host ?? process.env.FACTORY_HANDOFF_SSH_HOST,
+    host: resolveHandoffHost({ host: values.host, repo }),
   });
   if (values.json) {
     console.log(JSON.stringify(receipt));

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -9,6 +9,7 @@ import {
   fail,
   handoffErrorBody,
   printReceipt,
+  resolveHandoffHost,
   resolveHandoffRepo,
   sendHandoff,
   validateHandoffRequest,
@@ -87,6 +88,87 @@ describe("strict handoff request", () => {
     expect(() =>
       resolveHandoffRepo({ repos, cwd: "/tmp", repo: "missing" }),
     ).toThrow(/unconfigured repo/);
+  });
+});
+
+describe("handoff SSH host resolution", () => {
+  const home = "/home/operator";
+  const root = "/factory";
+  const filesFor = () =>
+    new Map([
+      [
+        "/factory/config/repos.yaml",
+        "repos:\n  - name: factory\n    handoff_host: repo-runner\n",
+      ],
+      ["/factory/config/policy.yaml", "handoff:\n  host: policy-runner\n"],
+      [
+        "/home/operator/.factory/config.json",
+        JSON.stringify({ handoff: { host: "config-runner" } }),
+      ],
+      [
+        "/home/operator/.factory/handoff.json",
+        JSON.stringify({ host: "handoff-runner" }),
+      ],
+      [
+        "/home/operator/.factory/secrets.env",
+        "FACTORY_HANDOFF_HOST=secrets-runner\n",
+      ],
+    ]);
+  const resolve = (files, overrides = {}) => {
+    const readFile = (file) => {
+      if (!files.has(file)) throw new Error(`missing ${file}`);
+      return files.get(file);
+    };
+    return resolveHandoffHost({
+      repo: "factory",
+      home,
+      root,
+      readFile,
+      env: {},
+      ...overrides,
+    });
+  };
+
+  test("uses every source in documented precedence order", () => {
+    const files = filesFor();
+    expect(resolve(files, { host: "flag-runner" })).toBe("flag-runner");
+    expect(
+      resolve(files, { env: { FACTORY_HANDOFF_SSH_HOST: "ssh-env-runner" } }),
+    ).toBe("ssh-env-runner");
+    expect(
+      resolve(files, { env: { FACTORY_HANDOFF_HOST: "env-runner" } }),
+    ).toBe("env-runner");
+    expect(resolve(files)).toBe("config-runner");
+
+    files.delete("/home/operator/.factory/config.json");
+    expect(resolve(files)).toBe("handoff-runner");
+    files.delete("/home/operator/.factory/handoff.json");
+    expect(resolve(files)).toBe("secrets-runner");
+    files.delete("/home/operator/.factory/secrets.env");
+    expect(resolve(files)).toBe("repo-runner");
+    files.set("/factory/config/repos.yaml", "repos: []\n");
+    expect(resolve(files)).toBe("policy-runner");
+    files.set("/factory/config/policy.yaml", "{}\n");
+    expect(resolve(files)).toBe("factory-runner");
+  });
+
+  test("accepts policy shorthand and ignores empty configured values", () => {
+    const files = filesFor();
+    files.delete("/home/operator/.factory/config.json");
+    files.delete("/home/operator/.factory/handoff.json");
+    files.delete("/home/operator/.factory/secrets.env");
+    expect(
+      resolve(files, {
+        repoConfig: null,
+        policy: { handoff_host: "policy-shorthand" },
+      }),
+    ).toBe("policy-shorthand");
+    expect(
+      resolve(files, {
+        repoConfig: { handoff_host: " " },
+        policy: { handoff: { host: "policy-runner" } },
+      }),
+    ).toBe("policy-runner");
   });
 });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2185

Resolve handoff SSH aliases predictably, including a factory-runner fallback.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test tools/handoff.test.mjs` | pass | 21 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2457 tests; emit, format, lint passed |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — CLI and documentation only; no user-facing surface

run:run_d8917b9b-372c-4642-ae10-7dd92602ecc4
