### PR TITLE
fix(runtime): clarify pre-claim lock cleanup

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -4547,7 +4547,6 @@ export async function executeClaimed(
         claimLockHeld = false;
       };
       const deferTransientGate = (reasonCode) => {
-        releaseGateLock();
         const deferred = deferTransientDispatchGate(db, {
           runId,
           attempt,
@@ -4680,7 +4679,6 @@ export async function executeClaimed(
         ) {
           return deferTransientGate("linear_read_failed");
         }
-        releaseGateLock();
         throw err;
       }
 
@@ -4709,13 +4707,13 @@ export async function executeClaimed(
           }
           return deferred;
         }
-        releaseGateLock();
         // The retained PR was rejected by the failed run's handoff gate and is
         // still open as a ready (non-draft) PR. Route it to review rather than
         // silently stranding it behind a refused continuation that cannot
         // open a second PR — and hold the PR itself (draft + quoted reason)
-        // so the merge stage cannot land it without a fix round. Runs after
-        // the claim lock is released: both are CLI subprocesses.
+        // so the merge stage cannot land it without a fix round. This happens
+        // before dispatch claim-lock acquisition, so both are independent CLI
+        // subprocesses rather than work inside the claim-lock window.
         if (
           gate === "dispatch" &&
           gateRefusal.reason === "ticket_pr_handoff_verification_failed" &&


### PR DESCRIPTION
Fixes watt-mind/factory#2240

Stale pre-claim cleanup removed and lock-order documentation corrected.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs --timeout 20000` | pass | 179 pass, 0 fail |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 613 existing warnings |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend runtime maintenance; no user-facing surface
run:run_253731f8-9680-48b3-bbec-3854ee34a23b
