### PR TITLE
fix(runtime): clear stale merge-fix refusal suppression

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -485,13 +485,15 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
  */
 function refusedMergeFixSuppressed(db, item, { github, now }) {
   if (!db) return null;
-  const refused = db
+  const latestTerminalAttempt = db
     .query(
-      `SELECT a.reason_code AS reasonCode, a.finished_at AS finishedAt
+      `SELECT a.terminal_state AS terminalState,
+              a.reason_code AS reasonCode,
+              a.finished_at AS finishedAt
          FROM runs r
          JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-        WHERE r.state = 'REFUSED'
-          AND a.terminal_state = 'REFUSED'
+        WHERE r.state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
+          AND a.terminal_state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
           AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'
           AND json_extract(r.spec_json, '$.input.pr') = ?
           AND json_extract(r.spec_json, '$.input.headSha') = ?
@@ -501,14 +503,20 @@ function refusedMergeFixSuppressed(db, item, { github, now }) {
         LIMIT 1`,
     )
     .get(item.pr, item.headSha, github, item.findingHash);
-  if (!refused?.reasonCode) return null;
-  const cooldownMs = DURABLE_MERGE_FIX_REFUSALS.has(refused.reasonCode)
+  if (
+    latestTerminalAttempt?.terminalState !== "REFUSED" ||
+    !latestTerminalAttempt.reasonCode
+  )
+    return null;
+  const cooldownMs = DURABLE_MERGE_FIX_REFUSALS.has(
+    latestTerminalAttempt.reasonCode,
+  )
     ? MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS
     : MERGE_FIX_REFUSAL_COOLDOWN_MS;
-  const finishedAt = Date.parse(refused.finishedAt ?? "");
+  const finishedAt = Date.parse(latestTerminalAttempt.finishedAt ?? "");
   if (!Number.isFinite(finishedAt)) return null;
   if (Number(now) - finishedAt >= cooldownMs) return null;
-  return refused.reasonCode;
+  return latestTerminalAttempt.reasonCode;
 }
 
 /**

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -110,6 +110,7 @@ function insertRefusedMergeFix(
     findingHash = REBASE_HASH,
     reasonCode,
     finishedAt = "2026-08-19T16:45:00.000Z",
+    terminalState = "REFUSED",
   },
 ) {
   const spec = JSON.stringify({
@@ -118,12 +119,12 @@ function insertRefusedMergeFix(
   });
   db.query(
     `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-     VALUES (?, ?, ?, 'sha256:test', 'REFUSED', 1, ?, ?)`,
-  ).run(runId, `idem-${runId}`, spec, finishedAt, finishedAt);
+     VALUES (?, ?, ?, 'sha256:test', ?, 1, ?, ?)`,
+  ).run(runId, `idem-${runId}`, spec, terminalState, finishedAt, finishedAt);
   db.query(
     `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
-     VALUES (?, 1, 1, ?, 'REFUSED', ?)`,
-  ).run(runId, finishedAt, reasonCode);
+     VALUES (?, 1, 1, ?, ?, ?)`,
+  ).run(runId, finishedAt, terminalState, reasonCode);
 }
 
 function insertOpenProposal(db, { id, agent, pr, headSha, github = GITHUB }) {
@@ -1181,6 +1182,36 @@ describe("merge-scan enumerator (WM-936)", () => {
 
     expect(result.artifact.fix).toEqual([]);
   });
+
+  test.each(["COMPLETED", "FAILED"])(
+    "a newer %s merge-fix clears a prior refusal's suppression",
+    (terminalState) => {
+      const db = openDb(":memory:");
+      upsertMergeReview(db, {
+        github: GITHUB,
+        pr: 9,
+        headSha: HEAD,
+        baseSha: BASE,
+        verdict: "MERGE",
+        plan: planItem(9),
+      });
+      insertRefusedMergeFix(db, {
+        runId: "run_fix_refused_first",
+        pr: 9,
+        reasonCode: "merge_fix_ticket_escalated",
+      });
+      insertRefusedMergeFix(db, {
+        runId: `run_fix_${terminalState.toLowerCase()}_latest`,
+        pr: 9,
+        terminalState,
+        finishedAt: "2026-08-19T16:45:01.000Z",
+      });
+
+      const result = conflictingScan(db, { now: REFUSED_AT + 60_000 });
+
+      expect(result.artifact.fix).toHaveLength(1);
+    },
+  );
 
   test("a durable refusal is retried once its long cooldown expires", () => {
     const db = openDb(":memory:");


### PR DESCRIPTION
Fixes watt-mind/factory#2227

Review the newest-terminal-attempt ordering that clears stale merge-fix refusal cooldowns.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass | 40 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | all gates passed; warnings only |
| UX critique          | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend runtime logic and tests only

run:run_2957e2cd-42d6-4a52-a4ea-b1f78609f00e