### PR TITLE
fix(handoff): harden host resolution parsing

### DIFF
--- a/config/policy.example.yaml
+++ b/config/policy.example.yaml
@@ -5,6 +5,10 @@
 packs: []
 extensions: []
 
+# Optional default SSH alias for remote ticket handoff. A repository's
+# `handoff_host` takes precedence over this value.
+# handoff_host: factory-runner
+
 # Workspace-only model runs fail closed when this host cannot provide the
 # Gondolin guest boundary. An operator may temporarily accept host execution
 # by naming, one by one, the agents they accept running unconfined. Nothing is

--- a/config/repos.example.yaml
+++ b/config/repos.example.yaml
@@ -17,6 +17,7 @@ repos:
     # Linear — without it the choice is global and moving one moves all.
     # control_plane: github
     base: develop # Base branch for promotion PRs; defaults to main.
+    # handoff_host: factory-runner # Optional SSH alias for remote ticket handoff.
     deploy_branch: main # Optional human-reviewed release branch.
     worktree_up: bin/worktree-up.sh # Script that creates an isolated ticket worktree.
     worktree_down: bin/worktree-down.sh # Script that tears down an isolated worktree.

--- a/docs/remote-handoff.md
+++ b/docs/remote-handoff.md
@@ -67,6 +67,11 @@ When `--host` is omitted, the client resolves the SSH alias in this order:
 5. `handoff.host` or `handoff_host` in `config/policy.yaml`
 6. the canonical `factory-runner` SSH alias
 
+`~/.factory/handoff.json` also accepts the bare top-level shorthand
+`{"host":"factory-runner"}`. In `~/.factory/secrets.env`, unquoted inline
+comments are stripped, so `FACTORY_HANDOFF_HOST=factory-runner # alias` uses
+the `factory-runner` alias.
+
 For example, an operator can set a repository-wide default without changing
 client shells:
 

--- a/tools/handoff.mjs
+++ b/tools/handoff.mjs
@@ -131,7 +131,9 @@ export function resolveHandoffRepo({ repos, cwd = process.cwd(), repo } = {}) {
 }
 
 function nonemptyString(value) {
-  return typeof value === "string" && value.trim() ? value : null;
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed || null;
 }
 
 function handoffHostFromConfig(config, { directHost = false } = {}) {
@@ -169,6 +171,11 @@ function parseDotenvFile(file, readFile) {
     if (equals <= 0) continue;
     const key = entry.slice(0, equals).trim();
     let value = entry.slice(equals + 1).trim();
+    // Match common dotenv syntax without treating a # inside a quoted value as
+    // a comment. A comment must be separated from an unquoted value by space.
+    if (!value.startsWith('"') && !value.startsWith("'")) {
+      value = value.replace(/\s+#.*$/, "").trimEnd();
+    }
     if (
       (value.startsWith('"') && value.endsWith('"')) ||
       (value.startsWith("'") && value.endsWith("'"))
@@ -184,6 +191,9 @@ function loadHandoffConfig({ root, readFile }) {
   let repos = null;
   let policy = null;
   try {
+    // Deliberately parse the operator-owned registry directly rather than use
+    // loadRepos(): its in-repo .factory.yaml merge must not let a PR redirect
+    // this SSH destination.
     repos = Bun.YAML.parse(
       readFile(resolveConfigPath("repos", { root }), "utf8"),
     );
@@ -214,6 +224,9 @@ export function resolveHandoffHost({
   repoConfig,
   policy,
 } = {}) {
+  if (host !== undefined && nonemptyString(host) === null) {
+    fail("ssh_host_missing", "ssh_host_missing");
+  }
   const configured =
     repoConfig === undefined || policy === undefined
       ? loadHandoffConfig({ root, readFile })

--- a/tools/handoff.test.mjs
+++ b/tools/handoff.test.mjs
@@ -170,6 +170,32 @@ describe("handoff SSH host resolution", () => {
       }),
     ).toBe("policy-runner");
   });
+
+  test("trims aliases, rejects an explicit blank flag, and strips dotenv comments", () => {
+    const files = filesFor();
+    expect(resolve(files, { host: " runner " })).toBe("runner");
+    expect(() => resolve(files, { host: "" })).toThrow(/ssh_host_missing/);
+
+    files.delete("/home/operator/.factory/config.json");
+    files.delete("/home/operator/.factory/handoff.json");
+    files.set(
+      "/home/operator/.factory/secrets.env",
+      "FACTORY_HANDOFF_HOST=secrets-runner # operator alias\n",
+    );
+    expect(resolve(files)).toBe("secrets-runner");
+  });
+
+  test("falls back when local JSON or raw configuration YAML is malformed", () => {
+    const files = filesFor();
+    files.set("/home/operator/.factory/config.json", "{oops");
+    files.delete("/home/operator/.factory/handoff.json");
+    files.delete("/home/operator/.factory/secrets.env");
+    files.set("/factory/config/repos.yaml", "repos: [");
+    expect(resolve(files)).toBe("policy-runner");
+
+    files.set("/factory/config/policy.yaml", "handoff: [");
+    expect(resolve(files)).toBe("factory-runner");
+  });
 });
 
 describe("forced-command accept server", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2194

Harden configured handoff aliases and document fallback behavior for operators.

## Validation

| Check                | Command                                                                                                       | Result  | Notes                    |
| -------------------- | ------------------------------------------------------------------------------------------------------------- | ------- | ------------------------ |
| Verification Command | `bun test tools/handoff.test.mjs --timeout 20000`                                                          | pass    | 23 tests, 0 failures     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | exit 0; warnings only    |
| UX critique          | factory-ux-critic                                                                                             | not run | no user-facing surface   |

UX critique: skipped — no user-facing surface

run:run_9488e6d9-9566-42a5-bb50-78a28fc88464