### PR TITLE
(#2216) Reduce homepage grid interference with text

### DIFF
--- a/site/src/styles/custom.css
+++ b/site/src/styles/custom.css
@@ -37,6 +37,7 @@
   --wm-color-outline: oklch(55% 0.018 178);
   --wm-color-outline-variant: oklch(84% 0.012 178);
   --wm-color-grid: oklch(39.325% 0.01702 185.19 / 0.12);
+  --wm-color-grid-wash: oklch(98.331% 0.00249 165.08 / 0.72);
   --wm-color-panel: oklch(100% 0 0 / 0.82);
   --wm-color-panel-hover: oklch(97% 0.005 178 / 0.96);
   --sl-color-accent-low: var(--wm-color-primary-container);
@@ -65,10 +66,22 @@ body {
 
 body:has(.hero) {
   background-image:
+    linear-gradient(
+      90deg,
+      transparent max(0px, calc(50% - 47rem)),
+      var(--wm-color-grid-wash) max(var(--wm-page-margin), calc(50% - 41rem)),
+      var(--wm-color-grid-wash)
+        min(calc(100% - var(--wm-page-margin)), calc(50% + 41rem)),
+      transparent min(100%, calc(50% + 47rem))
+    ),
     linear-gradient(var(--wm-color-grid) 0.5px, transparent 0.5px),
     linear-gradient(90deg, var(--wm-color-grid) 0.5px, transparent 0.5px);
   background-position: center;
-  background-size: 40px 40px;
+  background-repeat: no-repeat, repeat, repeat;
+  background-size:
+    100% 100%,
+    40px 40px,
+    40px 40px;
 }
 
 h1,

--- a/site/src/styles/tokens.css
+++ b/site/src/styles/tokens.css
@@ -16,7 +16,8 @@
   --wm-color-on-primary: oklch(30.244% 0.05381 183.18);
   --wm-color-outline: oklch(65.329% 0.01821 177.96);
   --wm-color-outline-variant: oklch(39.325% 0.01702 185.19);
-  --wm-color-grid: oklch(39.325% 0.01702 185.19 / 0.42);
+  --wm-color-grid: oklch(39.325% 0.01702 185.19 / 0.16);
+  --wm-color-grid-wash: oklch(18.77% 0.01139 175.67 / 0.78);
   --wm-color-panel: oklch(23.999% 0.01086 176.18 / 0.72);
   --wm-color-panel-hover: oklch(28.281% 0.00867 184.63 / 0.88);
   --wm-color-focus: var(--wm-color-primary);


### PR DESCRIPTION
## Summary
- Reduce the dark homepage grid alpha from 42% to 16% while preserving the 40px Factory texture.
- Add a theme-aware, edgeless central surface wash that protects the reading plane and fades into the grid at the margins.
- Keep the treatment scoped to pages with the homepage hero; ordinary documentation pages remain unchanged.

## Verification
- `bun run docs:build` — pass, 33 pages built.
- `bunx prettier --check site/src/styles/tokens.css site/src/styles/custom.css` — pass.
- Dark/light browser verification at 320, 375, 414, 768, and 1440px — pass with three valid background layers and no horizontal overflow.
- Non-homepage documentation background — unchanged (`background-image: none`).

## UX critique
- required — SHIP in 1 round; the grid remains visible, the wash reads as edgeless rather than card-like, and no in-scope findings were reported.

Fixes #2216