### PR TITLE
fix(runtime): move dispatch tracker reads outside claim lock

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4536,59 +4536,11 @@ export async function executeClaimed(
         };
       }
 
-      // Merge-fix never claims a ticket: it only revalidates the already-owned
-      // review ticket. Its tracker read can take the full read timeout, so do
-      // not serialize unrelated dispatch claims behind it.
+      // Tracker reads must finish before a dispatch contender acquires this
+      // repo's claim lock. A tracker brown-out is much longer than the small
+      // mutation window that the lock protects, and serialising it starves
+      // every other claimant for this repository.
       let claimLockHeld = false;
-      if (gate === "dispatch") {
-        claimLockHeld = acquireClaimLock(lockFile, {
-          pid: process.pid,
-          now: nowFn(),
-          isAlive: isAliveFn,
-        });
-        if (!claimLockHeld) {
-          const deferred = deferClaimLockContention(db, {
-            runId,
-            attempt,
-            fencingToken,
-            owner,
-            policyVersion,
-            now: nowFn,
-            maxRequeues: Number.isInteger(
-              dispatchOpts?.maxClaimLockContentionRequeues,
-            )
-              ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
-              : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
-            random: dispatchOpts?.random ?? Math.random,
-          });
-          if (deferred?.fenced) {
-            stopCancellationMonitor();
-            return { fenced: true };
-          }
-          if (deferred?.requeued) {
-            stopCancellationMonitor();
-            return {
-              runId,
-              attempt,
-              terminalState: "QUEUED",
-              reasonCode: "claim_lock_contention",
-              requeueAfterMs: deferred.backoffMs,
-            };
-          }
-          const res = refuseTerminal("claim_lock_starvation", [
-            "dispatch_claim_lock",
-          ]);
-          stopCancellationMonitor();
-          if (res?.fenced) return { fenced: true };
-          return {
-            runId,
-            attempt,
-            terminalState: "REFUSED",
-            reasonCode: "claim_lock_starvation",
-            receipt: res?.receipt,
-          };
-        }
-      }
       const releaseGateLock = () => {
         if (!claimLockHeld) return;
         releaseClaimLock(lockFile);
@@ -4633,6 +4585,10 @@ export async function executeClaimed(
         };
       };
 
