### PR TITLE
fix(cli): finish inbox remote targeting

### DIFF
--- a/bin/factory
+++ b/bin/factory
@@ -63,10 +63,7 @@ control_target=""
 control_target_kind=""
 case "$cmd" in
   # Speaks to the control API and honours a remote target.
-  events|status|ps) control_target_supported=1 ;;
-  # Control-API commands that do not route through the targeted client yet.
-  # Rejecting is better than exporting an env these paths ignore (see #2190).
-  inbox|approve|reject|inject|decide|memos) control_target_supported=0 ;;
+  events|status|ps|inbox|approve|reject|inject|decide|memos) control_target_supported=1 ;;
   # Not a control-API command: leave argv alone.
   *) control_target_supported="" ;;
 esac
@@ -177,6 +174,8 @@ case "$cmd" in
   approve)      run_bun event-runtime/cli.mjs approve "$@" ;;
   reject)       run_bun event-runtime/cli.mjs reject "$@" ;;
   inject)       run_bun event-runtime/cli.mjs inject "$@" ;;
+  decide)       run_bun event-runtime/cli.mjs decide "$@" ;;
+  memos)        run_bun event-runtime/cli.mjs memos "$@" ;;
   serve)
     _has_web=0
     for _a in "$@"; do
@@ -469,10 +468,11 @@ factory — control plane (FACTORY_ROOT=$ROOT)
   security      lib/security-check.sh (gitleaks + semgrep + actionlint on cwd repo)
   emit          build/emit.mjs (--link --link-bin --link-repos when called bare)
 
