### PR TITLE
feat(runtime): make merge-fix refusal cooldowns config-tunable

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -462,12 +462,32 @@ function hasInFlightAgent(db, agent, { github, pr, headSha }) {
   return Boolean(proposal);
 }
 
-const MERGE_FIX_REFUSAL_COOLDOWN_MS = 15 * 60_000;
-const MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS = 6 * 60 * 60_000;
+const MERGE_FIX_REFUSAL_COOLDOWN_DEFAULT_MINUTES = 15;
+const MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_DEFAULT_MINUTES = 6 * 60;
 const DURABLE_MERGE_FIX_REFUSALS = new Set([
   "merge_fix_ticket_escalated",
   "merge_fix_ticket_security",
 ]);
+
+export function mergeFixRefusalCooldownMs(env = process.env) {
+  const minutes = Number(env.FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES);
+  return (
+    (Number.isInteger(minutes) && minutes > 0
+      ? minutes
+      : MERGE_FIX_REFUSAL_COOLDOWN_DEFAULT_MINUTES) * 60_000
+  );
+}
+
+export function mergeFixDurableRefusalCooldownMs(env = process.env) {
+  const minutes = Number(
+    env.FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES,
+  );
+  return (
+    (Number.isInteger(minutes) && minutes > 0
+      ? minutes
+      : MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_DEFAULT_MINUTES) * 60_000
+  );
+}
 
 // Slack between a run's creation and its final attempt finishing. Runs are
 // bounded well below this by dispatch timeouts, so a run created before
@@ -475,16 +495,13 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
 const MERGE_FIX_MAX_RUN_LIFETIME_MS = 24 * 60 * 60_000;
 
 export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
