### PR TITLE
fix(runtime): bound merge-fix refusal lookup

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -469,6 +469,31 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
   "merge_fix_ticket_security",
 ]);
 
+export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
+  const refusalCutoff = new Date(
+    Number(now) - MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS,
+  ).toISOString();
+  return db
+    .query(
+      `SELECT a.terminal_state AS terminalState,
+              a.reason_code AS reasonCode,
+              a.finished_at AS finishedAt
+         FROM runs r
+         JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
+        WHERE r.state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
+          AND a.terminal_state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
+          AND a.finished_at > ?
+          AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'
+          AND json_extract(r.spec_json, '$.input.pr') = ?
+          AND json_extract(r.spec_json, '$.input.headSha') = ?
+          AND json_extract(r.spec_json, '$.input.github') = ?
+          AND json_extract(r.spec_json, '$.input.findingHash') = ?
+        ORDER BY a.finished_at DESC, r.rowid DESC
+        LIMIT 1`,
+    )
+    .get(refusalCutoff, item.pr, item.headSha, github, item.findingHash);
+}
+
 /**
  * A terminal merge-fix is normally safe to retry, but retrying the exact same
  * refusal every scan turns a tracker outage or an escalated ticket into a
@@ -485,24 +510,10 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
  */
 function refusedMergeFixSuppressed(db, item, { github, now }) {
   if (!db) return null;
-  const latestTerminalAttempt = db
-    .query(
-      `SELECT a.terminal_state AS terminalState,
-              a.reason_code AS reasonCode,
-              a.finished_at AS finishedAt
-         FROM runs r
-         JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-        WHERE r.state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
-          AND a.terminal_state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
-          AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'
-          AND json_extract(r.spec_json, '$.input.pr') = ?
-          AND json_extract(r.spec_json, '$.input.headSha') = ?
-          AND json_extract(r.spec_json, '$.input.github') = ?
-          AND json_extract(r.spec_json, '$.input.findingHash') = ?
-        ORDER BY a.finished_at DESC, r.rowid DESC
-        LIMIT 1`,
-    )
-    .get(item.pr, item.headSha, github, item.findingHash);
+  const latestTerminalAttempt = latestMergeFixTerminalAttempt(db, item, {
+    github,
+    now,
+  });
   if (
     latestTerminalAttempt?.terminalState !== "REFUSED" ||
     !latestTerminalAttempt.reasonCode

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -469,9 +469,22 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
   "merge_fix_ticket_security",
 ]);
 