+      // Evaluate every read-dependent eligibility check before the claim-lock
+      // acquisition below. The eventual claim remains the concurrency
+      // authority: if the ticket moved after this snapshot, its read-back is a
+      // normal failed claim rather than a second owner.
       let gateResult;
       try {
         if (gate === "merge-fix") {
@@ -4821,11 +4777,60 @@ export async function executeClaimed(
         };
       }
 
+      if (gate === "dispatch") {
+        claimLockHeld = acquireClaimLock(lockFile, {
+          pid: process.pid,
+          now: nowFn(),
+          isAlive: isAliveFn,
+        });
+        if (!claimLockHeld) {
+          const deferred = deferClaimLockContention(db, {
+            runId,
+            attempt,
+            fencingToken,
+            owner,
+            policyVersion,
+            now: nowFn,
+            maxRequeues: Number.isInteger(
+              dispatchOpts?.maxClaimLockContentionRequeues,
+            )
+              ? Math.max(0, dispatchOpts.maxClaimLockContentionRequeues)
+              : DEFAULT_MAX_CLAIM_LOCK_REQUEUES,
+            random: dispatchOpts?.random ?? Math.random,
+          });
+          if (deferred?.fenced) {
+            stopCancellationMonitor();
+            return { fenced: true };
+          }
+          if (deferred?.requeued) {
+            stopCancellationMonitor();
+            return {
+              runId,
+              attempt,
+              terminalState: "QUEUED",
+              reasonCode: "claim_lock_contention",
+              requeueAfterMs: deferred.backoffMs,
+            };
+          }
+          const res = refuseTerminal("claim_lock_starvation", [
+            "dispatch_claim_lock",
+          ]);
+          stopCancellationMonitor();
+          if (res?.fenced) return { fenced: true };
+          return {
+            runId,
+            attempt,
+            terminalState: "REFUSED",
+            reasonCode: "claim_lock_starvation",
+            receipt: res?.receipt,
+          };
+        }
+      }
+
       if (gate === "merge-fix") {
         // The ticket is already assigned and under review by definition. The
         // merge-fix gate proved those live facts; trying the dispatch claim
         // verb here would reject the valid run as ticket_assigned.
-        releaseGateLock();
       } else {
         // The retry gate has already re-read and authenticated the surviving
         // claim. Do not run the mutating claim command again: besides being

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6359,6 +6359,7 @@ sh -c 'sleep 5 & wait'
     );
     const lockFile = dispatchLockPath("factory", locksDir);
     let concurrentClaimantAcquired = false;
+    let lockHeldDuringFetch = null;
     const summary = await executeClaimed(
       db,
       registry,
@@ -6368,6 +6369,7 @@ sh -c 'sleep 5 & wait'
         dispatch: {
           locksDir,
           fetchTicket: () => {
+            lockHeldDuringFetch = existsSync(lockFile);
             concurrentClaimantAcquired = acquireClaimLock(lockFile, {
               pid: 2222,
               isAlive: () => true,
@@ -6384,7 +6386,90 @@ sh -c 'sleep 5 & wait'
       terminalState: "REFUSED",
       reasonCode: "merge_fix_ticket_read_failed",
     });
+    expect(lockHeldDuringFetch).toBe(false);
     expect(concurrentClaimantAcquired).toBe(true);
+    expect(existsSync(lockFile)).toBe(false);
+    db.close();
+  });
+
+  test("a stalled dispatch tracker read occurs before the claim lock", async () => {
+    const db = openDb(":memory:");
+    const locksDir = tmpDir("dispatch-ticket-read-locks-");
+    const ticket = "watt-mind/factory#2228";
+    const description =
+      "## Owned Paths\n- event-runtime/lib/worker.mjs\n\n## Verification Command\n`bun test event-runtime/lib/worker.test.mjs`\n";
+    const lockFile = dispatchLockPath("factory", locksDir);
+    const spec = queueRun(
+      db,
+      makeSpec({
+        agent: "dispatch@1",
+        input: {
+          repo: "factory",
+          ticket,
+          humanDecision: {
+            authorisation: {
+              repo: "factory",
+              ticket,
+              descriptionHash: hashBytes(description),
+              paths: ["event-runtime/lib/worker.mjs"],
+            },
+          },
+        },
+        workspace: { type: "worktree", retainOnFailure: true },
+        outputContract: "factory.dispatch-result/v1",
+      }),
+    );
+    const lockStatesDuringTrackerReads = [];
+    let concurrentClaimantAcquired = false;
+    let claimHeldLock = false;
+    const summary = await runOnce(
+      db,
+      registry,
+      adapters,
+      opts({
+        dispatch: {
+          configSnapshot: dispatchConfigSnapshot(),
+          locksDir,
+          fetchTicket: () => {
+            // Model a stalled tracker request by attempting a concurrent claim
+            // before this reader returns. The contender must not wait on this
+            // read, regardless of how long the real tracker takes to answer.
+            lockStatesDuringTrackerReads.push(existsSync(lockFile));
+            concurrentClaimantAcquired = acquireClaimLock(lockFile, {
+              pid: 2223,
+              isAlive: () => true,
+            });
+            if (concurrentClaimantAcquired) releaseClaimLock(lockFile);
+            return {
+              identifier: ticket,
+              state: { name: "Todo" },
+              assignee: null,
+              labels: { nodes: [{ name: "ai:agent-ready" }] },
+              description,
+            };
+          },
+          fetchInFlight: () => {
+            lockStatesDuringTrackerReads.push(existsSync(lockFile));
+            return [];
+          },
+          countLeases: () => 0,
+          budgetRefusal: () => null,
+          claimTicket: () => {
+            claimHeldLock = existsSync(lockFile);
+            return { ok: false, reasonCode: "ticket_claim_lost" };
+          },
+        },
+      }),
+    );
+
+    expect(summary).toMatchObject({
+      runId: spec.runId,
+      terminalState: "REFUSED",
+      reasonCode: "ticket_claim_lost",
+    });
+    expect(lockStatesDuringTrackerReads).toEqual([false, false]);
+    expect(concurrentClaimantAcquired).toBe(true);
+    expect(claimHeldLock).toBe(true);
     expect(existsSync(lockFile)).toBe(false);
     db.close();
   });


### PR DESCRIPTION
Fixes watt-mind/factory#2228

Move tracker gates before claim-lock acquisition so slow reads cannot serialize dispatch claimants.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs event-runtime/lib/planner.test.mjs --timeout 20000` | pass | 305 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2489 pass, 10 skipped |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — backend worker concurrency change; no user-facing surface.

run:run_5ba8bb00-d162-4eed-9350-cfb553c567a8