### PR TITLE
fix(packs): document editorial result envelopes

### DIFF
--- a/event-runtime/lib/pack-authoring.test.mjs
+++ b/event-runtime/lib/pack-authoring.test.mjs
@@ -60,6 +60,44 @@ test("the first-party reference packs all pass authoring validation", () => {
   }
 });
 
+test("editorial documented result envelopes validate their output schemas", () => {
+  const root = path.resolve("packs", "editorial");
+  const agentResultSchema = JSON.parse(
+    readFileSync(
+      path.resolve("event-runtime/schemas/factory.agent-result.v1.json"),
+      "utf8",
+    ),
+  );
+  const examples = ["topic-scan", "research", "draft", "review"];
+
+  for (const name of examples) {
+    const prompt = readFileSync(
+      path.join(root, "agents", `${name}.md`),
+      "utf8",
+    );
+    const output = prompt.slice(prompt.indexOf("## Output"));
+    const completed = [...output.matchAll(/```json\n([\s\S]*?)\n```/g)]
+      .map(([, source]) => JSON.parse(source))
+      .filter((example) => example.terminalState === "completed");
+    const outputSchema = JSON.parse(
+      readFileSync(path.join(root, "schemas", `${name}.output.json`), "utf8"),
+    );
+
+    expect(
+      completed,
+      `${name} must document one completed result envelope`,
+    ).toHaveLength(1);
+    expect(validate(agentResultSchema, completed[0])).toEqual({
+      valid: true,
+      errors: [],
+    });
+    expect(validate(outputSchema, completed[0].artifact)).toEqual({
+      valid: true,
+      errors: [],
+    });
+  }
+});
+
 /**
  * Walks every subschema node (the object itself, each `properties` value, and
  * `items`) so a keyword buried under a nested property is checked too —

--- a/packs/editorial/agents/draft.md
+++ b/packs/editorial/agents/draft.md
@@ -35,13 +35,25 @@ Your goal is to write a comprehensive, engaging, science-backed guide adhering t
    }
    ```
 
-4. **Write Final Result:**
-   Write your output to `./result.json` matching `schemas/editorial-draft.output.json`:
-   ```json
-   {
-     "revisionHash": "<sha256_hash>",
-     "revisionNumber": 1,
-     "wordCount": 1650,
-     "cellVersion": 3
-   }
-   ```
+## Output
+
+Write the complete `factory.agent-result/v1` envelope to `./result.json`. Its
+`artifact` must match `schemas/draft.output.json` exactly:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "articleId": "<input.json's articleId>",
+    "title": "Article Title",
+    "slug": "article-title",
+    "revisionHash": "<sha256_hash>",
+    "revisionNumber": 1,
+    "wordCount": 1650,
+    "cellVersion": 3
+  },
+  "evidence": { "commands": [] }
+}
+```

--- a/packs/editorial/agents/research.md
+++ b/packs/editorial/agents/research.md
@@ -37,12 +37,30 @@ Your goal is to gather authoritative scientific studies, physiological data, and
    }
    ```
 
-4. **Write Final Result:**
-   Write your output to `./result.json` matching `schemas/editorial-research.output.json`:
-   ```json
-   {
-     "sourcesCount": 3,
-     "sources": [...],
-     "cellVersion": 2
-   }
-   ```
+## Output
+
+Write the complete `factory.agent-result/v1` envelope to `./result.json`. Its
+`artifact` must match `schemas/research.output.json` exactly:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "articleId": "<input.json's articleId>",
+    "sources": [
+      {
+        "id": "src-study-01",
+        "title": "Study Title",
+        "url": "https://pubmed.ncbi.nlm.nih.gov/...",
+        "relevanceScore": 0.98,
+        "claims": ["Key physiological finding 1", "Key finding 2"]
+      }
+    ],
+    "summary": "Evidence-based research summary.",
+    "cellVersion": 2
+  },
+  "evidence": { "commands": [] }
+}
+```

--- a/packs/editorial/agents/review.md
+++ b/packs/editorial/agents/review.md
@@ -48,20 +48,31 @@ Your goal is to evaluate article drafts against editorial quality standards, sci
    }
    ```
 
-5. **Write Final Result:**
-   Write your output to `./result.json` matching `schemas/editorial-review.output.json`:
-   ```json
-   {
-     "verdict": "APPROVE",
-     "score": 0.95,
-     "findings": [
-       {
-         "category": "Accuracy",
-         "severity": "INFO",
-         "description": "Verified study claims."
-       }
-     ],
-     "instructions": "Approved for publication",
-     "cellVersion": 4
-   }
-   ```
+## Output
+
+Write the complete `factory.agent-result/v1` envelope to `./result.json`. Its
+`artifact` must match `schemas/review.output.json` exactly:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "articleId": "<input.json's articleId>",
+    "revisionHash": "<input.json's revisionHash>",
+    "verdict": "APPROVE",
+    "score": 0.95,
+    "findings": [
+      {
+        "category": "Accuracy",
+        "severity": "INFO",
+        "description": "Verified study claims."
+      }
+    ],
+    "instructions": "Approved for publication",
+    "cellVersion": 4
+  },
+  "evidence": { "commands": [] }
+}
+```

--- a/packs/editorial/agents/topic-scan.md
+++ b/packs/editorial/agents/topic-scan.md
@@ -39,12 +39,29 @@ Your goal is to propose authoritative, compelling topic ideas grounded in the si
    }
    ```
 
-4. **Write Final Result:**
-   Write your output to `./result.json` matching `schemas/editorial-topic-scan.output.json`:
-   ```json
-   {
-     "candidatesCount": 3,
-     "candidates": [...],
-     "cellVersion": 2
-   }
-   ```
+## Output
+
+Write the complete `factory.agent-result/v1` envelope to `./result.json`. Its
+`artifact` must match `schemas/topic-scan.output.json` exactly:
+
+```json
+{
+  "schemaVersion": "factory.agent-result/v1",
+  "terminalState": "completed",
+  "reasonCode": "ok",
+  "artifact": {
+    "siteId": "<input.json's siteId>",
+    "candidates": [
+      {
+        "id": "topic-unique-id",
+        "title": "Clear Actionable Title",
+        "slug": "url-friendly-slug",
+        "angle": "Unique angle or thesis",
+        "priority": 9
+      }
+    ],
+    "cellVersion": 2
+  },
+  "evidence": { "commands": [] }
+}
+```

--- a/packs/editorial/pins.json
+++ b/packs/editorial/pins.json
@@ -1,14 +1,14 @@
 {
-  "agents/draft.md": "sha256:04296881cad40466849654dc37778e1a776f94863056f1b3566bc42a29024a76",
+  "agents/draft.md": "sha256:1a858f8dd54615ec168b6da6285b707c9318e5469d10b266390bce26a7544d55",
   "schemas/draft.input.json": "sha256:b1bb319c307469ed183cffeb7304db993a540ae293a7c1c6886e523df722ebc0",
   "schemas/draft.output.json": "sha256:08059b5ad568f98c142ee771c9ca37f9dbcb0c5104db5976afe2847a91f93af9",
-  "agents/research.md": "sha256:2490666a03338ea4277974b1a758b4b9e6f30fe31592f6464895e5f2697009c9",
+  "agents/research.md": "sha256:dd0023ea7d80b30806bc8086f911041a90a45be898ebdf8040dd2b4526318ce3",
   "schemas/research.input.json": "sha256:681c812737f0fb5eb7d197b0f77468ca49b41102c348558ea9a17fa99e4bf8dd",
   "schemas/research.output.json": "sha256:f67596b0ee56f83e99d288ccd5f250e23ab96b7e1ac2aa450f6f7f66a82285ab",
-  "agents/review.md": "sha256:fccd80f7835b890745afdacb7479579034f14ba4cbc82231886fac384583a8de",
+  "agents/review.md": "sha256:f6143e2e54c6efdd4e9f74306532d55ebeff258c9e9de785327f0b347e8a49c0",
   "schemas/review.input.json": "sha256:3a15c07b0c268470d3e94c67bd7f8b332f58a8a4383248adab9bb584a951044e",
   "schemas/review.output.json": "sha256:147f259f03816286d70ddbf2a8b572ef1958f3e438a064cb3ea2c5d2e2dd728d",
-  "agents/topic-scan.md": "sha256:3ae4bbec280a7076d159101125ed0ae1cc0ef52c0516f6721b71cb4e910a1b4e",
+  "agents/topic-scan.md": "sha256:266b47600d4e2a489009ed006cdc93d5e6192b5b31e416da0b5251eae53146a9",
   "schemas/topic-scan.input.json": "sha256:4439977e3c3ae89f1424ca3417ef2e3cb6d4d31087d911c655be7e0cb45dc6f2",
   "schemas/topic-scan.output.json": "sha256:9e58e880bf857271c2b425b4d48ef510be414a2198e77fe3858f93af93e0f395"
 }


### PR DESCRIPTION
Fixes watt-mind/factory#2212

Editorial agents now emit schema-valid result envelopes, protected by fixture validation and refreshed pins.

## Validation

| Check                | Command                                                                    | Result  | Notes                                      |
| -------------------- | -------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/pack-authoring.test.mjs event-runtime/lib/registry.test.mjs --timeout 20000` | pass    | 69 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | completed; existing lint warnings only     |
| UX critique          | `factory-ux-critic`                                                     | not run | documentation and internal pack fixtures   |

UX critique: skipped — documentation and internal pack fixture coverage only

run:run_6ad738cf-578b-413a-bf68-e7a8ae8b5c51