+// Slack between a run's creation and its final attempt finishing. Runs are
+// bounded well below this by dispatch timeouts, so a run created before
+// `cooldown + slack` ago cannot have finished inside the cooldown horizon.
+const MERGE_FIX_MAX_RUN_LIFETIME_MS = 24 * 60 * 60_000;
+
 export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
   const refusalCutoff = new Date(
     Number(now) - MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS,
+  ).toISOString();
+  // Pure prefilter on the join's outer loop: it keeps whole runs (and their
+  // json_extract work) out of the scan without ever being the deciding term —
+  // `a.finished_at > refusalCutoff` remains the correctness bound.
+  const runCreatedCutoff = new Date(
+    Number(now) -
+      MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS -
+      MERGE_FIX_MAX_RUN_LIFETIME_MS,
   ).toISOString();
   return db
     .query(
@@ -483,6 +496,7 @@ export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
         WHERE r.state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
           AND a.terminal_state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
           AND a.finished_at > ?
+          AND r.created_at > ?
           AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'
           AND json_extract(r.spec_json, '$.input.pr') = ?
           AND json_extract(r.spec_json, '$.input.headSha') = ?
@@ -491,7 +505,14 @@ export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
         ORDER BY a.finished_at DESC, r.rowid DESC
         LIMIT 1`,
     )
-    .get(refusalCutoff, item.pr, item.headSha, github, item.findingHash);
+    .get(
+      refusalCutoff,
+      runCreatedCutoff,
+      item.pr,
+      item.headSha,
+      github,
+      item.findingHash,
+    );
 }
 
 /**

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -111,6 +111,7 @@ function insertRefusedMergeFix(
     findingHash = REBASE_HASH,
     reasonCode,
     finishedAt = "2026-08-19T16:45:00.000Z",
+    createdAt = finishedAt,
     terminalState = "REFUSED",
   },
 ) {
@@ -121,7 +122,7 @@ function insertRefusedMergeFix(
   db.query(
     `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
      VALUES (?, ?, ?, 'sha256:test', ?, 1, ?, ?)`,
-  ).run(runId, `idem-${runId}`, spec, terminalState, finishedAt, finishedAt);
+  ).run(runId, `idem-${runId}`, spec, terminalState, createdAt, finishedAt);
   db.query(
     `INSERT INTO attempts (run_id, attempt, fencing_token, finished_at, terminal_state, reason_code)
      VALUES (?, 1, 1, ?, ?, ?)`,
@@ -1194,6 +1195,71 @@ describe("merge-scan enumerator (WM-936)", () => {
         now: REFUSED_AT + 6 * 60 * 60_000 + 1,
       }).artifact.fix,
     ).toHaveLength(1);
+  });
+
+  test("the run-created prefilter keeps a long-lived run whose attempt finished inside the horizon", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    // Created 20h before it finished: well outside the 6h cooldown horizon, but
+    // inside the 24h lifetime slack the prefilter allows, so the attempt-side
+    // bound stays the deciding term.
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_long_lived",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+      createdAt: new Date(REFUSED_AT - 20 * 60 * 60_000).toISOString(),
+    });
+
+    expect(
+      latestMergeFixTerminalAttempt(
+        db,
+        { pr: 9, headSha: HEAD, findingHash: REBASE_HASH },
+        { github: GITHUB, now: REFUSED_AT + 60_000 },
+      )?.reasonCode,
+    ).toBe("merge_fix_ticket_escalated");
+    // Smoke check that the scan honours the same suppression; the falsifiable
+    // regression pin is the direct latestMergeFixTerminalAttempt assertion above.
+    expect(
+      conflictingScan(db, { now: REFUSED_AT + 60_000 }).artifact.fix,
+    ).toEqual([]);
+  });
+
+  test("the run-created prefilter drops a run created and finished outside the horizon", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_ancient",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+    });
+
+    // now is 31h after the run was created and finished: past both the 6h
+    // cooldown and the 30h prefilter cutoff.
+    const now = REFUSED_AT + 31 * 60 * 60_000;
+    expect(
+      latestMergeFixTerminalAttempt(
+        db,
+        { pr: 9, headSha: HEAD, findingHash: REBASE_HASH },
+        { github: GITHUB, now },
+      ),
+    ).toBeNull();
+    // Smoke check that the scan is unsuppressed; the falsifiable regression pin
+    // is the direct latestMergeFixTerminalAttempt assertion above.
+    expect(conflictingScan(db, { now }).artifact.fix).toHaveLength(1);
   });
 
   test("a refused escalated merge-fix does not re-emit the identical finding", () => {

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -10,6 +10,7 @@ import {
   defaultProveCi,
   enumerateMergePlan,
   enumerateMergeScan,
+  latestMergeFixTerminalAttempt,
   lookupMergeReview,
   persistMergeReviewFromResult,
   runScanCli,
@@ -1161,6 +1162,39 @@ describe("merge-scan enumerator (WM-936)", () => {
   }
 
   const REFUSED_AT = Date.parse("2026-08-19T16:45:00.000Z");
+
+  test("the terminal-attempt lookup excludes a matching refusal outside the durable horizon", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_expired",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+    });
+
+    expect(
+      latestMergeFixTerminalAttempt(
+        db,
+        { pr: 9, headSha: HEAD, findingHash: REBASE_HASH },
+        {
+          github: GITHUB,
+          now: REFUSED_AT + 6 * 60 * 60_000 + 1,
+        },
+      ),
+    ).toBeNull();
+    expect(
+      conflictingScan(db, {
+        now: REFUSED_AT + 6 * 60 * 60_000 + 1,
+      }).artifact.fix,
+    ).toHaveLength(1);
+  });
 
   test("a refused escalated merge-fix does not re-emit the identical finding", () => {
     const db = openDb(":memory:");


### PR DESCRIPTION
Fixes watt-mind/factory#2229

Bound merge-fix terminal-attempt lookups to the durable cooldown horizon.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass | 41 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2486 pass, 0 failures; warnings only |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend performance query; no user-facing surface

run:run_ff31f63e-7f48-49d2-b739-ac572e763ddd
