### PR TITLE
fix(runtime): warn on invalid minute config

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -56,6 +56,7 @@ const PR_VIEW_FIELDS = PR_LIST_FIELDS;
 const REBASE_FINDING = "rebase_onto_base";
 const FULL_VERIFICATION_CHECK = "Full verification";
 const REBASE_SKIP_FRESH_CI_DEFAULT_MINUTES = 60;
+const invalidMinuteConfigWarnings = new Set();
 const IN_FLIGHT_RUN_STATES = [
   "PROPOSED",
   "APPROVED",
@@ -273,11 +274,25 @@ function normalizeListedPr(raw, baseSha, github) {
   };
 }
 
-function rebaseSkipFreshCiMinutes(env = process.env) {
-  const value = Number(env.FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES);
-  return Number.isInteger(value) && value > 0
-    ? value
-    : REBASE_SKIP_FRESH_CI_DEFAULT_MINUTES;
+function positiveIntegerMinutes(env, name, defaultMinutes) {
+  const raw = env[name];
+  const value = Number(raw);
+  if (Number.isInteger(value) && value > 0) return value;
+  if (raw !== undefined && !invalidMinuteConfigWarnings.has(name)) {
+    invalidMinuteConfigWarnings.add(name);
+    console.warn(
+      `invalid ${name}=${JSON.stringify(raw)}; using default ${defaultMinutes} minutes`,
+    );
+  }
+  return defaultMinutes;
+}
+
+export function rebaseSkipFreshCiMinutes(env = process.env) {
+  return positiveIntegerMinutes(
+    env,
+    "FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES",
+    REBASE_SKIP_FRESH_CI_DEFAULT_MINUTES,
+  );
 }
 
 function fullVerificationRebaseSkip({ forge, github, pr, now }) {
@@ -474,22 +489,22 @@ const DURABLE_MERGE_FIX_REFUSALS = new Set([
 ]);
 
 export function mergeFixRefusalCooldownMs(env = process.env) {
-  const minutes = Number(env.FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES);
   return (
-    (Number.isInteger(minutes) && minutes > 0
-      ? minutes
-      : MERGE_FIX_REFUSAL_COOLDOWN_DEFAULT_MINUTES) * 60_000
+    positiveIntegerMinutes(
+      env,
+      "FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES",
+      MERGE_FIX_REFUSAL_COOLDOWN_DEFAULT_MINUTES,
+    ) * 60_000
   );
 }
 
 export function mergeFixDurableRefusalCooldownMs(env = process.env) {
-  const minutes = Number(
-    env.FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES,
-  );
   return (
-    (Number.isInteger(minutes) && minutes > 0
-      ? minutes
-      : MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_DEFAULT_MINUTES) * 60_000
+    positiveIntegerMinutes(
+      env,
+      "FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES",
+      MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_DEFAULT_MINUTES,
+    ) * 60_000
   );
 }
 

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -15,6 +15,7 @@ import {
   mergeFixDurableRefusalCooldownMs,
   mergeFixRefusalCooldownMs,
   persistMergeReviewFromResult,
+  rebaseSkipFreshCiMinutes,
   runScanCli,
   upsertMergeReview,
 } from "./merge-reviews.mjs";
@@ -42,41 +43,83 @@ const repos = new Map([
 describe("merge-fix refusal cooldown configuration", () => {
   test.each([
     [
+      "rebase fresh-CI",
+      rebaseSkipFreshCiMinutes,
+      "FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES",
+      60,
+      60,
+    ],
+    [
       "transient",
       mergeFixRefusalCooldownMs,
       "FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES",
       15 * 60_000,
+      15,
     ],
     [
       "durable",
       mergeFixDurableRefusalCooldownMs,
       "FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES",
       6 * 60 * 60_000,
+      6 * 60,
     ],
   ])(
-    "uses the %s default when unset or invalid",
-    (_name, accessor, key, defaultMs) => {
-      expect(accessor({})).toBe(defaultMs);
-      expect(accessor({ [key]: "not-a-number" })).toBe(defaultMs);
-      expect(accessor({ [key]: "0" })).toBe(defaultMs);
-      expect(accessor({ [key]: "1.5" })).toBe(defaultMs);
+    "warns once and uses the %s default for invalid values",
+    (_name, accessor, key, defaultValue, defaultMinutes) => {
+      const warnings = [];
+      const warn = console.warn;
+      console.warn = (message) => warnings.push(message);
+      try {
+        expect(accessor({ [key]: "not-a-number" })).toBe(defaultValue);
+        expect(accessor({ [key]: "0" })).toBe(defaultValue);
+        expect(accessor({ [key]: "1.5" })).toBe(defaultValue);
+      } finally {
+        console.warn = warn;
+      }
+      expect(warnings).toHaveLength(1);
+      expect(warnings[0]).toContain(key);
+      expect(warnings[0]).toContain("not-a-number");
+      expect(warnings[0]).toContain(`${defaultMinutes} minutes`);
     },
   );
 
   test.each([
     [
+      "rebase fresh-CI",
+      rebaseSkipFreshCiMinutes,
+      "FACTORY_MERGE_REBASE_SKIP_FRESH_CI_MINUTES",
+      60,
+      42,
+    ],
+    [
       "transient",
       mergeFixRefusalCooldownMs,
       "FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES",
+      15 * 60_000,
+      42 * 60_000,
     ],
     [
       "durable",
       mergeFixDurableRefusalCooldownMs,
       "FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES",
+      6 * 60 * 60_000,
+      42 * 60_000,
     ],
-  ])("honours the %s override", (_name, accessor, key) => {
-    expect(accessor({ [key]: "42" })).toBe(42 * 60_000);
-  });
+  ])(
+    "is silent when the %s value is unset or valid",
+    (_name, accessor, key, defaultValue, validValue) => {
+      const warnings = [];
+      const warn = console.warn;
+      console.warn = (message) => warnings.push(message);
+      try {
+        expect(accessor({})).toBe(defaultValue);
+        expect(accessor({ [key]: "42" })).toBe(validValue);
+      } finally {
+        console.warn = warn;
+      }
+      expect(warnings).toEqual([]);
+    },
+  );
 });
 
 function pr({


### PR DESCRIPTION
Fixes watt-mind/factory#2255

Invalid minute-valued merge-review configuration now warns once while retaining its safe default.

## Validation

| Check                | Command                                                                                                                                            | Result  | Notes                                  |
| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass    | 56 tests, 0 failures                   |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`                              | pass    | lib tests, emit, format, lint clean    |
| UX critique          | `factory-ux-critic`                                                                                                                               | not run | backend configuration; no user surface |

UX critique: skipped — backend configuration accessors; no user-facing surface
run:run_256d2cac-995e-4afc-beae-28a9a8ad2e95
