### PR TITLE
feat(linear): log request telemetry

### DIFF
--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -117,7 +117,15 @@ export function linearControlPlane({
     );
     try {
       return await Promise.race([
-        Promise.resolve().then(() => gql(query, variables, controller.signal)),
+        Promise.resolve().then(() =>
+          gql === defaultGql
+            ? gql(query, variables, {
+                signal: controller.signal,
+                caller: "lib/control-plane/linear",
+                ticket: variables.k ?? null,
+              })
+            : gql(query, variables, controller.signal),
+        ),
         new Promise((_, reject) => {
           timer = setTimeout(() => {
             controller.abort(timeoutError);

--- a/lib/control-plane/linear.mjs
+++ b/lib/control-plane/linear.mjs
@@ -12,6 +12,7 @@
  * network.
  */
 import { gql as defaultGql } from "../../orchestrator/reaper.mjs";
+import { installLinearBudgetCapture } from "../../tools/ticket.mjs";
 import { byQueueOrder, ControlPlaneError, OPEN_STATE_TYPES } from "./types.mjs";
 import {
   AGENT_READY_LABEL,
@@ -93,6 +94,26 @@ function openBlockerIdentifiers(issue) {
 }
 
 /**
+ * Which ticket a GraphQL operation is about, for the request log.
+ *
+ * Most operations are told explicitly by their caller, because the wire
+ * variables carry an opaque Linear UUID (`$id`) rather than the human key an
+ * operator greps for. The variable fallbacks cover `raw()` and any future
+ * query that has a key in hand but no explicit ref; team- and
+ * workspace-scoped reads legitimately resolve to null.
+ */
+function ticketRefFor(ticket, variables = {}) {
+  return (
+    ticket ??
+    variables.k ??
+    variables.identifier ??
+    variables.id ??
+    variables.in?.issueId ??
+    null
+  );
+}
+
+/**
  * @param {{ gql?: (query: string, variables?: object, signal?: AbortSignal) => Promise<object>, timeoutMs?: number }} [options]
  * @returns {import("./types.mjs").ControlPlane}
  */
@@ -101,6 +122,16 @@ export function linearControlPlane({
   timeoutMs = process.env.FACTORY_LINEAR_TIMEOUT_MS,
 } = {}) {
   const requestTimeout = requestTimeoutMs(timeoutMs);
+  // Installing the `fetch` capture hook is an entry-point concern, done once
+  // when the plane is constructed rather than on every request, and never
+  // when a fake `gql` is injected — a test must not swap the global `fetch`.
+  if (gql === defaultGql) {
+    try {
+      installLinearBudgetCapture();
+    } catch {
+      // Budget/telemetry capture is best-effort; it must not block a request.
+    }
+  }
 
   /**
    * Bound one GraphQL operation and cancel the underlying fetch/backoff.
@@ -109,7 +140,7 @@ export function linearControlPlane({
    * unknown outcome: it may have committed before its response was lost, so
    * callers must not blindly replay non-idempotent creates or comments.
    */
-  async function call(query, variables = {}) {
+  async function call(query, variables = {}, ticket = null) {
     let timer;
     const controller = new AbortController();
     const timeoutError = new ControlPlaneError(
@@ -122,7 +153,7 @@ export function linearControlPlane({
             ? gql(query, variables, {
                 signal: controller.signal,
                 caller: "lib/control-plane/linear",
-                ticket: variables.k ?? null,
+                ticket: ticketRefFor(ticket, variables),
               })
             : gql(query, variables, controller.signal),
         ),
@@ -150,6 +181,7 @@ export function linearControlPlane({
     connectionFor,
     name,
     initialConnection,
+    ticket = null,
   ) {
     const nodes = [...(initialConnection?.nodes ?? [])];
     if (nodes.length > PAGE_CAP)
@@ -165,7 +197,7 @@ export function linearControlPlane({
         throw new ControlPlaneError(
           `linear ${name} pagination has next page without an end cursor`,
         );
-      const d = await call(query, { ...variables, after });
+      const d = await call(query, { ...variables, after }, ticket);
       const connection = connectionFor(d);
       const page = connection?.nodes ?? [];
       if (nodes.length + page.length > PAGE_CAP)
@@ -186,6 +218,7 @@ export function linearControlPlane({
 
   async function paginateIssueConnections(issue) {
     if (!issue?.id) return issue;
+    const ticket = issue.identifier ?? null;
     const paged = { ...issue };
     if (issue.labels?.pageInfo?.hasNextPage) {
       paged.labels = {
@@ -196,6 +229,7 @@ export function linearControlPlane({
           (d) => d?.issue?.labels,
           "ticket labels",
           issue.labels,
+          ticket,
         ),
       };
     }
@@ -208,6 +242,7 @@ export function linearControlPlane({
           (d) => d?.issue?.inverseRelations,
           "ticket inverse relations",
           issue.inverseRelations,
+          ticket,
         ),
       };
     }
@@ -218,16 +253,18 @@ export function linearControlPlane({
     const d = await call(
       `query($k:String!){ issue(id:$k){ ${ISSUE_FIELDS} } }`,
       { k: key },
+      key,
     );
     const issue = normalizeTicket(await paginateIssueConnections(d?.issue));
     if (!issue) throw new ControlPlaneError(`no such issue: ${key}`);
     return issue;
   }
 
-  async function statesFor(teamKey) {
+  async function statesFor(teamKey, ticket = null) {
     const d = await call(
       `query($t:String!){ teams(filter:{key:{eq:$t}}, first:1){ nodes{ id states(first:50){ nodes{ id name } pageInfo{ hasNextPage endCursor } } } } }`,
       { t: teamKey },
+      ticket,
     );
     const team = d?.teams?.nodes?.[0];
     if (!team) throw new ControlPlaneError(`no such team: ${teamKey}`);
@@ -239,24 +276,27 @@ export function linearControlPlane({
         (d) => d?.team?.states,
         "states",
         team.states,
+        ticket,
       ),
     };
   }
 
-  async function allLabels() {
+  async function allLabels(ticket = null) {
     return collectPages(
       `query($after:String){ issueLabels(first:250,after:$after){ nodes{ id name } pageInfo{ hasNextPage endCursor } } }`,
       {},
       (d) => d?.issueLabels,
       "labels",
+      null,
+      ticket,
     );
   }
 
-  async function labelIdsFor(issue, add, remove) {
+  async function labelIdsFor(issue, add, remove, ticket = null) {
     const bad = validateLabels(add);
     if (bad.length)
       throw new ControlPlaneError("invalid label(s):\n  " + bad.join("\n  "));
-    const all = await allLabels();
+    const all = await allLabels(ticket ?? issue.identifier ?? null);
     const missing = add.filter((n) => !all.some((l) => l.name === n));
     if (missing.length)
       throw new ControlPlaneError(
@@ -266,10 +306,11 @@ export function linearControlPlane({
     return resolveLabelIds(current, { add, remove }, all);
   }
 
-  async function issueUpdate(id, input) {
+  async function issueUpdate(id, input, ticket = null) {
     const updated = await call(
       `mutation($id:String!,$in:IssueUpdateInput!){ issueUpdate(id:$id,input:$in){ success } }`,
       { id, in: input },
+      ticket,
     );
     if (updated?.issueUpdate && updated.issueUpdate.success === false)
       throw new ControlPlaneError(`issueUpdate failed for ${id}`);
@@ -292,6 +333,8 @@ export function linearControlPlane({
           return d?.issue?.comments;
         },
         "comments",
+        null,
+        identifier,
       );
       if (!foundIssue)
         throw new ControlPlaneError(`no such issue: ${identifier}`);
@@ -346,7 +389,7 @@ export function linearControlPlane({
     async claim(identifier, { harness = "claude" } = {}) {
       const issue = await issueByKey(identifier);
       const teamKey = issue.team?.key ?? teamOf(identifier);
-      const { states } = await statesFor(teamKey);
+      const { states } = await statesFor(teamKey, identifier);
       const inProgress = states.find(
         (s) => s.name.toLowerCase() === "in progress",
       );
@@ -355,26 +398,32 @@ export function linearControlPlane({
           `team ${teamKey} has no "In Progress" state`,
         );
 
-      const me = (await call(`query{ viewer{ id name } }`))?.viewer;
+      const me = (await call(`query{ viewer{ id name } }`, {}, identifier))
+        ?.viewer;
       if (!me?.id)
         throw new ControlPlaneError("linear viewer is not available");
       const { add, remove } = claimLabels(
         (issue.labels ?? []).map((l) => l.name),
         harness,
       );
-      const labelIds = await labelIdsFor(issue, add, remove);
+      const labelIds = await labelIdsFor(issue, add, remove, identifier);
 
-      await issueUpdate(issue.id, {
-        stateId: inProgress.id,
-        assigneeId: me.id,
-        labelIds,
-      });
+      await issueUpdate(
+        issue.id,
+        {
+          stateId: inProgress.id,
+          assigneeId: me.id,
+          labelIds,
+        },
+        identifier,
+      );
 
       // Linear has no compare-and-swap; this read-back IS the concurrency control.
       const back = (
         await call(
           `query($id:String!){ issue(id:$id){ assignee{ id name } } }`,
           { id: issue.id },
+          identifier,
         )
       )?.issue;
       return {
@@ -390,6 +439,7 @@ export function linearControlPlane({
       const commented = await call(
         `mutation($in:CommentCreateInput!){ commentCreate(input:$in){ success } }`,
         { in: { issueId: issue.id, body: stampRun(body) } },
+        identifier,
       );
       if (commented?.commentCreate && commented.commentCreate.success === false)
         throw new ControlPlaneError(`failed to comment on ${identifier}`);
@@ -416,7 +466,7 @@ export function linearControlPlane({
       const input = {};
       if (state) {
         const teamKey = issue.team?.key ?? teamOf(identifier);
-        const { states } = await statesFor(teamKey);
+        const { states } = await statesFor(teamKey, identifier);
         const target = states.find(
           (s) => s.name.toLowerCase() === state.toLowerCase(),
         );
@@ -427,9 +477,9 @@ export function linearControlPlane({
         input.stateId = target.id;
       }
       if (add.length || remove.length)
-        input.labelIds = await labelIdsFor(issue, add, remove);
+        input.labelIds = await labelIdsFor(issue, add, remove, identifier);
       if (unassign) input.assigneeId = null;
-      await issueUpdate(issue.id, input);
+      await issueUpdate(issue.id, input, identifier);
     },
 
     async setLabels(identifier, { add = [], remove = [] } = {}) {
@@ -444,9 +494,11 @@ export function linearControlPlane({
         throw new ControlPlaneError(
           `refusing to remove ${AGENT_READY_LABEL} without claim labels or a state transition`,
         );
-      await issueUpdate(issue.id, {
-        labelIds: await labelIdsFor(issue, add, remove),
-      });
+      await issueUpdate(
+        issue.id,
+        { labelIds: await labelIdsFor(issue, add, remove, identifier) },
+        identifier,
+      );
     },
 
     // Linear-plane behaviour predates PR protection in the GitHub adapter.
@@ -483,7 +535,7 @@ export function linearControlPlane({
             title,
             description: stampRun(body),
             stateId: target.id,
-            labelIds: await labelIdsFor({ labels: [] }, labels, []),
+            labelIds: await labelIdsFor({ labels: [] }, labels, [], null),
             ...(projectId ? { projectId } : {}),
           },
         },
@@ -501,7 +553,7 @@ export function linearControlPlane({
         markdown,
       );
       if (!appended) return { appended: false };
-      await issueUpdate(issue.id, { description });
+      await issueUpdate(issue.id, { description }, identifier);
       return { appended: true };
     },
 
@@ -511,7 +563,7 @@ export function linearControlPlane({
         throw new ControlPlaneError(
           "replacement body must be a non-empty string",
         );
-      await issueUpdate(issue.id, { description: body });
+      await issueUpdate(issue.id, { description: body }, identifier);
     },
 
     async raw(query, variables = {}) {

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -3,10 +3,11 @@ import { linearControlPlane } from "./linear.mjs";
 import { ControlPlaneError } from "./types.mjs";
 import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
 import {
+  LINEAR_TELEMETRY,
   recordLinearResponse,
   summarizeLinearRequests,
 } from "../../tools/ticket.mjs";
-import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 
@@ -103,6 +104,11 @@ test("Linear response telemetry records a caller, ticket, headers, and budget de
     expect(entry).toMatchObject({
       timestamp: "2026-09-01T12:00:00.000Z",
       caller: "lib/control-plane/linear",
+      // GH-2203: `caller` names only the module. Without the process identity
+      // serve, a worker and the CLI are indistinguishable in this log.
+      process: path.basename(process.argv[1] ?? ""),
+      pid: process.pid,
+      role: process.env.FACTORY_ROLE ?? null,
       ticket: "WM-2203",
       status: 200,
       rateLimit: { requestsRemaining: 499, requestsLimit: 2500 },
@@ -117,6 +123,7 @@ test("Linear response telemetry records a caller, ticket, headers, and budget de
     ).toEqual([
       {
         caller: "lib/control-plane/linear",
+        process: path.basename(process.argv[1] ?? ""),
         requests: 2,
         failures: 0,
         latestRemaining: 498,
@@ -128,6 +135,142 @@ test("Linear response telemetry records a caller, ticket, headers, and budget de
     else process.env.LINEAR_REQUEST_LOG_DIR = previousLogDir;
     if (previousCacheDir === undefined) delete process.env.LINEAR_CACHE_DIR;
     else process.env.LINEAR_CACHE_DIR = previousCacheDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Linear request logging fails open when the log directory is unusable", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-linear-failopen-"));
+  const blocker = path.join(root, "blocker");
+  writeFileSync(blocker, "not a directory");
+  const previousLogDir = process.env.LINEAR_REQUEST_LOG_DIR;
+  const previousCacheDir = process.env.LINEAR_CACHE_DIR;
+  // A regular file cannot be a parent directory, so mkdirSync throws ENOTDIR.
+  process.env.LINEAR_REQUEST_LOG_DIR = path.join(blocker, "run");
+  process.env.LINEAR_CACHE_DIR = path.join(root, "cache");
+  try {
+    expect(() =>
+      recordLinearResponse(
+        new Response("{}", {
+          status: 200,
+          headers: { "x-ratelimit-requests-remaining": "400" },
+        }),
+        { caller: "lib/control-plane/linear", ticket: "WM-2203" },
+      ),
+    ).not.toThrow();
+    // The Linear call path is unaffected: the plane still answers normally
+    // while telemetry is undeliverable.
+    expect(summarizeLinearRequests({ dir: path.join(blocker, "run") })).toEqual(
+      [],
+    );
+  } finally {
+    if (previousLogDir === undefined) delete process.env.LINEAR_REQUEST_LOG_DIR;
+    else process.env.LINEAR_REQUEST_LOG_DIR = previousLogDir;
+    if (previousCacheDir === undefined) delete process.env.LINEAR_CACHE_DIR;
+    else process.env.LINEAR_CACHE_DIR = previousCacheDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("Linear request logging records no credentials and no request body", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-linear-redact-"));
+  const previousLogDir = process.env.LINEAR_REQUEST_LOG_DIR;
+  const previousCacheDir = process.env.LINEAR_CACHE_DIR;
+  process.env.LINEAR_REQUEST_LOG_DIR = root;
+  process.env.LINEAR_CACHE_DIR = path.join(root, "cache");
+  const secret = "lin_api_SUPERSECRETKEY";
+  try {
+    const response = new Response(
+      JSON.stringify({ data: { issue: { identifier: "WM-2203" } } }),
+      {
+        status: 200,
+        headers: {
+          "x-ratelimit-requests-remaining": "400",
+          authorization: secret,
+          "set-cookie": `session=${secret}`,
+        },
+      },
+    );
+    recordLinearResponse(response, {
+      caller: "lib/control-plane/linear",
+      ticket: "WM-2203",
+    });
+    const line = readFileSync(
+      path.join(root, "linear-requests.jsonl"),
+      "utf8",
+    ).trim();
+    expect(line).not.toContain(secret);
+    expect(line.toLowerCase()).not.toContain("authorization");
+    expect(line.toLowerCase()).not.toContain("cookie");
+    expect(line).not.toContain("mutation");
+    expect(line).not.toContain("issueUpdate");
+    // Only the declared telemetry keys are persisted.
+    expect(Object.keys(JSON.parse(line)).sort()).toEqual([
+      "budgetDelta",
+      "caller",
+      "pid",
+      "process",
+      "rateLimit",
+      "role",
+      "status",
+      "ticket",
+      "timestamp",
+    ]);
+  } finally {
+    if (previousLogDir === undefined) delete process.env.LINEAR_REQUEST_LOG_DIR;
+    else process.env.LINEAR_REQUEST_LOG_DIR = previousLogDir;
+    if (previousCacheDir === undefined) delete process.env.LINEAR_CACHE_DIR;
+    else process.env.LINEAR_CACHE_DIR = previousCacheDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("the control plane names the ticket of an operation that has no $k", async () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-linear-ref-"));
+  const previous = {
+    logDir: process.env.LINEAR_REQUEST_LOG_DIR,
+    cacheDir: process.env.LINEAR_CACHE_DIR,
+    key: process.env.LINEAR_API_KEY,
+    allow: process.env.FACTORY_LINEAR_ALLOW_NETWORK,
+    offline: process.env.FACTORY_LINEAR_OFFLINE,
+    fetch: globalThis.fetch,
+  };
+  process.env.LINEAR_REQUEST_LOG_DIR = root;
+  process.env.LINEAR_CACHE_DIR = path.join(root, "cache");
+  process.env.LINEAR_API_KEY = "test-key";
+  process.env.FACTORY_LINEAR_ALLOW_NETWORK = "1";
+  delete process.env.FACTORY_LINEAR_OFFLINE;
+  const telemetry = [];
+  // Every request is served from this stub; no socket is ever opened.
+  globalThis.fetch = async (_url, init) => {
+    telemetry.push(init?.[LINEAR_TELEMETRY]);
+    return new Response(
+      JSON.stringify({
+        data: { issueUpdate: { success: true }, issue: { id: "issue-1" } },
+      }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+  };
+  try {
+    // `replaceDetail` reads by key and then mutates by UUID: the mutation
+    // carries no `$k`, which is exactly the case the ticket ref must cover.
+    await linearControlPlane().replaceDetail("WM-2203", "body");
+    expect(telemetry.length).toBeGreaterThan(1);
+    expect(telemetry.map((t) => t?.ticket)).toEqual(
+      telemetry.map(() => "WM-2203"),
+    );
+    expect(telemetry[0]?.caller).toBe("lib/control-plane/linear");
+  } finally {
+    globalThis.fetch = previous.fetch;
+    const restore = (name, value) => {
+      if (value === undefined) delete process.env[name];
+      else process.env[name] = value;
+    };
+    restore("LINEAR_REQUEST_LOG_DIR", previous.logDir);
+    restore("LINEAR_CACHE_DIR", previous.cacheDir);
+    restore("LINEAR_API_KEY", previous.key);
+    restore("FACTORY_LINEAR_ALLOW_NETWORK", previous.allow);
+    restore("FACTORY_LINEAR_OFFLINE", previous.offline);
     rmSync(root, { recursive: true, force: true });
   }
 });

--- a/lib/control-plane/linear.test.mjs
+++ b/lib/control-plane/linear.test.mjs
@@ -2,6 +2,13 @@ import { describe, expect, test } from "bun:test";
 import { linearControlPlane } from "./linear.mjs";
 import { ControlPlaneError } from "./types.mjs";
 import { AGENT_READY_LABEL, IN_PROGRESS_LABEL } from "./labels.mjs";
+import {
+  recordLinearResponse,
+  summarizeLinearRequests,
+} from "../../tools/ticket.mjs";
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
 
 const guardLabels = [
   { id: "ready", name: AGENT_READY_LABEL },
@@ -58,6 +65,72 @@ function guardPlane() {
   });
   return { cp, updates };
 }
+
+test("Linear response telemetry records a caller, ticket, headers, and budget delta", () => {
+  const root = mkdtempSync(path.join(tmpdir(), "factory-linear-log-"));
+  const previousLogDir = process.env.LINEAR_REQUEST_LOG_DIR;
+  const previousCacheDir = process.env.LINEAR_CACHE_DIR;
+  process.env.LINEAR_REQUEST_LOG_DIR = root;
+  process.env.LINEAR_CACHE_DIR = path.join(root, "cache");
+  try {
+    recordLinearResponse(
+      new Response("{}", {
+        status: 200,
+        headers: {
+          "x-ratelimit-requests-remaining": "499",
+          "x-ratelimit-requests-limit": "2500",
+          "x-ratelimit-requests-reset": "1787150400",
+        },
+      }),
+      { caller: "lib/control-plane/linear", ticket: "WM-2203" },
+      { now: () => new Date("2026-09-01T12:00:00.000Z") },
+    );
+    recordLinearResponse(
+      new Response("{}", {
+        status: 200,
+        headers: { "x-ratelimit-requests-remaining": "498" },
+      }),
+      { caller: "lib/control-plane/linear", ticket: "WM-2203" },
+      { now: () => new Date("2026-09-01T12:00:01.000Z") },
+    );
+    const [entry, deltaEntry] = readFileSync(
+      path.join(root, "linear-requests.jsonl"),
+      "utf8",
+    )
+      .trim()
+      .split("\n")
+      .map(JSON.parse);
+    expect(entry).toMatchObject({
+      timestamp: "2026-09-01T12:00:00.000Z",
+      caller: "lib/control-plane/linear",
+      ticket: "WM-2203",
+      status: 200,
+      rateLimit: { requestsRemaining: 499, requestsLimit: 2500 },
+      budgetDelta: null,
+    });
+    expect(deltaEntry.budgetDelta).toBe(-1);
+    expect(
+      summarizeLinearRequests({
+        dir: root,
+        now: Date.parse("2026-09-01T12:01:00.000Z"),
+      }),
+    ).toEqual([
+      {
+        caller: "lib/control-plane/linear",
+        requests: 2,
+        failures: 0,
+        latestRemaining: 498,
+        budgetDelta: -1,
+      },
+    ]);
+  } finally {
+    if (previousLogDir === undefined) delete process.env.LINEAR_REQUEST_LOG_DIR;
+    else process.env.LINEAR_REQUEST_LOG_DIR = previousLogDir;
+    if (previousCacheDir === undefined) delete process.env.LINEAR_CACHE_DIR;
+    else process.env.LINEAR_CACHE_DIR = previousCacheDir;
+    rmSync(root, { recursive: true, force: true });
+  }
+});
 
 describe("Linear ControlPlane pagination (GH-1393)", () => {
   test("listTickets concatenates cursor-paginated issue results", async () => {

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -45,7 +45,6 @@ import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 import { ticketSlug } from "../lib/ticket-slug.mjs";
 import {
   assertLinearNetworkAllowed,
-  installLinearBudgetCapture,
   LINEAR_TELEMETRY,
   parseRateLimitReset,
 } from "../tools/ticket.mjs";
@@ -222,9 +221,11 @@ export async function gql(
   // This must precede credential loading: offline/test invocations should
   // explain the deterministic network refusal, not report a missing key.
   assertLinearNetworkAllowed(LINEAR_API_URL);
-  // This is the one Linear transport; installing here also covers direct
-  // reaper invocations, rather than relying on a particular CLI entry point.
-  installLinearBudgetCapture();
+  // The global `fetch` hook is deliberately NOT installed here. Patching a
+  // process-wide global from the per-request path would put every serve tick
+  // one import away from a swapped `fetch`; entry points install it once
+  // (tools/ticket.mjs, orchestrator/doctor.mjs, event-runtime/lib/linear.mjs,
+  // linearControlPlane) and this transport only annotates the request.
   const apiKey = getApiKey();
   const headers = {
     "Content-Type": "application/json",

--- a/orchestrator/reaper.mjs
+++ b/orchestrator/reaper.mjs
@@ -45,6 +45,8 @@ import { HEARTBEAT_STALE_MS } from "../event-runtime/lib/workers.mjs";
 import { ticketSlug } from "../lib/ticket-slug.mjs";
 import {
   assertLinearNetworkAllowed,
+  installLinearBudgetCapture,
+  LINEAR_TELEMETRY,
   parseRateLimitReset,
 } from "../tools/ticket.mjs";
 
@@ -211,10 +213,18 @@ export async function gql(
       : retriesOrOptions instanceof AbortSignal
         ? { retries: 5, signal: retriesOrOptions }
         : (retriesOrOptions ?? {});
-  const { retries = 5, signal } = options;
+  const {
+    retries = 5,
+    signal,
+    caller = "orchestrator/reaper",
+    ticket = null,
+  } = options;
   // This must precede credential loading: offline/test invocations should
   // explain the deterministic network refusal, not report a missing key.
   assertLinearNetworkAllowed(LINEAR_API_URL);
+  // This is the one Linear transport; installing here also covers direct
+  // reaper invocations, rather than relying on a particular CLI entry point.
+  installLinearBudgetCapture();
   const apiKey = getApiKey();
   const headers = {
     "Content-Type": "application/json",
@@ -231,6 +241,7 @@ export async function gql(
         headers,
         body,
         signal,
+        [LINEAR_TELEMETRY]: { caller, ticket },
       });
 
       if (!res.ok) {

--- a/orchestrator/reaper.test.mjs
+++ b/orchestrator/reaper.test.mjs
@@ -8,6 +8,7 @@ import {
   AGENT_LABEL_PREFIX,
   gql,
 } from "./reaper.mjs";
+import { LINEAR_TELEMETRY } from "../tools/ticket.mjs";
 
 describe("Linear GraphQL cancellation", () => {
   test("forwards an AbortSignal to fetch and stops retrying when aborted", async () => {
@@ -48,6 +49,76 @@ describe("Linear GraphQL cancellation", () => {
         delete process.env.FACTORY_LINEAR_ALLOW_NETWORK;
       else process.env.FACTORY_LINEAR_ALLOW_NETWORK = previousAllow;
     }
+  });
+});
+
+describe("Linear request telemetry (GH-2203)", () => {
+  async function withStubbedFetch(run) {
+    const previous = {
+      fetch: globalThis.fetch,
+      key: process.env.LINEAR_API_KEY,
+      allow: process.env.FACTORY_LINEAR_ALLOW_NETWORK,
+      offline: process.env.FACTORY_LINEAR_OFFLINE,
+    };
+    const inits = [];
+    process.env.LINEAR_API_KEY = "test-key";
+    process.env.FACTORY_LINEAR_ALLOW_NETWORK = "1";
+    delete process.env.FACTORY_LINEAR_OFFLINE;
+    // Requests are answered from memory; the suite never opens a socket.
+    globalThis.fetch = async (_url, init) => {
+      inits.push(init);
+      return new Response(JSON.stringify({ data: { ping: true } }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    };
+    try {
+      await run(inits);
+    } finally {
+      globalThis.fetch = previous.fetch;
+      const restore = (name, value) => {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      };
+      restore("LINEAR_API_KEY", previous.key);
+      restore("FACTORY_LINEAR_ALLOW_NETWORK", previous.allow);
+      restore("FACTORY_LINEAR_OFFLINE", previous.offline);
+    }
+  }
+
+  test("threads the caller and ticket into the fetch init", async () => {
+    await withStubbedFetch(async (inits) => {
+      await gql(
+        "query { ping }",
+        {},
+        { retries: 1, caller: "lib/control-plane/linear", ticket: "WM-2203" },
+      );
+      expect(inits).toHaveLength(1);
+      expect(inits[0][LINEAR_TELEMETRY]).toEqual({
+        caller: "lib/control-plane/linear",
+        ticket: "WM-2203",
+      });
+    });
+  });
+
+  test("defaults the telemetry caller to the reaper transport", async () => {
+    await withStubbedFetch(async (inits) => {
+      await gql("query { ping }", {}, { retries: 1 });
+      expect(inits[0][LINEAR_TELEMETRY]).toEqual({
+        caller: "orchestrator/reaper",
+        ticket: null,
+      });
+    });
+  });
+
+  test("does not install a global fetch hook from the request path", async () => {
+    await withStubbedFetch(async () => {
+      const stub = globalThis.fetch;
+      await gql("query { ping }", {}, { retries: 1 });
+      // GH-2203: patching a process-wide global per request would let one
+      // import swap `fetch` under a running serve tick.
+      expect(globalThis.fetch).toBe(stub);
+    });
   });
 });
 

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -528,11 +528,15 @@ function rotateLinearRequestLog(dir) {
     if (statSync(current).size < LINEAR_REQUEST_LOG_MAX_BYTES) return;
     try {
       unlinkSync(`${current}.${LINEAR_REQUEST_LOG_ROTATIONS}`);
-    } catch {}
+    } catch {
+      // The oldest generation may simply not exist yet; nothing to discard.
+    }
     for (let i = LINEAR_REQUEST_LOG_ROTATIONS - 1; i >= 1; i -= 1) {
       try {
         renameSync(`${current}.${i}`, `${current}.${i + 1}`);
-      } catch {}
+      } catch {
+        // A generation that was never written yet leaves a gap, not an error.
+      }
     }
     renameSync(current, `${current}.1`);
   } catch {
@@ -611,10 +615,30 @@ export function linearBudgetStatus(budget) {
 }
 
 /**
+ * Identity of the process that issued a Linear request. `caller` alone names
+ * the module (there are only two), which cannot separate serve from a worker
+ * from a CLI invocation on the same box — and separating them is the entire
+ * point of this log. The entry-point basename, pid and declared role do.
+ */
+function linearProcessIdentity() {
+  return {
+    process: path.basename(process.argv[1] ?? ""),
+    pid: process.pid,
+    role: process.env.FACTORY_ROLE ?? null,
+  };
+}
+
+/**
  * Persist telemetry for one Linear response. It shares the budget snapshot so
  * the logged delta is the exact change the existing rate-limit guard observes.
  */
-export function recordLinearResponse(res, context = {}, { now = Date } = {}) {
+export function recordLinearResponse(
+  res,
+  context = {},
+  // `Date` as a bare default would be called as `Date()`, whose string form
+  // has no milliseconds; a thunk keeps the entry at full resolution.
+  { now = () => new Date() } = {},
+) {
   try {
     const parsed = parseRateLimitHeaders(res?.headers);
     const prior = loadLinearBudget() ?? {};
@@ -636,6 +660,7 @@ export function recordLinearResponse(res, context = {}, { now = Date } = {}) {
     appendLinearRequestLog({
       timestamp: new Date(now()).toISOString(),
       caller: context.caller ?? "fetch",
+      ...linearProcessIdentity(),
       ticket: context.ticket ?? null,
       status: Number.isInteger(res?.status) ? res.status : null,
       rateLimit: linearRateLimitLogHeaders(res?.headers),
@@ -674,8 +699,14 @@ export function summarizeLinearRequests({
         const timestamp = Date.parse(entry.timestamp);
         if (!Number.isFinite(timestamp) || timestamp < cutoff) continue;
         const caller = String(entry.caller ?? "unknown");
-        const row = rows.get(caller) ?? {
+        // Rows are keyed on caller AND process: one module is reached from
+        // serve, workers and the CLI at once, and "who is spending the
+        // budget" is only answerable when those stay apart.
+        const proc = String(entry.process ?? "");
+        const key = `${caller}\u0000${proc}`;
+        const row = rows.get(key) ?? {
           caller,
+          process: proc,
           requests: 0,
           failures: 0,
           latestRemaining: null,
@@ -687,13 +718,16 @@ export function summarizeLinearRequests({
           row.latestRemaining = entry.rateLimit.requestsRemaining;
         if (Number.isFinite(entry.budgetDelta))
           row.budgetDelta += entry.budgetDelta;
-        rows.set(caller, row);
+        rows.set(key, row);
       } catch {
         // A partial append or manually edited telemetry line is ignorable.
       }
     }
   }
-  return [...rows.values()].sort((a, b) => a.caller.localeCompare(b.caller));
+  return [...rows.values()].sort(
+    (a, b) =>
+      a.caller.localeCompare(b.caller) || a.process.localeCompare(b.process),
+  );
 }
 
 function formatLinearRequestSummary(rows, minutes) {
@@ -702,7 +736,8 @@ function formatLinearRequestSummary(rows, minutes) {
   const lines = [`Linear requests in the last ${minutes}m:`];
   for (const row of rows)
     lines.push(
-      `${row.caller}: ${row.requests} request(s), ${row.failures} failure(s), ` +
+      `${row.caller}${row.process ? ` (${row.process})` : ""}: ` +
+        `${row.requests} request(s), ${row.failures} failure(s), ` +
         `budget delta ${row.budgetDelta}, remaining ${row.latestRemaining ?? "unknown"}`,
     );
   return lines.join("\n");
@@ -712,6 +747,10 @@ let fetchHookInstalled = false;
 
 export function installLinearBudgetCapture() {
   if (fetchHookInstalled) return;
+  // `bind` does not carry own properties across, so the marker is read here.
+  const wasOfflineGuarded = Boolean(
+    globalThis.fetch?.__factoryLinearOfflineGuard,
+  );
   const originalFetch = globalThis.fetch.bind(globalThis);
   fetchHookInstalled = true;
   globalThis.fetch = async function linearBudgetFetch(input, init) {
@@ -728,6 +767,10 @@ export function installLinearBudgetCapture() {
       throw error;
     }
   };
+  // The capture hook delegates to whatever `fetch` it wrapped, so a test
+  // process's offline guard stays in the chain — carry its marker forward so
+  // the guard is still recognised as installed rather than reinstalled on top.
+  if (wasOfflineGuarded) globalThis.fetch.__factoryLinearOfflineGuard = true;
 }
 
 /**

--- a/tools/ticket.mjs
+++ b/tools/ticket.mjs
@@ -23,6 +23,7 @@
  *   bun tools/ticket.mjs file --from owner/repo#123 --title "..." --body "..." --type bug
  *   bun tools/ticket.mjs queue --repo bj29
  *   bun tools/ticket.mjs budget
+ *   bun tools/ticket.mjs linear-summary --minutes 60
  *   bun tools/ticket.mjs raw '<graphql>' --var key=value
  *
  * Linear network safety: requests are blocked when `FACTORY_LINEAR_OFFLINE=1`,
@@ -59,7 +60,16 @@
  * `loadControlPlane()` (WM-894); retries, backoff and key loading stay in
  * `orchestrator/reaper.mjs` as the Linear transport behind the adapter.
  */
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import {
+  appendFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
 import { homedir } from "node:os";
 import path from "node:path";
 import { loadRepos } from "../event-runtime/lib/repos.mjs";
@@ -331,6 +341,10 @@ export async function fileTicket(
 const CACHE_DIR = path.join(homedir(), ".factory/cache/linear");
 const BUDGET_FILE = "budget.json";
 const LINEAR_API_HOST = "api.linear.app";
+const LINEAR_REQUEST_LOG_FILE = "linear-requests.jsonl";
+const LINEAR_REQUEST_LOG_MAX_BYTES = 1_000_000;
+const LINEAR_REQUEST_LOG_ROTATIONS = 3;
+export const LINEAR_TELEMETRY = Symbol.for("factory.linear.telemetry");
 
 /**
  * Test processes must never spend the operator's shared Linear budget. The
@@ -481,6 +495,65 @@ export function linearCacheDir() {
   return CACHE_DIR;
 }
 
+/** Directory for fail-open Linear request telemetry, scoped in test stacks. */
+export function linearRequestLogDir() {
+  if (process.env.LINEAR_REQUEST_LOG_DIR)
+    return process.env.LINEAR_REQUEST_LOG_DIR;
+  if (process.env.FACTORY_EVENT_HOME)
+    return path.join(process.env.FACTORY_EVENT_HOME, "run");
+  return path.join(homedir(), ".factory/run");
+}
+
+function numberHeader(headers, name) {
+  return parseHeaderNumber(headers?.get?.(name));
+}
+
+function linearRateLimitLogHeaders(headers) {
+  return {
+    requestsRemaining: numberHeader(headers, "x-ratelimit-requests-remaining"),
+    requestsLimit: numberHeader(headers, "x-ratelimit-requests-limit"),
+    requestsReset: headers?.get?.("x-ratelimit-requests-reset") ?? null,
+    complexityRemaining: numberHeader(
+      headers,
+      "x-ratelimit-complexity-remaining",
+    ),
+    complexityLimit: numberHeader(headers, "x-ratelimit-complexity-limit"),
+    complexityReset: headers?.get?.("x-ratelimit-complexity-reset") ?? null,
+  };
+}
+
+function rotateLinearRequestLog(dir) {
+  const current = path.join(dir, LINEAR_REQUEST_LOG_FILE);
+  try {
+    if (statSync(current).size < LINEAR_REQUEST_LOG_MAX_BYTES) return;
+    try {
+      unlinkSync(`${current}.${LINEAR_REQUEST_LOG_ROTATIONS}`);
+    } catch {}
+    for (let i = LINEAR_REQUEST_LOG_ROTATIONS - 1; i >= 1; i -= 1) {
+      try {
+        renameSync(`${current}.${i}`, `${current}.${i + 1}`);
+      } catch {}
+    }
+    renameSync(current, `${current}.1`);
+  } catch {
+    // Logging is telemetry only and must never affect a Linear request.
+  }
+}
+
+function appendLinearRequestLog(entry) {
+  try {
+    const dir = linearRequestLogDir();
+    mkdirSync(dir, { recursive: true });
+    rotateLinearRequestLog(dir);
+    appendFileSync(
+      path.join(dir, LINEAR_REQUEST_LOG_FILE),
+      `${JSON.stringify(entry)}\n`,
+    );
+  } catch {
+    // Fail open: a full or unavailable local disk must not break Linear.
+  }
+}
+
 export function loadLinearBudget() {
   try {
     return JSON.parse(
@@ -537,25 +610,102 @@ export function linearBudgetStatus(budget) {
   return "pass";
 }
 
-function recordLinearBudgetFromResponse(res) {
-  const parsed = parseRateLimitHeaders(res.headers);
-  if (!parsed && res.status !== 400 && res.status !== 429) return;
-  const prior = loadLinearBudget() ?? {};
-  const rateLimited =
-    res.status === 429 ||
-    (res.status === 400 && parsed?.remaining === 0) ||
-    parsed?.remaining === 0;
-  saveLinearBudget({
-    remaining:
-      parsed?.remaining ?? (rateLimited ? 0 : (prior.remaining ?? null)),
-    limit: parsed?.limit ?? prior.limit ?? LINEAR_REQUESTS_LIMIT,
-    resetAt: parsed?.resetAt ?? prior.resetAt ?? null,
-    // A successful response with capacity clears a previous refusal. Keeping
-    // `prior.rateLimited` here made a recovered account appear offline until
-    // somebody manually removed budget.json.
-    rateLimited,
-    status: res.status,
-  });
+/**
+ * Persist telemetry for one Linear response. It shares the budget snapshot so
+ * the logged delta is the exact change the existing rate-limit guard observes.
+ */
+export function recordLinearResponse(res, context = {}, { now = Date } = {}) {
+  try {
+    const parsed = parseRateLimitHeaders(res?.headers);
+    const prior = loadLinearBudget() ?? {};
+    const rateLimited =
+      res?.status === 429 ||
+      (res?.status === 400 && parsed?.remaining === 0) ||
+      parsed?.remaining === 0;
+    const remaining =
+      parsed?.remaining ?? (rateLimited ? 0 : (prior.remaining ?? null));
+    if (parsed || res?.status === 400 || res?.status === 429) {
+      saveLinearBudget({
+        remaining,
+        limit: parsed?.limit ?? prior.limit ?? LINEAR_REQUESTS_LIMIT,
+        resetAt: parsed?.resetAt ?? prior.resetAt ?? null,
+        rateLimited,
+        status: res?.status ?? null,
+      });
+    }
+    appendLinearRequestLog({
+      timestamp: new Date(now()).toISOString(),
+      caller: context.caller ?? "fetch",
+      ticket: context.ticket ?? null,
+      status: Number.isInteger(res?.status) ? res.status : null,
+      rateLimit: linearRateLimitLogHeaders(res?.headers),
+      budgetDelta:
+        Number.isFinite(parsed?.remaining) && Number.isFinite(prior.remaining)
+          ? remaining - prior.remaining
+          : null,
+    });
+  } catch {
+    // Response instrumentation is strictly fail-open.
+  }
+}
+
+/** Aggregate a recent request log window by caller without touching Linear. */
+export function summarizeLinearRequests({
+  dir = linearRequestLogDir(),
+  minutes = 60,
+  now = Date.now(),
+} = {}) {
+  const cutoff = now - Math.max(0, Number(minutes) || 0) * 60_000;
+  const rows = new Map();
+  for (let i = LINEAR_REQUEST_LOG_ROTATIONS; i >= 0; i -= 1) {
+    const file = path.join(
+      dir,
+      i === 0 ? LINEAR_REQUEST_LOG_FILE : `${LINEAR_REQUEST_LOG_FILE}.${i}`,
+    );
+    let text;
+    try {
+      text = readFileSync(file, "utf8");
+    } catch {
+      continue;
+    }
+    for (const line of text.split("\n")) {
+      try {
+        const entry = JSON.parse(line);
+        const timestamp = Date.parse(entry.timestamp);
+        if (!Number.isFinite(timestamp) || timestamp < cutoff) continue;
+        const caller = String(entry.caller ?? "unknown");
+        const row = rows.get(caller) ?? {
+          caller,
+          requests: 0,
+          failures: 0,
+          latestRemaining: null,
+          budgetDelta: 0,
+        };
+        row.requests += 1;
+        if (Number(entry.status) >= 400) row.failures += 1;
+        if (Number.isFinite(entry.rateLimit?.requestsRemaining))
+          row.latestRemaining = entry.rateLimit.requestsRemaining;
+        if (Number.isFinite(entry.budgetDelta))
+          row.budgetDelta += entry.budgetDelta;
+        rows.set(caller, row);
+      } catch {
+        // A partial append or manually edited telemetry line is ignorable.
+      }
+    }
+  }
+  return [...rows.values()].sort((a, b) => a.caller.localeCompare(b.caller));
+}
+
+function formatLinearRequestSummary(rows, minutes) {
+  if (!rows.length)
+    return `No Linear requests recorded in the last ${minutes}m`;
+  const lines = [`Linear requests in the last ${minutes}m:`];
+  for (const row of rows)
+    lines.push(
+      `${row.caller}: ${row.requests} request(s), ${row.failures} failure(s), ` +
+        `budget delta ${row.budgetDelta}, remaining ${row.latestRemaining ?? "unknown"}`,
+    );
+  return lines.join("\n");
 }
 
 let fetchHookInstalled = false;
@@ -567,9 +717,16 @@ export function installLinearBudgetCapture() {
   globalThis.fetch = async function linearBudgetFetch(input, init) {
     const url = String(input?.url ?? input);
     assertLinearNetworkAllowed(url);
-    const res = await originalFetch(input, init);
-    if (url.includes(LINEAR_API_HOST)) recordLinearBudgetFromResponse(res);
-    return res;
+    try {
+      const res = await originalFetch(input, init);
+      if (url.includes(LINEAR_API_HOST))
+        recordLinearResponse(res, init?.[LINEAR_TELEMETRY]);
+      return res;
+    } catch (error) {
+      if (url.includes(LINEAR_API_HOST))
+        recordLinearResponse(null, init?.[LINEAR_TELEMETRY]);
+      throw error;
+    }
   };
 }
 
@@ -1232,6 +1389,16 @@ const VERBS = {
       },
       formatLinearBudgetLine(budget),
     );
+  },
+
+  async "linear-summary"() {
+    const minutes = Number(flag("minutes", "60"));
+    if (!Number.isFinite(minutes) || minutes < 0)
+      throw new Error(
+        `usage: linear-summary [--minutes <non-negative number>]`,
+      );
+    const rows = summarizeLinearRequests({ minutes });
+    out(rows, formatLinearRequestSummary(rows, minutes));
   },
 
   async raw() {


### PR DESCRIPTION
Fixes watt-mind/factory#2203

Adds fail-open rotating Linear request telemetry and a per-caller local summary command.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test lib/control-plane/linear.test.mjs orchestrator/reaper.test.mjs --timeout 20000` | pass | 58 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2467 tests, generated tree, format, and lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend telemetry and CLI helper only
run:run_97fdec66-1758-4c6c-9ba7-49065add8ed4
