### PR TITLE
fix(runtime): age-floor proposal-less proposed runs

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -1,7 +1,11 @@
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, rmSync, statSync } from "node:fs";
 import path from "node:path";
-import { artifactsRoot, runtimeHome } from "./config.mjs";
+import {
+  artifactsRoot,
+  DEFAULT_PROPOSAL_TTL_SECONDS,
+  runtimeHome,
+} from "./config.mjs";
 import { openDb, txImmediate } from "./db.mjs";
 import { ALL_TERMINAL_STATES, transition } from "./lifecycle.mjs";
 import { isProposalExpired } from "./proposals.mjs";
@@ -92,31 +96,47 @@ function sweepTerminalRows(db, { rowCutoff, nowIso, apply }) {
 
 /**
  * Find proposal runs that no longer have a possible admission path. A run
- * without any proposal is also dead: its universal proposal condition is
- * vacuously true and it cannot be approved.
+ * without any proposal is only dead after the proposal TTL: a just-created
+ * run may still be between its creation and proposal insert statements.
  */
 function expiredProposedRunIds(db, now) {
   const proposalsByRun = new Map();
   for (const row of db
     .query(
-      `SELECT runs.run_id AS proposed_run_id, proposals.*
+      `SELECT runs.run_id AS proposed_run_id,
+              runs.created_at AS run_created_at,
+              proposals.*
          FROM runs
          LEFT JOIN proposals ON proposals.run_id = runs.run_id
         WHERE runs.state = 'PROPOSED'
         ORDER BY runs.run_id, proposals.rowid`,
     )
     .all()) {
-    const proposals = proposalsByRun.get(row.proposed_run_id) ?? [];
-    if (row.id !== null) proposals.push(row);
-    proposalsByRun.set(row.proposed_run_id, proposals);
+    const entry = proposalsByRun.get(row.proposed_run_id) ?? {
+      createdAt: row.run_created_at,
+      proposals: [],
+    };
+    if (row.id !== null) entry.proposals.push(row);
+    proposalsByRun.set(row.proposed_run_id, entry);
   }
-  return [...proposalsByRun].flatMap(([runId, proposals]) =>
+  return [...proposalsByRun].flatMap(([runId, { createdAt, proposals }]) =>
     proposals.some(
       (proposal) =>
         proposal.status === "open" && !isProposalExpired(proposal, now),
     )
       ? []
-      : [runId],
+      : proposals.length === 0 &&
+          !isProposalLessRunExpired(createdAt, now)
+        ? []
+        : [runId],
+  );
+}
+
+function isProposalLessRunExpired(createdAt, now) {
+  const createdAtMs = Date.parse(createdAt);
+  return (
+    Number.isFinite(createdAtMs) &&
+    createdAtMs + DEFAULT_PROPOSAL_TTL_SECONDS * 1000 < now
   );
 }
 

--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -125,8 +125,7 @@ function expiredProposedRunIds(db, now) {
         proposal.status === "open" && !isProposalExpired(proposal, now),
     )
       ? []
-      : proposals.length === 0 &&
-          !isProposalLessRunExpired(createdAt, now)
+      : proposals.length === 0 && !isProposalLessRunExpired(createdAt, now)
         ? []
         : [runId],
   );

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test";
 import { mkdirSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-janitor-test-mjs";
+import { DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
 import { openDb } from "./db.mjs";
 import {
   DEFAULT_ARTIFACT_RETENTION_DAYS,
@@ -308,6 +309,9 @@ describe("terminal row retention (#1065)", () => {
     const db = openDb(path.join(root, "runtime.db"));
     const expired = new Date(now - 2 * 60 * 60 * 1000).toISOString();
     const fresh = new Date(now - 5 * 60 * 1000).toISOString();
+    const oldWithoutProposals = new Date(
+      now - DEFAULT_PROPOSAL_TTL_SECONDS * 1000 - 1,
+    ).toISOString();
     try {
       mkdirSync(store);
       for (const runId of [
@@ -318,9 +322,15 @@ describe("terminal row retention (#1065)", () => {
         "run-expired-human-needed",
         "run-mixed",
         "run-open",
-        "run-without-proposals",
+        "run-without-proposals-fresh",
+        "run-without-proposals-old",
       ]) {
-        insertRun(db, runId, "PROPOSED", fresh);
+        insertRun(
+          db,
+          runId,
+          "PROPOSED",
+          runId === "run-without-proposals-old" ? oldWithoutProposals : fresh,
+        );
       }
       insertProposal(db, "proposal-expired", "open", expired, 60, {
         runId: "run-expired",
@@ -391,7 +401,16 @@ describe("terminal row retention (#1065)", () => {
       expect(
         db
           .query(
-            `SELECT state FROM runs WHERE run_id = 'run-without-proposals'`,
+            `SELECT state FROM runs
+             WHERE run_id = 'run-without-proposals-fresh'`,
+          )
+          .get().state,
+      ).toBe("PROPOSED");
+      expect(
+        db
+          .query(
+            `SELECT state FROM runs
+             WHERE run_id = 'run-without-proposals-old'`,
           )
           .get().state,
       ).toBe("CANCELLED");


### PR DESCRIPTION
Fixes watt-mind/factory#2249

Age proposal-less PROPOSED runs by 30 minutes before janitor cancellation.

## Validation

| Check                | Command                                                                                                                      | Result  | Notes                                      |
| -------------------- | ---------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/janitor.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2507 pass, 10 skipped; lint warnings only |
| UX critique          | `factory-ux-critic` | not run | backend retention logic; no user-facing surface |

UX critique: skipped — backend retention logic; no user-facing surface
run:run_39ef2466-2cce-4be3-8fff-74dd3514d8cc