### PR TITLE
fix(merge): suppress refused merge-fix storms (#2221)

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -462,6 +462,46 @@ function hasInFlightAgent(db, agent, { github, pr, headSha }) {
   return Boolean(proposal);
 }
 
+const MERGE_FIX_REFUSAL_COOLDOWN_MS = 15 * 60_000;
+const DURABLE_MERGE_FIX_REFUSALS = new Set([
+  "merge_fix_ticket_escalated",
+  "merge_fix_ticket_security",
+]);
+
+/**
+ * A terminal merge-fix is normally safe to retry, but retrying the exact same
+ * refusal every scan turns a tracker outage or an escalated ticket into a
+ * dispatch storm. Keep the suppression scoped to the finding and pinned head:
+ * a new commit is fresh evidence and remains eligible for a new correction.
+ */
+function refusedMergeFixSuppressed(db, item, { github, now }) {
+  if (!db) return false;
+  const refused = db
+    .query(
+      `SELECT a.reason_code AS reasonCode, a.finished_at AS finishedAt
+         FROM runs r
+         JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+        WHERE r.state = 'REFUSED'
+          AND a.terminal_state = 'REFUSED'
+          AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'
+          AND json_extract(r.spec_json, '$.input.pr') = ?
+          AND json_extract(r.spec_json, '$.input.headSha') = ?
+          AND json_extract(r.spec_json, '$.input.github') = ?
+          AND json_extract(r.spec_json, '$.input.findingHash') = ?
+        ORDER BY a.finished_at DESC, r.rowid DESC
+        LIMIT 1`,
+    )
+    .get(item.pr, item.headSha, github, item.findingHash);
+  if (!refused?.reasonCode) return false;
+  if (DURABLE_MERGE_FIX_REFUSALS.has(refused.reasonCode)) return true;
+  if (refused.reasonCode !== "merge_fix_ticket_read_failed") return false;
+  const finishedAt = Date.parse(refused.finishedAt ?? "");
+  return (
+    Number.isFinite(finishedAt) &&
+    Number(now) - finishedAt < MERGE_FIX_REFUSAL_COOLDOWN_MS
+  );
+}
+
 /**
  * Deterministic enumerator. Does not review diffs — it classifies live PRs
  * against the ledger and emits reviews for misses (or every selected PR).
@@ -663,7 +703,10 @@ function assemble({
         continue;
       }
       const item = rebaseFixItem(pr, hit, { forge, github });
-      if (item) fix.push(item);
+      if (!item || refusedMergeFixSuppressed(db, item, { github, now })) {
+        continue;
+      }
+      fix.push(item);
       continue;
     }
     if (hit.verdict === "MERGE") mergeHits.push(hit);

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -463,6 +463,7 @@ function hasInFlightAgent(db, agent, { github, pr, headSha }) {
 }
 
 const MERGE_FIX_REFUSAL_COOLDOWN_MS = 15 * 60_000;
+const MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS = 6 * 60 * 60_000;
 const DURABLE_MERGE_FIX_REFUSALS = new Set([
   "merge_fix_ticket_escalated",
   "merge_fix_ticket_security",
@@ -473,9 +474,17 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
  * refusal every scan turns a tracker outage or an escalated ticket into a
  * dispatch storm. Keep the suppression scoped to the finding and pinned head:
  * a new commit is fresh evidence and remains eligible for a new correction.
+ *
+ * Any refusal earns at least the transient cooldown — a per-code allowlist
+ * silently misses every reason code added later. Refusals that need a human to
+ * clear a blocker get a much longer cooldown, but never permanent suppression:
+ * the blocker can be lifted without a new push, and the scan must eventually
+ * re-notice that.
+ *
+ * Returns the suppressing reason code, or null when the item is dispatchable.
  */
 function refusedMergeFixSuppressed(db, item, { github, now }) {
-  if (!db) return false;
+  if (!db) return null;
   const refused = db
     .query(
       `SELECT a.reason_code AS reasonCode, a.finished_at AS finishedAt
@@ -492,14 +501,14 @@ function refusedMergeFixSuppressed(db, item, { github, now }) {
         LIMIT 1`,
     )
     .get(item.pr, item.headSha, github, item.findingHash);
-  if (!refused?.reasonCode) return false;
-  if (DURABLE_MERGE_FIX_REFUSALS.has(refused.reasonCode)) return true;
-  if (refused.reasonCode !== "merge_fix_ticket_read_failed") return false;
+  if (!refused?.reasonCode) return null;
+  const cooldownMs = DURABLE_MERGE_FIX_REFUSALS.has(refused.reasonCode)
+    ? MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS
+    : MERGE_FIX_REFUSAL_COOLDOWN_MS;
   const finishedAt = Date.parse(refused.finishedAt ?? "");
-  return (
-    Number.isFinite(finishedAt) &&
-    Number(now) - finishedAt < MERGE_FIX_REFUSAL_COOLDOWN_MS
-  );
+  if (!Number.isFinite(finishedAt)) return null;
+  if (Number(now) - finishedAt >= cooldownMs) return null;
+  return refused.reasonCode;
 }
 
 /**
@@ -703,7 +712,10 @@ function assemble({
         continue;
       }
       const item = rebaseFixItem(pr, hit, { forge, github });
-      if (!item || refusedMergeFixSuppressed(db, item, { github, now })) {
+      if (!item) continue;
+      const suppressed = refusedMergeFixSuppressed(db, item, { github, now });
+      if (suppressed) {
+        rebaseSkipped.push({ pr: pr.number, reason: `refused_${suppressed}` });
         continue;
       }
       fix.push(item);

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -1138,6 +1138,29 @@ describe("merge-scan enumerator (WM-936)", () => {
     expect(result.artifact.reviews).toEqual([]);
   });
 
+  function conflictingScan(db, { now } = {}) {
+    return enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+          }),
+        ],
+        {
+          baseSha: BASE2,
+        },
+      ),
+      repos,
+      ...(now === undefined ? {} : { now }),
+    });
+  }
+
+  const REFUSED_AT = Date.parse("2026-08-19T16:45:00.000Z");
+
   test("a refused escalated merge-fix does not re-emit the identical finding", () => {
     const db = openDb(":memory:");
     upsertMergeReview(db, {
@@ -1154,25 +1177,85 @@ describe("merge-scan enumerator (WM-936)", () => {
       reasonCode: "merge_fix_ticket_escalated",
     });
 
-    const result = enumerateMergeScan({
-      input: { repo: "factory" },
-      db,
-      forge: forgeWith(
-        [
-          pr({
-            number: 9,
-            headRefName: "feat/WM-9",
-            mergeable: "CONFLICTING",
-          }),
-        ],
-        {
-          baseSha: BASE2,
-        },
-      ),
-      repos,
-    });
+    const result = conflictingScan(db, { now: REFUSED_AT + 60_000 });
 
     expect(result.artifact.fix).toEqual([]);
+  });
+
+  test("a durable refusal is retried once its long cooldown expires", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_security",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_security",
+    });
+
+    const withinWindow = conflictingScan(db, {
+      now: REFUSED_AT + 5 * 60 * 60_000,
+    });
+    const afterWindow = conflictingScan(db, {
+      now: REFUSED_AT + 6 * 60 * 60_000 + 60_000,
+    });
+
+    expect(withinWindow.artifact.fix).toEqual([]);
+    expect(afterWindow.artifact.fix).toHaveLength(1);
+  });
+
+  test("an unrecognised refusal code still earns the transient cooldown", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_unknown",
+      pr: 9,
+      reasonCode: "merge_fix_run_check_failed",
+    });
+
+    const beforeCooldown = conflictingScan(db, { now: REFUSED_AT + 60_000 });
+    const afterCooldown = conflictingScan(db, {
+      now: REFUSED_AT + 16 * 60_000,
+    });
+
+    expect(beforeCooldown.artifact.fix).toEqual([]);
+    expect(afterCooldown.artifact.fix).toHaveLength(1);
+  });
+
+  test("a suppressed rebase fix is reported in the scan summary", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_reported",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+    });
+
+    const result = conflictingScan(db, { now: REFUSED_AT + 60_000 });
+
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain(
+      "rebase_skipped:refused_merge_fix_ticket_escalated #9",
+    );
   });
 
   test("a refused ticket-read merge-fix retries only after its cooldown", () => {

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -101,6 +101,31 @@ function insertRun(db, { runId, agent, pr, headSha, state, github = GITHUB }) {
   ).run(runId, `idem-${runId}`, spec, state, now, now);
 }
 
+function insertRefusedMergeFix(
+  db,
+  {
+    runId,
+    pr,
+    headSha = HEAD,
+    findingHash = REBASE_HASH,
+    reasonCode,
+    finishedAt = "2026-08-19T16:45:00.000Z",
+  },
+) {
+  const spec = JSON.stringify({
+    agent: "merge-fix@1",
+    input: { github: GITHUB, pr, headSha, baseSha: BASE, findingHash },
+  });
+  db.query(
+    `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+     VALUES (?, ?, ?, 'sha256:test', 'REFUSED', 1, ?, ?)`,
+  ).run(runId, `idem-${runId}`, spec, finishedAt, finishedAt);
+  db.query(
+    `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
+     VALUES (?, 1, 1, ?, 'REFUSED', ?)`,
+  ).run(runId, finishedAt, reasonCode);
+}
+
 function insertOpenProposal(db, { id, agent, pr, headSha, github = GITHUB }) {
   const now = "2026-08-19T16:45:00.000Z";
   const runId = `run-${id}`;
@@ -1095,13 +1120,117 @@ describe("merge-scan enumerator (WM-936)", () => {
     const result = enumerateMergeScan({
       input: { repo: "factory" },
       db,
-      forge: forgeWith([pr({ number: 9, headRefName: "feat/WM-9" })], {
-        baseSha: BASE2,
-      }),
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+          }),
+        ],
+        {
+          baseSha: BASE2,
+        },
+      ),
       repos,
     });
     expect(result.artifact.fix).toEqual([]);
     expect(result.artifact.reviews).toEqual([]);
+  });
+
+  test("a refused escalated merge-fix does not re-emit the identical finding", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_escalated",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+    });
+
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+          }),
+        ],
+        {
+          baseSha: BASE2,
+        },
+      ),
+      repos,
+    });
+
+    expect(result.artifact.fix).toEqual([]);
+  });
+
+  test("a refused ticket-read merge-fix retries only after its cooldown", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    const refusedAt = Date.parse("2026-08-19T16:45:00.000Z");
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_read_failed",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_read_failed",
+    });
+
+    const beforeCooldown = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+          }),
+        ],
+        {
+          baseSha: BASE2,
+        },
+      ),
+      repos,
+      now: refusedAt + 60_000,
+    });
+    const afterCooldown = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith(
+        [
+          pr({
+            number: 9,
+            headRefName: "feat/WM-9",
+            mergeable: "CONFLICTING",
+          }),
+        ],
+        {
+          baseSha: BASE2,
+        },
+      ),
+      repos,
+      now: refusedAt + 16 * 60_000,
+    });
+
+    expect(beforeCooldown.artifact.fix).toEqual([]);
+    expect(afterCooldown.artifact.fix).toHaveLength(1);
   });
 });
 

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4463,56 +4463,89 @@ export async function executeClaimed(
         };
       }
 
-      const lockAcquired = acquireClaimLock(lockFile, {
-        pid: process.pid,
-        now: nowFn(),
-        isAlive: isAliveFn,
-      });
-      if (!lockAcquired) {
-        const deferred = deferClaimLockContention(db, {
-          runId,
-          attempt,
-          fencingToken,
-          owner,
-          policyVersion,
-          now: nowFn,
-          maxRequeues: Number.isInteger(
-            dispatchOpts?.maxClaimLockContentionRequeues,
-          )
-            ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
-            : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
-          random: dispatchOpts?.random ?? Math.random,
-        });
-        if (deferred?.fenced) {
-          stopCancellationMonitor();
-          return { fenced: true };
-        }
-        if (deferred?.requeued) {
-          stopCancellationMonitor();
-          return {
-            runId,
-            attempt,
-            terminalState: "QUEUED",
-            reasonCode: "claim_lock_contention",
-            requeueAfterMs: deferred.backoffMs,
-          };
-        }
-        const res = refuseTerminal("claim_lock_starvation", [
-          "dispatch_claim_lock",
-        ]);
-        stopCancellationMonitor();
+      // WM-469 de-hardcoded the merge-fix role from the kernel: the definition
+      // declares `dispatchGateExempt: true` (validated by the registry) instead
+      // of a `gate: "merge-fix"` literal the worker string-matched. Keep the
+      // planner and worker keyed off the SAME declarative field — a legacy
+      // `gate` value is still honoured so an older pinned spec cannot silently
+      // fall through to the dispatch claim gate and refuse with ticket_assigned.
+      const gate =
+        def?.dispatchGateExempt === true
+          ? "merge-fix"
+          : (def?.gate ?? "dispatch");
+      if (!["dispatch", "merge-fix"].includes(gate)) {
+        const reasonCode = "worktree_gate_unknown";
+        const res = refuseTerminal(reasonCode, ["worktree_gate"]);
         if (res?.fenced) return { fenced: true };
         return {
           runId,
           attempt,
           terminalState: "REFUSED",
-          reasonCode: "claim_lock_starvation",
+          reasonCode,
           receipt: res?.receipt,
         };
       }
 
-      const deferTransientGate = (reasonCode) => {
+      // Merge-fix never claims a ticket: it only revalidates the already-owned
+      // review ticket. Its tracker read can take the full read timeout, so do
+      // not serialize unrelated dispatch claims behind it.
+      let claimLockHeld = false;
+      if (gate === "dispatch") {
+        claimLockHeld = acquireClaimLock(lockFile, {
+          pid: process.pid,
+          now: nowFn(),
+          isAlive: isAliveFn,
+        });
+        if (!claimLockHeld) {
+          const deferred = deferClaimLockContention(db, {
+            runId,
+            attempt,
+            fencingToken,
+            owner,
+            policyVersion,
+            now: nowFn,
+            maxRequeues: Number.isInteger(
+              dispatchOpts?.maxClaimLockContentionRequeues,
+            )
+              ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
+              : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
+            random: dispatchOpts?.random ?? Math.random,
+          });
+          if (deferred?.fenced) {
+            stopCancellationMonitor();
+            return { fenced: true };
+          }
+          if (deferred?.requeued) {
+            stopCancellationMonitor();
+            return {
+              runId,
+              attempt,
+              terminalState: "QUEUED",
+              reasonCode: "claim_lock_contention",
+              requeueAfterMs: deferred.backoffMs,
+            };
+          }
+          const res = refuseTerminal("claim_lock_starvation", [
+            "dispatch_claim_lock",
+          ]);
+          stopCancellationMonitor();
+          if (res?.fenced) return { fenced: true };
+          return {
+            runId,
+            attempt,
+            terminalState: "REFUSED",
+            reasonCode: "claim_lock_starvation",
+            receipt: res?.receipt,
+          };
+        }
+      }
+      const releaseGateLock = () => {
+        if (!claimLockHeld) return;
         releaseClaimLock(lockFile);
+        claimLockHeld = false;
+      };
+      const deferTransientGate = (reasonCode) => {
+        releaseGateLock();
         const deferred = deferTransientDispatchGate(db, {
           runId,
           attempt,
@@ -4549,30 +4582,6 @@ export async function executeClaimed(
           receipt: res?.receipt,
         };
       };
-
-      // WM-469 de-hardcoded the merge-fix role from the kernel: the definition
-      // declares `dispatchGateExempt: true` (validated by the registry) instead
-      // of a `gate: "merge-fix"` literal the worker string-matched. Keep the
-      // planner and worker keyed off the SAME declarative field — a legacy
-      // `gate` value is still honoured so an older pinned spec cannot silently
-      // fall through to the dispatch claim gate and refuse with ticket_assigned.
-      const gate =
-        def?.dispatchGateExempt === true
-          ? "merge-fix"
-          : (def?.gate ?? "dispatch");
-      if (!["dispatch", "merge-fix"].includes(gate)) {
-        releaseClaimLock(lockFile);
-        const reasonCode = "worktree_gate_unknown";
-        const res = refuseTerminal(reasonCode, ["worktree_gate"]);
-        if (res?.fenced) return { fenced: true };
-        return {
-          runId,
-          attempt,
-          terminalState: "REFUSED",
-          reasonCode,
-          receipt: res?.receipt,
-        };
-      }
 
       let gateResult;
       try {
@@ -4665,7 +4674,7 @@ export async function executeClaimed(
         ) {
           return deferTransientGate("linear_read_failed");
         }
-        releaseClaimLock(lockFile);
+        releaseGateLock();
         throw err;
       }
 
@@ -4694,7 +4703,7 @@ export async function executeClaimed(
           }
           return deferred;
         }
-        releaseClaimLock(lockFile);
+        releaseGateLock();
         // The retained PR was rejected by the failed run's handoff gate and is
         // still open as a ready (non-draft) PR. Route it to review rather than
         // silently stranding it behind a refused continuation that cannot
@@ -4766,7 +4775,7 @@ export async function executeClaimed(
         // The ticket is already assigned and under review by definition. The
         // merge-fix gate proved those live facts; trying the dispatch claim
         // verb here would reject the valid run as ticket_assigned.
-        releaseClaimLock(lockFile);
+        releaseGateLock();
       } else {
         // The retry gate has already re-read and authenticated the surviving
         // claim. Do not run the mutating claim command again: besides being
@@ -4784,7 +4793,7 @@ export async function executeClaimed(
               harness: spec.adapter ?? "claude",
             });
           } finally {
-            releaseClaimLock(lockFile);
+            releaseGateLock();
           }
 
           if (!claimRes?.ok) {
@@ -4800,7 +4809,7 @@ export async function executeClaimed(
             };
           }
         } else {
-          releaseClaimLock(lockFile);
+          releaseGateLock();
         }
 
         ticketClaimed = true;

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6329,6 +6329,65 @@ sh -c 'sleep 5 & wait'
     expect(await runOnce(db, registry, adapters, opts())).toBeNull();
   });
 
+  test("a slow merge-fix ticket read does not hold the dispatch claim lock", async () => {
+    const db = openDb(":memory:");
+    const locksDir = tmpDir("merge-fix-ticket-read-locks-");
+    const ticket = "watt-mind/factory#2221";
+    const spec = queueRun(
+      db,
+      makeSpec({
+        agent: "merge-fix@1",
+        input: {
+          repo: "factory",
+          github: "watt-mind/factory",
+          base: "develop",
+          pr: 2221,
+          headSha: "a".repeat(40),
+          baseSha: "b".repeat(40),
+          headRef: "fix/gh-2221",
+          ticket,
+          finding: "rebase_onto_base",
+          findingHash: "c".repeat(64),
+          round: 1,
+          mechanical: true,
+          withinOwnedPaths: true,
+          ownedPaths: ["event-runtime/lib/worker.mjs"],
+        },
+        workspace: { type: "worktree", retainOnFailure: true },
+      }),
+    );
+    const lockFile = dispatchLockPath("factory", locksDir);
+    let concurrentClaimantAcquired = false;
+    const summary = await executeClaimed(
+      db,
+      registry,
+      adapters,
+      claimNext(db, opts()),
+      opts({
+        dispatch: {
+          locksDir,
+          fetchTicket: () => {
+            concurrentClaimantAcquired = acquireClaimLock(lockFile, {
+              pid: 2222,
+              isAlive: () => true,
+            });
+            if (concurrentClaimantAcquired) releaseClaimLock(lockFile);
+            throw new Error("tracker read timed out");
+          },
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      runId: spec.runId,
+      terminalState: "REFUSED",
+      reasonCode: "merge_fix_ticket_read_failed",
+    });
+    expect(concurrentClaimantAcquired).toBe(true);
+    expect(existsSync(lockFile)).toBe(false);
+    db.close();
+  });
+
   test("accurate attempt timestamps: started_at < finished_at with clock function (OPS-430)", async () => {
     const db = openDb(":memory:");
     const spec = queueRun(db, makeSpec());


### PR DESCRIPTION
Fixes watt-mind/factory#2221

Suppresses refused merge-fix re-dispatch storms and removes tracker reads from the claim-lock critical section.

## Validation

| Check | Command | Result | Notes |
| --- | --- | --- | --- |
| Verification Command | `bun test event-runtime/lib/merge-reviews.test.mjs event-runtime/lib/planner.test.mjs event-runtime/lib/worker.test.mjs` | pass | 336 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,480 tests; emit, format, lint clean |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — backend/runtime-only merge orchestration behavior
run:run_9b40c1fe-6d2c-4dd0-bf73-34eb80c15706
