### PR TITLE
fix(runtime): pin janitor approved proposal invariant

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -140,7 +140,9 @@ function isProposalLessRunExpired(createdAt, now) {
 }
 
 /**
- * Cancel PROPOSED runs after every proposal is expired or terminally decided.
+ * Cancel PROPOSED runs when no open proposal remains within its TTL. Runs
+ * without proposals wait one proposal TTL, allowing proposal insertion to
+ * follow run creation.
  * The candidate query and legal transitions share an immediate transaction so
  * a concurrent replan cannot insert a fresh proposal between the two.
  */

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -320,6 +320,7 @@ describe("terminal row retention (#1065)", () => {
         "run-superseded",
         "run-resolved-noop",
         "run-expired-human-needed",
+        "run-approved",
         "run-mixed",
         "run-open",
         "run-without-proposals-fresh",
@@ -356,6 +357,13 @@ describe("terminal row retention (#1065)", () => {
           decision: "human_needed",
         },
       );
+      // This fixture must remain otherwise unreachable: approveRun transitions
+      // PROPOSED -> APPROVED -> QUEUED before it marks the proposal approved,
+      // and tier escalation transitions before inserting its approved proposal.
+      // If either ordering changes, the janitor correctly sweeps this run.
+      insertProposal(db, "proposal-approved", "approved", fresh, 3600, {
+        runId: "run-approved",
+      });
       insertProposal(db, "proposal-mixed-expired", "open", expired, 60, {
         runId: "run-mixed",
       });
@@ -371,9 +379,9 @@ describe("terminal row retention (#1065)", () => {
         now,
         log: (message) => dryLog.push(message),
       });
-      expect(dry.proposed).toEqual({ cancelled: 6, dryRun: true });
+      expect(dry.proposed).toEqual({ cancelled: 7, dryRun: true });
       expect(dryLog).toEqual([
-        "retention: 0 trace rows and 0 artifacts (0 bytes), 6 proposed runs would be cancelled, 0 runs, 0 proposals, 0 events would be deleted",
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs would be cancelled, 0 runs, 0 proposals, 0 events would be deleted",
       ]);
       expect(
         db.query(`SELECT COUNT(*) AS count FROM lifecycle_events`).get().count,
@@ -385,9 +393,9 @@ describe("terminal row retention (#1065)", () => {
         apply: true,
         log: (message) => applyLog.push(message),
       });
-      expect(applied.proposed).toEqual({ cancelled: 6, dryRun: false });
+      expect(applied.proposed).toEqual({ cancelled: 7, dryRun: false });
       expect(applyLog).toEqual([
-        "retention: 0 trace rows and 0 artifacts (0 bytes), 6 proposed runs cancelled, 0 runs, 0 proposals, 0 events deleted (VACUUMed)",
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs cancelled, 0 runs, 0 proposals, 0 events deleted (VACUUMed)",
       ]);
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-expired'`).get()
@@ -412,6 +420,10 @@ describe("terminal row retention (#1065)", () => {
             `SELECT state FROM runs WHERE run_id = 'run-expired-human-needed'`,
           )
           .get().state,
+      ).toBe("CANCELLED");
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-approved'`).get()
+          .state,
       ).toBe("CANCELLED");
       expect(
         db


### PR DESCRIPTION
Fixes watt-mind/factory#2270

Review the updated live-proposal contract and the approved-proposal ordering-invariant fixture.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/janitor.test.mjs --timeout 20000` | pass | 9 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | all subchecks passed; 613 existing lint warnings |
| UX critique | `factory-ux-critic` | not run | backend library comment and unit fixture; no user-facing surface |

UX critique: skipped — backend library comment and unit fixture; no user-facing surface

run:run_dd6abe58-5c0d-46a5-82b7-446a0cc0db0b
