### PR TITLE
fix(celld): align smoke artifact contract

### DIFF
--- a/event-runtime/agents/celld-smoke.json
+++ b/event-runtime/agents/celld-smoke.json
@@ -22,8 +22,8 @@
   "limits": { "timeout_seconds": 120, "attempts": 1 },
   "mutating": false,
   "pins": {
-    "agents/celld-smoke.md": "sha256:627867cbed98dad67bb826a442133944c79df92bd1043d146907f432bfcaa8d0",
+    "agents/celld-smoke.md": "sha256:560a698add23d7d5fc554747045cd47233b88b7bf65bfd8221586ea0bc8a5de4",
     "schemas/celld-smoke.input.json": "sha256:92a26727efcdaae87b169fb8869783f53c30f42929db5619746e6a614b5f700e",
-    "schemas/celld-smoke.output.json": "sha256:f4c3930dff0665c11e91a3fae3a72d1762e360316f2aaee27369f8116416a90f"
+    "schemas/celld-smoke.output.json": "sha256:7c7d8ca7c073c698fe2ba7f738fd74eb832b70fac1f8d5f4639a51c225f5bf19"
   }
 }

--- a/event-runtime/agents/celld-smoke.md
+++ b/event-runtime/agents/celld-smoke.md
@@ -33,7 +33,12 @@ Write `./result.json`:
     "cellVersion": 2,
     "migrated": true,
     "entityVersion": 1,
-    "verified": true
+    "verified": true,
+    "endpoint": "http://127.0.0.1:9876",
+    "migrationId": "001_celld_smoke_init",
+    "collection": "smoke_tests",
+    "entityId": "<input.json's testKey>",
+    "cellVersionAfterMigration": 2
   },
   "evidence": { "commands": [] }
 }

--- a/event-runtime/lib/celld-smoke.test.mjs
+++ b/event-runtime/lib/celld-smoke.test.mjs
@@ -1,10 +1,11 @@
-import { describe, it, beforeAll, afterAll, expect } from "bun:test";
+import { describe, it, beforeAll, afterAll, expect, test } from "bun:test";
 import { spawn } from "node:child_process";
-import { cpSync, existsSync, mkdirSync, rmSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, readFileSync, rmSync } from "node:fs";
 import { createServer } from "node:net";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { CellClient, VersionConflictError } from "./cell-client.mjs";
+import { validate } from "./schema.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, "../..");
@@ -13,6 +14,37 @@ const TMP_TEST_DIR = path.resolve(
   REPO_ROOT,
   ".factory/test-celld-smoke-" + Date.now(),
 );
+
+test("celld-smoke documented artifact validates its output schema", () => {
+  const prompt = readFileSync(
+    path.join(REPO_ROOT, "event-runtime", "agents", "celld-smoke.md"),
+    "utf8",
+  );
+  const example = prompt.match(/```json\n([\s\S]*?)\n```/);
+  expect(example).not.toBeNull();
+
+  const artifact = JSON.parse(example[1]).artifact;
+  const schema = JSON.parse(
+    readFileSync(
+      path.join(
+        REPO_ROOT,
+        "event-runtime",
+        "schemas",
+        "celld-smoke.output.json",
+      ),
+      "utf8",
+    ),
+  );
+
+  expect(artifact).toMatchObject({
+    endpoint: "http://127.0.0.1:9876",
+    migrationId: "001_celld_smoke_init",
+    collection: "smoke_tests",
+    entityId: "<input.json's testKey>",
+    cellVersionAfterMigration: 2,
+  });
+  expect(validate(schema, artifact)).toEqual({ valid: true, errors: [] });
+});
 
 // `celld` is a local developer daemon; it is not provisioned in CI or in the
 // sandbox, so the whole suite is gated on the binary being present.

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -447,8 +447,10 @@ describe("registry", () => {
     // pinned prompt/definition digest changes with that recovery contract.
     // Regenerated (#2149): factory.celld-smoke.requested routes to
     // celld-smoke@1 on the claude adapter, so the merged view gains a mapping.
+    // Regenerated (#2208): celld-smoke's documented interaction details are
+    // optional artifact fields, and the definition was re-pinned.
     const expected =
-      "sha256:e23895b901edd0d011c1e60af256621dca969e869d94505a619b9562712693d9";
+      "sha256:f081d6b00380dd88c13822a7b532c107ae974befd8f5ff9e4543f72e733cc882";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 

--- a/event-runtime/schemas/celld-smoke.output.json
+++ b/event-runtime/schemas/celld-smoke.output.json
@@ -32,6 +32,31 @@
     "verified": {
       "type": "boolean",
       "description": "True if post-write read-back matched input payload"
+    },
+    "endpoint": {
+      "type": "string",
+      "format": "uri",
+      "description": "celld endpoint used for the smoke interaction"
+    },
+    "migrationId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Migration the smoke agent ensured was applied"
+    },
+    "collection": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Collection containing the smoke-test entity"
+    },
+    "entityId": {
+      "type": "string",
+      "minLength": 1,
+      "description": "Identifier of the persisted smoke-test entity"
+    },
+    "cellVersionAfterMigration": {
+      "type": "integer",
+      "minimum": 1,
+      "description": "Cell version returned immediately after migration"
     }
   }
 }


### PR DESCRIPTION
Fixes watt-mind/factory#2208

Celld smoke runs can retain migration and entity diagnostics without contract rejection.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/celld-smoke.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000` | pass | 69 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | unit, emit, format, lint clean; 615 warnings |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend agent schema, prompt, pins, and test only

run:run_983d54e3-ae99-44fd-8a74-cc9a774fcac9