### PR TITLE
test(runtime): pin dispatch claim lock seam liveness

### DIFF
--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -6449,6 +6449,7 @@ sh -c 'sleep 5 & wait'
       }),
     );
     const lockStatesDuringTrackerReads = [];
+    let acquireClaimLockCalls = 0;
     let concurrentClaimantAcquired = false;
     let claimHeldLock = false;
     const summary = await runOnce(
@@ -6456,6 +6457,10 @@ sh -c 'sleep 5 & wait'
       registry,
       adapters,
       opts({
+        acquireClaimLock: (...args) => {
+          acquireClaimLockCalls += 1;
+          return acquireClaimLock(...args);
+        },
         dispatch: {
           configSnapshot: dispatchConfigSnapshot(),
           locksDir,
@@ -6496,6 +6501,7 @@ sh -c 'sleep 5 & wait'
       terminalState: "REFUSED",
       reasonCode: "ticket_claim_lost",
     });
+    expect(acquireClaimLockCalls).toBeGreaterThan(0);
     expect(lockStatesDuringTrackerReads).toEqual([false, false]);
     expect(concurrentClaimantAcquired).toBe(true);
     expect(claimHeldLock).toBe(true);


### PR DESCRIPTION
Fixes watt-mind/factory#2269

Pins the dispatch claim-lock injection seam so the structural lock-order test cannot become vacuous.

## Validation

| Check                | Command                          | Result  | Notes                              |
| -------------------- | -------------------------------- | ------- | ---------------------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/worker.test.mjs --timeout 20000` | pass | 179 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2507 pass, 10 skip, 0 failures |
| UX critique          | factory-ux-critic                | not run | test-only runtime change; no user-facing surface |


UX critique: skipped — test-only runtime change; no user-facing surface

run:run_ae9cd5c3-51db-474a-861f-fc046a9221f3