-Remote targeting (#2188): events, status and ps accept --host/--remote after
-the subcommand. A bare --host alias is dispatched over ssh; a URL or host:port
-targets the control API directly. Plaintext http to a non-loopback host is
-refused (use https:// or FACTORY_CONTROL_API_ALLOW_INSECURE=1).
+Remote targeting (#2188): events, status, ps, inbox, approve, reject, inject,
+decide, and memos accept --host/--remote after the subcommand. A bare --host
+alias is dispatched over ssh; a URL or host:port targets the control API
+directly. Plaintext http to a non-loopback host is refused (use https:// or
+FACTORY_CONTROL_API_ALLOW_INSECURE=1).
 
 Works from any cwd (worktrees included).
   factory notify "BLOCKED LAB-176: need approval"

--- a/bin/factory
+++ b/bin/factory
@@ -98,11 +98,6 @@ if [[ -n "$control_target_supported" ]]; then
     esac
   done
   set -- ${forwarded_args[@]+"${forwarded_args[@]}"}
-
-  if [[ -n "$control_target" && "$control_target_supported" -eq 0 ]]; then
-    echo "factory: remote targeting not yet supported for $cmd (see #2190)" >&2
-    exit 2
-  fi
 fi
 
 if [[ -n "$control_target" ]]; then

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -69,11 +69,36 @@ export { COMMAND_NAMES, COMMANDS } from "./cli/commands.mjs";
 
 let controlClient;
 
+/**
+ * A CLI-side usage error, not a transport failure.
+ *
+ * `withClient` blames the control API for any error carrying no `status`, so a
+ * bare `new Error("usage: …")` thrown out of a command prints "control API not
+ * reachable" even with serve up (#2197). Tagging the error keeps withClient on
+ * its `fail(err.message)` path.
+ */
+function usageError(message) {
+  const error = new Error(message);
+  error.status = "usage";
+  return error;
+}
+
 /** Resolve the control target once so every leg of `decide` uses one client. */
 function getControlClient() {
   // The factory --host/--remote flags arrive as FACTORY_EVENT_HOST, which the
   // client resolver validates before any bearer is sent.
   return (controlClient ??= apiClient({ resolveTarget: true }));
+}
+
+/**
+ * Run one control-API command under withClient's connection diagnostics, reusing
+ * the client withClient already resolved instead of building a second one.
+ */
+function withControlClient(run) {
+  return withClient((client) => {
+    controlClient = client;
+    return run();
+  });
 }
 
 async function callControl(method, pathname, body) {
@@ -134,7 +159,7 @@ export async function memosCommand(args = []) {
   }
   const [subjectType, subjectId] = positional;
   if (!subjectType || !subjectId) {
-    throw new Error("usage: memos <subjectType> <id> [--kind k] [--all]");
+    throw usageError("usage: memos <subjectType> <id> [--kind k] [--all]");
   }
   const query = new URLSearchParams({
     subjectType,
@@ -168,15 +193,15 @@ const INBOX_RESOLVE_USAGE = 'usage: inbox resolve <item-id> --reason "<text>"';
 
 function parseInboxResolveArgs(args = []) {
   const [itemId, ...rest] = args;
-  if (!itemId) throw new Error(INBOX_RESOLVE_USAGE);
+  if (!itemId) throw usageError(INBOX_RESOLVE_USAGE);
   let reason;
   for (let index = 0; index < rest.length; index++) {
     if (rest[index] !== "--reason" || rest[index + 1] === undefined) {
-      throw new Error(`unexpected inbox resolve argument: ${rest[index]}`);
+      throw usageError(`unexpected inbox resolve argument: ${rest[index]}`);
     }
     reason = rest[++index];
   }
-  if (!reason || !reason.trim()) throw new Error(INBOX_RESOLVE_USAGE);
+  if (!reason || !reason.trim()) throw usageError(INBOX_RESOLVE_USAGE);
   return { itemId, reason: reason.trim() };
 }
 
@@ -199,7 +224,7 @@ export async function inboxCommand(args = []) {
   const [sub, ...rest] = args;
   if (sub === "resolve") return inboxResolveCommand(rest);
   if (sub !== undefined) {
-    throw new Error(`unknown inbox subcommand: ${sub}`);
+    throw usageError(`unknown inbox subcommand: ${sub}`);
   }
   const body = await callControl("GET", "/inbox?status=open");
   if (body.items.length === 0) {
@@ -229,25 +254,25 @@ function parseDecisionField(field, raw) {
 }
 
 export async function decideCommand(args) {
-  const [itemId, optionId, ...rest] = parseDecideArgs(args);
+  const { itemId, optionId, rest } = parseDecideArgs(args);
   const detail = await callControl(
     "GET",
     `/inbox/${encodeURIComponent(itemId)}`,
   );
   if (!detail.item.decision)
-    throw new Error(`inbox item ${itemId} has no decision`);
+    throw usageError(`inbox item ${itemId} has no decision`);
   const declared = new Map(
     (detail.item.decision.fields ?? []).map((field) => [field.id, field]),
   );
   const fields = {};
   for (let index = 0; index < rest.length; index++) {
     if (rest[index] !== "--field" || !rest[index + 1]) {
-      throw new Error(`unexpected decide argument: ${rest[index]}`);
+      throw usageError(`unexpected decide argument: ${rest[index]}`);
     }
     const assignment = rest[++index];
     const equals = assignment.indexOf("=");
     if (equals <= 0)
-      throw new Error(`--field expects key=value, got ${assignment}`);
+      throw usageError(`--field expects key=value, got ${assignment}`);
     const key = assignment.slice(0, equals);
     const raw = assignment.slice(equals + 1);
     fields[key] = parseDecisionField(declared.get(key), raw);
@@ -275,13 +300,13 @@ export async function decideCommand(args) {
 }
 
 function parseDecideArgs(args = []) {
-  const [itemId, optionId] = args;
+  const [itemId, optionId, ...rest] = args;
   if (!itemId || !optionId) {
-    throw new Error(
+    throw usageError(
       "usage: decide <item-id> <option-id> [--field key=value]...",
     );
   }
-  return args;
+  return { itemId, optionId, rest };
 }
 
 /**
@@ -490,15 +515,13 @@ export async function dispatch(argv = process.argv.slice(2)) {
     return;
   }
   if (command === "init") return initCommand(args);
-  if (command === "decide") {
-    parseDecideArgs(args);
-    return withClient(() => decideCommand(args));
-  }
-  if (command === "inbox") {
-    if (args[0] === "resolve") parseInboxResolveArgs(args.slice(1));
-    return withClient(() => inboxCommand(args));
-  }
-  if (command === "memos") return withClient(() => memosCommand(args));
+  // approve, reject and inject reach the control API through COMMANDS below;
+  // each of those wraps its own withClient(), so apiClient({resolveTarget:true})
+  // — and with it the loopback pin and the plaintext-bearer refusal — applies to
+  // them exactly as it does here.
+  if (command === "decide") return withControlClient(() => decideCommand(args));
+  if (command === "inbox") return withControlClient(() => inboxCommand(args));
+  if (command === "memos") return withControlClient(() => memosCommand(args));
   if (command === "extensions") return extensionsCommand(args);
   if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);

--- a/event-runtime/cli.mjs
+++ b/event-runtime/cli.mjs
@@ -67,11 +67,17 @@ export {
 } from "./cli/supervise.mjs";
 export { COMMAND_NAMES, COMMANDS } from "./cli/commands.mjs";
 
-async function callControl(method, pathname, body) {
-  // Keep these top-level verbs on the same resolved target as COMMANDS. The
-  // factory --host/--remote flags arrive as FACTORY_EVENT_HOST, which the
+let controlClient;
+
+/** Resolve the control target once so every leg of `decide` uses one client. */
+function getControlClient() {
+  // The factory --host/--remote flags arrive as FACTORY_EVENT_HOST, which the
   // client resolver validates before any bearer is sent.
-  const client = apiClient({ resolveTarget: true });
+  return (controlClient ??= apiClient({ resolveTarget: true }));
+}
+
+async function callControl(method, pathname, body) {
+  const client = getControlClient();
   const res = await fetch(`${client.baseUrl}${pathname}`, {
     method,
     headers: {
@@ -160,8 +166,7 @@ export async function memosCommand(args = []) {
 
 const INBOX_RESOLVE_USAGE = 'usage: inbox resolve <item-id> --reason "<text>"';
 
-/** `inbox resolve <item-id> --reason "<text>"` — POST /inbox/:id/resolve (AC3). */
-export async function inboxResolveCommand(args = []) {
+function parseInboxResolveArgs(args = []) {
   const [itemId, ...rest] = args;
   if (!itemId) throw new Error(INBOX_RESOLVE_USAGE);
   let reason;
@@ -172,13 +177,19 @@ export async function inboxResolveCommand(args = []) {
     reason = rest[++index];
   }
   if (!reason || !reason.trim()) throw new Error(INBOX_RESOLVE_USAGE);
+  return { itemId, reason: reason.trim() };
+}
+
+/** `inbox resolve <item-id> --reason "<text>"` — POST /inbox/:id/resolve (AC3). */
+export async function inboxResolveCommand(args = []) {
+  const { itemId, reason } = parseInboxResolveArgs(args);
   const result = await callControl(
     "POST",
     `/inbox/${encodeURIComponent(itemId)}/resolve`,
-    { reason: reason.trim() },
+    { reason },
   );
   console.log(
-    `${result.item.id}: resolved (${result.item.resolvedReason ?? reason.trim()})`,
+    `${result.item.id}: resolved (${result.item.resolvedReason ?? reason})`,
   );
   return result;
 }
@@ -218,12 +229,7 @@ function parseDecisionField(field, raw) {
 }
 
 export async function decideCommand(args) {
-  const [itemId, optionId, ...rest] = args;
-  if (!itemId || !optionId) {
-    throw new Error(
-      "usage: decide <item-id> <option-id> [--field key=value]...",
-    );
-  }
+  const [itemId, optionId, ...rest] = parseDecideArgs(args);
   const detail = await callControl(
     "GET",
     `/inbox/${encodeURIComponent(itemId)}`,
@@ -266,6 +272,16 @@ export async function decideCommand(args) {
     );
   }
   return result;
+}
+
+function parseDecideArgs(args = []) {
+  const [itemId, optionId] = args;
+  if (!itemId || !optionId) {
+    throw new Error(
+      "usage: decide <item-id> <option-id> [--field key=value]...",
+    );
+  }
+  return args;
 }
 
 /**
@@ -474,9 +490,15 @@ export async function dispatch(argv = process.argv.slice(2)) {
     return;
   }
   if (command === "init") return initCommand(args);
-  if (command === "decide") return decideCommand(args);
-  if (command === "inbox") return inboxCommand(args);
-  if (command === "memos") return memosCommand(args);
+  if (command === "decide") {
+    parseDecideArgs(args);
+    return withClient(() => decideCommand(args));
+  }
+  if (command === "inbox") {
+    if (args[0] === "resolve") parseInboxResolveArgs(args.slice(1));
+    return withClient(() => inboxCommand(args));
+  }
+  if (command === "memos") return withClient(() => memosCommand(args));
   if (command === "extensions") return extensionsCommand(args);
   if (command === "pack") return packCommand(args);
   if (command === "artifacts") return artifactsCommand(args);

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -23,6 +23,43 @@ import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
 
 const FACTORY = path.resolve(import.meta.dir, "../bin/factory");
 
+const DECIDE_ITEM = { id: "item-target", decision: { fields: [] } };
+
+/**
+ * One stub control API answering every top-level remote-target verb, so the
+ * loopback pin and the plaintext refusal can be asserted for each of them
+ * against identical routing (#2197).
+ */
+function stubControlApi(onRequest = () => {}) {
+  return Bun.serve({
+    port: Number(freePort()),
+    fetch(request) {
+      const url = new URL(request.url);
+      onRequest(request, url);
+      const route = `${request.method} ${url.pathname}`;
+      if (route === "GET /inbox") return Response.json({ items: [] });
+      if (route === `GET /inbox/${DECIDE_ITEM.id}`)
+        return Response.json({ item: DECIDE_ITEM });
+      if (route === `POST /inbox/${DECIDE_ITEM.id}/decide`)
+        return Response.json({
+          item: DECIDE_ITEM,
+          effect: { kind: "approve_proposal", outcome: "applied" },
+        });
+      if (route === "GET /memos") return Response.json({ memos: [] });
+      if (route === "POST /proposals/prop-target/approve")
+        return Response.json({ approved: true, runId: "run-target" });
+      return new Response("not found", { status: 404 });
+    },
+  });
+}
+
+/** The control-API verbs `factory` forwards --host/--remote to. */
+const REMOTE_TARGET_VERBS = [
+  ["inbox", []],
+  ["decide", [DECIDE_ITEM.id, "approve"]],
+  ["memos", ["repo", "factory"]],
+];
+
 const EXPECTED_COMMANDS = [
   "serve",
   "work",
@@ -179,49 +216,28 @@ describe("cli routing", () => {
     },
   );
 
-  test("factory forwards --host to inbox and decide", async () => {
-    const token = "factory-wrapper-target-token";
+  test("factory forwards --host to the control-API verbs", async () => {
     const requests = [];
-    const item = { id: "item-wrapper", decision: { fields: [] } };
-    const server = Bun.serve({
-      port: Number(freePort()),
-      async fetch(request) {
-        const url = new URL(request.url);
-        requests.push(`${request.method} ${url.pathname}${url.search}`);
-        if (request.method === "GET" && url.pathname === "/inbox") {
-          return Response.json({ items: [] });
-        }
-        if (
-          request.method === "GET" &&
-          url.pathname === "/inbox/item-wrapper"
-        ) {
-          return Response.json({ item });
-        }
-        if (
-          request.method === "POST" &&
-          url.pathname === "/inbox/item-wrapper/decide"
-        ) {
-          return Response.json({
-            item,
-            effect: { kind: "approve_proposal", outcome: "applied" },
-          });
-        }
-        return new Response("not found", { status: 404 });
-      },
-    });
+    const server = stubControlApi((request, url) =>
+      requests.push(`${request.method} ${url.pathname}${url.search}`),
+    );
     const env = {
       ...process.env,
       FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
       FACTORY_RUN_DIR: throwawayRunDir(),
-      FACTORY_CONTROL_API_TOKEN: token,
+      FACTORY_CONTROL_API_TOKEN: "factory-wrapper-target-token",
     };
     const target = `127.0.0.1:${server.port}`;
     try {
+      // approve/reject/inject route through withClient →
+      // apiClient({ resolveTarget: true }) in their own command modules, so the
+      // wrapper only has to forward the flag; approve stands in for all three.
       for (const args of [
-        ["inbox", "--host", target],
-        ["decide", "item-wrapper", "approve", "--host", target],
+        ["inbox"],
+        ["decide", DECIDE_ITEM.id, "approve"],
+        ["approve", "prop-target"],
       ]) {
-        const child = Bun.spawn(["bash", FACTORY, ...args], {
+        const child = Bun.spawn(["bash", FACTORY, ...args, "--host", target], {
           env,
           stdout: "pipe",
           stderr: "pipe",
@@ -234,85 +250,85 @@ describe("cli routing", () => {
       }
       expect(requests).toEqual([
         "GET /inbox?status=open",
-        "GET /inbox/item-wrapper",
-        "POST /inbox/item-wrapper/decide",
+        `GET /inbox/${DECIDE_ITEM.id}`,
+        `POST /inbox/${DECIDE_ITEM.id}/decide`,
+        "POST /proposals/prop-target/approve",
       ]);
     } finally {
       server.stop(true);
     }
   });
 
-  test("top-level control verbs pin no-target requests to loopback", async () => {
-    let hostname;
-    const server = Bun.serve({
-      port: Number(freePort()),
-      fetch(request) {
-        hostname = new URL(request.url).hostname;
-        return Response.json({ memos: [] });
-      },
-    });
-    try {
-      const child = Bun.spawn(["bun", CLI, "memos", "repo", "factory"], {
-        env: {
-          ...process.env,
-          HOME: tmpDir("evrt-cli-home-"),
-          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
-          FACTORY_EVENT_PORT: String(server.port),
-          FACTORY_EVENT_HOST: "",
-          FACTORY_CONTROL_API_URL: "",
-          FACTORY_RUN_DIR: throwawayRunDir(),
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [status, stderr] = await Promise.all([
-        child.exited,
-        new Response(child.stderr).text(),
-      ]);
-      expect(status, stderr).toBe(0);
-      expect(hostname).toBe("127.0.0.1");
-    } finally {
-      server.stop(true);
-    }
-  });
-
-  test("top-level control verbs refuse plaintext remote targets before requests", async () => {
-    let requests = 0;
-    const server = Bun.serve({
-      port: Number(freePort()),
-      fetch() {
-        requests++;
-        return Response.json({ memos: [] });
-      },
-    });
-    try {
-      const child = Bun.spawn(["bun", CLI, "memos", "repo", "factory"], {
-        env: {
-          ...process.env,
-          HOME: tmpDir("evrt-cli-home-"),
-          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
-          FACTORY_EVENT_HOST: `example.test:${server.port}`,
-          FACTORY_CONTROL_API_URL: "",
-          FACTORY_CONTROL_API_ALLOW_INSECURE: "",
-          FACTORY_RUN_DIR: throwawayRunDir(),
-        },
-        stdout: "pipe",
-        stderr: "pipe",
-      });
-      const [status, stdout, stderr] = await Promise.all([
-        child.exited,
-        new Response(child.stdout).text(),
-        new Response(child.stderr).text(),
-      ]);
-      expect(status).not.toBe(0);
-      expect(`${stdout}${stderr}`).toContain(
-        "refusing to send the control API bearer in plaintext",
+  test.each(REMOTE_TARGET_VERBS)(
+    "top-level %s pins a no-target request to loopback",
+    async (command, rest) => {
+      const hostnames = [];
+      const server = stubControlApi((_request, url) =>
+        hostnames.push(url.hostname),
       );
-      expect(requests).toBe(0);
-    } finally {
-      server.stop(true);
-    }
-  });
+      try {
+        const child = Bun.spawn(["bun", CLI, command, ...rest], {
+          env: {
+            ...process.env,
+            HOME: tmpDir("evrt-cli-home-"),
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_PORT: String(server.port),
+            FACTORY_EVENT_HOST: "",
+            FACTORY_CONTROL_API_URL: "",
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [status, stderr] = await Promise.all([
+          child.exited,
+          new Response(child.stderr).text(),
+        ]);
+        expect(status, stderr).toBe(0);
+        expect(hostnames.length).toBeGreaterThan(0);
+        expect(new Set(hostnames)).toEqual(new Set(["127.0.0.1"]));
+      } finally {
+        server.stop(true);
+      }
+    },
+  );
+
+  test.each(REMOTE_TARGET_VERBS)(
+    "top-level %s refuses a plaintext remote target before any request",
+    async (command, rest) => {
+      let requests = 0;
+      const server = stubControlApi(() => {
+        requests++;
+      });
+      try {
+        const child = Bun.spawn(["bun", CLI, command, ...rest], {
+          env: {
+            ...process.env,
+            HOME: tmpDir("evrt-cli-home-"),
+            FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+            FACTORY_EVENT_HOST: `example.test:${server.port}`,
+            FACTORY_CONTROL_API_URL: "",
+            FACTORY_CONTROL_API_ALLOW_INSECURE: "",
+            FACTORY_RUN_DIR: throwawayRunDir(),
+          },
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [status, stdout, stderr] = await Promise.all([
+          child.exited,
+          new Response(child.stdout).text(),
+          new Response(child.stderr).text(),
+        ]);
+        expect(status).not.toBe(0);
+        expect(`${stdout}${stderr}`).toContain(
+          "refusing to send the control API bearer in plaintext",
+        );
+        expect(requests).toBe(0);
+      } finally {
+        server.stop(true);
+      }
+    },
+  );
 
   test.each([
     ["inbox"],
@@ -343,6 +359,42 @@ describe("cli routing", () => {
     );
     expect(`${stdout}${stderr}`).not.toContain("at dispatch");
   });
+
+  // A usage error is the CLI's own, not the server's: it must never be
+  // reported as an unreachable control API, even when serve is down (#2197).
+  test.each([
+    [["memos"], "usage: memos"],
+    [["inbox", "bogus"], "unknown inbox subcommand: bogus"],
+    [["decide"], "usage: decide <item-id> <option-id>"],
+    [["inbox", "resolve"], "usage: inbox resolve <item-id>"],
+  ])(
+    "top-level %s reports its usage error, not a dead control API",
+    async (args, expected) => {
+      const child = Bun.spawn(["bun", CLI, ...args], {
+        env: {
+          ...process.env,
+          HOME: tmpDir("evrt-cli-home-"),
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+          FACTORY_EVENT_PORT: DEAD_PORT,
+          FACTORY_EVENT_HOST: "",
+          FACTORY_CONTROL_API_URL: "",
+          FACTORY_RUN_DIR: throwawayRunDir(),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      const output = `${stdout}${stderr}`;
+      expect(status).not.toBe(0);
+      expect(output).toContain(expected);
+      expect(output).not.toContain("not reachable");
+      expect(output).not.toContain("at dispatch");
+    },
+  );
 
   test.each([
     [401, "unauthorized"],

--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,4 +1,5 @@
 import { describe, expect, test } from "bun:test";
+import path from "node:path";
 import { COMMAND_NAMES } from "./cli/commands.mjs";
 import { events } from "./cli/events.mjs";
 import { inbox as legacyInbox } from "./cli/inbox.mjs";
@@ -19,6 +20,8 @@ import {
 } from "./cli/test-helpers.mjs";
 import { apiClient } from "./lib/client.mjs";
 import { tmpDir } from "./test-support/tmp.mjs?file=event-runtime-cli-test-mjs";
+
+const FACTORY = path.resolve(import.meta.dir, "../bin/factory");
 
 const EXPECTED_COMMANDS = [
   "serve",
@@ -86,7 +89,7 @@ describe("cli routing", () => {
     ["--host", (port) => `127.0.0.1:${port}`],
     ["--remote", (port) => `http://127.0.0.1:${port}`],
   ])(
-    "top-level inbox and decide use the target forwarded by factory %s",
+    "top-level inbox and decide honor FACTORY_EVENT_HOST %s",
     async (_flag, targetFor) => {
       const token = "cli-remote-control-token";
       const requests = [];
@@ -175,6 +178,171 @@ describe("cli routing", () => {
       }
     },
   );
+
+  test("factory forwards --host to inbox and decide", async () => {
+    const token = "factory-wrapper-target-token";
+    const requests = [];
+    const item = { id: "item-wrapper", decision: { fields: [] } };
+    const server = Bun.serve({
+      port: Number(freePort()),
+      async fetch(request) {
+        const url = new URL(request.url);
+        requests.push(`${request.method} ${url.pathname}${url.search}`);
+        if (request.method === "GET" && url.pathname === "/inbox") {
+          return Response.json({ items: [] });
+        }
+        if (
+          request.method === "GET" &&
+          url.pathname === "/inbox/item-wrapper"
+        ) {
+          return Response.json({ item });
+        }
+        if (
+          request.method === "POST" &&
+          url.pathname === "/inbox/item-wrapper/decide"
+        ) {
+          return Response.json({
+            item,
+            effect: { kind: "approve_proposal", outcome: "applied" },
+          });
+        }
+        return new Response("not found", { status: 404 });
+      },
+    });
+    const env = {
+      ...process.env,
+      FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+      FACTORY_RUN_DIR: throwawayRunDir(),
+      FACTORY_CONTROL_API_TOKEN: token,
+    };
+    const target = `127.0.0.1:${server.port}`;
+    try {
+      for (const args of [
+        ["inbox", "--host", target],
+        ["decide", "item-wrapper", "approve", "--host", target],
+      ]) {
+        const child = Bun.spawn(["bash", FACTORY, ...args], {
+          env,
+          stdout: "pipe",
+          stderr: "pipe",
+        });
+        const [status, stderr] = await Promise.all([
+          child.exited,
+          new Response(child.stderr).text(),
+        ]);
+        expect(status, stderr).toBe(0);
+      }
+      expect(requests).toEqual([
+        "GET /inbox?status=open",
+        "GET /inbox/item-wrapper",
+        "POST /inbox/item-wrapper/decide",
+      ]);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("top-level control verbs pin no-target requests to loopback", async () => {
+    let hostname;
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch(request) {
+        hostname = new URL(request.url).hostname;
+        return Response.json({ memos: [] });
+      },
+    });
+    try {
+      const child = Bun.spawn(["bun", CLI, "memos", "repo", "factory"], {
+        env: {
+          ...process.env,
+          HOME: tmpDir("evrt-cli-home-"),
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+          FACTORY_EVENT_PORT: String(server.port),
+          FACTORY_EVENT_HOST: "",
+          FACTORY_CONTROL_API_URL: "",
+          FACTORY_RUN_DIR: throwawayRunDir(),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stderr).text(),
+      ]);
+      expect(status, stderr).toBe(0);
+      expect(hostname).toBe("127.0.0.1");
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test("top-level control verbs refuse plaintext remote targets before requests", async () => {
+    let requests = 0;
+    const server = Bun.serve({
+      port: Number(freePort()),
+      fetch() {
+        requests++;
+        return Response.json({ memos: [] });
+      },
+    });
+    try {
+      const child = Bun.spawn(["bun", CLI, "memos", "repo", "factory"], {
+        env: {
+          ...process.env,
+          HOME: tmpDir("evrt-cli-home-"),
+          FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+          FACTORY_EVENT_HOST: `example.test:${server.port}`,
+          FACTORY_CONTROL_API_URL: "",
+          FACTORY_CONTROL_API_ALLOW_INSECURE: "",
+          FACTORY_RUN_DIR: throwawayRunDir(),
+        },
+        stdout: "pipe",
+        stderr: "pipe",
+      });
+      const [status, stdout, stderr] = await Promise.all([
+        child.exited,
+        new Response(child.stdout).text(),
+        new Response(child.stderr).text(),
+      ]);
+      expect(status).not.toBe(0);
+      expect(`${stdout}${stderr}`).toContain(
+        "refusing to send the control API bearer in plaintext",
+      );
+      expect(requests).toBe(0);
+    } finally {
+      server.stop(true);
+    }
+  });
+
+  test.each([
+    ["inbox"],
+    ["decide", "item-unreachable", "approve"],
+    ["memos", "repo", "factory"],
+  ])("top-level %s gives a friendly connection failure", async (...args) => {
+    const child = Bun.spawn(["bun", CLI, ...args], {
+      env: {
+        ...process.env,
+        HOME: tmpDir("evrt-cli-home-"),
+        FACTORY_EVENT_HOME: tmpDir("evrt-cli-"),
+        FACTORY_EVENT_PORT: DEAD_PORT,
+        FACTORY_EVENT_HOST: "",
+        FACTORY_CONTROL_API_URL: "",
+        FACTORY_RUN_DIR: throwawayRunDir(),
+      },
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const [status, stdout, stderr] = await Promise.all([
+      child.exited,
+      new Response(child.stdout).text(),
+      new Response(child.stderr).text(),
+    ]);
+    expect(status).not.toBe(0);
+    expect(`${stdout}${stderr}`).toContain(
+      `control API not reachable on 127.0.0.1:${DEAD_PORT}`,
+    );
+    expect(`${stdout}${stderr}`).not.toContain("at dispatch");
+  });
 
   test.each([
     [401, "unauthorized"],


### PR DESCRIPTION
Fixes watt-mind/factory#2197

Remote-target inbox, decide, and memos commands can now reach the selected control API.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/cli.test.mjs --timeout 20000` | pass | 37 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; existing lint warnings only |
| UX critique          | factory-ux-critic                | not run | backend CLI; no user-facing surface |

UX critique: skipped — backend CLI tooling; no user-facing surface

run:run_17d3d7d9-f7e8-4dd8-9642-08367e7a4d4f