### PR TITLE
fix(cli): route top-level inbox through resolved target

### DIFF
--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -9,8 +9,6 @@ import { backfillResultArtifacts } from "./lib/artifacts.mjs";
 import { initPack } from "./lib/pack-init.mjs";
 import { validatePack } from "./lib/pack-validate.mjs";
 import {
-  API_HOST,
-  DEFAULT_PORT,
   FACTORY_ROOT,
   artifactsRoot,
   initializeLocalConfig,
@@ -18,7 +16,7 @@ import {
 } from "./lib/config.mjs";
 import { openDb } from "./lib/db.mjs";
 import { decisionRequestHash } from "./lib/decision.mjs";
-import { unauthorizedMessage } from "./lib/client.mjs";
+import { apiClient, unauthorizedMessage } from "./lib/client.mjs";
 import { resolveRefs } from "./lib/presentation.mjs";
 import { renderText } from "./lib/presentation-text.mjs";
 import {
@@ -69,18 +67,16 @@ export {
 } from "./cli/supervise.mjs";
 export { COMMAND_NAMES, COMMANDS } from "./cli/commands.mjs";
 
-function controlUrl(pathname) {
-  const port = Number(process.env.FACTORY_EVENT_PORT ?? DEFAULT_PORT);
-  return `http://${API_HOST}:${port}${pathname}`;
-}
-
 async function callControl(method, pathname, body) {
-  const token = process.env.FACTORY_CONTROL_API_TOKEN || null;
-  const res = await fetch(controlUrl(pathname), {
+  // Keep these top-level verbs on the same resolved target as COMMANDS. The
+  // factory --host/--remote flags arrive as FACTORY_EVENT_HOST, which the
+  // client resolver validates before any bearer is sent.
+  const client = apiClient({ resolveTarget: true });
+  const res = await fetch(`${client.baseUrl}${pathname}`, {
     method,
     headers: {
       "content-type": "application/json",
-      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...(client.token ? { authorization: `Bearer ${client.token}` } : {}),
     },
     ...(body === undefined ? {} : { body: JSON.stringify(body) }),
   });
@@ -89,7 +85,7 @@ async function callControl(method, pathname, body) {
     const err = new Error(
       res.status === 401 ||
         (res.status === 503 && payload?.error === "control_api_token_unset")
-        ? unauthorizedMessage(Boolean(token))
+        ? unauthorizedMessage(Boolean(client.token))
         : (payload?.message ?? payload?.error ?? `HTTP ${res.status}`),
     );
     err.status = res.status;

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -83,6 +83,100 @@ describe("cli routing", () => {
   });
 
   test.each([
+    ["--host", (port) => `127.0.0.1:${port}`],
+    ["--remote", (port) => `http://127.0.0.1:${port}`],
+  ])(
+    "top-level inbox and decide use the target forwarded by factory %s",
+    async (_flag, targetFor) => {
+      const token = "cli-remote-control-token";
+      const requests = [];
+      const item = { id: "item-remote", decision: { fields: [] } };
+      const server = Bun.serve({
+        port: Number(freePort()),
+        async fetch(request) {
+          const url = new URL(request.url);
+          requests.push({
+            method: request.method,
+            pathname: url.pathname,
+            search: url.search,
+            authorization: request.headers.get("authorization"),
+          });
+          if (request.method === "GET" && url.pathname === "/inbox") {
+            return Response.json({ items: [] });
+          }
+          if (
+            request.method === "GET" &&
+            url.pathname === "/inbox/item-remote"
+          ) {
+            return Response.json({ item });
+          }
+          if (
+            request.method === "POST" &&
+            url.pathname === "/inbox/item-remote/decide"
+          ) {
+            return Response.json({
+              item,
+              effect: { kind: "approve_proposal", outcome: "applied" },
+            });
+          }
+          return new Response("not found", { status: 404 });
+        },
+      });
+      const env = {
+        ...process.env,
+        FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+        FACTORY_EVENT_HOST: targetFor(server.port),
+        FACTORY_CONTROL_API_TOKEN: token,
+        FACTORY_RUN_DIR: throwawayRunDir(),
+      };
+      try {
+        const inbox = Bun.spawn(["bun", CLI, "inbox"], {
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [inboxStatus, inboxStderr] = await Promise.all([
+          inbox.exited,
+          new Response(inbox.stderr).text(),
+        ]);
+        expect(inboxStatus, inboxStderr).toBe(0);
+
+        const decide = Bun.spawn(
+          ["bun", CLI, "decide", "item-remote", "approve"],
+          { env, stdout: "pipe", stderr: "pipe" },
+        );
+        const [decideStatus, decideStderr] = await Promise.all([
+          decide.exited,
+          new Response(decide.stderr).text(),
+        ]);
+        expect(decideStatus, decideStderr).toBe(0);
+        expect(requests).toEqual([
+          {
+            method: "GET",
+            pathname: "/inbox",
+            search: "?status=open",
+            authorization: `Bearer ${token}`,
+          },
+          {
+            method: "GET",
+            pathname: "/inbox/item-remote",
+            search: "",
+            authorization: `Bearer ${token}`,
+          },
+          {
+            method: "POST",
+            pathname: "/inbox/item-remote/decide",
+            search: "",
+            authorization: `Bearer ${token}`,
+          },
+        ]);
+      } finally {
+        server.stop(true);
+      }
+    },
+  );
+
+  test.each([
     [401, "unauthorized"],
     [503, "control_api_token_unset"],
   ])(


### PR DESCRIPTION
Fixes watt-mind/factory#2190

Route inbox and decision CLI requests through the resolved remote control API target.

## Validation

| Check                | Command                                                                          | Result  | Notes                       |
| -------------------- | -------------------------------------------------------------------------------- | ------- | --------------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000`                         | pass    | 31 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 615 baseline warnings |
| UX critique          | factory-ux-critic                                                                | not run | no user-facing surface      |

UX critique: skipped — backend CLI-only change

run:run_163a0c8b-1854-47e1-ac6f-24c8f11fb35a
