### PR TITLE
feat(cli): support remote control API targets

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -54,47 +54,69 @@ show_banner() {
 cmd="${1:-}"
 shift || true
 
-# Targeting is global so operators can place it before or after the event
-# command. Strip it before command-specific parsers see it, and use the
-# documented FACTORY_EVENT_HOST precedence for direct HTTP(S) destinations.
+# Remote control-API targeting (#2188). --host/--remote are recognised only for
+# the subcommands that speak to the control API, and only *after* the
+# subcommand — `factory status --host …`, never `factory --host … status`,
+# because $1 is consumed as the subcommand above. Every other subcommand keeps
+# its own flags untouched, notably `factory handoff --host <ssh-alias>` (#2191).
 control_target=""
 control_target_kind=""
-forwarded_args=()
-while [[ $# -gt 0 ]]; do
-  case "$1" in
-    --host|--remote)
-      if [[ $# -lt 2 || -z "${2:-}" || "$2" == --* ]]; then
-        echo "$1 requires a URL, host, or SSH alias" >&2
-        exit 2
-      fi
-      control_target="$2"
-      control_target_kind="${1#--}"
-      shift 2
-      ;;
-    --host=*|--remote=*)
-      control_target="${1#*=}"
-      control_target_kind="${1%%=*}"
-      control_target_kind="${control_target_kind#--}"
-      if [[ -z "$control_target" ]]; then
-        echo "--${control_target_kind} requires a URL, host, or SSH alias" >&2
-        exit 2
-      fi
-      shift
-      ;;
-    *)
-      forwarded_args+=("$1")
-      shift
-      ;;
-  esac
-done
-set -- "${forwarded_args[@]}"
+case "$cmd" in
+  # Speaks to the control API and honours a remote target.
+  events|status|ps) control_target_supported=1 ;;
+  # Control-API commands that do not route through the targeted client yet.
+  # Rejecting is better than exporting an env these paths ignore (see #2190).
+  inbox|approve|reject|inject|decide|memos) control_target_supported=0 ;;
+  # Not a control-API command: leave argv alone.
+  *) control_target_supported="" ;;
+esac
+
+if [[ -n "$control_target_supported" ]]; then
+  forwarded_args=()
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --host|--remote)
+        if [[ $# -lt 2 || -z "${2:-}" || "$2" == --* ]]; then
+          echo "$1 requires a URL, host, or SSH alias" >&2
+          exit 2
+        fi
+        control_target="$2"
+        control_target_kind="${1#--}"
+        shift 2
+        ;;
+      --host=*|--remote=*)
+        control_target="${1#*=}"
+        control_target_kind="${1%%=*}"
+        control_target_kind="${control_target_kind#--}"
+        if [[ -z "$control_target" ]]; then
+          echo "--${control_target_kind} requires a URL, host, or SSH alias" >&2
+          exit 2
+        fi
+        shift
+        ;;
+      *)
+        forwarded_args+=("$1")
+        shift
+        ;;
+    esac
+  done
+  set -- ${forwarded_args[@]+"${forwarded_args[@]}"}
+
+  if [[ -n "$control_target" && "$control_target_supported" -eq 0 ]]; then
+    echo "factory: remote targeting not yet supported for $cmd (see #2190)" >&2
+    exit 2
+  fi
+fi
 
 if [[ -n "$control_target" ]]; then
   # A bare --host value without a domain or port is an SSH alias. --remote is
   # explicitly a URL, so it always remains a direct control-API destination.
   if [[ "$control_target_kind" == "host" && "$control_target" != *://* && "$control_target" != *.* && "$control_target" != *:* && "$control_target" != */* && "$control_target" != "localhost" ]]; then
-    exec ssh "$control_target" factory "$cmd" "$@"
+    # Quote every word so remote argv survives the shell ssh runs it under, and
+    # so a value containing ;, $( ) or backticks cannot execute there.
+    exec ssh "$control_target" "$(printf '%q ' factory "$cmd" "$@")"
   fi
+  # The library never reads argv; the flag reaches it as the documented env.
   export FACTORY_EVENT_HOST="$control_target"
 fi
 
@@ -446,6 +468,11 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   notify        durable human inbox + notify.py projection (direct fallback when serve is offline or its push fails)
   security      lib/security-check.sh (gitleaks + semgrep + actionlint on cwd repo)
   emit          build/emit.mjs (--link --link-bin --link-repos when called bare)
+
+Remote targeting (#2188): events, status and ps accept --host/--remote after
+the subcommand. A bare --host alias is dispatched over ssh; a URL or host:port
+targets the control API directly. Plaintext http to a non-loopback host is
+refused (use https:// or FACTORY_CONTROL_API_ALLOW_INSECURE=1).
 
 Works from any cwd (worktrees included).
   factory notify "BLOCKED LAB-176: need approval"

--- a/bin/factory
+++ b/bin/factory
@@ -54,6 +54,50 @@ show_banner() {
 cmd="${1:-}"
 shift || true
 
+# Targeting is global so operators can place it before or after the event
+# command. Strip it before command-specific parsers see it, and use the
+# documented FACTORY_EVENT_HOST precedence for direct HTTP(S) destinations.
+control_target=""
+control_target_kind=""
+forwarded_args=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --host|--remote)
+      if [[ $# -lt 2 || -z "${2:-}" || "$2" == --* ]]; then
+        echo "$1 requires a URL, host, or SSH alias" >&2
+        exit 2
+      fi
+      control_target="$2"
+      control_target_kind="${1#--}"
+      shift 2
+      ;;
+    --host=*|--remote=*)
+      control_target="${1#*=}"
+      control_target_kind="${1%%=*}"
+      control_target_kind="${control_target_kind#--}"
+      if [[ -z "$control_target" ]]; then
+        echo "--${control_target_kind} requires a URL, host, or SSH alias" >&2
+        exit 2
+      fi
+      shift
+      ;;
+    *)
+      forwarded_args+=("$1")
+      shift
+      ;;
+  esac
+done
+set -- "${forwarded_args[@]}"
+
+if [[ -n "$control_target" ]]; then
+  # A bare --host value without a domain or port is an SSH alias. --remote is
+  # explicitly a URL, so it always remains a direct control-API destination.
+  if [[ "$control_target_kind" == "host" && "$control_target" != *://* && "$control_target" != *.* && "$control_target" != *:* && "$control_target" != */* && "$control_target" != "localhost" ]]; then
+    exec ssh "$control_target" factory "$cmd" "$@"
+  fi
+  export FACTORY_EVENT_HOST="$control_target"
+fi
+
 run_bun() {
   exec bun "$ROOT/$1" "${@:2}"
 }
@@ -75,10 +119,19 @@ case "$cmd" in
   queue)        run_bun orchestrator/queue.mjs "$@" ;;
   next)         run_bun orchestrator/next.mjs "$@" ;;
   state)        run_bun orchestrator/state.mjs "$@" ;;
-  status)       run_bun orchestrator/status.mjs "$@" ;;
+  # With an explicit direct target these are control-API queries, rather than
+  # local process surveys. SSH aliases delegated above keep the remote factory
+  # command's normal behaviour.
+  status)
+    if [[ -n "$control_target" ]]; then run_bun event-runtime/cli.mjs status "$@"; fi
+    run_bun orchestrator/status.mjs "$@"
+    ;;
   pulse)        run_bun orchestrator/pulse.mjs "$@" ;;
   watchdog)     run_bun orchestrator/watchdog.mjs "$@" ;;
