### PR TITLE
fix(runtime): terminalize proposed runs without live proposals

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -111,14 +111,12 @@ function expiredProposedRunIds(db, now) {
     proposalsByRun.set(row.proposed_run_id, proposals);
   }
   return [...proposalsByRun].flatMap(([runId, proposals]) =>
-    proposals.every(
+    proposals.some(
       (proposal) =>
-        proposal.status === "rejected" ||
-        proposal.status === "superseded" ||
-        isProposalExpired(proposal, now),
+        proposal.status === "open" && !isProposalExpired(proposal, now),
     )
-      ? [runId]
-      : [],
+      ? []
+      : [runId],
   );
 }
 

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -302,7 +302,7 @@ describe("terminal row retention (#1065)", () => {
     }
   });
 
-  test("terminalizes PROPOSED runs only after every proposal is expired or decided", () => {
+  test("terminalizes PROPOSED runs when no live proposal remains", () => {
     const root = tmpDir("evrt-proposed-rows-");
     const store = path.join(root, "artifacts");
     const db = openDb(path.join(root, "runtime.db"));
@@ -314,6 +314,8 @@ describe("terminal row retention (#1065)", () => {
         "run-expired",
         "run-rejected",
         "run-superseded",
+        "run-resolved-noop",
+        "run-expired-human-needed",
         "run-mixed",
         "run-open",
         "run-without-proposals",
@@ -329,6 +331,21 @@ describe("terminal row retention (#1065)", () => {
       insertProposal(db, "proposal-superseded", "superseded", fresh, 3600, {
         runId: "run-superseded",
       });
+      insertProposal(db, "proposal-resolved-noop", "resolved", fresh, 3600, {
+        runId: "run-resolved-noop",
+        decision: "noop",
+      });
+      insertProposal(
+        db,
+        "proposal-expired-human-needed",
+        "expired",
+        fresh,
+        3600,
+        {
+          runId: "run-expired-human-needed",
+          decision: "human_needed",
+        },
+      );
       insertProposal(db, "proposal-mixed-expired", "open", expired, 60, {
         runId: "run-mixed",
       });
@@ -340,13 +357,13 @@ describe("terminal row retention (#1065)", () => {
       });
 
       const dry = sweepRuntimeRetention(db, store, { now });
-      expect(dry.proposed).toEqual({ cancelled: 4, dryRun: true });
+      expect(dry.proposed).toEqual({ cancelled: 6, dryRun: true });
       expect(
         db.query(`SELECT COUNT(*) AS count FROM lifecycle_events`).get().count,
       ).toBe(0);
 
       const applied = sweepRuntimeRetention(db, store, { now, apply: true });
-      expect(applied.proposed).toEqual({ cancelled: 4, dryRun: false });
+      expect(applied.proposed).toEqual({ cancelled: 6, dryRun: false });
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-expired'`).get()
           .state,
@@ -358,6 +375,18 @@ describe("terminal row retention (#1065)", () => {
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-superseded'`).get()
           .state,
+      ).toBe("CANCELLED");
+      expect(
+        db
+          .query(`SELECT state FROM runs WHERE run_id = 'run-resolved-noop'`)
+          .get().state,
+      ).toBe("CANCELLED");
+      expect(
+        db
+          .query(
+            `SELECT state FROM runs WHERE run_id = 'run-expired-human-needed'`,
+          )
+          .get().state,
       ).toBe("CANCELLED");
       expect(
         db


### PR DESCRIPTION
Fixes watt-mind/factory#2248

Review the inverted liveness predicate and its terminal proposal coverage.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/janitor.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; 613 pre-existing warnings |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — backend janitor predicate and unit tests only
run:run_16373e22-4091-44c5-b826-62799f4c55d9