-  const refusalCutoff = new Date(
-    Number(now) - MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS,
-  ).toISOString();
+  const durableCooldownMs = mergeFixDurableRefusalCooldownMs();
+  const refusalCutoff = new Date(Number(now) - durableCooldownMs).toISOString();
   // Pure prefilter on the join's outer loop: it keeps whole runs (and their
   // json_extract work) out of the scan without ever being the deciding term —
   // `a.finished_at > refusalCutoff` remains the correctness bound.
   const runCreatedCutoff = new Date(
-    Number(now) -
-      MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS -
-      MERGE_FIX_MAX_RUN_LIFETIME_MS,
+    Number(now) - durableCooldownMs - MERGE_FIX_MAX_RUN_LIFETIME_MS,
   ).toISOString();
   return db
     .query(
@@ -543,8 +560,8 @@ function refusedMergeFixSuppressed(db, item, { github, now }) {
   const cooldownMs = DURABLE_MERGE_FIX_REFUSALS.has(
     latestTerminalAttempt.reasonCode,
   )
-    ? MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MS
-    : MERGE_FIX_REFUSAL_COOLDOWN_MS;
+    ? mergeFixDurableRefusalCooldownMs()
+    : mergeFixRefusalCooldownMs();
   const finishedAt = Date.parse(latestTerminalAttempt.finishedAt ?? "");
   if (!Number.isFinite(finishedAt)) return null;
   if (Number(now) - finishedAt >= cooldownMs) return null;

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -495,13 +495,21 @@ export function mergeFixDurableRefusalCooldownMs(env = process.env) {
 const MERGE_FIX_MAX_RUN_LIFETIME_MS = 24 * 60 * 60_000;
 
 export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
+  // The query bound must cover the widest cooldown any reason code can earn,
+  // not just the durable one: an operator can configure the durable window
+  // below the transient one, and a bound derived from the durable window alone
+  // would then drop transient refusals that are still inside their cooldown.
   const durableCooldownMs = mergeFixDurableRefusalCooldownMs();
-  const refusalCutoff = new Date(Number(now) - durableCooldownMs).toISOString();
+  const maxCooldownMs = Math.max(
+    durableCooldownMs,
+    mergeFixRefusalCooldownMs(),
+  );
+  const refusalCutoff = new Date(Number(now) - maxCooldownMs).toISOString();
   // Pure prefilter on the join's outer loop: it keeps whole runs (and their
   // json_extract work) out of the scan without ever being the deciding term —
   // `a.finished_at > refusalCutoff` remains the correctness bound.
   const runCreatedCutoff = new Date(
-    Number(now) - durableCooldownMs - MERGE_FIX_MAX_RUN_LIFETIME_MS,
+    Number(now) - maxCooldownMs - MERGE_FIX_MAX_RUN_LIFETIME_MS,
   ).toISOString();
   return db
     .query(

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -12,6 +12,8 @@ import {
   enumerateMergeScan,
   latestMergeFixTerminalAttempt,
   lookupMergeReview,
+  mergeFixDurableRefusalCooldownMs,
+  mergeFixRefusalCooldownMs,
   persistMergeReviewFromResult,
   runScanCli,
   upsertMergeReview,
@@ -36,6 +38,46 @@ const repos = new Map([
     },
   ],
 ]);
+
+describe("merge-fix refusal cooldown configuration", () => {
+  test.each([
+    [
+      "transient",
+      mergeFixRefusalCooldownMs,
+      "FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES",
+      15 * 60_000,
+    ],
+    [
+      "durable",
+      mergeFixDurableRefusalCooldownMs,
+      "FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES",
+      6 * 60 * 60_000,
+    ],
+  ])(
+    "uses the %s default when unset or invalid",
+    (_name, accessor, key, defaultMs) => {
+      expect(accessor({})).toBe(defaultMs);
+      expect(accessor({ [key]: "not-a-number" })).toBe(defaultMs);
+      expect(accessor({ [key]: "0" })).toBe(defaultMs);
+      expect(accessor({ [key]: "1.5" })).toBe(defaultMs);
+    },
+  );
+
+  test.each([
+    [
+      "transient",
+      mergeFixRefusalCooldownMs,
+      "FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES",
+    ],
+    [
+      "durable",
+      mergeFixDurableRefusalCooldownMs,
+      "FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES",
+    ],
+  ])("honours the %s override", (_name, accessor, key) => {
+    expect(accessor({ [key]: "42" })).toBe(42 * 60_000);
+  });
+});
 
 function pr({
   number,

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -1488,6 +1488,104 @@ describe("merge-scan enumerator (WM-936)", () => {
     expect(beforeCooldown.artifact.fix).toEqual([]);
     expect(afterCooldown.artifact.fix).toHaveLength(1);
   });
+
+  function withEnv(key, value, fn) {
+    const previous = process.env[key];
+    process.env[key] = value;
+    try {
+      return fn();
+    } finally {
+      if (previous === undefined) delete process.env[key];
+      else process.env[key] = previous;
+    }
+  }
+
+  test("a durable cooldown configured below the transient one still suppresses a transient refusal", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_narrow_durable",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_read_failed",
+    });
+
+    // The durable window is narrower than the transient one, so a query bound
+    // derived from the durable cooldown alone would drop this refusal five
+    // minutes in and re-dispatch it every scan for the next ten.
+    withEnv("FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES", "1", () => {
+      const now = REFUSED_AT + 5 * 60_000;
+      expect(
+        latestMergeFixTerminalAttempt(
+          db,
+          { pr: 9, headSha: HEAD, findingHash: REBASE_HASH },
+          { github: GITHUB, now },
+        )?.reasonCode,
+      ).toBe("merge_fix_ticket_read_failed");
+      expect(conflictingScan(db, { now }).artifact.fix).toEqual([]);
+    });
+  });
+
+  test("the transient cooldown boundary follows its environment override", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_transient_override",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_read_failed",
+    });
+
+    // 29 minutes in is past the 15-minute default but inside the override.
+    withEnv("FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES", "30", () => {
+      expect(
+        conflictingScan(db, { now: REFUSED_AT + 29 * 60_000 }).artifact.fix,
+      ).toEqual([]);
+      expect(
+        conflictingScan(db, { now: REFUSED_AT + 31 * 60_000 }).artifact.fix,
+      ).toHaveLength(1);
+    });
+  });
+
+  test("the durable cooldown boundary follows its environment override", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "MERGE",
+      plan: planItem(9),
+    });
+    insertRefusedMergeFix(db, {
+      runId: "run_fix_durable_override",
+      pr: 9,
+      reasonCode: "merge_fix_ticket_escalated",
+    });
+
+    // 7h in is past the 6h default but inside the 10h override.
+    withEnv("FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES", "600", () => {
+      expect(
+        conflictingScan(db, { now: REFUSED_AT + 7 * 60 * 60_000 }).artifact.fix,
+      ).toEqual([]);
+      expect(
+        conflictingScan(db, { now: REFUSED_AT + 11 * 60 * 60_000 }).artifact
+          .fix,
+      ).toHaveLength(1);
+    });
+  });
 });
 
 describe("merge-plan batch selection (WM-908)", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2230

Configure merge-fix refusal cooldowns through validated minute-based environment settings.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass | 47 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean |
| UX critique | factory-ux-critic | not run | backend configuration and tests only |

UX critique: skipped — backend configuration and tests only; no user-facing surface

run:run_7117f458-0a4b-4ee2-b155-47544a7be650
