### PR TITLE
fix(runtime): dead-letter registry_stale queued runs

### DIFF
--- a/event-runtime/cli/work.mjs
+++ b/event-runtime/cli/work.mjs
@@ -213,6 +213,19 @@ export default async function work(args) {
     ];
   }
 
+  /**
+   * One line per run claimNext terminalized as unclaimable, so a dead-letter is
+   * never silent — the skip report can no longer show these rows, since they
+   * have left QUEUED.
+   */
+  function logDeadLettered(claim) {
+    for (const entry of claim?.deadLettered ?? []) {
+      log(
+        `dead-lettered ${entry.runId} (registry_stale): run ${entry.specVersion}, worker registry ${entry.workerRegistryVersion}, checkout registry ${entry.checkoutRegistryVersion}`,
+      );
+    }
+  }
+
   /** Refresh the bounded snapshot the registry row and heartbeat publish. */
   function snapshotSkippedQueuedRuns(now) {
     skippedQueuedRuns = inspectSkippedQueuedRuns(now);
@@ -364,7 +377,10 @@ export default async function work(args) {
           registryVersion: pv,
           currentRegistryVersion: checkoutPolicyVersion,
           labels,
-          adapters: adapterOverride ? null : adapterNames,
+          // Always hand over the allow-list: --adapter-override lets the
+          // worker execute anything, but claimNext still needs the list to
+          // scope which stale runs it may dead-letter (GH-2226).
+          adapters: adapterNames,
           ...(adapterOverride ? { adapterOverride } : {}),
         });
         if (!claim) {
@@ -379,10 +395,12 @@ export default async function work(args) {
             );
           if (claim.reloadRequired)
             return finish("registry_stale", CODE_RELOAD_EXIT);
+          logDeadLettered(claim);
           reportSkipsWhenDue(Date.now());
           await new Promise((resolve) => setTimeout(resolve, pollMs));
           continue;
         }
