### PR TITLE
fix(runtime): separate cancelled runs in retention log

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -278,7 +278,8 @@ export function sweepRuntimeRetention(
   };
   log(
     `retention: ${trace} trace rows and ${deleted} artifacts (${freedBytes} bytes)` +
-      `, ${proposed.cancelled} proposed runs, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
+      `, ${proposed.cancelled} proposed runs ${apply ? "cancelled" : "would be cancelled"}` +
+      `, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
       `${apply ? "deleted (VACUUMed)" : "would be deleted"}`,
   );
   return result;

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -366,14 +366,29 @@ describe("terminal row retention (#1065)", () => {
         runId: "run-open",
       });
 
-      const dry = sweepRuntimeRetention(db, store, { now });
+      const dryLog = [];
+      const dry = sweepRuntimeRetention(db, store, {
+        now,
+        log: (message) => dryLog.push(message),
+      });
       expect(dry.proposed).toEqual({ cancelled: 6, dryRun: true });
+      expect(dryLog).toEqual([
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 6 proposed runs would be cancelled, 0 runs, 0 proposals, 0 events would be deleted",
+      ]);
       expect(
         db.query(`SELECT COUNT(*) AS count FROM lifecycle_events`).get().count,
       ).toBe(0);
 
-      const applied = sweepRuntimeRetention(db, store, { now, apply: true });
+      const applyLog = [];
+      const applied = sweepRuntimeRetention(db, store, {
+        now,
+        apply: true,
+        log: (message) => applyLog.push(message),
+      });
       expect(applied.proposed).toEqual({ cancelled: 6, dryRun: false });
+      expect(applyLog).toEqual([
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 6 proposed runs cancelled, 0 runs, 0 proposals, 0 events deleted (VACUUMed)",
+      ]);
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-expired'`).get()
           .state,


### PR DESCRIPTION
Fixes watt-mind/factory#2250

Separate cancelled PROPOSED-run counts from deleted-row retention totals.

## Validation

| Check | Command | Result | Notes |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/janitor.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2507 pass, 0 failures |
| UX critique | factory-ux-critic | not run | no user-facing surface |

UX critique: skipped — no user-facing surface

run:run_b657ce06-cf25-4f05-a5a9-4548f59d15f0
