### PR TITLE
fix(adapters): repair malformed Pi dispatch results

### DIFF
--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -142,15 +142,57 @@ not invent top-level fields. In particular,
 \`{ command, passed, output }\`; never write \`ticketGate\` or \`repoGate\`.
 `;
 
-function piPrompt(def, resultRepair = null) {
-  const base = verifiedPrompt(def, "pi") + PI_RESULT_ENVELOPE_CONTRACT;
-  if (!resultRepair?.violations?.length) return base;
+/** Bytes of the rejected envelope echoed back into the repair prompt. */
+const REPAIR_PRIOR_RESULT_CHARS = 8000;
 
+/**
+ * The repair turn is not a re-run. Re-issuing the dispatch prompt to what is
+ * normally a cold session (the run's resume token is usually null, and the
+ * sandbox drops it outright) invites the agent to redo the work and open a
+ * second PR. Send the envelope contract, the validator's complaints, and the
+ * bytes the agent already wrote — nothing that describes the task.
+ */
+function repairPrompt(resultRepair) {
   const violations = resultRepair.violations
     .slice(0, 16)
     .map((violation) => `- ${String(violation).slice(0, 500)}`)
     .join("\n");
-  return `${base}\n\n## Bounded result repair\nThe prior result.json was rejected by the validator. Do not repeat completed work or open another PR. Rewrite only the result envelope at the required path, using these validator errors verbatim:\n${violations}`;
+  const priorPath = resultRepair.priorResultPath ?? "the result path";
+  const prior =
+    typeof resultRepair.priorResult === "string" &&
+    resultRepair.priorResult !== ""
+      ? resultRepair.priorResult.slice(0, REPAIR_PRIOR_RESULT_CHARS)
+      : "(the prior result could not be read)";
+  return [
+    "# Result envelope repair",
+    "",
+    "A previous session finished this task and wrote a result file that the",
+    "factory validator rejected. Your only job now is to rewrite that result",
+    "file so it satisfies the contract below.",
+    PI_RESULT_ENVELOPE_CONTRACT.trim(),
+    "",
+    "## Validator errors",
+    violations,
+    "",
+    `## Prior result written to ${priorPath}`,
+    "```json",
+    prior,
+    "```",
+    "",
+    "## Rules",
+    "- Do not run any tools, commands, or tests.",
+    "- Do not modify the repository, do not commit, and do not open a pull request.",
+    "- Do not repeat or re-verify the completed work.",
+    "- Do not invent field values. Restate only what the prior result already",
+    "  says, mapped onto the required envelope fields; if the prior result does",
+    "  not say something, omit the optional field rather than guessing.",
+    "- Write the corrected envelope to the result path and then stop.",
+  ].join("\n");
+}
+
+function piPrompt(def, resultRepair = null) {
+  if (resultRepair?.violations?.length) return repairPrompt(resultRepair);
+  return verifiedPrompt(def, "pi") + PI_RESULT_ENVELOPE_CONTRACT;
 }
 
 /** Trace events preview text; the recorder's byte bound is the real limit. */

--- a/event-runtime/lib/adapters/pi.mjs
+++ b/event-runtime/lib/adapters/pi.mjs
@@ -123,6 +123,36 @@ export const SANDBOX_PROMPT_FILE = ".prompt.md";
 /** Terminate a detached CLI and every subprocess it started (WM-263). */
 export { killProcessGroup };
 
+/**
+ * Pi's Codex sessions need the envelope called out in their own prompt bytes,
+ * rather than relying on a reference to the shared Claude suffix.  Keep this
+ * independent of an individual output artifact: every agent result uses this
+ * wrapper while the registered output contract defines `artifact`.
+ */
+export const PI_RESULT_ENVELOPE_CONTRACT = `
+
+## Result envelope (required)
+
+Before finishing, write exactly one \`factory.agent-result/v1\` JSON envelope
+to \`$FACTORY_RESULT_PATH\` (or \`./result.json\` when it is unset). Its top
+level includes \`schemaVersion\`, \`terminalState\`, \`reasonCode\`, and
+\`artifact\`; add only optional fields allowed by the registered contract. Do
+not invent top-level fields. In particular,
+\`verification\` belongs inside the dispatch artifact and is exactly
+\`{ command, passed, output }\`; never write \`ticketGate\` or \`repoGate\`.
+`;
+
+function piPrompt(def, resultRepair = null) {
+  const base = verifiedPrompt(def, "pi") + PI_RESULT_ENVELOPE_CONTRACT;
+  if (!resultRepair?.violations?.length) return base;
+
+  const violations = resultRepair.violations
+    .slice(0, 16)
+    .map((violation) => `- ${String(violation).slice(0, 500)}`)
+    .join("\n");
+  return `${base}\n\n## Bounded result repair\nThe prior result.json was rejected by the validator. Do not repeat completed work or open another PR. Rewrite only the result envelope at the required path, using these validator errors verbatim:\n${violations}`;
+}
+
 /** Trace events preview text; the recorder's byte bound is the real limit. */
 const TEXT_PREVIEW_CHARS = 4000;
 
@@ -601,6 +631,7 @@ async function executeSandboxed({
   onUsage,
   transcriptMaxBytes: maxTranscriptBytes,
   resume,
+  resultRepair,
   abortSignal,
   runSandbox,
 }) {
@@ -616,7 +647,7 @@ async function executeSandboxed({
   // this preflight also covers injected VM runners used by tests and leaves
   // no stray prompt behind when the definition itself is invalid.
   normalizePolicy(def.sandbox, { workspaceDir });
-  const prompt = verifiedPrompt(def, "pi");
+  const prompt = piPrompt(def, resultRepair);
   writeFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), prompt, "utf8");
   const argv = [
     bin,
@@ -679,6 +710,7 @@ export async function execute({
   onTrace,
   onUsage,
   resume = null,
+  resultRepair = null,
   abortSignal,
   signal,
   runSandbox,
@@ -697,12 +729,13 @@ export async function execute({
       onUsage,
       transcriptMaxBytes: maxTranscriptBytes,
       resume,
+      resultRepair,
       abortSignal: abortSignal ?? signal,
       runSandbox,
     });
   }
 
-  const prompt = verifiedPrompt(def, "pi");
+  const prompt = piPrompt(def, resultRepair);
   // A remote worker can execute this checked-out adapter from a persistent
   // runner checkout, whose ignored config/ is intentionally absent. Preserve
   // the launching operator's root for the ticket CLI instead of replacing it

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -824,15 +824,30 @@ process.stdin.on("end", () => {
       },
       resultRepair: {
         violations: ["$.schemaVersion: expected const factory.agent-result/v1"],
+        priorResultPath: path.join(workspaceDir, "result.json"),
+        priorResult: '{"status":"completed","summary":"invented shape"}',
       },
     });
 
     const record = JSON.parse(readFileSync(recordFile, "utf8"));
-    expect(record.stdin).toContain("## Bounded result repair");
+    expect(record.stdin).toContain("# Result envelope repair");
     expect(record.stdin).toContain(
       "$.schemaVersion: expected const factory.agent-result/v1",
     );
-    expect(record.stdin).toContain("Do not repeat completed work");
+    // The envelope contract still rides along, so the agent knows the shape.
+    expect(record.stdin).toContain("factory.agent-result/v1");
+    // The rejected bytes are the only description of the completed work.
+    expect(record.stdin).toContain(
+      '{"status":"completed","summary":"invented shape"}',
+    );
+    expect(record.stdin).toContain(path.join(workspaceDir, "result.json"));
+    // A cold repair session must not be re-handed the dispatch task, or it
+    // redoes the work and opens a second PR.
+    expect(record.stdin).not.toContain("You are a test agent.");
+    expect(record.stdin).not.toContain(PROMPT_SUFFIX);
+    expect(record.stdin).toContain("Do not run any tools");
+    expect(record.stdin).toContain("do not open a pull request");
+    expect(record.stdin).toContain("Do not invent field values");
   });
 
   test("nonzero exit code propagates and timedOut is false", async () => {

--- a/event-runtime/lib/adapters/pi.test.mjs
+++ b/event-runtime/lib/adapters/pi.test.mjs
@@ -24,6 +24,7 @@ import {
   mapStreamEvent,
   PUSH_CREDENTIAL_ENV,
   MUTATING_TOOLS,
+  PI_RESULT_ENVELOPE_CONTRACT,
   piExtensions,
   piTools,
   READ_ONLY_TOOLS,
@@ -767,8 +768,12 @@ process.stdin.on("end", () => {
     expect(record.env.CUSTOM_VAR).toBe("custom_value");
 
     // 3. Prompt on stdin, not argv; argv shape
-    expect(record.stdin).toBe(`You are a test agent.${PROMPT_SUFFIX}`);
-    expect(record.argv).not.toContain(`You are a test agent.${PROMPT_SUFFIX}`);
+    expect(record.stdin).toBe(
+      `You are a test agent.${PROMPT_SUFFIX}${PI_RESULT_ENVELOPE_CONTRACT}`,
+    );
+    expect(record.argv).not.toContain(
+      `You are a test agent.${PROMPT_SUFFIX}${PI_RESULT_ENVELOPE_CONTRACT}`,
+    );
     expect(record.argv).toContain("-p");
     expect(record.argv).toContain("--mode");
     expect(record.argv).toContain("json");
@@ -780,6 +785,9 @@ process.stdin.on("end", () => {
     expect(record.argv[record.argv.indexOf("--tools") + 1]).toBe(
       "read,grep,find,ls,write,bash,exec_command,apply_patch",
     );
+    expect(record.stdin).toContain("factory.agent-result/v1");
+    expect(record.stdin).toContain("verification");
+    expect(record.stdin).toContain("ticketGate");
 
     // 4. .transcript.json artifact capture
     const transcriptPath = path.join(workspaceDir, ".transcript.json");
@@ -799,6 +807,32 @@ process.stdin.on("end", () => {
     expect(usageEvent.payload.numTurns).toBe(1);
     expect(usageEvent.payload.costUSD).toBeCloseTo(0.001, 6);
     expect(usageEvent.payload.usage.input).toBe(15);
+  });
+
+  test("Codex repair prompt carries bounded validator errors with the envelope contract", async () => {
+    const workspaceDir = ws();
+    const recordFile = path.join(workspaceDir, "record.json");
+    await execute({
+      spec: { ...defaultSpec, model: "openai-codex/gpt-5.6-terra" },
+      def: defaultDef,
+      workspaceDir,
+      timeoutMs: 5000,
+      env: {
+        PATH: `${stubBinDir}${path.delimiter}${process.env.PATH}`,
+        FACTORY_TEST_BEHAVIOR: "normal",
+        FACTORY_TEST_RECORD_FILE: recordFile,
+      },
+      resultRepair: {
+        violations: ["$.schemaVersion: expected const factory.agent-result/v1"],
+      },
+    });
+
+    const record = JSON.parse(readFileSync(recordFile, "utf8"));
+    expect(record.stdin).toContain("## Bounded result repair");
+    expect(record.stdin).toContain(
+      "$.schemaVersion: expected const factory.agent-result/v1",
+    );
+    expect(record.stdin).toContain("Do not repeat completed work");
   });
 
   test("nonzero exit code propagates and timedOut is false", async () => {
@@ -1249,7 +1283,9 @@ describe("sandboxed execution (WM-313)", () => {
     );
     expect(
       readFileSync(path.join(workspaceDir, SANDBOX_PROMPT_FILE), "utf8"),
-    ).toBe(`You are a sandboxed test agent.${PROMPT_SUFFIX}`);
+    ).toBe(
+      `You are a sandboxed test agent.${PROMPT_SUFFIX}${PI_RESULT_ENVELOPE_CONTRACT}`,
+    );
 
     // 3. Guest env is built, not inherited: no host key, no push token, no
     //    caller var, no host HOME/PATH; PI_OFFLINE keeps update traffic off

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -928,6 +928,79 @@ export const HANDOFF_FORGE_UNAVAILABLE = "handoff_forge_unavailable";
 /** Non-`ContractViolation` throw from `verifyResult` / `assertHandoffPullRequestBase`. */
 const VERIFICATION_INTERNAL_ERROR = "verification_internal_error";
 
+/**
+ * The repair turn only restates an envelope the agent already produced, so it
+ * gets its own small budget rather than a second full run's worth of wall
+ * clock. A wedged repair must not be able to consume the attempt deadline.
+ */
+const PI_RESULT_REPAIR_TIMEOUT_MS = 5 * 60 * 1000;
+
+/** Evidence copy of the rejected envelope, kept beside the workspace result. */
+const INVALID_RESULT_FILE = "result.invalid.json";
+
+/** Bound on the rejected bytes echoed into the repair prompt and the trace. */
+const INVALID_RESULT_PREVIEW_BYTES = 8000;
+
+const USAGE_SUM_FIELDS = [
+  "inputTokens",
+  "outputTokens",
+  "cacheCreationInputTokens",
+  "cacheReadInputTokens",
+  "costUSD",
+];
+
+/**
+ * The repair is a second billable adapter turn on the same attempt. Attempt
+ * usage is a total, not a last-writer-wins snapshot, so add its tokens and
+ * cost to what the primary execution already reported.
+ */
+function mergeAttemptUsage(base, extra, adapterKey) {
+  const merged = { adapter: adapterKey, ...(base ?? {}), ...(extra ?? {}) };
+  for (const field of USAGE_SUM_FIELDS) {
+    const snake = field.replace(/[A-Z]/g, (c) => `_${c.toLowerCase()}`);
+    const read = (usage) => {
+      const value = usage?.[field] ?? usage?.[snake];
+      return Number.isFinite(value) && value >= 0 ? value : 0;
+    };
+    const total = read(base) + read(extra);
+    if (total > 0) merged[field] = total;
+    delete merged[snake];
+  }
+  return merged;
+}
+
+/**
+ * Snapshot the rejected envelope before the repair turn overwrites
+ * `result.json`. The invalid payload is the primary evidence for why the run
+ * failed; a repair that fails again must not be the reason it disappeared.
+ */
+function snapshotInvalidResult({ workspaceDir, onTrace }) {
+  let raw;
+  const source = path.join(workspaceDir, "result.json");
+  const target = path.join(workspaceDir, INVALID_RESULT_FILE);
+  try {
+    raw = readFileSync(source);
+    writeFileSync(target, raw);
+  } catch (err) {
+    onTrace?.("lifecycle", {
+      event: "pi_result_repair_snapshot_failed",
+      source,
+      error: String(err?.message ?? err),
+    });
+    return null;
+  }
+  const text = raw.toString("utf8");
+  const snapshot = {
+    source,
+    path: target,
+    bytes: raw.length,
+    sha256: sha256Hex(raw),
+    preview: text.slice(0, INVALID_RESULT_PREVIEW_BYTES),
+  };
+  onTrace?.("lifecycle", { event: "pi_result_repair_snapshot", ...snapshot });
+  return snapshot;
+}
+
 /** A zero-exit Pi run gets one chance to correct its own invalid envelope. */
 function mayRepairPiResult({ adapterKey, outcome, error }) {
   return (
@@ -3869,25 +3942,32 @@ export async function executeClaimed(
   };
 
   const abortController = new AbortController();
-  ACTIVE_EXECUTIONS.set(runId, {
-    abort: (reason) => abortController.abort(reason),
-    controller: abortController,
-    runId,
-    attempt,
-  });
-  let cancelPoll = setInterval(() => {
-    try {
-      const state = db
-        .query(`SELECT state FROM runs WHERE run_id = ?`)
-        .get(runId)?.state;
-      if (state === "CANCELLED" && !abortController.signal.aborted) {
-        abortController.abort("db_cancelled");
+  let cancelPoll = null;
+  // Idempotent so a supervised follow-up adapter turn (the bounded Pi result
+  // repair) can re-arm cancellation after the primary execution stopped it.
+  const startCancellationMonitor = () => {
+    ACTIVE_EXECUTIONS.set(runId, {
+      abort: (reason) => abortController.abort(reason),
+      controller: abortController,
+      runId,
+      attempt,
+    });
+    if (cancelPoll) return;
+    cancelPoll = setInterval(() => {
+      try {
+        const state = db
+          .query(`SELECT state FROM runs WHERE run_id = ?`)
+          .get(runId)?.state;
+        if (state === "CANCELLED" && !abortController.signal.aborted) {
+          abortController.abort("db_cancelled");
+        }
+      } catch {
+        // ignore
       }
-    } catch {
-      // ignore
-    }
-  }, 250);
-  cancelPoll?.unref?.();
+    }, 250);
+    cancelPoll?.unref?.();
+  };
+  startCancellationMonitor();
   const stopCancellationMonitor = () => {
     if (cancelPoll) clearInterval(cancelPoll);
     cancelPoll = null;
@@ -4957,9 +5037,15 @@ export async function executeClaimed(
       deadlineTimer = setTimeout(refreshDeadline, leftMs);
       deadlineTimer.unref?.();
     };
-    refreshDeadline();
-    deadlinePoll = setInterval(refreshDeadline, DEADLINE_POLL_MS);
-    deadlinePoll.unref?.();
+    // Idempotent for the same reason as `startCancellationMonitor`: the
+    // bounded Pi result repair re-arms the durable deadline for its own turn.
+    const startDeadlineMonitor = () => {
+      if (deadlinePoll) return;
+      refreshDeadline();
+      deadlinePoll = setInterval(refreshDeadline, DEADLINE_POLL_MS);
+      deadlinePoll.unref?.();
+    };
+    startDeadlineMonitor();
     const stopDeadlineMonitor = () => {
       if (deadlineTimer) clearTimeout(deadlineTimer);
       if (deadlinePoll) clearInterval(deadlinePoll);
@@ -4973,6 +5059,48 @@ export async function executeClaimed(
       env.FACTORY_EVENT_PORT ?? process.env.FACTORY_EVENT_PORT;
     const workerControlToken =
       env.FACTORY_CONTROL_API_TOKEN ?? process.env.FACTORY_CONTROL_API_TOKEN;
+    // The agent may have retained a notification because it deliberately
+    // lacks the control bearer. Callers drain in `finally` so an adapter throw
+    // can never strand a retained escalation, and only after the adapter has
+    // fully stopped, so no writer races the read/truncate cycle. Neither the
+    // drain nor its ticket comment may throw: the agent's primary terminal
+    // outcome (or error) always wins.
+    const drainNotifyOutboxSafely = async () => {
+      try {
+        const notificationDrain = isWorktree
+          ? await drainLocalNotifyOutbox({
+              runId,
+              home: workerEventHome,
+              port: workerEventPort,
+              token: workerControlToken,
+              fetchFn: localNotifyFetch,
+            })
+          : { delivered: [], undelivered: [] };
+        if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {
+          try {
+            const messages = notificationDrain.undelivered
+              .slice(0, 10)
+              .map(
+                ({ title, error }) => `- ${JSON.stringify(title)} — ${error}`,
+              )
+              .join("\n");
+            commentTicketFn({
+              repo: repoName,
+              ticket: ticketId,
+              body:
+                `## Notification outbox\n` +
+                `Worker could not deliver ${notificationDrain.undelivered.length} retained notification(s); intended text:\n${messages}`,
+            });
+          } catch {
+            // The retained outbox remains the recovery source if the tracker
+            // is down.
+          }
+        }
+      } catch (err) {
+        recordTerminalError("drainLocalNotifyOutbox", err);
+      }
+    };
+
     let outcome;
     let adapterEnv;
     try {
@@ -5014,45 +5142,7 @@ export async function executeClaimed(
     } finally {
       stopDeadlineMonitor();
       stopCancellationMonitor();
-      // The agent may have retained a notification because it deliberately
-      // lacks the control bearer. Drain in `finally` so an adapter throw can
-      // never strand a retained escalation, and only after the adapter has
-      // fully stopped, so no writer races the read/truncate cycle. Neither the
-      // drain nor its ticket comment may throw: the agent's primary terminal
-      // outcome (or error) always wins.
-      try {
-        const notificationDrain = isWorktree
-          ? await drainLocalNotifyOutbox({
-              runId,
-              home: workerEventHome,
-              port: workerEventPort,
-              token: workerControlToken,
-              fetchFn: localNotifyFetch,
-            })
-          : { delivered: [], undelivered: [] };
-        if (notificationDrain.undelivered.length && mayMutateClaimedTicket()) {
-          try {
-            const messages = notificationDrain.undelivered
-              .slice(0, 10)
-              .map(
-                ({ title, error }) => `- ${JSON.stringify(title)} — ${error}`,
-              )
-              .join("\n");
-            commentTicketFn({
-              repo: repoName,
-              ticket: ticketId,
-              body:
-                `## Notification outbox\n` +
-                `Worker could not deliver ${notificationDrain.undelivered.length} retained notification(s); intended text:\n${messages}`,
-            });
-          } catch {
-            // The retained outbox remains the recovery source if the tracker
-            // is down.
-          }
-        }
-      } catch (err) {
-        recordTerminalError("drainLocalNotifyOutbox", err);
-      }
+      await drainNotifyOutboxSafely();
     }
 
     if (outcome?.usage)
@@ -5376,28 +5466,69 @@ export async function executeClaimed(
       // contract failure one bounded turn with the validator diagnostics; a
       // handoff-gate failure must never be retried as an envelope repair.
       if (mayRepairPiResult({ adapterKey, outcome, error: activeError })) {
+        const originalViolations = activeError.violations;
+        const invalidSnapshot = snapshotInvalidResult({
+          workspaceDir,
+          onTrace,
+        });
+        let repairOutcome = null;
+        let repairUsage = null;
+        // The repair is a live adapter turn like any other: it runs under the
+        // same durable deadline and cancellation supervision, and drains the
+        // notify outbox in `finally` so a throw can never strand a retained
+        // escalation.
+        startCancellationMonitor();
+        startDeadlineMonitor();
         try {
-          const repairOutcome = await adapter.execute({
+          repairOutcome = await adapter.execute({
             spec:
               executionInput === spec.input
                 ? spec
                 : { ...spec, input: executionInput },
             def,
             workspaceDir,
-            timeoutMs: adapterExecuteTimeoutMs({
-              adapterKey,
-              spec,
-              maxRunMinutes: policyMaxRunMinutes(policyRoot),
-            }),
+            timeoutMs: PI_RESULT_REPAIR_TIMEOUT_MS,
             env: adapterEnv,
             onTrace,
-            onUsage,
+            onUsage: (usage) => {
+              repairUsage = usage ?? null;
+            },
             resume: created.resume ?? null,
             abortSignal: abortController.signal,
             signal: abortController.signal,
-            resultRepair: { violations: activeError.violations },
+            resultRepair: {
+              violations: originalViolations,
+              priorResultPath: invalidSnapshot?.source ?? null,
+              priorResult: invalidSnapshot?.preview ?? null,
+            },
           });
-          if (repairOutcome?.exitCode === 0 && !repairOutcome?.timedOut) {
+        } catch (repairError) {
+          // The repair is best-effort commentary on an already-failed
+          // envelope. An adapter throw leaves the original violations
+          // standing rather than reclassifying the run.
+          onTrace("lifecycle", {
+            event: "pi_result_repair_failed",
+            error: String(repairError?.message ?? repairError),
+          });
+          repairOutcome = null;
+        } finally {
+          stopDeadlineMonitor();
+          stopCancellationMonitor();
+          await drainNotifyOutboxSafely();
+        }
+        if (repairOutcome?.usage) repairUsage = repairOutcome.usage;
+        if (repairUsage)
+          attemptUsage = mergeAttemptUsage(
+            attemptUsage,
+            repairUsage,
+            adapterKey,
+          );
+        if (
+          repairOutcome?.exitCode === 0 &&
+          !repairOutcome?.timedOut &&
+          !abortController.signal.aborted
+        ) {
+          try {
             verified = verifyResultFn({
               spec,
               def,
@@ -5417,12 +5548,28 @@ export async function executeClaimed(
               });
             }
             break verificationAttempt;
+          } catch (repairError) {
+            if (!(repairError instanceof ContractViolation)) {
+              return failVerificationInternal(repairError);
+            }
+            // The rejected original is what a human has to read; the repair's
+            // own violations are appended detail, never a replacement.
+            activeError = new ContractViolation(
+              [
+                ...originalViolations,
+                ...(repairError.violations ?? []).map(
+                  (violation) => `after repair: ${violation}`,
+                ),
+                ...(invalidSnapshot
+                  ? [`rejected envelope retained at ${invalidSnapshot.path}`]
+                  : []),
+              ],
+              {
+                reasonCode: activeError.reasonCode,
+                handoff: repairError.handoff ?? activeError.handoff ?? null,
+              },
+            );
           }
-        } catch (repairError) {
-          if (!(repairError instanceof ContractViolation)) {
-            return failVerificationInternal(repairError);
-          }
-          activeError = repairError;
         }
       }
       if (activeError.reasonCode === HANDOFF_FORGE_UNAVAILABLE) {

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -928,6 +928,20 @@ export const HANDOFF_FORGE_UNAVAILABLE = "handoff_forge_unavailable";
 /** Non-`ContractViolation` throw from `verifyResult` / `assertHandoffPullRequestBase`. */
 const VERIFICATION_INTERNAL_ERROR = "verification_internal_error";
 
+/** A zero-exit Pi run gets one chance to correct its own invalid envelope. */
+function mayRepairPiResult({ adapterKey, outcome, error }) {
+  return (
+    adapterKey === "pi" &&
+    outcome?.exitCode === 0 &&
+    outcome?.timedOut !== true &&
+    error instanceof ContractViolation &&
+    error.reasonCode === "contract_violation" &&
+    !error.handoff &&
+    Array.isArray(error.violations) &&
+    error.violations.length > 0
+  );
+}
+
 const ENVIRONMENT_FAILURES = new Set([
   "adapter_error",
   "lease_expired",
@@ -4960,6 +4974,7 @@ export async function executeClaimed(
     const workerControlToken =
       env.FACTORY_CONTROL_API_TOKEN ?? process.env.FACTORY_CONTROL_API_TOKEN;
     let outcome;
+    let adapterEnv;
     try {
       // Dispatch identity comes from the immutable RunSpec, never the ambient
       // worker environment. The adapter's child-environment builder preserves
@@ -4969,7 +4984,7 @@ export async function executeClaimed(
         if (dispatchEnv[key] === undefined && process.env[key] !== undefined)
           dispatchEnv[key] = process.env[key];
       }
-      const adapterEnv = dispatchIdentityEnv({
+      adapterEnv = dispatchIdentityEnv({
         spec,
         env: dispatchEnv,
         runId,
@@ -5354,6 +5369,60 @@ export async function executeClaimed(
             return failVerificationInternal(recoveryError);
           }
           activeError = recoveryError;
+        }
+      }
+      // Codex-tier Pi sessions have historically completed the ticket while
+      // writing an invented result shape. Give only that zero-exit, pre-handoff
+      // contract failure one bounded turn with the validator diagnostics; a
+      // handoff-gate failure must never be retried as an envelope repair.
+      if (mayRepairPiResult({ adapterKey, outcome, error: activeError })) {
+        try {
+          const repairOutcome = await adapter.execute({
+            spec:
+              executionInput === spec.input
+                ? spec
+                : { ...spec, input: executionInput },
+            def,
+            workspaceDir,
+            timeoutMs: adapterExecuteTimeoutMs({
+              adapterKey,
+              spec,
+              maxRunMinutes: policyMaxRunMinutes(policyRoot),
+            }),
+            env: adapterEnv,
+            onTrace,
+            onUsage,
+            resume: created.resume ?? null,
+            abortSignal: abortController.signal,
+            signal: abortController.signal,
+            resultRepair: { violations: activeError.violations },
+          });
+          if (repairOutcome?.exitCode === 0 && !repairOutcome?.timedOut) {
+            verified = verifyResultFn({
+              spec,
+              def,
+              registry,
+              workspaceDir,
+              attempt,
+              attemptStartedAt: started.startedAt,
+              extraArtifacts: RUNTIME_ARTIFACTS,
+              worktreeRecord,
+              onTrace,
+            });
+            if (verified.handoff && handoffPrNumber(verified.handoff)) {
+              assertHandoffPullRequestBase({
+                handoff: verified.handoff,
+                base: worktreeRecord?.base,
+                fetchPullRequest: fetchHandoffPullRequestFn,
+              });
+            }
+            break verificationAttempt;
+          }
+        } catch (repairError) {
+          if (!(repairError instanceof ContractViolation)) {
+            return failVerificationInternal(repairError);
+          }
+          activeError = repairError;
         }
       }
       if (activeError.reasonCode === HANDOFF_FORGE_UNAVAILABLE) {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -2146,6 +2146,88 @@ sh -c 'sleep 5 & wait'
     );
   });
 
+  test("Pi retries each observed malformed result shape once with validator detail", async () => {
+    const malformed = [
+      { status: "completed", summary: "done", verification: {} },
+      {
+        ticket: "watt-mind/factory#1952",
+        repo: "factory",
+        outcome: "PR_OPEN",
+        summary: "real work completed",
+        prUrl: "https://github.com/watt-mind/factory/pull/1952",
+        branch: "feat/1952",
+        verification: {},
+      },
+      {
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        reasonCode: "ok",
+        artifact: {
+          repos: [
+            {
+              name: "factory",
+              triage: 0,
+              agentReady: 0,
+              inProgress: 0,
+              blocked: 0,
+            },
+          ],
+          recommendedAction: "wait",
+        },
+        verification: { ticketGate: "pass", repoGate: "pass" },
+        followUpIssue: "WM-2076",
+      },
+    ];
+
+    for (const candidate of malformed) {
+      const db = openDb(":memory:");
+      const spec = queueRun(db, makeSpec({ adapter: "pi" }));
+      const repairs = [];
+      const pi = {
+        async execute({ workspaceDir, resultRepair }) {
+          if (!resultRepair) {
+            writeFileSync(
+              path.join(workspaceDir, "result.json"),
+              JSON.stringify(candidate),
+            );
+          } else {
+            repairs.push(resultRepair);
+            writeFileSync(
+              path.join(workspaceDir, "result.json"),
+              JSON.stringify({
+                schemaVersion: "factory.agent-result/v1",
+                terminalState: "completed",
+                reasonCode: "ok",
+                artifact: {
+                  repos: [
+                    {
+                      name: "factory",
+                      triage: 0,
+                      agentReady: 0,
+                      inProgress: 0,
+                      blocked: 0,
+                    },
+                  ],
+                  recommendedAction: "wait",
+                },
+              }),
+            );
+          }
+          return { exitCode: 0, timedOut: false };
+        },
+      };
+
+      const summary = await runOnce(db, registry, { pi }, opts());
+      expect(summary).toMatchObject({ terminalState: "COMPLETED" });
+      expect(repairs).toHaveLength(1);
+      expect(repairs[0].violations.join("\n")).toMatch(
+        /\$|required|additional/,
+      );
+      expect(runState(db, spec.runId)).toBe("COMPLETED");
+      db.close();
+    }
+  });
+
   test("escape: artifact outside the workspace is a contract violation", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec({ input: { repos: ["escape"] } }));

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -390,36 +390,39 @@ describe("worker", () => {
     LOCAL_NOTIFY_PROBE_TIMEOUT_MS,
   );
 
-  test("keeps exactly one local notify drain in the adapter finally to prevent double delivery", () => {
+  test("keeps exactly one local notify drain, reached only from a finally", () => {
     // Two drain sites could race the same outbox read/truncate cycle and
     // deliver a BLOCKED or escalation notification twice. Keep this structural
     // guard alongside the behavioral drain tests so a future refactor cannot
-    // silently add another call site.
+    // silently add another call site — and so every supervised adapter turn
+    // (the primary execution and the bounded Pi result repair) still drains
+    // from a `finally`, where an adapter throw cannot strand a retained
+    // escalation.
     const source = readFileSync(
       new URL("./worker.mjs", import.meta.url),
       "utf8",
     );
-    const marker =
-      "    } finally {\n      stopDeadlineMonitor();\n      stopCancellationMonitor();\n";
-    const start = source.indexOf(marker);
-    expect(start).toBeGreaterThan(-1);
-    const open = source.indexOf("{", start);
-    let depth = 0;
-    let end = -1;
-    for (let i = open; i < source.length; i += 1) {
-      if (source[i] === "{") depth += 1;
-      else if (source[i] === "}") {
-        depth -= 1;
-        if (depth === 0) {
-          end = i;
-          break;
-        }
-      }
-    }
-    expect(end).toBeGreaterThan(open);
-    const finallyBody = source.slice(open, end);
-    expect(finallyBody).toContain("await drainLocalNotifyOutbox({");
+    // Exactly one place actually touches the outbox...
     expect(source.split("await drainLocalNotifyOutbox({")).toHaveLength(2);
+    const helper = source.indexOf(
+      "const drainNotifyOutboxSafely = async () => {",
+    );
+    expect(helper).toBeGreaterThan(-1);
+    expect(source.indexOf("await drainLocalNotifyOutbox({")).toBeGreaterThan(
+      helper,
+    );
+    // ...and every caller of it sits directly in a `finally`.
+    const callSites = [
+      ...source.matchAll(/await drainNotifyOutboxSafely\(\);/g),
+    ];
+    expect(callSites.length).toBeGreaterThanOrEqual(2);
+    for (const site of callSites) {
+      const preamble = source.slice(Math.max(0, site.index - 200), site.index);
+      expect(preamble).toContain("} finally {");
+      expect(preamble.slice(preamble.lastIndexOf("} finally {"))).not.toContain(
+        "try {",
+      );
+    }
   });
 
   test("retains an undelivered local notification for handoff recovery", async () => {
@@ -2147,41 +2150,68 @@ sh -c 'sleep 5 & wait'
   });
 
   test("Pi retries each observed malformed result shape once with validator detail", async () => {
+    const goodResult = {
+      schemaVersion: "factory.agent-result/v1",
+      terminalState: "completed",
+      reasonCode: "ok",
+      artifact: {
+        repos: [
+          {
+            name: "factory",
+            triage: 0,
+            agentReady: 0,
+            inProgress: 0,
+            blocked: 0,
+          },
+        ],
+        recommendedAction: "wait",
+      },
+    };
     const malformed = [
-      { status: "completed", summary: "done", verification: {} },
       {
-        ticket: "watt-mind/factory#1952",
-        repo: "factory",
-        outcome: "PR_OPEN",
-        summary: "real work completed",
-        prUrl: "https://github.com/watt-mind/factory/pull/1952",
-        branch: "feat/1952",
-        verification: {},
+        candidate: { status: "completed", summary: "done", verification: {} },
+        expected: [
+          '$: missing required property "schemaVersion"',
+          '$: missing required property "terminalState"',
+          '$: unknown property "status"',
+          '$: unknown property "verification"',
+        ],
       },
       {
-        schemaVersion: "factory.agent-result/v1",
-        terminalState: "completed",
-        reasonCode: "ok",
-        artifact: {
-          repos: [
-            {
-              name: "factory",
-              triage: 0,
-              agentReady: 0,
-              inProgress: 0,
-              blocked: 0,
-            },
-          ],
-          recommendedAction: "wait",
+        candidate: {
+          ticket: "watt-mind/factory#1952",
+          repo: "factory",
+          outcome: "PR_OPEN",
+          summary: "real work completed",
+          prUrl: "https://github.com/watt-mind/factory/pull/1952",
+          branch: "feat/1952",
+          verification: {},
         },
-        verification: { ticketGate: "pass", repoGate: "pass" },
-        followUpIssue: "WM-2076",
+        expected: [
+          '$: missing required property "schemaVersion"',
+          '$: missing required property "terminalState"',
+          '$: unknown property "outcome"',
+          '$: unknown property "prUrl"',
+        ],
+      },
+      {
+        candidate: {
+          ...goodResult,
+          terminalState: "completed",
+          verification: { ticketGate: "pass", repoGate: "pass" },
+          followUpIssue: "WM-2076",
+        },
+        expected: [
+          '$: unknown property "verification"',
+          '$: unknown property "followUpIssue"',
+        ],
       },
     ];
 
-    for (const candidate of malformed) {
+    for (const { candidate, expected } of malformed) {
       const db = openDb(":memory:");
       const spec = queueRun(db, makeSpec({ adapter: "pi" }));
+      const o = opts();
       const repairs = [];
       const pi = {
         async execute({ workspaceDir, resultRepair }) {
@@ -2191,41 +2221,156 @@ sh -c 'sleep 5 & wait'
               JSON.stringify(candidate),
             );
           } else {
-            repairs.push(resultRepair);
+            repairs.push({
+              ...resultRepair,
+              // The snapshot only survives while the workspace does; a
+              // COMPLETED run destroys it, so read it here.
+              retained: readFileSync(
+                path.join(workspaceDir, "result.invalid.json"),
+                "utf8",
+              ),
+            });
             writeFileSync(
               path.join(workspaceDir, "result.json"),
-              JSON.stringify({
-                schemaVersion: "factory.agent-result/v1",
-                terminalState: "completed",
-                reasonCode: "ok",
-                artifact: {
-                  repos: [
-                    {
-                      name: "factory",
-                      triage: 0,
-                      agentReady: 0,
-                      inProgress: 0,
-                      blocked: 0,
-                    },
-                  ],
-                  recommendedAction: "wait",
-                },
-              }),
+              JSON.stringify(goodResult),
             );
           }
           return { exitCode: 0, timedOut: false };
         },
       };
 
-      const summary = await runOnce(db, registry, { pi }, opts());
+      const summary = await runOnce(db, registry, { pi }, o);
       expect(summary).toMatchObject({ terminalState: "COMPLETED" });
       expect(repairs).toHaveLength(1);
-      expect(repairs[0].violations.join("\n")).toMatch(
-        /\$|required|additional/,
+      // Shape-specific: the repair turn must be handed the validator's own
+      // complaints, not merely some non-empty string.
+      for (const violation of expected) {
+        expect(repairs[0].violations).toContain(violation);
+      }
+      // The rejected bytes travel with the repair request, and are kept on
+      // disk as the evidence of what the agent originally wrote.
+      expect(repairs[0].priorResult).toBe(JSON.stringify(candidate));
+      expect(repairs[0].retained).toBe(JSON.stringify(candidate));
+      expect(repairs[0].priorResultPath).toBe(
+        path.join(o.workspacesRoot, `${spec.runId}-a1`, "result.json"),
       );
       expect(runState(db, spec.runId)).toBe("COMPLETED");
       db.close();
     }
+  });
+
+  test("Pi repair that is still invalid FAILS with the ORIGINAL violations and retains the invalid envelope", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "pi" }));
+    const o = opts();
+    const invalid = { status: "completed", summary: "done" };
+    let calls = 0;
+    const pi = {
+      async execute({ workspaceDir }) {
+        calls += 1;
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify(
+            calls === 1 ? invalid : { schemaVersion: "wrong/v0", oops: true },
+          ),
+        );
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+
+    const summary = await runOnce(db, registry, { pi }, o);
+    expect(calls).toBe(2);
+    expect(summary).toMatchObject({
+      terminalState: "FAILED",
+      reasonCode: "contract_violation",
+    });
+    const reason = lifecycleOf(db, spec.runId)
+      .map((event) => event.reason ?? "")
+      .join("\n");
+    // The original complaint is what a human has to read; the repair's own
+    // violations are appended detail, never a replacement.
+    expect(reason).toContain('$: missing required property "schemaVersion"');
+    expect(reason).toContain('$: unknown property "status"');
+    expect(reason).toContain("after repair:");
+    const workspaceDir = path.join(o.workspacesRoot, `${spec.runId}-a1`);
+    expect(
+      readFileSync(path.join(workspaceDir, "result.invalid.json"), "utf8"),
+    ).toBe(JSON.stringify(invalid));
+  });
+
+  test("Pi repair that exits nonzero leaves the original violations standing and is not retried", async () => {
+    for (const repairOutcome of [
+      { exitCode: 3, timedOut: false },
+      { exitCode: 0, timedOut: true },
+      "throw",
+    ]) {
+      const db = openDb(":memory:");
+      const spec = queueRun(db, makeSpec({ adapter: "pi" }));
+      let calls = 0;
+      const pi = {
+        async execute({ workspaceDir, resultRepair }) {
+          calls += 1;
+          if (!resultRepair) {
+            writeFileSync(
+              path.join(workspaceDir, "result.json"),
+              JSON.stringify({ status: "completed", summary: "done" }),
+            );
+            return { exitCode: 0, timedOut: false };
+          }
+          if (repairOutcome === "throw") throw new Error("pi crashed");
+          // A failed repair must not be able to smuggle a result through.
+          return repairOutcome;
+        },
+      };
+
+      const summary = await runOnce(db, registry, { pi }, opts());
+      expect(calls).toBe(2);
+      expect(summary).toMatchObject({
+        terminalState: "FAILED",
+        reasonCode: "contract_violation",
+      });
+      const reason = lifecycleOf(db, spec.runId)
+        .map((event) => event.reason ?? "")
+        .join("\n");
+      expect(reason).toContain('$: unknown property "status"');
+      expect(reason).not.toContain("after repair:");
+      expect(runState(db, spec.runId)).toBe("FAILED");
+      db.close();
+    }
+  });
+
+  test("a handoff-gate contract violation is never repaired as an envelope", async () => {
+    const db = openDb(":memory:");
+    queueRun(db, makeSpec({ adapter: "pi" }));
+    let calls = 0;
+    const pi = {
+      async execute({ workspaceDir }) {
+        calls += 1;
+        writeFileSync(
+          path.join(workspaceDir, "result.json"),
+          JSON.stringify({ status: "completed" }),
+        );
+        return { exitCode: 0, timedOut: false };
+      },
+    };
+    const verifyResultStub = () => {
+      throw new ContractViolation(["handoff verification did not pass"], {
+        reasonCode: "handoff_verification_failed",
+        handoff: { command: "bun test", passed: false, output: "red" },
+      });
+    };
+
+    const summary = await runOnce(
+      db,
+      registry,
+      { pi },
+      { ...opts(), verifyResult: verifyResultStub },
+    );
+    // The gate refused the WORK, not the envelope: re-prompting the agent to
+    // restate its result would launder a real verification failure.
+    expect(calls).toBe(1);
+    expect(summary).toMatchObject({ terminalState: "FAILED" });
+    expect(summary.reasonCode).toBe("handoff_verification_failed");
   });
 
   test("escape: artifact outside the workspace is a contract violation", async () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2189

Pi dispatch now embeds the result-envelope contract and gets one validator-guided repair pass for malformed results.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/adapters/pi.test.mjs event-runtime/lib/worker.test.mjs` | pass | 220 pass, 3 skipped |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (warnings only) |
| UX critique          | factory-ux-critic                | not run | backend adapter and worker changes |

UX critique: skipped — no user-facing surface
run:run_d11b9c6f-adc4-4cf3-b915-2e84cd4ad884