+        logDeadLettered(claim);
         inFlight = claim.runId;
         idleSince = null;
         for (const key of reportedSkips.keys()) {

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -187,7 +187,7 @@ describe("work command", () => {
   );
 
   test(
-    "folds stale registry refusals into the rate-limited skip report",
+    "dead-letters a queued run stale to the current registry",
     async () => {
       const home = tmpDir("evrt-work-registry-skip-");
       await seedSkippedRun(home, {
@@ -206,26 +206,19 @@ describe("work command", () => {
         { FACTORY_EVENT_HOME: home },
       );
       try {
-        await waitFor(box, '"runId":"run_registry_skip"');
         await until(
-          "the next registry skip-report interval",
-          () =>
-            (box.out.match(/"runId":"run_registry_skip"/g) ?? []).length >= 2,
+          "the stale queued run to be terminalized",
+          () => {
+            const db = openDb(path.join(home, "runtime.db"));
+            const state = db
+              .query(`SELECT state FROM runs WHERE run_id = ?`)
+              .get("run_registry_skip")?.state;
+            db.close();
+            return state === "CANCELLED";
+          },
           { timeoutMs: 5_000, everyMs: 10 },
         );
-        expect(box.out.match(/"runId":"run_registry_skip"/g)).toHaveLength(2);
-        expect(box.out).toMatch(
-          /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
-        );
         expect(box.out).not.toContain("refused run_registry_skip");
-        const worker = await registeredWorker(home);
-        expect(worker.skipped).toEqual([
-          {
-            runId: "run_registry_skip",
-            definition: "factory-status-report@1",
-            reason: expect.stringMatching(/^registry_stale:/),
-          },
-        ]);
       } finally {
         box.child.kill("SIGTERM");
         await exitOf(box.child);

--- a/event-runtime/cli/work.test.mjs
+++ b/event-runtime/cli/work.test.mjs
@@ -56,7 +56,13 @@ async function registeredWorker(home, { timeoutMs = 5_000 } = {}) {
 
 async function seedSkippedRun(
   home,
-  { runId, placement, promptVersion = WORKER_POLICY_VERSION, queuedReason },
+  {
+    runId,
+    placement,
+    promptVersion = WORKER_POLICY_VERSION,
+    queuedReason,
+    queuedAt = Date.now(),
+  },
 ) {
   const { createRun, transition } = await import("../lib/lifecycle.mjs");
   const { canonicalJson, hashJson } = await import("../lib/canonical.mjs");
@@ -87,15 +93,15 @@ async function seedSkippedRun(
     specHash: hashJson(spec),
     actor: "test",
     policyVersion: "test",
-    now: Date.now(),
+    now: queuedAt,
   });
-  transition(db, { runId, to: "APPROVED", actor: "test", now: Date.now() });
+  transition(db, { runId, to: "APPROVED", actor: "test", now: queuedAt });
   transition(db, {
     runId,
     to: "QUEUED",
     actor: "test",
     ...(queuedReason ? { reason: queuedReason } : {}),
-    now: Date.now(),
+    now: queuedAt,
   });
   db.close();
 }
@@ -187,12 +193,68 @@ describe("work command", () => {
   );
 
   test(
-    "dead-letters a queued run stale to the current registry",
+    "folds a mismatched run still inside the deploy window into the skip report",
     async () => {
       const home = tmpDir("evrt-work-registry-skip-");
       await seedSkippedRun(home, {
         runId: "run_registry_skip",
         promptVersion: "git:older-registry",
+      });
+      const box = spawnWorker(
+        [
+          "--adapter-override",
+          "fake",
+          "--poll-ms",
+          "25",
+          "--skip-report-ms",
+          "100",
+        ],
+        { FACTORY_EVENT_HOME: home },
+      );
+      try {
+        await waitFor(box, '"runId":"run_registry_skip"');
+        await until(
+          "the next registry skip-report interval",
+          () =>
+            (box.out.match(/"runId":"run_registry_skip"/g) ?? []).length >= 2,
+          { timeoutMs: 5_000, everyMs: 10 },
+        );
+        expect(box.out).toMatch(
+          /registry_stale:spec=git:older-registry\/git:older-registry:worker=git:[^:"]+:checkout=git:[^"}]+/,
+        );
+        expect(box.out).not.toContain("refused run_registry_skip");
+        expect(box.out).not.toContain("dead-lettered run_registry_skip");
+        const worker = await registeredWorker(home);
+        expect(worker.skipped).toEqual([
+          {
+            runId: "run_registry_skip",
+            definition: "factory-status-report@1",
+            reason: expect.stringMatching(/^registry_stale:/),
+          },
+        ]);
+        const db = openDb(path.join(home, "runtime.db"));
+        const state = db
+          .query(`SELECT state FROM runs WHERE run_id = ?`)
+          .get("run_registry_skip")?.state;
+        db.close();
+        expect(state).toBe("QUEUED");
+      } finally {
+        box.child.kill("SIGTERM");
+        await exitOf(box.child);
+        rmSync(home, { recursive: true, force: true });
+      }
+    },
+    loadAdjustedTimeout(30_000),
+  );
+
+  test(
+    "dead-letters a queued run that stayed stale past the deploy window",
+    async () => {
+      const home = tmpDir("evrt-work-registry-dead-letter-");
+      await seedSkippedRun(home, {
+        runId: "run_registry_stale",
+        promptVersion: "git:older-registry",
+        queuedAt: Date.now() - 60 * 60_000,
       });
       const box = spawnWorker(
         [
@@ -212,13 +274,15 @@ describe("work command", () => {
             const db = openDb(path.join(home, "runtime.db"));
             const state = db
               .query(`SELECT state FROM runs WHERE run_id = ?`)
-              .get("run_registry_skip")?.state;
+              .get("run_registry_stale")?.state;
             db.close();
             return state === "CANCELLED";
           },
           { timeoutMs: 5_000, everyMs: 10 },
         );
-        expect(box.out).not.toContain("refused run_registry_skip");
+        await waitFor(box, "dead-lettered run_registry_stale");
+        expect(box.out).toContain("dead-lettered run_registry_stale");
+        expect(box.out).not.toContain("refused run_registry_stale");
       } finally {
         box.child.kill("SIGTERM");
         await exitOf(box.child);

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -2432,11 +2432,12 @@ export function claimNext(
         !adapters.includes(candidateSpec.adapter)
       )
         continue;
-      // The worker snapshots the registry and policy at startup. A run planned
-      // against another checkout must stay QUEUED; leasing it would execute and
-      // validate with incompatible definitions. Compare the live checkout too
-      // so only an actually stale worker reloads — an older queued spec must not
-      // put a fresh supervisor into an endless exit-75 loop.
+      // The worker snapshots the registry and policy at startup. Leasing a run
+      // planned against another checkout would execute and validate with
+      // incompatible definitions. Compare the live checkout too: a run matching
+      // the current checkout asks this stale worker to reload, while a run that
+      // differs from the current checkout can never become claimable and must
+      // not keep singleton schedules in flight forever.
       if (
         registryVersion &&
         (candidateSpec.promptVersion !== registryVersion ||
@@ -2458,7 +2459,18 @@ export function claimNext(
           checkoutRegistryVersion: current,
         };
         if (reloadRequired) return refusal;
+        transition(db, {
+          runId: candidate.run_id,
+          to: "CANCELLED",
+          expectFrom: "QUEUED",
+          actor: owner,
+          reason: "registry_stale",
+          policyVersion,
+          now: claimNow,
+        });
         staleRefusal ??= refusal;
+        // Continue looking so one orphaned run cannot keep compatible queued
+        // work behind it from being leased in this claim transaction.
         continue;
       }
       row = candidate;

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -521,6 +521,14 @@ const RUNTIME_ARTIFACTS = [
 export const LEASE_GRACE_SECONDS = 120;
 
 /**
+ * How long a QUEUED run planned against a checkout nobody runs any more must
+ * sit before a worker dead-letters it (GH-2226). A deploy legitimately leaves
+ * freshly planned runs mismatched for the length of the rollout, so only a run
+ * still stale after this window is treated as unclaimable rather than early.
+ */
+export const STALE_DEAD_LETTER_MS = 15 * 60_000;
+
+/**
  * Adapters that honor AbortSignal, so the worker's durable DB-backed deadline
  * monitor — not the adapter's own TERM/KILL timer — is the authoritative
  * timer and can move while an attempt is running (WM-566). Their `timeoutMs`
@@ -2405,6 +2413,8 @@ export function claimNext(
     let row = null;
     let spec = null;
     let staleRefusal = null;
+    /** Runs terminalized in this transaction, so the caller can log each one. */
+    const deadLettered = [];
     let checkoutVersion;
     const resolveCheckoutVersion = () => {
       if (checkoutVersion !== undefined) return checkoutVersion;
@@ -2426,18 +2436,20 @@ export function claimNext(
         continue;
       const candidateSpec = JSON.parse(candidate.spec_json);
       if (!satisfiesPlacement(labels, candidateSpec.placement)) continue;
-      if (
-        adapters &&
-        !adapterOverride &&
-        !adapters.includes(candidateSpec.adapter)
-      )
-        continue;
+      // An allow-list bounds what this worker may claim; --adapter-override
+      // lets it execute anything with the forced adapter, so the claim path
+      // ignores the list. The dead-letter path below does not: terminalizing a
+      // run is a decision about work this worker is actually responsible for.
+      const adapterAllowed =
+        !adapters || adapters.includes(candidateSpec.adapter);
+      if (adapters && !adapterOverride && !adapterAllowed) continue;
       // The worker snapshots the registry and policy at startup. Leasing a run
       // planned against another checkout would execute and validate with
       // incompatible definitions. Compare the live checkout too: a run matching
       // the current checkout asks this stale worker to reload, while a run that
-      // differs from the current checkout can never become claimable and must
-      // not keep singleton schedules in flight forever.
+      // differs from the current checkout can never become claimable and — once
+      // it has outlived a deploy window — must not keep singleton schedules in
+      // flight forever.
       if (
         registryVersion &&
         (candidateSpec.promptVersion !== registryVersion ||
@@ -2459,16 +2471,32 @@ export function claimNext(
           checkoutRegistryVersion: current,
         };
         if (reloadRequired) return refusal;
-        transition(db, {
-          runId: candidate.run_id,
-          to: "CANCELLED",
-          expectFrom: "QUEUED",
-          actor: owner,
-          reason: "registry_stale",
-          policyVersion,
-          now: claimNow,
-        });
         staleRefusal ??= refusal;
+        // Dead-letter only what is provably unclaimable. checkoutPolicyVersion()
+        // degrades to "unknown" on a transient `git rev-parse` failure, and a
+        // mismatch against a version we could not read is no evidence at all —
+        // one failed probe must not terminalize the whole queue.
+        const queuedAt = Date.parse(candidate.queued_at);
+        const aged =
+          Number.isFinite(queuedAt) &&
+          queuedAt + STALE_DEAD_LETTER_MS <= claimNow;
+        if (current && current !== "unknown" && adapterAllowed && aged) {
+          transition(db, {
+            runId: candidate.run_id,
+            to: "CANCELLED",
+            expectFrom: "QUEUED",
+            actor: owner,
+            reason: "registry_stale",
+            policyVersion,
+            now: claimNow,
+          });
+          deadLettered.push({
+            runId: candidate.run_id,
+            specVersion: `${candidateSpec.promptVersion}/${candidateSpec.policyVersion}`,
+            workerRegistryVersion: registryVersion,
+            checkoutRegistryVersion: current,
+          });
+        }
         // Continue looking so one orphaned run cannot keep compatible queued
         // work behind it from being leased in this claim transaction.
         continue;
@@ -2477,7 +2505,11 @@ export function claimNext(
       spec = candidateSpec;
       break;
     }
-    if (!row) return staleRefusal;
+    if (!row) {
+      if (staleRefusal && deadLettered.length)
+        staleRefusal.deadLettered = deadLettered;
+      return staleRefusal;
+    }
     const attempt = row.attempts + 1;
     const fencingToken = nextCounter(db, "fencing");
     const leaseExpiresAt = iso(
@@ -2502,7 +2534,13 @@ export function claimNext(
       now: claimNow,
     });
 
-    return { runId: row.run_id, attempt, fencingToken, spec };
+    return {
+      runId: row.run_id,
+      attempt,
+      fencingToken,
+      spec,
+      ...(deadLettered.length ? { deadLettered } : {}),
+    };
   });
 }
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6457,7 +6457,7 @@ sh -c 'sleep 5 & wait'
     ).toHaveLength(0);
   });
 
-  test("claimNext does not restart-loop a fresh worker on an older queued spec (WM-613)", () => {
+  test("claimNext dead-letters an old queued spec so a singleton can schedule again (GH-2226)", async () => {
     const db = openDb(":memory:");
     const staleSpec = queueRun(
       db,
@@ -6481,7 +6481,29 @@ sh -c 'sleep 5 & wait'
       reloadRequired: false,
       reasonCode: "registry_stale",
     });
-    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+    expect(runState(db, staleSpec.runId)).toBe("CANCELLED");
+    expect(lifecycleOf(db, staleSpec.runId).at(-1)).toMatchObject({
+      from_state: "QUEUED",
+      to_state: "CANCELLED",
+      reason: "registry_stale",
+    });
+
+    const { inFlightRunsForAgent } = await import("./in-flight-runs.mjs");
+    expect(inFlightRunsForAgent(db, staleSpec.agent)).toEqual([]);
+
+    // The next singleton schedule slot can now enqueue a replacement rather
+    // than being deduped against an impossible pre-redeploy run.
+    const freshSpec = queueRun(
+      db,
+      makeSpec({
+        promptVersion: "git:current",
+        policyVersion: "git:current",
+      }),
+      T0 + 1000,
+    );
+    expect(inFlightRunsForAgent(db, staleSpec.agent)).toEqual([
+      expect.objectContaining({ run_id: freshSpec.runId, state: "QUEUED" }),
+    ]);
   });
 
   test("claimNext skips an incompatible old spec and claims compatible queued work (WM-613)", () => {
@@ -6511,7 +6533,7 @@ sh -c 'sleep 5 & wait'
     });
 
     expect(claim.runId).toBe(compatibleSpec.runId);
-    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+    expect(runState(db, staleSpec.runId)).toBe("CANCELLED");
     expect(runState(db, compatibleSpec.runId)).toBe("LEASED");
   });
 

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -132,6 +132,7 @@ import {
   resolveLinearApiKey,
   reconcileTierEscalations,
   scheduleTierEscalation,
+  STALE_DEAD_LETTER_MS,
   sweepOrphanedLocalNotifyOutbox,
   tierEscalationContinuationGuard,
   tierEscalationEligibility,
@@ -6469,6 +6470,7 @@ sh -c 'sleep 5 & wait'
 
     const refusal = claimNext(db, {
       ...opts(),
+      now: T0 + STALE_DEAD_LETTER_MS,
       policyVersion: "git:current",
       registryVersion: "git:current",
       currentRegistryVersion: "git:current",
@@ -6480,6 +6482,14 @@ sh -c 'sleep 5 & wait'
       retryable: true,
       reloadRequired: false,
       reasonCode: "registry_stale",
+      deadLettered: [
+        expect.objectContaining({
+          runId: staleSpec.runId,
+          specVersion: "git:old/git:old",
+          workerRegistryVersion: "git:current",
+          checkoutRegistryVersion: "git:current",
+        }),
+      ],
     });
     expect(runState(db, staleSpec.runId)).toBe("CANCELLED");
     expect(lifecycleOf(db, staleSpec.runId).at(-1)).toMatchObject({
@@ -6533,8 +6543,102 @@ sh -c 'sleep 5 & wait'
     });
 
     expect(claim.runId).toBe(compatibleSpec.runId);
-    expect(runState(db, staleSpec.runId)).toBe("CANCELLED");
+    // Still inside the deploy window: skipped, not terminalized.
+    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+    expect(claim.deadLettered).toBeUndefined();
     expect(runState(db, compatibleSpec.runId)).toBe("LEASED");
+  });
+
+  test("claimNext leaves a freshly queued mismatched run QUEUED until it outlives the deploy window (GH-2226)", () => {
+    const db = openDb(":memory:");
+    const staleSpec = queueRun(
+      db,
+      makeSpec({ promptVersion: "git:old", policyVersion: "git:old" }),
+    );
+
+    const refusal = claimNext(db, {
+      ...opts(),
+      now: T0 + STALE_DEAD_LETTER_MS - 1,
+      policyVersion: "git:current",
+      registryVersion: "git:current",
+      currentRegistryVersion: "git:current",
+    });
+
+    expect(refusal).toMatchObject({
+      runId: staleSpec.runId,
+      refused: true,
+      reloadRequired: false,
+      reasonCode: "registry_stale",
+    });
+    expect(refusal.deadLettered).toBeUndefined();
+    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+  });
+
+  test("claimNext never dead-letters against an unreadable checkout version (GH-2226)", () => {
+    const db = openDb(":memory:");
+    const staleSpec = queueRun(
+      db,
+      makeSpec({ promptVersion: "git:old", policyVersion: "git:old" }),
+    );
+
+    // checkoutPolicyVersion() degrades to "unknown" when `git rev-parse` fails.
+    // A mismatch against a version we could not read is not evidence of a
+    // stale run, so one transient probe failure must terminalize nothing.
+    const refusal = claimNext(db, {
+      ...opts(),
+      now: T0 + STALE_DEAD_LETTER_MS * 10,
+      policyVersion: "git:current",
+      registryVersion: "git:current",
+      currentRegistryVersion: "unknown",
+    });
+
+    expect(refusal).toMatchObject({
+      runId: staleSpec.runId,
+      refused: true,
+      reloadRequired: false,
+      reasonCode: "registry_stale",
+      checkoutRegistryVersion: "unknown",
+    });
+    expect(refusal.deadLettered).toBeUndefined();
+    expect(runState(db, staleSpec.runId)).toBe("QUEUED");
+  });
+
+  test("claimNext dead-letters only adapters this worker serves, even under an override (GH-2226)", () => {
+    const db = openDb(":memory:");
+    const foreignSpec = queueRun(
+      db,
+      makeSpec({
+        adapter: "other_adapter",
+        promptVersion: "git:old",
+        policyVersion: "git:old",
+      }),
+    );
+    const ownSpec = queueRun(
+      db,
+      makeSpec({
+        adapter: "fake",
+        promptVersion: "git:old",
+        policyVersion: "git:old",
+      }),
+      T0 + 1,
+    );
+
+    const refusal = claimNext(db, {
+      ...opts(),
+      now: T0 + STALE_DEAD_LETTER_MS + 1000,
+      policyVersion: "git:current",
+      registryVersion: "git:current",
+      currentRegistryVersion: "git:current",
+      adapters: ["fake"],
+      adapterOverride: "fake",
+    });
+
+    expect(refusal.refused).toBe(true);
+    expect(runState(db, foreignSpec.runId)).toBe("QUEUED");
+    expect(runState(db, ownSpec.runId)).toBe("CANCELLED");
+    expect(refusal.deadLettered).toEqual([
+      expect.objectContaining({ runId: ownSpec.runId }),
+    ]);
   });
 
   test("claimNext unconstrained candidate query: 60 unsatisfiable placement runs do not starve matching run (OPS-454)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2226

Stale queued registry specs are cancelled so singleton scans can schedule fresh replacements.

## Validation

| Check                | Command                                                                                                                                                                                      | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs event-runtime/lib/reaper.test.mjs event-runtime/cli/work.test.mjs --timeout 20000` | pass    | 205 tests, 0 failures              |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                                                                         | pass    | completed; 613 existing warnings   |
| UX critique          | `factory-ux-critic`                                                                                                                                                                          | not run | no user-facing backend surface     |

UX critique: skipped — worker/reaper backend behavior has no user-facing surface.

run:run_09c999b2-386e-493c-b405-5711ecc788b0
