### PR TITLE
refactor(tools): share dispatch terminal states (#2251)

### DIFF
--- a/orchestrator/watchdog.mjs
+++ b/orchestrator/watchdog.mjs
@@ -712,6 +712,8 @@ export async function sendWatchdogNotification(issues) {
  * Run states that do not occupy the factory. Mirrors the singleton predicate
  * in event-runtime/lib/schedules.mjs — PROPOSED is deliberately *not* in
  * flight (an unapproved proposal is exactly the stall we are here to clear).
+ * This intentionally differs from ALL_TERMINAL_STATES because it includes
+ * PROPOSED; do not replace it with the lifecycle export.
  */
 export const IDLE_TERMINAL_RUN_STATES = new Set([
   "PROPOSED",

--- a/orchestrator/watchdog.test.mjs
+++ b/orchestrator/watchdog.test.mjs
@@ -1,6 +1,7 @@
 import { test, expect } from "bun:test";
 import { readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
+import { ALL_TERMINAL_STATES } from "../event-runtime/lib/lifecycle.mjs";
 import {
   assessServeHealth,
   controlApiFailureCode,
@@ -14,10 +15,17 @@ import {
   runIdleWatchdogTick,
   runWatchdogCheck,
   FLEET_CHECK_TIMEOUT_MS,
+  IDLE_TERMINAL_RUN_STATES,
   SANDBOX_REFUSAL_MAX_PAGES,
   SANDBOX_REFUSAL_MAX_RUNS,
   SCAN_LOOP_AGENTS,
 } from "./watchdog.mjs";
+
+test("idle terminal states add only PROPOSED to lifecycle terminal states", () => {
+  expect([...IDLE_TERMINAL_RUN_STATES].sort()).toEqual(
+    [...ALL_TERMINAL_STATES, "PROPOSED"].sort(),
+  );
+});
 
 test("assessServeHealth flags a served stale registry and reload error", () => {
   const result = assessServeHealth(

--- a/tools/dispatch.mjs
+++ b/tools/dispatch.mjs
@@ -13,6 +13,7 @@
  */
 import { parseArgs } from "node:util";
 import { unauthorizedMessage } from "../event-runtime/lib/client.mjs";
+import { ALL_TERMINAL_STATES } from "../event-runtime/lib/lifecycle.mjs";
 
 export const DEFAULT_PORT = 7381;
 export const DEFAULT_TIMEOUT_MS = 30_000;
@@ -24,13 +25,7 @@ export const EXIT = {
   RUN_NOT_COMPLETED: 2,
   NO_PROPOSAL: 3,
 };
-const TERMINAL_STATES = new Set([
-  "COMPLETED",
-  "FAILED",
-  "CANCELLED",
-  "REFUSED",
-  "TIMED_OUT",
-]);
+export const TERMINAL_STATES = ALL_TERMINAL_STATES;
 
 export function resolvePort(env = process.env) {
   return env.FACTORY_EVENT_PORT ? Number(env.FACTORY_EVENT_PORT) : DEFAULT_PORT;

--- a/tools/dispatch.test.mjs
+++ b/tools/dispatch.test.mjs
@@ -1,13 +1,20 @@
 import { expect, test } from "bun:test";
 import path from "node:path";
+import { ALL_TERMINAL_STATES } from "../event-runtime/lib/lifecycle.mjs";
 import {
   DEFAULT_PORT,
   DEFAULT_TIMEOUT_MS,
   resolvePort,
   resolveTimeoutMs,
+  TERMINAL_STATES,
 } from "./dispatch.mjs";
 
 const DISPATCH = path.join(import.meta.dir, "dispatch.mjs");
+
+test("dispatch terminal states derive from the lifecycle terminal states", () => {
+  expect(TERMINAL_STATES).toBe(ALL_TERMINAL_STATES);
+  expect([...TERMINAL_STATES].sort()).toEqual([...ALL_TERMINAL_STATES].sort());
+});
 
 async function runDispatch(server, args, extraEnv = {}) {
   const child = Bun.spawn(["bun", DISPATCH, ...args], {


### PR DESCRIPTION
Fixes #2251

Dispatch now consumes the canonical lifecycle terminal-state set while watchdog's intentional PROPOSED exception is pinned by tests.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test tools/dispatch.test.mjs orchestrator/watchdog.test.mjs --timeout 20000` | pass | 71 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,505 pass, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — internal CLI/orchestrator refactor with no user-facing surface

run:run_aa315d13-db66-49c8-8b3a-2a2c4bab8550