### PR TITLE
test(runtime): count merge-fix claim-lock acquisitions

### DIFF
--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -3810,6 +3810,7 @@ export async function executeClaimed(
     sandboxAvailability,
     materializeWorktree,
     localNotifyFetch,
+    acquireClaimLock: acquireClaimLockFn = acquireClaimLock,
     verifyResult: verifyResultFn = verifyResult,
   } = {},
 ) {
@@ -4776,7 +4777,7 @@ export async function executeClaimed(
       }
 
       if (gate === "dispatch") {
-        claimLockHeld = acquireClaimLock(lockFile, {
+        claimLockHeld = acquireClaimLockFn(lockFile, {
           pid: process.pid,
           now: nowFn(),
           isAlive: isAliveFn,

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6359,6 +6359,7 @@ sh -c 'sleep 5 & wait'
     );
     const lockFile = dispatchLockPath("factory", locksDir);
     let concurrentClaimantAcquired = false;
+    let acquireClaimLockCalls = 0;
     const lockStates = [];
     const observeLock = () => lockStates.push(existsSync(lockFile));
     const summary = await executeClaimed(
@@ -6374,6 +6375,10 @@ sh -c 'sleep 5 & wait'
       },
       claimNext(db, opts()),
       opts({
+        acquireClaimLock: (...args) => {
+          acquireClaimLockCalls += 1;
+          return acquireClaimLock(...args);
+        },
         dispatch: {
           locksDir,
           fetchTicket: () => {
@@ -6408,7 +6413,9 @@ sh -c 'sleep 5 & wait'
       reasonCode: "agent_exit_1",
     });
     observeLock();
-    expect(lockStates).toEqual([false, false, false, false, false]);
+    expect(acquireClaimLockCalls).toBe(0);
+    expect(lockStates.length).toBeGreaterThan(0);
+    expect(lockStates.every((state) => state === false)).toBe(true);
     expect(concurrentClaimantAcquired).toBe(true);
     expect(existsSync(lockFile)).toBe(false);
     db.close();


### PR DESCRIPTION
Fixes watt-mind/factory#2252

Review the acquisition seam that makes the merge-fix claim-lock regression test gap-free.

## Validation

| Check                | Command                                                                                                                        | Result  | Notes                    |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------ |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs --timeout 20000` | pass | 179 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (613 warnings) |
| UX critique          | `factory-ux-critic`                                                                                                             | not run | no user-facing surface |

UX critique: skipped — no user-facing surface
run:run_c59c38ef-f634-42a3-9c86-fb83d1e49077