### PR TITLE
fix(runtime): terminalize expired proposed runs

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -3,6 +3,8 @@ import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { artifactsRoot, runtimeHome } from "./config.mjs";
 import { openDb, txImmediate } from "./db.mjs";
+import { transition } from "./lifecycle.mjs";
+import { isProposalExpired } from "./proposals.mjs";
 import { reposRoot } from "./repos.mjs";
 
 /** Bound so a hung Linear call cannot freeze serve forever (OPS-301 review). */
@@ -94,6 +96,64 @@ function sweepTerminalRows(db, { rowCutoff, nowIso, apply }) {
   };
 }
 
+/**
+ * Find proposal runs that no longer have a possible admission path. A run
+ * without any proposal is also dead: its universal proposal condition is
+ * vacuously true and it cannot be approved.
+ */
+function expiredProposedRunIds(db, now) {
+  const proposalsByRun = new Map();
+  for (const row of db
+    .query(
+      `SELECT runs.run_id AS proposed_run_id, proposals.*
+         FROM runs
+         LEFT JOIN proposals ON proposals.run_id = runs.run_id
+        WHERE runs.state = 'PROPOSED'
+        ORDER BY runs.run_id, proposals.rowid`,
+    )
+    .all()) {
+    const proposals = proposalsByRun.get(row.proposed_run_id) ?? [];
+    if (row.id !== null) proposals.push(row);
+    proposalsByRun.set(row.proposed_run_id, proposals);
+  }
+  return [...proposalsByRun].flatMap(([runId, proposals]) =>
+    proposals.every(
+      (proposal) =>
+        proposal.status === "rejected" ||
+        proposal.status === "superseded" ||
+        isProposalExpired(proposal, now),
+    )
+      ? [runId]
+      : [],
+  );
+}
+
+/**
+ * Cancel PROPOSED runs after every proposal is expired or terminally decided.
+ * The candidate query and legal transitions share an immediate transaction so
+ * a concurrent replan cannot insert a fresh proposal between the two.
+ */
+function terminalizeExpiredProposedRuns(db, { now, apply }) {
+  const cancel = () => {
+    const runIds = expiredProposedRunIds(db, now);
+    if (apply) {
+      for (const runId of runIds) {
+        transition(db, {
+          runId,
+          to: "CANCELLED",
+          expectFrom: "PROPOSED",
+          actor: "janitor",
+          reason: "proposal_expired",
+          now,
+        });
+      }
+    }
+    return runIds.length;
+  };
+  const cancelled = apply ? txImmediate(db, cancel) : cancel();
+  return { cancelled, dryRun: !apply };
+}
+
 function retentionMs(days, name) {
   if (!Number.isFinite(days) || days <= 0)
     throw new Error(`${name} must be a positive number of days`);
@@ -138,6 +198,7 @@ export function sweepRuntimeRetention(
     now - retentionMs(rowRetentionDays, "rowRetentionDays"),
   ).toISOString();
   const nowIso = new Date(now).toISOString();
+  const proposed = terminalizeExpiredProposedRuns(db, { now, apply });
   const trace = db
     .query(`SELECT COUNT(*) AS count FROM attempt_trace WHERE ts < ?`)
     .get(traceCutoff).count;
@@ -198,6 +259,7 @@ export function sweepRuntimeRetention(
   const result = {
     trace: { deleted: trace, dryRun: !apply },
     artifacts: { deleted, freedBytes, retained, dryRun: !apply },
+    proposed,
     runs: rows.runs,
     proposals: rows.proposals,
     events: rows.events,
@@ -205,7 +267,7 @@ export function sweepRuntimeRetention(
   };
   log(
     `retention: ${trace} trace rows and ${deleted} artifacts (${freedBytes} bytes)` +
-      `, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
+      `, ${proposed.cancelled} proposed runs, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
       `${apply ? "deleted (VACUUMed)" : "would be deleted"}`,
   );
   return result;

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -134,11 +134,19 @@ describe("terminal row retention (#1065)", () => {
     ).run(runId, `${runId}-key`, state, updatedAt, updatedAt);
   }
 
-  function insertProposal(db, id, status, createdAt, ttlSeconds) {
+  function insertProposal(
+    db,
+    id,
+    status,
+    createdAt,
+    ttlSeconds,
+    { runId = null, decision = "run" } = {},
+  ) {
     db.query(
-      `INSERT INTO proposals (id, event_source, event_id, decision, status, created_at, ttl_seconds)
-       VALUES (?, 'test', ?, 'run', ?, ?, ?)`,
-    ).run(id, `${id}-evt`, status, createdAt, ttlSeconds);
+      `INSERT INTO proposals
+         (id, event_source, event_id, run_id, decision, status, created_at, ttl_seconds)
+       VALUES (?, 'test', ?, ?, ?, ?, ?, ?)`,
+    ).run(id, `${id}-evt`, runId, decision, status, createdAt, ttlSeconds);
   }
 
   function insertEvent(db, eventId, admittedAt, archivedAt) {
@@ -289,6 +297,98 @@ describe("terminal row retention (#1065)", () => {
         .all()
         .map((r) => r.run_id);
       expect(remaining).toEqual(["run-at-cutoff"]);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("terminalizes PROPOSED runs only after every proposal is expired or decided", () => {
+    const root = tmpDir("evrt-proposed-rows-");
+    const store = path.join(root, "artifacts");
+    const db = openDb(path.join(root, "runtime.db"));
+    const expired = new Date(now - 2 * 60 * 60 * 1000).toISOString();
+    const fresh = new Date(now - 5 * 60 * 1000).toISOString();
+    try {
+      mkdirSync(store);
+      for (const runId of [
+        "run-expired",
+        "run-rejected",
+        "run-superseded",
+        "run-mixed",
+        "run-open",
+        "run-without-proposals",
+      ]) {
+        insertRun(db, runId, "PROPOSED", fresh);
+      }
+      insertProposal(db, "proposal-expired", "open", expired, 60, {
+        runId: "run-expired",
+      });
+      insertProposal(db, "proposal-rejected", "rejected", fresh, 3600, {
+        runId: "run-rejected",
+      });
+      insertProposal(db, "proposal-superseded", "superseded", fresh, 3600, {
+        runId: "run-superseded",
+      });
+      insertProposal(db, "proposal-mixed-expired", "open", expired, 60, {
+        runId: "run-mixed",
+      });
+      insertProposal(db, "proposal-mixed-open", "open", fresh, 3600, {
+        runId: "run-mixed",
+      });
+      insertProposal(db, "proposal-open", "open", fresh, 3600, {
+        runId: "run-open",
+      });
+
+      const dry = sweepRuntimeRetention(db, store, { now });
+      expect(dry.proposed).toEqual({ cancelled: 4, dryRun: true });
+      expect(
+        db.query(`SELECT COUNT(*) AS count FROM lifecycle_events`).get().count,
+      ).toBe(0);
+
+      const applied = sweepRuntimeRetention(db, store, { now, apply: true });
+      expect(applied.proposed).toEqual({ cancelled: 4, dryRun: false });
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-expired'`).get()
+          .state,
+      ).toBe("CANCELLED");
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-rejected'`).get()
+          .state,
+      ).toBe("CANCELLED");
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-superseded'`).get()
+          .state,
+      ).toBe("CANCELLED");
+      expect(
+        db
+          .query(
+            `SELECT state FROM runs WHERE run_id = 'run-without-proposals'`,
+          )
+          .get().state,
+      ).toBe("CANCELLED");
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-mixed'`).get()
+          .state,
+      ).toBe("PROPOSED");
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-open'`).get()
+          .state,
+      ).toBe("PROPOSED");
+      expect(
+        db
+          .query(
+            `SELECT reason FROM lifecycle_events
+           WHERE run_id = 'run-expired' AND to_state = 'CANCELLED'`,
+          )
+          .get().reason,
+      ).toBe("proposal_expired");
+
+      expect(
+        sweepRuntimeRetention(db, store, { now, apply: true }).proposed,
+      ).toEqual({
+        cancelled: 0,
+        dryRun: false,
+      });
     } finally {
       db.close();
     }


### PR DESCRIPTION
Fixes watt-mind/factory#2236

Janitor now terminalizes proposal-dead PROPOSED runs without touching runs that retain an open proposal.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/janitor.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2500 pass, 10 skip |
| UX critique          | factory-ux-critic                | not run | backend maintenance; no user-facing surface |

UX critique: skipped — backend maintenance; no user-facing surface

run:run_9cb010c5-2eae-4345-9714-175b529032f2
