### PR TITLE
refactor(runtime): centralize finished run states

### DIFF
--- a/event-runtime/lib/inbox.mjs
+++ b/event-runtime/lib/inbox.mjs
@@ -24,6 +24,7 @@ import {
   templateFor,
 } from "./decision-templates.mjs";
 import { txImmediate } from "./db.mjs";
+import { ALL_TERMINAL_STATES } from "./lifecycle.mjs";
 import { registerInboxDecisionMemos } from "./memos.mjs";
 import { loadRepos } from "./repos.mjs";
 
@@ -1531,13 +1532,6 @@ const LINEAR_POLL_INTERVAL_MS = 60_000;
 const linearPollAt = new WeakMap();
 /** Unactionable parked notices must not remain in the operator queue forever. */
 export const MAX_PARKED_INBOX_AGE_MS = 48 * 60 * 60 * 1000;
-const TERMINAL_RUN_STATES = new Set([
-  "COMPLETED",
-  "FAILED",
-  "REFUSED",
-  "TIMED_OUT",
-  "CANCELLED",
-]);
 // Notices that only report how a run went. Their referent is the run itself,
 // so a terminal run makes them stale. Asks are deliberately excluded: an
 // ESCALATED item is *born* on a REFUSED run, and a decision the operator has
@@ -1942,7 +1936,7 @@ export function reconcileInbox(
       const run = db
         .query("SELECT state FROM runs WHERE run_id = ?")
         .get(refs.runId);
-      if (run && TERMINAL_RUN_STATES.has(run.state)) {
+      if (run && ALL_TERMINAL_STATES.has(run.state)) {
         resolvedBy = "auto:stale_ref";
         resolvedReason = "stale_ref";
       }

--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -3,7 +3,7 @@ import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
 import { artifactsRoot, runtimeHome } from "./config.mjs";
 import { openDb, txImmediate } from "./db.mjs";
-import { transition } from "./lifecycle.mjs";
+import { ALL_TERMINAL_STATES, transition } from "./lifecycle.mjs";
 import { isProposalExpired } from "./proposals.mjs";
 import { reposRoot } from "./repos.mjs";
 
@@ -25,13 +25,7 @@ const SHA256 = /^[a-f0-9]{64}$/;
  * to sweep here. Active/in-flight states (PROPOSED, APPROVED, QUEUED, LEASED,
  * RUNNING, VERIFYING) are deliberately absent so they can never be removed.
  */
-const TERMINAL_RUN_STATES = [
-  "COMPLETED",
-  "REFUSED",
-  "TIMED_OUT",
-  "CANCELLED",
-  "FAILED",
-];
+const TERMINAL_RUN_STATES = [...ALL_TERMINAL_STATES];
 
 /** Per-run child tables keyed by run_id, cleared alongside a swept run. */
 const RUN_CHILD_TABLES = [

--- a/event-runtime/lib/lifecycle.mjs
+++ b/event-runtime/lib/lifecycle.mjs
@@ -30,6 +30,12 @@ export const TERMINAL_STATES = new Set([
   "CANCELLED",
 ]);
 
+/**
+ * Every finished run state. Unlike TERMINAL_STATES, this includes FAILED for
+ * consumers that only need to know whether a run has finished its attempt.
+ */
+export const ALL_TERMINAL_STATES = new Set([...TERMINAL_STATES, "FAILED"]);
+
 const LEGAL = {
   PROPOSED: ["APPROVED", "CANCELLED"],
   APPROVED: ["QUEUED", "CANCELLED"],

--- a/event-runtime/lib/lifecycle.test.mjs
+++ b/event-runtime/lib/lifecycle.test.mjs
@@ -3,6 +3,7 @@ import { describe, expect, test } from "bun:test";
 import path from "node:path";
 import { openDb } from "./db.mjs";
 import {
+  ALL_TERMINAL_STATES,
   IllegalTransition,
   TERMINAL_STATES,
   createRun,
@@ -57,6 +58,22 @@ function failRun(db, runId, attempts) {
 }
 
 describe("lifecycle", () => {
+  test("exports distinct terminal state sets with pinned memberships", () => {
+    expect([...TERMINAL_STATES]).toEqual([
+      "COMPLETED",
+      "REFUSED",
+      "TIMED_OUT",
+      "CANCELLED",
+    ]);
+    expect([...ALL_TERMINAL_STATES]).toEqual([
+      "COMPLETED",
+      "REFUSED",
+      "TIMED_OUT",
+      "CANCELLED",
+      "FAILED",
+    ]);
+  });
+
   test("createRun persists a normalized ticket subject", () => {
     const db = openDb(":memory:");
     createRun(db, {

--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -14,6 +14,7 @@ import path from "node:path";
 import { loadForge, ForgeError } from "../../lib/forge/index.mjs";
 import { sha256Hex } from "./canonical.mjs";
 import { openDb } from "./db.mjs";
+import { ALL_TERMINAL_STATES } from "./lifecycle.mjs";
 import { policyMergeBatchSize } from "./planner.mjs";
 import { getRepo, loadRepos, RepoError } from "./repos.mjs";
 import {
@@ -35,6 +36,9 @@ const GITHUB_REF_TICKET = /(?:^|\/)gh-([0-9]+)$/i;
 const BARE_GITHUB_REF_TICKET = /^([0-9]+)$/;
 const GITHUB_BODY_TICKET =
   /(?:^|\n)\s*fixes\s+([A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+#[0-9]+)\b/i;
+const allTerminalStateList = [...ALL_TERMINAL_STATES]
+  .map((state) => `'${state}'`)
+  .join(", ");
 const PR_LIST_FIELDS = [
   "number",
   "state",
@@ -518,8 +522,8 @@ export function latestMergeFixTerminalAttempt(db, item, { github, now }) {
               a.finished_at AS finishedAt
          FROM runs r
          JOIN attempts a ON a.run_id = r.run_id AND a.attempt = r.attempts
-        WHERE r.state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
-          AND a.terminal_state IN ('REFUSED', 'FAILED', 'COMPLETED', 'TIMED_OUT', 'CANCELLED')
+        WHERE r.state IN (${allTerminalStateList})
+          AND a.terminal_state IN (${allTerminalStateList})
           AND a.finished_at > ?
           AND r.created_at > ?
           AND json_extract(r.spec_json, '$.agent') = 'merge-fix@1'


### PR DESCRIPTION
Fixes watt-mind/factory#2237

Centralize the finished-run state set so lifecycle consumers cannot drift.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/lifecycle.test.mjs event-runtime/lib/merge-reviews.test.mjs event-runtime/lib/janitor.test.mjs event-runtime/lib/inbox.test.mjs --timeout 20000` | pass | 137 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2505 pass, 10 skip, 0 failures |
| UX critique | factory-ux-critic | not run | backend-only state constant refactor |

UX critique: skipped — backend-only state constant refactor

run:run_c36d3127-e3db-4f92-9812-0c028eebf078
