### PR TITLE
docs(agents): document merge-fix cooldowns

### DIFF
--- a/event-runtime/agents/merge-fix.json
+++ b/event-runtime/agents/merge-fix.json
@@ -20,7 +20,7 @@
   "limits": { "timeout_seconds": 2700, "attempts": 1, "budget_usd": 15 },
   "mutating": true,
   "pins": {
-    "agents/merge-fix.md": "sha256:42015b3e724645bfa3d445ce85818c692db631595462af4f48ad68267d197ad7",
+    "agents/merge-fix.md": "sha256:b0fe10f442706b568065b4c9a5da7fabdcddb573cbc31c32654cdd58964f0d11",
     "schemas/merge-fix.input.json": "sha256:332e1c82296541678b8f95b49f65fba63a87219315dbfc6b9556cd4d3df9ecbd",
     "schemas/merge-fix.output.json": "sha256:636ab0de7337d7358e47fd95c52abc80eedbebb618a968f9546b67da07150ff3"
   }

--- a/event-runtime/agents/merge-fix.md
+++ b/event-runtime/agents/merge-fix.md
@@ -54,6 +54,15 @@ isolated worktree for the ticket. This is not a general implementation run.
      gh api "repos/<github>/commits/${expectedRemoteSha}/check-runs?per_page=100"
      ```
 
+     Refused merge-fix findings are retried after
+     `FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES` (default `15` minutes).
+     Refusals with reason `merge_fix_ticket_escalated` or
+     `merge_fix_ticket_security` use the longer
+     `FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES` (default `360`
+     minutes) because they need a human to clear a blocker. The refusal lookup
+     is bounded by the larger of these two cooldowns, so raising either one
+     widens the scan window for both kinds of refusal.
+
      A `CONFLICTING` PR still needs a rebase even when CI is running or fresh.
      Query the live PR labels too (`gh pr view <pr> --repo <github> --json
 labels`); an `ai:landing` label always blocks this mechanical rebase with

--- a/event-runtime/agents/merge-scan.json
+++ b/event-runtime/agents/merge-scan.json
@@ -23,7 +23,7 @@
     }
   ],
   "pins": {
-    "agents/merge-scan.md": "sha256:7bd516697f5330f3700f7e5a50ebc20e804b73fbe3a03abb3fcb205e864883a4",
+    "agents/merge-scan.md": "sha256:7e6df7dc4c419423299851b9b0a78881e5899a41f73ad8e08d9d3151e97a7b7d",
     "schemas/merge-scan.input.json": "sha256:dcd0cf7d2c17ae1142edc93d2e48016c23f824e2447edc4bc929daf89ec9d80b",
     "schemas/merge-scan.output.json": "sha256:e7edeca34a7a702ab35301de599b3a8dcb137e62f33f5a63df399318df04a636"
   }

--- a/event-runtime/agents/merge-scan.md
+++ b/event-runtime/agents/merge-scan.md
@@ -26,6 +26,13 @@ running `merge-review@1` proposal or run already exists at the same
 queued as `planRequests[]` so `merge-plan@1` can batch them. `plan[]` on a
 scan artifact is always empty.
 
+The scan also suppresses a prior refused merge-fix finding for
+`FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES` (default 15 minutes). The durable
+cooldown, `FACTORY_MERGE_FIX_DURABLE_REFUSAL_COOLDOWN_MINUTES` (default 360
+minutes), applies to `merge_fix_ticket_escalated` and
+`merge_fix_ticket_security` refusals. Its refusal lookup is bounded by the
+larger cooldown, so raising either setting widens the scan window for both.
+
 When `prNumbers` is absent, enumerate **all** open PRs and consider every
 base-targeting, non-draft PR. Emit an `escalate[]` item for every non-draft PR
 with an identifiable ticket that targets a different base, and name every

--- a/event-runtime/lib/registry.test.mjs
+++ b/event-runtime/lib/registry.test.mjs
@@ -449,8 +449,10 @@ describe("registry", () => {
     // celld-smoke@1 on the claude adapter, so the merged view gains a mapping.
     // Regenerated (#2208): celld-smoke's documented interaction details are
     // optional artifact fields, and the definition was re-pinned.
+    // Regenerated (#2254): merge-fix and merge-scan document their refusal
+    // cooldown tunables and are re-pinned.
     const expected =
-      "sha256:f081d6b00380dd88c13822a7b532c107ae974befd8f5ff9e4543f72e733cc882";
+      "sha256:9d9c76cd1295cac210de3fbf6660521e6269ebe60b8bb28adb70e38637ca98b1";
     expect(registryDigest(loadRegistry({ packRoots: [] }))).toBe(expected);
   });
 


### PR DESCRIPTION
Fixes watt-mind/factory#2254

Document both refusal cooldowns, their durable-reason scope, and the shared lookback bound.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/registry.test.mjs --timeout 20000 && grep -l FACTORY_MERGE_FIX_REFUSAL_COOLDOWN_MINUTES event-runtime/agents/merge-fix.md` | pass | 61 pass, prompt found |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2,507 pass; emit, format, lint clean |
| UX critique | factory-ux-critic | not run | docs-only; no user-facing surface |

UX critique: skipped — no user-facing surface
run:run_583ff0fa-a932-4f98-af08-36475f0c031c