### PR TITLE
cli: preserve HTTPS inbox URLs

### DIFF
--- a/event-runtime/cli.test.mjs
+++ b/event-runtime/cli.test.mjs
@@ -1,6 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import path from "node:path";
-import { COMMAND_NAMES } from "./cli/commands.mjs";
+import { COMMAND_NAMES, COMMANDS } from "./cli/commands.mjs";
 import { events } from "./cli/events.mjs";
 import { inbox as legacyInbox } from "./cli/inbox.mjs";
 import { renderInspect } from "./cli/inspect.mjs";
@@ -444,12 +444,53 @@ describe("cli routing", () => {
     const originalLog = console.log;
     console.log = (...values) => logs.push(values.join(" "));
     try {
-      await legacyInbox({ host: "127.0.0.1", port: server.port, token });
+      await legacyInbox({
+        baseUrl: `http://127.0.0.1:${server.port}`,
+        host: "127.0.0.1",
+        port: server.port,
+        token,
+      });
       expect(authorization).toBe(`Bearer ${token}`);
       expect(logs).toEqual(["no open inbox items"]);
     } finally {
       console.log = originalLog;
       server.stop(true);
+    }
+  });
+
+  test("COMMANDS.inbox preserves an HTTPS target and path prefix", async () => {
+    const originalFetch = globalThis.fetch;
+    const originalLog = console.log;
+    const originalUrl = process.env.FACTORY_CONTROL_API_URL;
+    const originalHost = process.env.FACTORY_EVENT_HOST;
+    const originalToken = process.env.FACTORY_CONTROL_API_TOKEN;
+    let request;
+    globalThis.fetch = async (url, options) => {
+      request = new Request(url, options);
+      return Response.json({ items: [] });
+    };
+    console.log = () => {};
+    process.env.FACTORY_CONTROL_API_URL = "https://control.example.test/api";
+    delete process.env.FACTORY_EVENT_HOST;
+    process.env.FACTORY_CONTROL_API_TOKEN = "inbox-control-token";
+    try {
+      await COMMANDS.inbox([]);
+      expect(request.url).toBe(
+        "https://control.example.test/api/inbox?status=open",
+      );
+      expect(request.headers.get("authorization")).toBe(
+        "Bearer inbox-control-token",
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+      console.log = originalLog;
+      if (originalUrl === undefined) delete process.env.FACTORY_CONTROL_API_URL;
+      else process.env.FACTORY_CONTROL_API_URL = originalUrl;
+      if (originalHost === undefined) delete process.env.FACTORY_EVENT_HOST;
+      else process.env.FACTORY_EVENT_HOST = originalHost;
+      if (originalToken === undefined)
+        delete process.env.FACTORY_CONTROL_API_TOKEN;
+      else process.env.FACTORY_CONTROL_API_TOKEN = originalToken;
     }
   });
 

--- a/event-runtime/cli/inbox.mjs
+++ b/event-runtime/cli/inbox.mjs
@@ -3,12 +3,10 @@ import { unauthorizedMessage } from "../lib/client.mjs";
 
 export async function inbox(client) {
   const token = client.token ?? process.env.FACTORY_CONTROL_API_TOKEN ?? null;
-  const res = await fetch(
-    `http://${client.host}:${client.port}/inbox?status=open`,
-    {
-      headers: token ? { authorization: `Bearer ${token}` } : {},
-    },
-  );
+  const inboxUrl = new URL("inbox?status=open", `${client.baseUrl}/`);
+  const res = await fetch(inboxUrl, {
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+  });
   const body = await res.json();
   if (!res.ok) {
     const err = new Error(

--- a/event-runtime/demo/verify.mjs
+++ b/event-runtime/demo/verify.mjs
@@ -37,7 +37,7 @@ const check = (label, ok, detail = "") => {
 
 const sha256hex = (data) => createHash("sha256").update(data).digest("hex");
 
-const inboxUrl = `http://${client.host}:${port}/inbox?status=open`;
+const inboxUrl = new URL("inbox?status=open", `${client.baseUrl}/`);
 const inboxHeaders = client.token
   ? { authorization: `Bearer ${client.token}` }
   : {};


### PR DESCRIPTION
Fixes watt-mind/factory#2199

Review the secure, path-prefix-aware inbox request change. Authorization: operator:preapproved-2026-08-29 (decided 2026-09-01T09:54:43.809Z).

## Validation

| Check                | Command                                                                                 | Result  | Notes                              |
| -------------------- | --------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/cli --timeout 20000`                                            | pass    | 134 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | lib tests, emit, format, lint clean |
| UX critique          | factory-ux-critic                                                                       | not run | no user-facing surface             |

UX critique: skipped — backend/CLI security fix; no user-facing surface

run:run_a284794e-bf8e-4c2c-b2d4-43e0acd56a15