-  ps)           run_bun orchestrator/ps.mjs "$@" ;;
+  ps)
+    if [[ -n "$control_target" ]]; then run_bun event-runtime/cli.mjs ps "$@"; fi
+    run_bun orchestrator/ps.mjs "$@"
+    ;;
   workers)      run_bun orchestrator/workers.mjs "$@" ;;
   friction)     run_bun orchestrator/friction.mjs "$@" ;;
   economics)    run_bun orchestrator/economics.mjs "$@" ;;

--- a/event-runtime/cli/shared.mjs
+++ b/event-runtime/cli/shared.mjs
@@ -43,7 +43,7 @@ export async function withClient(fn) {
   } catch (err) {
     if (err.status === undefined) {
       fail(
-        `control API not reachable on ${client.host}:${client.port} — start it with: bun event-runtime/cli.mjs serve`,
+        `control API not reachable at ${client.baseUrl} — start it with: bun event-runtime/cli.mjs serve`,
       );
     }
     fail(err.message);

--- a/event-runtime/cli/shared.mjs
+++ b/event-runtime/cli/shared.mjs
@@ -35,15 +35,22 @@ export function fail(message) {
   process.exit(1);
 }
 
-/** Run one client verb; connection refusal names the fix, exactly (§12). */
+/**
+ * Run one client verb; connection refusal names the fix, exactly (§12).
+ *
+ * The client is built inside the try so a bad operator target (#2188 — an
+ * unparsable URL, or plaintext http to a non-loopback host) exits through
+ * fail() with the message rather than a stack trace.
+ */
 export async function withClient(fn) {
-  const client = apiClient();
+  let client = null;
   try {
+    client = apiClient({ resolveTarget: true });
     await fn(client);
   } catch (err) {
-    if (err.status === undefined) {
+    if (client && err.status === undefined) {
       fail(
-        `control API not reachable at ${client.baseUrl} — start it with: bun event-runtime/cli.mjs serve`,
+        `control API not reachable on ${client.host}:${client.port} — start it with: bun event-runtime/cli.mjs serve`,
       );
     }
     fail(err.message);

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -1,5 +1,5 @@
 /**
- * Client for the loopback control API (docs/event-runtime.md §12).
+ * Client for the control API (docs/event-runtime.md §12) — loopback by default.
  *
  * The CLI — and any future TUI or web app — talks to the runtime exclusively
  * through this module: one small method per endpoint, parsed JSON back, and a
@@ -7,7 +7,7 @@
  * non-2xx response. A connection failure (serve not running) surfaces as an
  * error with no `.status`, which callers use to say exactly that.
  */
-import { resolveControlApiTarget } from "./config.mjs";
+import { API_HOST, DEFAULT_PORT, resolveControlApiTarget } from "./config.mjs";
 
 export { resolveControlApiTarget } from "./config.mjs";
 
@@ -22,6 +22,16 @@ export function unauthorizedMessage(tokenPresent) {
     : "control API requires FACTORY_CONTROL_API_TOKEN; set it in ~/.factory/secrets.env";
 }
 
+/** The historic loopback pin: no environment, no config, no argv. */
+function pinnedLoopbackTarget(port) {
+  return {
+    baseUrl: `http://${API_HOST}:${port}`,
+    host: API_HOST,
+    port,
+    source: "pinned",
+  };
+}
+
 export function apiClient({
   /** A complete HTTP(S) control API URL, including an optional path prefix. */
   url,
@@ -33,11 +43,26 @@ export function apiClient({
   // without changes; sent on every request (webhook/health ignore it). Never
   // logged. Unset means no header, matching the pre-token behavior.
   token = process.env.FACTORY_CONTROL_API_TOKEN || null,
+  /**
+   * Opt in to ambient target resolution — the environment and
+   * ~/.factory/config.json (#2188). Left unset it is true only for a caller
+   * that names no target at all (the CLI entrypoints), so every existing
+   * `apiClient({ port })` caller keeps its 127.0.0.1 pin unchanged. The library
+   * never reads process.argv; bin/factory turns operator flags into env.
+   */
+  resolveTarget,
 } = {}) {
-  const target = resolveControlApiTarget({
-    target: url ?? host,
-    defaultPort: port,
-  });
+  const explicit = url ?? host ?? null;
+  const shouldResolve =
+    resolveTarget ??
+    (url === undefined && host === undefined && port === undefined);
+  const target =
+    explicit || shouldResolve
+      ? resolveControlApiTarget({
+          target: explicit,
+          ...(port === undefined ? {} : { defaultPort: port }),
+        })
+      : pinnedLoopbackTarget(port ?? DEFAULT_PORT);
   const base = target.baseUrl;
   const authHeader = token ? { authorization: `Bearer ${token}` } : {};
 

--- a/event-runtime/lib/client.mjs
+++ b/event-runtime/lib/client.mjs
@@ -7,7 +7,9 @@
  * non-2xx response. A connection failure (serve not running) surfaces as an
  * error with no `.status`, which callers use to say exactly that.
  */
-import { API_HOST, DEFAULT_PORT } from "./config.mjs";
+import { resolveControlApiTarget } from "./config.mjs";
+
+export { resolveControlApiTarget } from "./config.mjs";
 
 /**
  * Actionable text for a control-API auth failure (#1132). Names the variable and the
@@ -21,15 +23,22 @@ export function unauthorizedMessage(tokenPresent) {
 }
 
 export function apiClient({
-  port = DEFAULT_PORT,
-  host = API_HOST,
+  /** A complete HTTP(S) control API URL, including an optional path prefix. */
+  url,
+  /** Backwards-compatible host override; a bare host uses the selected port. */
+  host,
+  port,
   // WM-1152: bearer the control API requires when FACTORY_CONTROL_API_TOKEN is
   // set. Read from env by default so every CLI/worker caller authenticates
   // without changes; sent on every request (webhook/health ignore it). Never
   // logged. Unset means no header, matching the pre-token behavior.
   token = process.env.FACTORY_CONTROL_API_TOKEN || null,
 } = {}) {
-  const base = `http://${host}:${port}`;
+  const target = resolveControlApiTarget({
+    target: url ?? host,
+    defaultPort: port,
+  });
+  const base = target.baseUrl;
   const authHeader = token ? { authorization: `Bearer ${token}` } : {};
 
   async function call(method, path, { body, headers = {} } = {}) {
@@ -67,8 +76,9 @@ export function apiClient({
   }
 
   return {
-    host,
-    port,
+    host: target.host,
+    port: target.port,
+    baseUrl: target.baseUrl,
     token,
     health: () => call("GET", "/health"),
     /** Webhook intake: raw body string plus the §14 signature headers. */

--- a/event-runtime/lib/client.test.mjs
+++ b/event-runtime/lib/client.test.mjs
@@ -4,7 +4,11 @@
  * 401 comes back as an actionable message that never carries the token value.
  */
 import { afterAll, beforeAll, expect, test } from "bun:test";
-import { apiClient, unauthorizedMessage } from "./client.mjs";
+import {
+  apiClient,
+  resolveControlApiTarget,
+  unauthorizedMessage,
+} from "./client.mjs";
 
 const TOKEN = "test-secret-token-1132";
 let server;
@@ -55,6 +59,83 @@ test("sends the bearer when a token is passed", async () => {
   const client = apiClient({ port, token: TOKEN });
   lastAuthorization = undefined;
   await expect(client.runs()).resolves.toEqual({ runs: [] });
+  expect(lastAuthorization).toBe(`Bearer ${TOKEN}`);
+});
+
+test("resolves a CLI target before environment, local config, and the loopback default", () => {
+  expect(
+    resolveControlApiTarget({
+      args: ["runs", "--host", "https://flag.example.test/api"],
+      env: {
+        FACTORY_EVENT_HOST: "env.example.test:7444",
+        FACTORY_CONTROL_API_URL: "https://control.example.test",
+        FACTORY_EVENT_URL: "https://event.example.test",
+      },
+      localConfig: { host: "config.example.test:7555" },
+    }),
+  ).toEqual({
+    baseUrl: "https://flag.example.test/api",
+    host: "flag.example.test",
+    port: 443,
+    source: "flag",
+  });
+});
+
+test("normalizes a configured bare host and preserves its non-default port", () => {
+  expect(
+    resolveControlApiTarget({
+      env: {},
+      localConfig: { host: "runner.whale-pike.ts.net:7389" },
+    }),
+  ).toEqual({
+    baseUrl: "http://runner.whale-pike.ts.net:7389",
+    host: "runner.whale-pike.ts.net",
+    port: 7389,
+    source: "config",
+  });
+});
+
+test("uses the documented environment order before local config", () => {
+  const localConfig = { host: "config.example.test:7555" };
+  expect(
+    resolveControlApiTarget({
+      args: [],
+      env: {
+        FACTORY_EVENT_HOST: "event-host.example.test:7444",
+        FACTORY_CONTROL_API_URL: "https://control-url.example.test",
+        FACTORY_EVENT_URL: "https://event-url.example.test",
+      },
+      localConfig,
+    }).baseUrl,
+  ).toBe("http://event-host.example.test:7444");
+  expect(
+    resolveControlApiTarget({
+      args: [],
+      env: {
+        FACTORY_CONTROL_API_URL: "https://control-url.example.test",
+        FACTORY_EVENT_URL: "https://event-url.example.test",
+      },
+      localConfig,
+    }).baseUrl,
+  ).toBe("https://control-url.example.test");
+  expect(
+    resolveControlApiTarget({
+      args: [],
+      env: { FACTORY_EVENT_URL: "https://event-url.example.test" },
+      localConfig,
+    }).baseUrl,
+  ).toBe("https://event-url.example.test");
+});
+
+test("uses the resolved URL while preserving bearer propagation", async () => {
+  lastAuthorization = undefined;
+  const client = apiClient({
+    url: `http://127.0.0.1:${port}`,
+    token: TOKEN,
+  });
+  await expect(client.runs()).resolves.toEqual({ runs: [] });
+  expect(client.host).toBe("127.0.0.1");
+  expect(client.port).toBe(port);
   expect(lastAuthorization).toBe(`Bearer ${TOKEN}`);
 });
 

--- a/event-runtime/lib/client.test.mjs
+++ b/event-runtime/lib/client.test.mjs
@@ -62,22 +62,21 @@ test("sends the bearer when a token is passed", async () => {
   expect(lastAuthorization).toBe(`Bearer ${TOKEN}`);
 });
 
-test("resolves a CLI target before environment, local config, and the loopback default", () => {
+test("an explicit target outranks environment and local config", () => {
   expect(
     resolveControlApiTarget({
-      args: ["runs", "--host", "https://flag.example.test/api"],
+      target: "https://flag.example.test/api",
       env: {
         FACTORY_EVENT_HOST: "env.example.test:7444",
         FACTORY_CONTROL_API_URL: "https://control.example.test",
-        FACTORY_EVENT_URL: "https://event.example.test",
       },
-      localConfig: { host: "config.example.test:7555" },
+      localConfig: { url: "https://config.example.test:7555" },
     }),
   ).toEqual({
     baseUrl: "https://flag.example.test/api",
     host: "flag.example.test",
     port: 443,
-    source: "flag",
+    source: "explicit",
   });
 });
 
@@ -86,6 +85,7 @@ test("normalizes a configured bare host and preserves its non-default port", () 
     resolveControlApiTarget({
       env: {},
       localConfig: { host: "runner.whale-pike.ts.net:7389" },
+      allowInsecure: true,
     }),
   ).toEqual({
     baseUrl: "http://runner.whale-pike.ts.net:7389",
@@ -96,35 +96,120 @@ test("normalizes a configured bare host and preserves its non-default port", () 
 });
 
 test("uses the documented environment order before local config", () => {
-  const localConfig = { host: "config.example.test:7555" };
+  const localConfig = { url: "https://config.example.test:7555" };
   expect(
     resolveControlApiTarget({
-      args: [],
       env: {
         FACTORY_EVENT_HOST: "event-host.example.test:7444",
         FACTORY_CONTROL_API_URL: "https://control-url.example.test",
-        FACTORY_EVENT_URL: "https://event-url.example.test",
       },
       localConfig,
+      allowInsecure: true,
     }).baseUrl,
   ).toBe("http://event-host.example.test:7444");
   expect(
     resolveControlApiTarget({
-      args: [],
-      env: {
-        FACTORY_CONTROL_API_URL: "https://control-url.example.test",
-        FACTORY_EVENT_URL: "https://event-url.example.test",
-      },
+      env: { FACTORY_CONTROL_API_URL: "https://control-url.example.test" },
       localConfig,
     }).baseUrl,
   ).toBe("https://control-url.example.test");
+  expect(resolveControlApiTarget({ env: {}, localConfig }).baseUrl).toBe(
+    "https://config.example.test:7555",
+  );
+});
+
+// FACTORY_EVENT_URL already names the handoff event URL (tools/handoff.mjs,
+// docs/remote-handoff.md). Honouring it here would silently redirect a handoff
+// operator's control bearer, so #2188's AC was narrowed to exclude it.
+test("ignores FACTORY_EVENT_URL — it belongs to remote handoff", () => {
   expect(
     resolveControlApiTarget({
-      args: [],
       env: { FACTORY_EVENT_URL: "https://event-url.example.test" },
-      localConfig,
+      localConfig: {},
+      defaultPort: 7381,
+    }),
+  ).toEqual({
+    baseUrl: "http://127.0.0.1:7381",
+    host: "127.0.0.1",
+    port: 7381,
+    source: "default",
+  });
+});
+
+test("refuses to send the bearer in plaintext to a non-loopback host", () => {
+  expect(() =>
+    resolveControlApiTarget({
+      env: { FACTORY_EVENT_HOST: "runner.example.test:7381" },
+      localConfig: {},
+    }),
+  ).toThrow(/refusing to send the control API bearer in plaintext/);
+  expect(() =>
+    resolveControlApiTarget({
+      env: { FACTORY_EVENT_HOST: "runner.example.test:7381" },
+      localConfig: {},
+    }),
+  ).toThrow(/FACTORY_CONTROL_API_ALLOW_INSECURE=1/);
+
+  // https is always fine, and so is plaintext that never leaves the box.
+  expect(
+    resolveControlApiTarget({
+      env: { FACTORY_EVENT_HOST: "https://runner.example.test" },
+      localConfig: {},
     }).baseUrl,
-  ).toBe("https://event-url.example.test");
+  ).toBe("https://runner.example.test");
+  for (const loopback of [
+    "127.0.0.1:7381",
+    "localhost:7381",
+    "127.9.9.9:7000",
+  ]) {
+    expect(
+      resolveControlApiTarget({
+        env: { FACTORY_EVENT_HOST: loopback },
+        localConfig: {},
+      }).baseUrl,
+    ).toBe(`http://${loopback}`);
+  }
+
+  // The explicit opt-in is honoured, so a trusted tailnet stays reachable.
+  expect(
+    resolveControlApiTarget({
+      env: {
+        FACTORY_EVENT_HOST: "runner.example.test:7381",
+        FACTORY_CONTROL_API_ALLOW_INSECURE: "1",
+      },
+      localConfig: {},
+    }).baseUrl,
+  ).toBe("http://runner.example.test:7381");
+});
+
+// The reviewer's blocking concern on #2192: a library that reads ambient state
+// would retarget every existing caller. Only a caller that names no target at
+// all resolves; `{ port }` keeps the historic loopback pin (§14).
+test("apiClient({ port }) stays pinned to loopback whatever the environment says", () => {
+  const saved = process.env.FACTORY_EVENT_HOST;
+  process.env.FACTORY_EVENT_HOST = "https://elsewhere.example.test";
+  try {
+    const client = apiClient({ port: 7999, token: null });
+    expect(client.host).toBe("127.0.0.1");
+    expect(client.port).toBe(7999);
+    expect(client.baseUrl).toBe("http://127.0.0.1:7999");
+  } finally {
+    if (saved === undefined) delete process.env.FACTORY_EVENT_HOST;
+    else process.env.FACTORY_EVENT_HOST = saved;
+  }
+});
+
+test("apiClient with no target resolves the environment target", () => {
+  const saved = process.env.FACTORY_EVENT_HOST;
+  process.env.FACTORY_EVENT_HOST = "https://elsewhere.example.test";
+  try {
+    expect(apiClient({ token: null }).baseUrl).toBe(
+      "https://elsewhere.example.test",
+    );
+  } finally {
+    if (saved === undefined) delete process.env.FACTORY_EVENT_HOST;
+    else process.env.FACTORY_EVENT_HOST = saved;
+  }
 });
 
 test("uses the resolved URL while preserving bearer propagation", async () => {

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -159,52 +159,60 @@ export function environmentName(home = runtimeHome()) {
   return base.replace(/^event-runtime-?/, "") || base;
 }
 
-/** Loopback is the default control API target; clients can override it safely. */
+/**
+ * Loopback is the default control API target and the local trust surface (§14):
+ * with no explicit opt-in every client pins 127.0.0.1 exactly as the MVP did.
+ * Remote targeting (#2188) is opt-in — an operator flag (`factory <cmd> --host`,
+ * which bin/factory forwards as FACTORY_EVENT_HOST) or ~/.factory/config.json —
+ * and plaintext http to a non-loopback host is refused unless the operator sets
+ * FACTORY_CONTROL_API_ALLOW_INSECURE=1, because the bearer travels in the clear.
+ */
 export const API_HOST = "127.0.0.1";
 export const DEFAULT_PORT = Number(process.env.FACTORY_EVENT_PORT || 7381);
 
+/**
+ * Environment overrides for the control API target, highest precedence first.
+ *
+ * FACTORY_EVENT_URL is deliberately excluded: it already names the handoff
+ * event URL (tools/handoff.mjs, docs/remote-handoff.md), so honouring it here
+ * would silently redirect a handoff operator's control bearer to that host.
+ */
 const CONTROL_API_ENV_KEYS = Object.freeze([
   "FACTORY_EVENT_HOST",
   "FACTORY_CONTROL_API_URL",
-  "FACTORY_EVENT_URL",
 ]);
 
+const LOOPBACK_HOSTNAMES = new Set(["localhost", "127.0.0.1", "::1"]);
+
+/** True for the addresses where an unencrypted bearer never leaves the box. */
+export function isLoopbackHostname(hostname) {
+  const host = String(hostname || "")
+    .toLowerCase()
+    .replace(/^\[|\]$/g, "");
+  if (LOOPBACK_HOSTNAMES.has(host)) return true;
+  return /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(host);
+}
+
 /**
- * Read the operator's optional control target without making a malformed local
- * config prevent an explicit flag or environment override from working.
+ * Read the operator's optional control target from the `controlApi` block of
+ * ~/.factory/config.json. A malformed file never blocks an explicit override.
  */
 export function loadControlApiConfig({
   configPath = path.join(homedir(), ".factory", "config.json"),
 } = {}) {
   try {
     const parsed = JSON.parse(readFileSync(configPath, "utf8"));
-    return parsed && typeof parsed === "object" ? parsed : {};
+    const block = parsed?.controlApi;
+    return block && typeof block === "object" ? block : {};
   } catch {
     return {};
   }
 }
 
-/** Return the last supported targeting flag, matching normal CLI override order. */
-export function controlApiFlagValue(args = []) {
-  let value = null;
-  for (let index = 0; index < args.length; index += 1) {
-    const arg = args[index];
-    if (arg === "--host" || arg === "--remote") {
-      const next = args[index + 1];
-      if (!next || next.startsWith("--")) {
-        throw new Error(`${arg} requires a URL, host, or SSH alias`);
-      }
-      value = next;
-      index += 1;
-    } else if (arg.startsWith("--host=") || arg.startsWith("--remote=")) {
-      value = arg.slice(arg.indexOf("=") + 1);
-      if (!value) throw new Error(`${arg.split("=", 1)[0]} requires a value`);
-    }
-  }
-  return value;
-}
-
-function normalizedControlApiTarget(value, { defaultPort, source }) {
+function normalizedControlApiTarget(
+  value,
+  { defaultPort, source, allowInsecure },
+) {
   const raw = String(value ?? "").trim();
   if (!raw) throw new Error("control API target must not be empty");
   const hasScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(raw);
@@ -224,6 +232,19 @@ function normalizedControlApiTarget(value, { defaultPort, source }) {
     throw new Error("control API target must not contain a query or fragment");
   }
   if (!hasScheme && !parsed.port) parsed.port = String(defaultPort);
+  // The control API bearer is sent on every request. Over plaintext to anything
+  // but loopback that hands the token to the network, so refuse by default and
+  // make the operator either use https:// or opt in explicitly (#2188 review).
+  if (
+    parsed.protocol === "http:" &&
+    !isLoopbackHostname(parsed.hostname) &&
+    !allowInsecure
+  ) {
+    throw new Error(
+      `refusing to send the control API bearer in plaintext to ${parsed.host} — ` +
+        "use https://, or set FACTORY_CONTROL_API_ALLOW_INSECURE=1 to accept the risk",
+    );
+  }
 
   const pathname = parsed.pathname.replace(/\/+$/, "");
   const protocolDefault = parsed.protocol === "https:" ? 443 : 80;
@@ -236,25 +257,22 @@ function normalizedControlApiTarget(value, { defaultPort, source }) {
 }
 
 /**
- * Resolve the control API target consistently for every client command.
+ * Resolve the control API target for a caller that opted into remote targeting.
  *
- * An explicit target (used by apiClient's programmatic API) and CLI flags win,
- * then the documented environment sequence, then `~/.factory/config.json`,
- * and finally the loopback development runtime.
+ * An explicit target (apiClient's `url`/`host`) wins, then the documented
+ * environment sequence, then ~/.factory/config.json, then loopback. Command-line
+ * flags are parsed by bin/factory and arrive as FACTORY_EVENT_HOST — this
+ * library never reads process.argv, so importing it can never retarget a caller.
  */
 export function resolveControlApiTarget({
   target = null,
-  args = process.argv.slice(2),
   env = process.env,
   localConfig = undefined,
   defaultPort = Number(env.FACTORY_EVENT_PORT || DEFAULT_PORT),
+  allowInsecure = env.FACTORY_CONTROL_API_ALLOW_INSECURE === "1",
 } = {}) {
   let value = target;
   let source = target ? "explicit" : null;
-  if (!value) {
-    value = controlApiFlagValue(args);
-    source = value ? "flag" : null;
-  }
   if (!value) {
     for (const key of CONTROL_API_ENV_KEYS) {
       if (env[key]) {
@@ -267,14 +285,16 @@ export function resolveControlApiTarget({
   if (!value) {
     const config =
       localConfig === undefined ? loadControlApiConfig() : localConfig;
-    if (config?.host) {
-      value = config.host;
+    const configured = config?.url || config?.host;
+    if (configured) {
+      value = configured;
       source = "config";
     }
   }
   return normalizedControlApiTarget(value || API_HOST, {
     defaultPort,
     source: source || "default",
+    allowInsecure,
   });
 }
 

--- a/event-runtime/lib/config.mjs
+++ b/event-runtime/lib/config.mjs
@@ -159,9 +159,124 @@ export function environmentName(home = runtimeHome()) {
   return base.replace(/^event-runtime-?/, "") || base;
 }
 
-/** Loopback only in the MVP — the control API is a local trust surface (§14). */
+/** Loopback is the default control API target; clients can override it safely. */
 export const API_HOST = "127.0.0.1";
 export const DEFAULT_PORT = Number(process.env.FACTORY_EVENT_PORT || 7381);
+
+const CONTROL_API_ENV_KEYS = Object.freeze([
+  "FACTORY_EVENT_HOST",
+  "FACTORY_CONTROL_API_URL",
+  "FACTORY_EVENT_URL",
+]);
+
+/**
+ * Read the operator's optional control target without making a malformed local
+ * config prevent an explicit flag or environment override from working.
+ */
+export function loadControlApiConfig({
+  configPath = path.join(homedir(), ".factory", "config.json"),
+} = {}) {
+  try {
+    const parsed = JSON.parse(readFileSync(configPath, "utf8"));
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+/** Return the last supported targeting flag, matching normal CLI override order. */
+export function controlApiFlagValue(args = []) {
+  let value = null;
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (arg === "--host" || arg === "--remote") {
+      const next = args[index + 1];
+      if (!next || next.startsWith("--")) {
+        throw new Error(`${arg} requires a URL, host, or SSH alias`);
+      }
+      value = next;
+      index += 1;
+    } else if (arg.startsWith("--host=") || arg.startsWith("--remote=")) {
+      value = arg.slice(arg.indexOf("=") + 1);
+      if (!value) throw new Error(`${arg.split("=", 1)[0]} requires a value`);
+    }
+  }
+  return value;
+}
+
+function normalizedControlApiTarget(value, { defaultPort, source }) {
+  const raw = String(value ?? "").trim();
+  if (!raw) throw new Error("control API target must not be empty");
+  const hasScheme = /^[a-z][a-z\d+.-]*:\/\//i.test(raw);
+  let parsed;
+  try {
+    parsed = new URL(hasScheme ? raw : `http://${raw}`);
+  } catch {
+    throw new Error(`invalid control API target: ${raw}`);
+  }
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("control API target must use http or https");
+  }
+  if (parsed.username || parsed.password) {
+    throw new Error("control API target must not contain credentials");
+  }
+  if (parsed.search || parsed.hash) {
+    throw new Error("control API target must not contain a query or fragment");
+  }
+  if (!hasScheme && !parsed.port) parsed.port = String(defaultPort);
+
+  const pathname = parsed.pathname.replace(/\/+$/, "");
+  const protocolDefault = parsed.protocol === "https:" ? 443 : 80;
+  return {
+    baseUrl: `${parsed.protocol}//${parsed.host}${pathname}`,
+    host: parsed.hostname,
+    port: Number(parsed.port || protocolDefault),
+    source,
+  };
+}
+
+/**
+ * Resolve the control API target consistently for every client command.
+ *
+ * An explicit target (used by apiClient's programmatic API) and CLI flags win,
+ * then the documented environment sequence, then `~/.factory/config.json`,
+ * and finally the loopback development runtime.
+ */
+export function resolveControlApiTarget({
+  target = null,
+  args = process.argv.slice(2),
+  env = process.env,
+  localConfig = undefined,
+  defaultPort = Number(env.FACTORY_EVENT_PORT || DEFAULT_PORT),
+} = {}) {
+  let value = target;
+  let source = target ? "explicit" : null;
+  if (!value) {
+    value = controlApiFlagValue(args);
+    source = value ? "flag" : null;
+  }
+  if (!value) {
+    for (const key of CONTROL_API_ENV_KEYS) {
+      if (env[key]) {
+        value = env[key];
+        source = "environment";
+        break;
+      }
+    }
+  }
+  if (!value) {
+    const config =
+      localConfig === undefined ? loadControlApiConfig() : localConfig;
+    if (config?.host) {
+      value = config.host;
+      source = "config";
+    }
+  }
+  return normalizedControlApiTarget(value || API_HOST, {
+    defaultPort,
+    source: source || "default",
+  });
+}
 
 /** Shared secret for webhook HMAC. Absent secret means intake refuses webhooks. */
 export function webhookSecret() {


### PR DESCRIPTION
Fixes watt-mind/factory#2188

Use --host/--remote or config to target the desired Factory control API.

## Narrowing decisions

The reviewer raised escalation-shaped concerns on the first revision. #2188 is operator-authored, so the feature stands, but it has been narrowed to secure defaults. Three deviations from the ticket's AC are deliberate:

1. **`FACTORY_EVENT_URL` excluded: collides with existing handoff semantics.** The AC listed it in the precedence chain, but it already means the handoff event URL (`tools/handoff.mjs:244`, `docs/remote-handoff.md:75`). Honouring it here would silently redirect a handoff operator's control-API bearer to that host. The unambiguous `FACTORY_CONTROL_API_URL` is supported instead; precedence is `FACTORY_EVENT_HOST` → `FACTORY_CONTROL_API_URL` → `~/.factory/config.json` (`controlApi.url`/`controlApi.host`) → loopback.

2. **Plaintext http to a non-loopback host is refused.** The bearer travels on every request, so `http://` to anything but loopback now errors with `refusing to send the control API bearer in plaintext to <host> — use https://, or set FACTORY_CONTROL_API_ALLOW_INSECURE=1 to accept the risk`. Loopback http (127.0.0.0/8, localhost, ::1) is unaffected.

3. **Per-subcommand rejection instead of silently-ignored flags.** `--host`/`--remote` are parsed only for `events`, `status` and `ps`. `inbox|approve|reject|inject|decide|memos` do not route through the targeted client yet, so they exit 2 with `remote targeting not yet supported for <cmd> (see #2190)` rather than exporting an env they ignore. Every other subcommand's argv is left untouched — notably `factory handoff --host <ssh-alias>` (#2191), which was being hijacked into an ssh dispatch by the first revision.

Also narrowed/fixed in review:

- **The library no longer reads ambient state on behalf of callers that name a target.** `apiClient({ port })` keeps its historic 127.0.0.1 pin (demo/verify.mjs, demo/seed.mjs, api-test-helpers and every test suite are unchanged). Only a caller naming no target at all — the two CLI entrypoints — or one passing `resolveTarget: true` consults the environment and config. `process.argv` is never read inside `event-runtime/lib`; `bin/factory` parses the flags and forwards them as `FACTORY_EVENT_HOST`.
- **SSH argv is quoted** with `printf '%q '`, so `;`, `$( )` and backticks in an argument cannot execute on the remote and quoted arguments survive.
- **`set -- "${forwarded_args[@]}"`** is guarded for the empty-array case under `set -u`.
- **The flag-position comment matches the parser**: `--host` is recognised after the subcommand only (`$1` is consumed as the subcommand).
- **No stack traces**: `apiClient()` moved inside `withClient`'s `try`, so a malformed target or an insecure-http refusal exits through `fail()`.
- `config.mjs`'s doc comment is truthful again: loopback is the default and the local trust surface; remote targeting is explicit opt-in behind the insecure-http guard.
- The "not reachable" wording is kept as `on <host>:<port>` (now the *resolved* host/port), which keeps `event-runtime/cli/status.mjs`'s `--json` error and the text path identical and leaves `event-runtime/cli/status.test.mjs` green.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/client.test.mjs event-runtime/cli/status.test.mjs --timeout 20000` | pass | 28 pass, 0 fail |
| Repo verify | `bun test event-runtime/lib --timeout 20000` | pass | 2455 pass, 10 skip, 0 fail |
| Repo verify | `bun test event-runtime/cli --timeout 20000` | pass | 117 pass, 0 fail |
| Repo verify | `bun run check && bun run format:check && bun run lint` | pass | 0 errors |
| bin/factory dispatch matrix | manual dry-run (stub `ssh`/`bun` on PATH) | pass | see below |
| UX critique | factory-ux-critic | not run | CLI flag surface only |

Dry-run matrix (stubbed `ssh` and `bun`):

- `factory handoff --host runner CLNT-1` → `tools/handoff.mjs --host runner CLNT-1` (flag intact, no ssh, no env) ✔
- `factory status --host runner` → `ssh runner 'factory status '` ✔
- `factory events runs --host runner --grep 'a b; rm -rf /' --json` → `ssh runner "factory events runs --grep a\ b\;\ rm\ -rf\ / --json"` ✔
- `factory ps --remote https://x.test --json` → `event-runtime/cli.mjs ps --json` with `FACTORY_EVENT_HOST=https://x.test` ✔
- `factory inbox --host runner` → exit 2, `remote targeting not yet supported for inbox (see #2190)` ✔
- `factory status` (no flags) → `orchestrator/status.mjs`, no env exported ✔
- `factory ticket get --host foo` → `tools/ticket.mjs get --host foo` (untouched) ✔

New tests in `event-runtime/lib/client.test.mjs`: loopback pinning preserved for `{ port }`-only callers under a hostile `FACTORY_EVENT_HOST`; bare `apiClient()` resolving; insecure-http refusal plus the https/loopback/opt-in escapes; `FACTORY_EVENT_URL` ignored; environment/config precedence.

run:run_30b03ba3-6876-4b13-9082-d39ac4c15cda
