### PR TITLE
fix(ci): skip unavailable sandbox checks on cloud lane

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,17 +162,19 @@ jobs:
 
   fast-unit-tests:
     name: Fast unit tests
-    # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
-    # this job is still evaluated when `shadow-runner-health` is intentionally
-    # skipped on the cloud lane (WM-1122). It stays fail-closed: a cancelled
-    # workflow or a failed `route` skips it, and on the self-hosted lane it
-    # still requires a healthy shadow fleet.
+    # Dispatch/worktree cases in this suite exercise the production handoff
+    # sandbox, which GitHub-hosted runners cannot create. Cloud-lane PRs
+    # (including Dependabot) therefore intentionally receive no fast-unit or
+    # downstream full-verification coverage; Verify records that explicit
+    # tradeoff below instead of reporting sandbox_unavailable as a code red.
+    # The self-hosted shadow lane remains fail-closed on fleet health.
     if: >-
       ${{
         !cancelled() &&
         needs.route.result == 'success' &&
+        needs.route.outputs.self_hosted == 'true' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
+        needs.shadow-runner-health.result == 'success'
       }}
     needs: [route, shadow-runner-health]
     # Measurements recorded in docs/ci.md show this bounded suite can run
@@ -424,12 +426,17 @@ jobs:
     # host/CI green plus this lane red is a hermeticity regression. A future
     # flaky quarantine must be explicit in this workflow and leave a visible,
     # non-green signal; it must never silently make the smoke advisory.
+    # GitHub-hosted cloud runners cannot create the required unprivileged
+    # user+mount namespace. Skip this sandbox-only check there; Verify emits a
+    # notice documenting that Dependabot-style PRs lack this coverage. The
+    # self-hosted shadow lane still runs and requires this smoke to pass.
     if: >-
       ${{
         !cancelled() &&
         needs.route.result == 'success' &&
+        needs.route.outputs.self_hosted == 'true' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
+        needs.shadow-runner-health.result == 'success'
       }}
     needs: [route, shadow-runner-health]
     runs-on: ${{ fromJSON(needs.route.outputs.verify_labels) }}
@@ -866,20 +873,36 @@ jobs:
 
           # This job is intentionally `always()` so it reports cancelled and
           # skipped dependencies instead of inheriting GitHub's implicit
-          # success gate. The cloud lane is the sole expected skipped job.
+          # success gate. Cloud runners cannot support the production handoff
+          # sandbox, so their Fast/Full/Sandbox jobs are expected skips with a
+          # visible notice; self-hosted runs remain strictly fail-closed.
           require_success "Route CI lane" "$ROUTE_RESULT"
           if [ "$SELF_HOSTED" = "true" ]; then
             require_success "Shadow runner fleet available" "$HEALTH_RESULT"
+            require_success "Fast unit tests" "$FAST_RESULT"
+            require_success "Full verification" "$FULL_RESULT"
+            require_success "Sandboxed verify smoke" "$SANDBOX_SMOKE_RESULT"
           else
             echo "Shadow runner fleet available=$HEALTH_RESULT (expected skipped on cloud lane)"
             if [ "$HEALTH_RESULT" != "skipped" ]; then
               echo "::error::Cloud lane expected Shadow runner fleet available to be skipped."
               failed=1
             fi
+            for check in \
+              "Fast unit tests=$FAST_RESULT" \
+              "Full verification=$FULL_RESULT" \
+              "Sandboxed verify smoke=$SANDBOX_SMOKE_RESULT"; do
+              name="${check%%=*}"
+              result="${check#*=}"
+              echo "$name=$result (expected skipped on cloud lane)"
+              if [ "$result" != "skipped" ]; then
+                echo "::error::Cloud lane expected $name to be skipped."
+                failed=1
+              else
+                echo "::notice::$name skipped: GitHub-hosted runners cannot provide the production handoff sandbox."
+              fi
+            done
           fi
-          require_success "Fast unit tests" "$FAST_RESULT"
-          require_success "Full verification" "$FULL_RESULT"
-          require_success "Sandboxed verify smoke" "$SANDBOX_SMOKE_RESULT"
 
           if [ "$failed" -ne 0 ]; then
             echo "::error::One or more required verification jobs did not succeed; Verify cannot be green."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -162,19 +162,24 @@ jobs:
 
   fast-unit-tests:
     name: Fast unit tests
-    # Dispatch/worktree cases in this suite exercise the production handoff
-    # sandbox, which GitHub-hosted runners cannot create. Cloud-lane PRs
-    # (including Dependabot) therefore intentionally receive no fast-unit or
-    # downstream full-verification coverage; Verify records that explicit
-    # tradeoff below instead of reporting sandbox_unavailable as a code red.
-    # The self-hosted shadow lane remains fail-closed on fleet health.
+    # `!cancelled()` overrides GitHub's implicit `success()` gate on `needs`, so
+    # this job is still evaluated when `shadow-runner-health` is intentionally
+    # skipped on the cloud lane (WM-1122). It stays fail-closed: a cancelled
+    # workflow or a failed `route` skips it, and on the self-hosted lane it
+    # still requires a healthy shadow fleet.
+    #
+    # This suite runs on BOTH lanes and is required on both: fork and
+    # Dependabot PRs must keep full unit/lint/format/build coverage (GH-2267).
+    # The handful of cases that need a real unprivileged user+mount namespace
+    # self-skip on hosts without one, via the `handoffSandboxAvailable` probe
+    # in event-runtime/lib/verify.mjs — a host-capability probe, never an
+    # env flag a PR could set.
     if: >-
       ${{
         !cancelled() &&
         needs.route.result == 'success' &&
-        needs.route.outputs.self_hosted == 'true' &&
         (github.event_name != 'pull_request' || github.event.pull_request.draft == false) &&
-        needs.shadow-runner-health.result == 'success'
+        (needs.route.outputs.self_hosted != 'true' || needs.shadow-runner-health.result == 'success')
       }}
     needs: [route, shadow-runner-health]
     # Measurements recorded in docs/ci.md show this bounded suite can run
@@ -421,15 +426,18 @@ jobs:
   sandboxed-verify-smoke:
     name: Sandboxed verify smoke
     # This is the production handoff boundary exercised against the PR head,
-    # not an approximation of it. Unlike the non-blocking Timing-bound tests,
-    # a red sandbox smoke is merge-blocking through required-verify below:
-    # host/CI green plus this lane red is a hermeticity regression. A future
-    # flaky quarantine must be explicit in this workflow and leave a visible,
-    # non-green signal; it must never silently make the smoke advisory.
-    # GitHub-hosted cloud runners cannot create the required unprivileged
-    # user+mount namespace. Skip this sandbox-only check there; Verify emits a
-    # notice documenting that Dependabot-style PRs lack this coverage. The
-    # self-hosted shadow lane still runs and requires this smoke to pass.
+    # not an approximation of it. It is the ONLY job gated on the self-hosted
+    # lane: GitHub-hosted runners cannot create the unprivileged user+mount
+    # namespace it exists to exercise, so on the cloud lane there is nothing to
+    # smoke and required-verify records the gap as an explicit annotated skip
+    # (GH-2267). Every other check — unit tests, lint, format, typecheck,
+    # build — still runs on the cloud lane.
+    #
+    # On the self-hosted lane this smoke is merge-blocking through
+    # required-verify below: host/CI green plus this lane red is a hermeticity
+    # regression. A future flaky quarantine must be explicit in this workflow
+    # and leave a visible, non-green signal; it must never silently make the
+    # smoke advisory on the self-hosted lane.
     if: >-
       ${{
         !cancelled() &&
@@ -873,24 +881,21 @@ jobs:
 
           # This job is intentionally `always()` so it reports cancelled and
           # skipped dependencies instead of inheriting GitHub's implicit
-          # success gate. Cloud runners cannot support the production handoff
-          # sandbox, so their Fast/Full/Sandbox jobs are expected skips with a
-          # visible notice; self-hosted runs remain strictly fail-closed.
+          # success gate. Exactly two jobs are expected to be skipped on the
+          # cloud lane — the shadow fleet health check and the sandbox smoke,
+          # both of which exercise host facilities GitHub-hosted runners do not
+          # have (GH-2267). Everything else, on either lane, must be `success`:
+          # a fork or Dependabot PR gets the same unit/lint/format/build gate a
+          # self-hosted PR does.
           require_success "Route CI lane" "$ROUTE_RESULT"
+          require_success "Fast unit tests" "$FAST_RESULT"
+          require_success "Full verification" "$FULL_RESULT"
           if [ "$SELF_HOSTED" = "true" ]; then
             require_success "Shadow runner fleet available" "$HEALTH_RESULT"
-            require_success "Fast unit tests" "$FAST_RESULT"
-            require_success "Full verification" "$FULL_RESULT"
             require_success "Sandboxed verify smoke" "$SANDBOX_SMOKE_RESULT"
           else
-            echo "Shadow runner fleet available=$HEALTH_RESULT (expected skipped on cloud lane)"
-            if [ "$HEALTH_RESULT" != "skipped" ]; then
-              echo "::error::Cloud lane expected Shadow runner fleet available to be skipped."
-              failed=1
-            fi
             for check in \
-              "Fast unit tests=$FAST_RESULT" \
-              "Full verification=$FULL_RESULT" \
+              "Shadow runner fleet available=$HEALTH_RESULT" \
               "Sandboxed verify smoke=$SANDBOX_SMOKE_RESULT"; do
               name="${check%%=*}"
               result="${check#*=}"
@@ -898,10 +903,9 @@ jobs:
               if [ "$result" != "skipped" ]; then
                 echo "::error::Cloud lane expected $name to be skipped."
                 failed=1
-              else
-                echo "::notice::$name skipped: GitHub-hosted runners cannot provide the production handoff sandbox."
               fi
             done
+            echo "::notice::Sandboxed verify smoke skipped: GitHub-hosted runners cannot create the unprivileged user+mount namespace the handoff sandbox requires. This run has no sandbox-boundary coverage; all other checks ran."
           fi
 
           if [ "$failed" -ne 0 ]; then

--- a/event-runtime/lib/dispatch.test.mjs
+++ b/event-runtime/lib/dispatch.test.mjs
@@ -19,6 +19,7 @@ import {
 } from "./planner.mjs";
 import { approveProposal, openProposals } from "./proposals.mjs";
 import { loadRegistry } from "./registry.mjs";
+import { sandboxTest } from "../test-support/sandbox.mjs";
 import { runOnce } from "./worker.mjs";
 
 const registry = loadRegistry();
@@ -461,88 +462,97 @@ describe("dispatch e2e: propose → approve → execute → receipt (WM-108)", (
     },
   };
 
-  test("an approved dispatch run builds the worktree by delegation, completes, and tears it down", async () => {
-    const db = openDb(path.join(tmpDir("evrt-dispatch-db-"), "runtime.db"));
-    const workspaces = tmpDir("evrt-dispatch-ws-");
-    const trackerCalls = [];
-    fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
+  // GH-2267: this case drives the verified-PR handoff to a COMPLETED terminal
+  // state, which only a host that can enter a namespace can reach. See
+  // ../test-support/sandbox.mjs for why it self-skips where it cannot.
+  sandboxTest(
+    "an approved dispatch run builds the worktree by delegation, completes, and tears it down",
+    async () => {
+      const db = openDb(path.join(tmpDir("evrt-dispatch-db-"), "runtime.db"));
+      const workspaces = tmpDir("evrt-dispatch-ws-");
+      const trackerCalls = [];
+      fixtures.push(path.dirname(db.filename ?? workspaces), workspaces);
 
-    admitEvent(
-      db,
-      registry,
-      dispatchEnvelope({ repo: "wt29", ticket: "WM-501" }, "d-e2e"),
-    );
-    planAdmittedEvents(db, registry, {
-      policyVersion: PV,
-      dispatch: openWorld(),
-    });
-
-    const proposal = openProposals(db, {}).find(
-      (p) => p.spec?.agent === "dispatch@1",
-    );
-    expect(proposal).toBeTruthy();
-    expect(proposal.status).toBe("open"); // watched: nothing mutates without approval
-    expect(proposal.spec.workspace).toEqual({
-      type: "worktree",
-      checkoutDir: "repo",
-      retainOnFailure: true,
-    });
-    // WM-810 (#724): the planner folds declared memos into input.memoPin on
-    // every dispatch spec; with no memos declared the pin is empty but present.
-    expect(proposal.spec.input).toEqual({
-      repo: "wt29",
-      ticket: "WM-501",
-      memoPin: { entries: [], foldedAt: expect.any(String) },
-    });
-    expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
-
-    const approved = approveProposal(db, registry, proposal.id, {
-      actor: "operator",
-      policyVersion: PV,
-    });
-    const summary = await runOnce(
-      db,
-      registry,
-      // dispatch@1 rides cursor (WM-215/WM-694).
-      { cursor: dispatchFake },
-      {
-        workspacesRoot: workspaces,
-        owner: "w-test",
+      admitEvent(
+        db,
+        registry,
+        dispatchEnvelope({ repo: "wt29", ticket: "WM-501" }, "d-e2e"),
+      );
+      planAdmittedEvents(db, registry, {
         policyVersion: PV,
-        // The verified PR handoff performs tracker state/comment projections.
-        // Keep this end-to-end worker test hermetic and make both projections
-        // explicit rather than falling through to the real tracker CLI.
-        dispatch: openWorld({
-          reconcileVerifiedHandoffTicket: ({ ticket }) => {
-            trackerCalls.push(`state ${ticket} In Review`);
-            return true;
-          },
-          commentTicket: ({ ticket }) => {
-            trackerCalls.push(`comment ${ticket}`);
-            return true;
-          },
-        }),
-      },
-    );
+        dispatch: openWorld(),
+      });
 
-    expect(summary.terminalState).toBe("COMPLETED");
-    expect(summary.reasonCode).toBe("ok");
-    expect(summary.receipt).toBeTruthy();
-    expect(calls()).toContain("up WM-501");
-    expect(calls()).toContain("down WM-501"); // torn down on completion
-    expect(existsSync(path.join(wtRoot, "WM-501"))).toBe(false);
-    expect(trackerCalls).toEqual(["state WM-501 In Review", "comment WM-501"]);
+      const proposal = openProposals(db, {}).find(
+        (p) => p.spec?.agent === "dispatch@1",
+      );
+      expect(proposal).toBeTruthy();
+      expect(proposal.status).toBe("open"); // watched: nothing mutates without approval
+      expect(proposal.spec.workspace).toEqual({
+        type: "worktree",
+        checkoutDir: "repo",
+        retainOnFailure: true,
+      });
+      // WM-810 (#724): the planner folds declared memos into input.memoPin on
+      // every dispatch spec; with no memos declared the pin is empty but present.
+      expect(proposal.spec.input).toEqual({
+        repo: "wt29",
+        ticket: "WM-501",
+        memoPin: { entries: [], foldedAt: expect.any(String) },
+      });
+      expect(calls()).not.toContain("up WM-501"); // claim → worktree → spawn: nothing before approval
 
-    const row = db
-      .query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`)
-      .get(approved.runId);
-    const result = JSON.parse(row.result_json);
-    expect(result.artifact.outcome).toBe("PR_OPEN");
-    expect(result.artifact.prUrl).toContain("/pull/42");
-    expect(result.artifact.verification.passed).toBe(true);
-    expect(result.evidence.treeVisible).toBe(true);
-    expect(JSON.parse(row.receipt_json).runId).toBe(approved.runId);
-  });
+      const approved = approveProposal(db, registry, proposal.id, {
+        actor: "operator",
+        policyVersion: PV,
+      });
+      const summary = await runOnce(
+        db,
+        registry,
+        // dispatch@1 rides cursor (WM-215/WM-694).
+        { cursor: dispatchFake },
+        {
+          workspacesRoot: workspaces,
+          owner: "w-test",
+          policyVersion: PV,
+          // The verified PR handoff performs tracker state/comment projections.
+          // Keep this end-to-end worker test hermetic and make both projections
+          // explicit rather than falling through to the real tracker CLI.
+          dispatch: openWorld({
+            reconcileVerifiedHandoffTicket: ({ ticket }) => {
+              trackerCalls.push(`state ${ticket} In Review`);
+              return true;
+            },
+            commentTicket: ({ ticket }) => {
+              trackerCalls.push(`comment ${ticket}`);
+              return true;
+            },
+          }),
+        },
+      );
+
+      expect(summary.terminalState).toBe("COMPLETED");
+      expect(summary.reasonCode).toBe("ok");
+      expect(summary.receipt).toBeTruthy();
+      expect(calls()).toContain("up WM-501");
+      expect(calls()).toContain("down WM-501"); // torn down on completion
+      expect(existsSync(path.join(wtRoot, "WM-501"))).toBe(false);
+      expect(trackerCalls).toEqual([
+        "state WM-501 In Review",
+        "comment WM-501",
+      ]);
+
+      const row = db
+        .query(`SELECT result_json, receipt_json FROM results WHERE run_id = ?`)
+        .get(approved.runId);
+      const result = JSON.parse(row.result_json);
+      expect(result.artifact.outcome).toBe("PR_OPEN");
+      expect(result.artifact.prUrl).toContain("/pull/42");
+      expect(result.artifact.verification.passed).toBe(true);
+      expect(result.evidence.treeVisible).toBe(true);
+      expect(JSON.parse(row.receipt_json).runId).toBe(approved.runId);
+    },
+  );
 
   test("execution rechecks stale security eligibility before worktree and adapter", async () => {
     const db = openDb(":memory:");

--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -500,6 +500,28 @@ export function resetHandoffSandboxProbe() {
   sandboxProbeCache = null;
 }
 
+/**
+ * Why a suite whose case genuinely drives the production handoff boundary must
+ * not run here — or `null` when this host can build the sandbox (GH-2267).
+ *
+ * A few end-to-end cases (the WM-108 dispatch e2e in particular) assert a
+ * COMPLETED terminal state that is only reachable when the verified-PR handoff
+ * can actually enter a namespace; on a host without one the run legitimately
+ * refuses with `sandbox_unavailable`, and the case fails for an environment
+ * reason rather than a code one. GitHub-hosted cloud runners are exactly such
+ * a host, and the cloud lane must keep running the rest of the suite.
+ *
+ * The decision comes from `handoffSandboxAvailable` — the same real `unshare`
+ * probe the production gate uses — and from nothing else. There is
+ * deliberately no environment variable or CI flag in this path: a skip that a
+ * pull request could switch on for itself would let a fork drop the coverage
+ * it is supposed to be held to.
+ */
+export function handoffSandboxSkipReason(options = {}) {
+  if (handoffSandboxAvailable(options)) return null;
+  return `${HANDOFF_SANDBOX_UNAVAILABLE}: host cannot create an unprivileged user+mount namespace (probed with ${HANDOFF_SANDBOX_PYTHON} + /usr/bin/unshare); skipping the cases that require a real handoff sandbox`;
+}
+
 /** Thrown when the host cannot provide the handoff sandbox (GH-967). */
 export class SandboxUnavailable extends Error {
   constructor() {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -38,6 +38,8 @@ import {
   handoffRuntimeBinaries,
   handoffGitMounts,
   handoffSandboxAvailable,
+  handoffSandboxSkipReason,
+  HANDOFF_SANDBOX_UNAVAILABLE,
   HANDOFF_SANDBOX_PYTHON,
   MAX_HANDOFF_SANDBOX_TMPFS_MB,
   clampHandoffSandboxTmpfsMb,
@@ -54,6 +56,7 @@ import {
   ticketVerifyCoveredByRepoVerify,
   verifyResult,
 } from "./verify.mjs";
+import { sandboxTest } from "../test-support/sandbox.mjs";
 
 const registry = loadRegistry();
 const def = getAgent(registry, "factory-status-report@1");
@@ -1223,164 +1226,182 @@ describe("worktree baseline verification (WM-334)", () => {
     return { dir, record };
   }
 
-  test("a matching pre-existing failure is rejected with the distinct baseline_red reason", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf 'entry chunk exceeds budget\\n' >&2; exit 9",
-      {
-        status: "red",
-        check: "web_build",
-        output: "entry chunk exceeds budget",
-      },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("baseline_red");
-      expect(err.violations[0]).toContain("repo_verify_failed");
-    }
-  });
+  sandboxTest(
+    "a matching pre-existing failure is rejected with the distinct baseline_red reason",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "printf 'entry chunk exceeds budget\\n' >&2; exit 9",
+        {
+          status: "red",
+          check: "web_build",
+          output: "entry chunk exceeds budget",
+        },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("baseline_red");
+        expect(err.violations[0]).toContain("repo_verify_failed");
+      }
+    },
+  );
 
-  test("a recorded test baseline does not absorb an additional branch-only failure", () => {
-    const baselineOutput = [
-      "event-runtime/lib/worker.test.mjs:",
-      "(fail) worker > pre-existing flaky probe",
-    ].join("\n");
-    const { dir, record } = worktreeWorkspace(
-      `printf '%s\\n' '${baselineOutput}' 'event-runtime/lib/new.test.mjs:' '(fail) new suite > branch-only failure' >&2; exit 9`,
-      { status: "red", check: "repo_verify", output: baselineOutput },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("handoff_verification_failed");
-    }
-  });
+  sandboxTest(
+    "a recorded test baseline does not absorb an additional branch-only failure",
+    () => {
+      const baselineOutput = [
+        "event-runtime/lib/worker.test.mjs:",
+        "(fail) worker > pre-existing flaky probe",
+      ].join("\n");
+      const { dir, record } = worktreeWorkspace(
+        `printf '%s\\n' '${baselineOutput}' 'event-runtime/lib/new.test.mjs:' '(fail) new suite > branch-only failure' >&2; exit 9`,
+        { status: "red", check: "repo_verify", output: baselineOutput },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("handoff_verification_failed");
+      }
+    },
+  );
 
-  test("a recorded test baseline still absorbs a branch that fixed some of its failures", () => {
-    const baselineOutput = [
-      "event-runtime/lib/worker.test.mjs:",
-      "(fail) worker > pre-existing flaky probe",
-      "(fail) worker > second pre-existing probe",
-    ].join("\n");
-    const { dir, record } = worktreeWorkspace(
-      `printf '%s\\n' 'event-runtime/lib/worker.test.mjs:' '(fail) worker > pre-existing flaky probe' >&2; exit 9`,
-      { status: "red", check: "repo_verify", output: baselineOutput },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("baseline_red");
-    }
-  });
+  sandboxTest(
+    "a recorded test baseline still absorbs a branch that fixed some of its failures",
+    () => {
+      const baselineOutput = [
+        "event-runtime/lib/worker.test.mjs:",
+        "(fail) worker > pre-existing flaky probe",
+        "(fail) worker > second pre-existing probe",
+      ].join("\n");
+      const { dir, record } = worktreeWorkspace(
+        `printf '%s\\n' 'event-runtime/lib/worker.test.mjs:' '(fail) worker > pre-existing flaky probe' >&2; exit 9`,
+        { status: "red", check: "repo_verify", output: baselineOutput },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("baseline_red");
+      }
+    },
+  );
 
-  test("a truncated failing-test list is never absorbed by a recorded baseline", () => {
-    const names = Array.from({ length: 25 }, (_, i) => `probe ${i}`);
-    const lines = ["event-runtime/lib/worker.test.mjs:"].concat(
-      names.map((name) => `(fail) worker > ${name}`),
-    );
-    const { dir, record } = worktreeWorkspace(
-      `printf '%s\\n' ${lines.map((line) => `'${line}'`).join(" ")} >&2; exit 9`,
-      { status: "red", check: "repo_verify", output: lines.join("\n") },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("handoff_verification_failed");
-    }
-  });
+  sandboxTest(
+    "a truncated failing-test list is never absorbed by a recorded baseline",
+    () => {
+      const names = Array.from({ length: 25 }, (_, i) => `probe ${i}`);
+      const lines = ["event-runtime/lib/worker.test.mjs:"].concat(
+        names.map((name) => `(fail) worker > ${name}`),
+      );
+      const { dir, record } = worktreeWorkspace(
+        `printf '%s\\n' ${lines.map((line) => `'${line}'`).join(" ")} >&2; exit 9`,
+        { status: "red", check: "repo_verify", output: lines.join("\n") },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("handoff_verification_failed");
+      }
+    },
+  );
 
   // WM-718: a post-agent repo verify failure at handoff is the handoff gate
   // refusing (`handoff_verification_failed`), no longer a generic
   // `contract_violation` — same FAILED path, but named so the ticket goes back
   // to Todo + ai:agent-ready and the PR is held as draft.
-  test("shared baseline output plus a new failure does not classify as baseline_red", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf 'entry chunk exceeds budget\\nnew failure in CI\\n' >&2; exit 9",
-      {
-        status: "red",
-        check: "web_build",
-        output: "entry chunk exceeds budget",
-      },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("handoff_verification_failed");
-      expect(err.handoff.repoVerify.exitCode).toBe(9);
-    }
-  });
+  sandboxTest(
+    "shared baseline output plus a new failure does not classify as baseline_red",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "printf 'entry chunk exceeds budget\\nnew failure in CI\\n' >&2; exit 9",
+        {
+          status: "red",
+          check: "web_build",
+          output: "entry chunk exceeds budget",
+        },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("handoff_verification_failed");
+        expect(err.handoff.repoVerify.exitCode).toBe(9);
+      }
+    },
+  );
 
-  test("an unrelated post-agent failure refuses the handoff (not baseline_red)", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf 'new test regression\\nerror: script \"build\" exited with code 1\\n' >&2; exit 9",
-      {
-        status: "red",
-        check: "web_build",
-        output:
-          'entry chunk exceeds budget\nerror: script "build" exited with code 1',
-      },
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.reasonCode).toBe("handoff_verification_failed");
-      expect(err.violations[0]).toStartWith("repo_verify_failed:");
-    }
-  });
+  sandboxTest(
+    "an unrelated post-agent failure refuses the handoff (not baseline_red)",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "printf 'new test regression\\nerror: script \"build\" exited with code 1\\n' >&2; exit 9",
+        {
+          status: "red",
+          check: "web_build",
+          output:
+            'entry chunk exceeds budget\nerror: script "build" exited with code 1',
+        },
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.reasonCode).toBe("handoff_verification_failed");
+        expect(err.violations[0]).toStartWith("repo_verify_failed:");
+      }
+    },
+  );
 
   test("rechecks an unchanged failing test file at the merge base before charging the branch", () => {
     const { dir, record } = worktreeWorkspace("repo-verify", null);
@@ -1494,216 +1515,208 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(calls).toEqual(["repo-verify"]);
   });
 
-  test("a multi-line verification failure retains the failing test name and full log", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf 'suite start\\n(pass) timing-test registry (WM-918) > parseFailingTests reads bun (fail) and ✗ lines\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
-      null,
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations[0]).toContain(
-        "(fail) totals > rejects an invalid total",
-      );
-      expect(err.violations[0]).toContain("error: expected 400, received 200");
-      // A passing test whose name contains "(fail)" is not a failure marker.
-      expect(err.violations[0]).not.toContain("(pass) timing-test registry");
-      expect(err.handoff.repoVerify.executionContext).toBe("dispatch_worktree");
-      expect(err.handoff.repoVerify.failingTests).toEqual([
-        "totals > rejects an invalid total",
-      ]);
-    }
-
-    const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");
-    expect(verifyLog).toContain("suite start");
-    expect(verifyLog).toContain("(fail) totals > rejects an invalid total");
-    expect(verifyLog).toContain("Ran 2045 tests across 150 files.");
-    expect(verifyLog).toContain("error: expected 400, received 200");
-  });
-
-  test("handoff commands scrub instance FACTORY_* values and pin the worktree root", () => {
-    const instanceRoot = tmpDir("evrt-handoff-instance-");
-    const { dir, record } = worktreeWorkspace(
-      'printf \'repos=%s\\nroot=%s\\nhome=%s\\nport=%s\\n\' "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_EVENT_HOME-unset}" "${FACTORY_EVENT_PORT-unset}"',
-      null,
-    );
-    const keys = [
-      "FACTORY_REPOS_ROOT",
-      "FACTORY_ROOT",
-      "FACTORY_EVENT_HOME",
-      "FACTORY_EVENT_PORT",
-    ];
-    const previous = Object.fromEntries(
-      keys.map((key) => [key, process.env[key]]),
-    );
-    Object.assign(process.env, {
-      FACTORY_REPOS_ROOT: instanceRoot,
-      FACTORY_ROOT: instanceRoot,
-      FACTORY_EVENT_HOME: instanceRoot,
-      FACTORY_EVENT_PORT: "9999",
-    });
-    try {
-      const out = verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      expect(out.kind).toBe("completed");
-      const observed = out.handoff.repoVerify.output;
-      // The worktree is mounted at /workspace in the sandbox (#967); the pin
-      // still names the worktree root, in the coordinates the command sees.
-      // When this suite is itself running inside a sandbox the boundary does
-      // not nest and the command keeps the real paths.
-      expect(observed).toContain(
-        `repos=${insideHandoffSandbox() ? realpathSync(record.path) : "/workspace"}`,
-      );
-      expect(observed).toContain("root=unset");
-      expect(observed).toContain("home=unset");
-      expect(observed).toContain("port=unset");
-      expect(observed).not.toContain(instanceRoot);
-    } finally {
-      for (const key of keys) {
-        if (previous[key] === undefined) delete process.env[key];
-        else process.env[key] = previous[key];
-      }
-    }
-  });
-
-  test("the web build pins FACTORY_REPOS_ROOT to the worktree root, not its web cwd", () => {
-    const instanceRoot = tmpDir("evrt-handoff-instance-");
-    const { dir, record } = worktreeWorkspace("true", null);
-    record.base = "develop";
-    const repo = record.path;
-    const git = (...args) => execFileSync("git", args, { cwd: repo });
-    git("init", "-q", "-b", "develop");
-    git("config", "user.email", "t@t");
-    git("config", "user.name", "t");
-    const webDir = path.join(repo, "event-runtime", "web");
-    mkdirSync(path.join(webDir, "src"), { recursive: true });
-    writeFileSync(
-      path.join(webDir, "package.json"),
-      JSON.stringify({
-        name: "web-fixture",
-        scripts: {
-          build:
-            'printf \'cwd=%s\\nrepos=%s\\nroot=%s\\ntimeout=%s\\n\' "$PWD" "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_REPO_VERIFY_TIMEOUT_MS-unset}"',
-        },
-      }),
-    );
-    git("add", "-A");
-    git("commit", "-qm", "base");
-    git("update-ref", "refs/remotes/origin/develop", "HEAD");
-    git("checkout", "-qb", "feat/x");
-    writeFileSync(path.join(webDir, "src", "app.ts"), "export {};\n");
-    git("add", "-A");
-    git("commit", "-qm", "work");
-    const keys = ["FACTORY_REPOS_ROOT", "FACTORY_ROOT"];
-    const previous = Object.fromEntries(
-      keys.map((key) => [key, process.env[key]]),
-    );
-    Object.assign(process.env, {
-      FACTORY_REPOS_ROOT: instanceRoot,
-      FACTORY_ROOT: instanceRoot,
-    });
-    try {
-      const out = verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      expect(out.kind).toBe("completed");
-      expect(out.result.verification.checks).toContain("web_build_passed");
-      const observed = out.handoff.webBuild.output;
-      const guestRoot = insideHandoffSandbox()
-        ? realpathSync(repo)
-        : "/workspace";
-      expect(observed).toContain(`cwd=${guestRoot}/event-runtime/web`);
-      expect(observed).toContain(`repos=${guestRoot}\n`);
-      expect(observed).not.toContain(`repos=${guestRoot}/event-runtime/web`);
-      expect(observed).toContain("root=unset");
-      expect(observed).toContain("timeout=unset");
-      expect(observed).not.toContain(instanceRoot);
-    } finally {
-      for (const key of keys) {
-        if (previous[key] === undefined) delete process.env[key];
-        else process.env[key] = previous[key];
-      }
-    }
-  });
-
-  test("later error noise cannot displace a failing test name from the bounded reason", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf '(fail) billing > rejects a duplicate charge\\n'; i=1; while [ \"$i\" -le 45 ]; do printf 'error: detail %s\\n' \"$i\"; i=$((i + 1)); done; exit 1",
-      null,
-    );
-    try {
-      verifyResult({
-        spec: dispatchSpec,
-        def: dispatchDef,
-        registry,
-        workspaceDir: dir,
-        attempt: 1,
-        worktreeRecord: record,
-      });
-      throw new Error("expected ContractViolation");
-    } catch (err) {
-      expect(err).toBeInstanceOf(ContractViolation);
-      expect(err.violations[0]).toContain(
-        "(fail) billing > rejects a duplicate charge",
-      );
-      expect(err.violations[0].split("\n").length).toBeLessThanOrEqual(40);
-    }
-  });
-
-  test("a recorded red baseline never weakens a now-green post-agent verification", () => {
-    const { dir, record } = worktreeWorkspace(
-      "printf 'verification repaired\\n'",
-      {
-        status: "red",
-        check: "web_build",
-        output: "entry chunk exceeds budget",
-      },
-    );
-    const out = verifyResult({
-      spec: dispatchSpec,
-      def: dispatchDef,
-      registry,
-      workspaceDir: dir,
-      attempt: 1,
-      worktreeRecord: record,
-    });
-    expect(out.kind).toBe("completed");
-    expect(out.result.verification.checks).toContain("repo_verify_passed");
-  });
-
-  test("a worker-recovered result.json is never reported as an agent claim (#1592)", () => {
-    for (const [reasonCode, recovered] of [
-      ["worker_recovered_missing_result", true],
-      ["ok", false],
-    ]) {
+  sandboxTest(
+    "a multi-line verification failure retains the failing test name and full log",
+    () => {
       const { dir, record } = worktreeWorkspace(
-        "printf 'verification passed\\n'",
+        "printf 'suite start\\n(pass) timing-test registry (WM-918) > parseFailingTests reads bun (fail) and ✗ lines\\n(fail) totals > rejects an invalid total\\nRan 2045 tests across 150 files.\\n'; printf 'error: expected 400, received 200\\n' >&2; exit 1",
         null,
       );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.violations[0]).toContain(
+          "(fail) totals > rejects an invalid total",
+        );
+        expect(err.violations[0]).toContain(
+          "error: expected 400, received 200",
+        );
+        // A passing test whose name contains "(fail)" is not a failure marker.
+        expect(err.violations[0]).not.toContain("(pass) timing-test registry");
+        expect(err.handoff.repoVerify.executionContext).toBe(
+          "dispatch_worktree",
+        );
+        expect(err.handoff.repoVerify.failingTests).toEqual([
+          "totals > rejects an invalid total",
+        ]);
+      }
+
+      const verifyLog = readFileSync(path.join(dir, ".verify.log"), "utf8");
+      expect(verifyLog).toContain("suite start");
+      expect(verifyLog).toContain("(fail) totals > rejects an invalid total");
+      expect(verifyLog).toContain("Ran 2045 tests across 150 files.");
+      expect(verifyLog).toContain("error: expected 400, received 200");
+    },
+  );
+
+  sandboxTest(
+    "handoff commands scrub instance FACTORY_* values and pin the worktree root",
+    () => {
+      const instanceRoot = tmpDir("evrt-handoff-instance-");
+      const { dir, record } = worktreeWorkspace(
+        'printf \'repos=%s\\nroot=%s\\nhome=%s\\nport=%s\\n\' "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_EVENT_HOME-unset}" "${FACTORY_EVENT_PORT-unset}"',
+        null,
+      );
+      const keys = [
+        "FACTORY_REPOS_ROOT",
+        "FACTORY_ROOT",
+        "FACTORY_EVENT_HOME",
+        "FACTORY_EVENT_PORT",
+      ];
+      const previous = Object.fromEntries(
+        keys.map((key) => [key, process.env[key]]),
+      );
+      Object.assign(process.env, {
+        FACTORY_REPOS_ROOT: instanceRoot,
+        FACTORY_ROOT: instanceRoot,
+        FACTORY_EVENT_HOME: instanceRoot,
+        FACTORY_EVENT_PORT: "9999",
+      });
+      try {
+        const out = verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        expect(out.kind).toBe("completed");
+        const observed = out.handoff.repoVerify.output;
+        // The worktree is mounted at /workspace in the sandbox (#967); the pin
+        // still names the worktree root, in the coordinates the command sees.
+        // When this suite is itself running inside a sandbox the boundary does
+        // not nest and the command keeps the real paths.
+        expect(observed).toContain(
+          `repos=${insideHandoffSandbox() ? realpathSync(record.path) : "/workspace"}`,
+        );
+        expect(observed).toContain("root=unset");
+        expect(observed).toContain("home=unset");
+        expect(observed).toContain("port=unset");
+        expect(observed).not.toContain(instanceRoot);
+      } finally {
+        for (const key of keys) {
+          if (previous[key] === undefined) delete process.env[key];
+          else process.env[key] = previous[key];
+        }
+      }
+    },
+  );
+
+  sandboxTest(
+    "the web build pins FACTORY_REPOS_ROOT to the worktree root, not its web cwd",
+    () => {
+      const instanceRoot = tmpDir("evrt-handoff-instance-");
+      const { dir, record } = worktreeWorkspace("true", null);
+      record.base = "develop";
+      const repo = record.path;
+      const git = (...args) => execFileSync("git", args, { cwd: repo });
+      git("init", "-q", "-b", "develop");
+      git("config", "user.email", "t@t");
+      git("config", "user.name", "t");
+      const webDir = path.join(repo, "event-runtime", "web");
+      mkdirSync(path.join(webDir, "src"), { recursive: true });
       writeFileSync(
-        path.join(dir, "result.json"),
-        JSON.stringify({ ...dispatchResult, reasonCode }),
-        "utf8",
+        path.join(webDir, "package.json"),
+        JSON.stringify({
+          name: "web-fixture",
+          scripts: {
+            build:
+              'printf \'cwd=%s\\nrepos=%s\\nroot=%s\\ntimeout=%s\\n\' "$PWD" "$FACTORY_REPOS_ROOT" "${FACTORY_ROOT-unset}" "${FACTORY_REPO_VERIFY_TIMEOUT_MS-unset}"',
+          },
+        }),
+      );
+      git("add", "-A");
+      git("commit", "-qm", "base");
+      git("update-ref", "refs/remotes/origin/develop", "HEAD");
+      git("checkout", "-qb", "feat/x");
+      writeFileSync(path.join(webDir, "src", "app.ts"), "export {};\n");
+      git("add", "-A");
+      git("commit", "-qm", "work");
+      const keys = ["FACTORY_REPOS_ROOT", "FACTORY_ROOT"];
+      const previous = Object.fromEntries(
+        keys.map((key) => [key, process.env[key]]),
+      );
+      Object.assign(process.env, {
+        FACTORY_REPOS_ROOT: instanceRoot,
+        FACTORY_ROOT: instanceRoot,
+      });
+      try {
+        const out = verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        expect(out.kind).toBe("completed");
+        expect(out.result.verification.checks).toContain("web_build_passed");
+        const observed = out.handoff.webBuild.output;
+        const guestRoot = insideHandoffSandbox()
+          ? realpathSync(repo)
+          : "/workspace";
+        expect(observed).toContain(`cwd=${guestRoot}/event-runtime/web`);
+        expect(observed).toContain(`repos=${guestRoot}\n`);
+        expect(observed).not.toContain(`repos=${guestRoot}/event-runtime/web`);
+        expect(observed).toContain("root=unset");
+        expect(observed).toContain("timeout=unset");
+        expect(observed).not.toContain(instanceRoot);
+      } finally {
+        for (const key of keys) {
+          if (previous[key] === undefined) delete process.env[key];
+          else process.env[key] = previous[key];
+        }
+      }
+    },
+  );
+
+  sandboxTest(
+    "later error noise cannot displace a failing test name from the bounded reason",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "printf '(fail) billing > rejects a duplicate charge\\n'; i=1; while [ \"$i\" -le 45 ]; do printf 'error: detail %s\\n' \"$i\"; i=$((i + 1)); done; exit 1",
+        null,
+      );
+      try {
+        verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        throw new Error("expected ContractViolation");
+      } catch (err) {
+        expect(err).toBeInstanceOf(ContractViolation);
+        expect(err.violations[0]).toContain(
+          "(fail) billing > rejects a duplicate charge",
+        );
+        expect(err.violations[0].split("\n").length).toBeLessThanOrEqual(40);
+      }
+    },
+  );
+
+  sandboxTest(
+    "a recorded red baseline never weakens a now-green post-agent verification",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "printf 'verification repaired\\n'",
+        {
+          status: "red",
+          check: "web_build",
+          output: "entry chunk exceeds budget",
+        },
       );
       const out = verifyResult({
         spec: dispatchSpec,
@@ -1714,59 +1727,94 @@ describe("worktree baseline verification (WM-334)", () => {
         worktreeRecord: record,
       });
       expect(out.kind).toBe("completed");
-      // The persisted artifact's reasonCode is the source of the marker; the
-      // schema keeps `verification` closed, so nothing is stamped into it.
-      expect(out.handoff.agentReported).toMatchObject({
-        command: "bun test",
-        passed: true,
-        recovered,
-      });
-      const body = composeHandoffVerification(out.handoff);
-      if (recovered) {
-        expect(body).toContain("agent-reported: recovered — not agent-claimed");
-      } else {
-        expect(body).toContain("agent-reported: `bun test`");
+      expect(out.result.verification.checks).toContain("repo_verify_passed");
+    },
+  );
+
+  sandboxTest(
+    "a worker-recovered result.json is never reported as an agent claim (#1592)",
+    () => {
+      for (const [reasonCode, recovered] of [
+        ["worker_recovered_missing_result", true],
+        ["ok", false],
+      ]) {
+        const { dir, record } = worktreeWorkspace(
+          "printf 'verification passed\\n'",
+          null,
+        );
+        writeFileSync(
+          path.join(dir, "result.json"),
+          JSON.stringify({ ...dispatchResult, reasonCode }),
+          "utf8",
+        );
+        const out = verifyResult({
+          spec: dispatchSpec,
+          def: dispatchDef,
+          registry,
+          workspaceDir: dir,
+          attempt: 1,
+          worktreeRecord: record,
+        });
+        expect(out.kind).toBe("completed");
+        // The persisted artifact's reasonCode is the source of the marker; the
+        // schema keeps `verification` closed, so nothing is stamped into it.
+        expect(out.handoff.agentReported).toMatchObject({
+          command: "bun test",
+          passed: true,
+          recovered,
+        });
+        const body = composeHandoffVerification(out.handoff);
+        if (recovered) {
+          expect(body).toContain(
+            "agent-reported: recovered — not agent-claimed",
+          );
+        } else {
+          expect(body).toContain("agent-reported: `bun test`");
+        }
       }
-    }
-  });
+    },
+  );
 
-  test("a ticket test command covered by the repo verify does not run a second sandbox step", () => {
-    const { dir, record } = worktreeWorkspace(
-      "bun test event-runtime/lib --timeout 20000",
-      null,
-    );
-    const testFile = path.join(
-      record.path,
-      "event-runtime",
-      "lib",
-      "covered.test.mjs",
-    );
-    mkdirSync(path.dirname(testFile), { recursive: true });
-    writeFileSync(
-      testFile,
-      'import { expect, test } from "bun:test"; test("covered", () => expect(true).toBe(true));\n',
-    );
-    record.handoff = {
-      verificationCommand:
-        "bun test event-runtime/lib/covered.test.mjs --timeout 30000",
-    };
+  sandboxTest(
+    "a ticket test command covered by the repo verify does not run a second sandbox step",
+    () => {
+      const { dir, record } = worktreeWorkspace(
+        "bun test event-runtime/lib --timeout 20000",
+        null,
+      );
+      const testFile = path.join(
+        record.path,
+        "event-runtime",
+        "lib",
+        "covered.test.mjs",
+      );
+      mkdirSync(path.dirname(testFile), { recursive: true });
+      writeFileSync(
+        testFile,
+        'import { expect, test } from "bun:test"; test("covered", () => expect(true).toBe(true));\n',
+      );
+      record.handoff = {
+        verificationCommand:
+          "bun test event-runtime/lib/covered.test.mjs --timeout 30000",
+      };
 
-    const out = verifyResult({
-      spec: dispatchSpec,
-      def: dispatchDef,
-      registry,
-      workspaceDir: dir,
-      attempt: 1,
-      worktreeRecord: record,
-    });
+      const out = verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: record,
+      });
 
-    expect(out.kind).toBe("completed");
-    expect(out.handoff.verification).toBe(out.handoff.repoVerify);
-    expect(out.result.verification.checks).toContain(
-      "ticket_verify_covered_by_repo_verify",
-    );
-    expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
-  });
+      expect(out.kind).toBe("completed");
+      expect(out.handoff.verification).toBe(out.handoff.repoVerify);
+      expect(out.result.verification.checks).toContain(
+        "ticket_verify_covered_by_repo_verify",
+      );
+      expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
+    },
+  );
 
   function commitHandoffDiff(record, changedPath) {
     record.base = "develop";
@@ -2322,7 +2370,7 @@ describe("worktree baseline verification (WM-334)", () => {
     expect(installs).toBe(2);
   });
 
-  test("a ticket-step failure names its sandbox limits", () => {
+  sandboxTest("a ticket-step failure names its sandbox limits", () => {
     const { dir, record } = worktreeWorkspace("true", null);
     record.handoff = { verificationCommand: "printf ticket-red >&2; exit 7" };
     try {
@@ -2343,39 +2391,42 @@ describe("worktree baseline verification (WM-334)", () => {
     }
   });
 
-  test("a timed-out repository verification fails closed without hanging", () => {
-    const { dir, record } = worktreeWorkspace("while :; do :; done", null);
-    const previous = process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
-    process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = "25";
-    const started = Date.now();
-    try {
+  sandboxTest(
+    "a timed-out repository verification fails closed without hanging",
+    () => {
+      const { dir, record } = worktreeWorkspace("while :; do :; done", null);
+      const previous = process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
+      process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = "25";
+      const started = Date.now();
       try {
-        verifyResult({
-          spec: dispatchSpec,
-          def: dispatchDef,
-          registry,
-          workspaceDir: dir,
-          attempt: 1,
-          worktreeRecord: record,
-        });
-        throw new Error("expected ContractViolation");
-      } catch (err) {
-        expect(err).toBeInstanceOf(ContractViolation);
-        expect(err.violations).toEqual([
-          "repo_verify_failed: timed out after 25ms",
-        ]);
-        expect(err.handoff.repoVerify.executionContext).toBe(
-          "dispatch_worktree",
-        );
-        expect(err.handoff.repoVerify.failingTests).toEqual([]);
-        expect(Date.now() - started).toBeLessThan(1_000);
+        try {
+          verifyResult({
+            spec: dispatchSpec,
+            def: dispatchDef,
+            registry,
+            workspaceDir: dir,
+            attempt: 1,
+            worktreeRecord: record,
+          });
+          throw new Error("expected ContractViolation");
+        } catch (err) {
+          expect(err).toBeInstanceOf(ContractViolation);
+          expect(err.violations).toEqual([
+            "repo_verify_failed: timed out after 25ms",
+          ]);
+          expect(err.handoff.repoVerify.executionContext).toBe(
+            "dispatch_worktree",
+          );
+          expect(err.handoff.repoVerify.failingTests).toEqual([]);
+          expect(Date.now() - started).toBeLessThan(1_000);
+        }
+      } finally {
+        if (previous === undefined)
+          delete process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
+        else process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = previous;
       }
-    } finally {
-      if (previous === undefined)
-        delete process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS;
-      else process.env.FACTORY_REPO_VERIFY_TIMEOUT_MS = previous;
-    }
-  });
+    },
+  );
 });
 
 describe("repoVerifyFailingTests", () => {
@@ -2531,30 +2582,33 @@ describe("handoff gate provenance (#944)", () => {
     expect(existsSync(path.join(dir, ".verify.ticket.log"))).toBe(false);
   });
 
-  test("the worker's in-memory record still drives the gate for the same workspace", () => {
-    const dir = forgedWorkspace({
-      repo: "factory",
-      verify: "printf 'forged\\n'",
-    });
-    // Same on-disk marker, but the worker hands over the record it created:
-    // the gate runs the worker's command, not the marker's.
-    const out = verifyResult({
-      spec: dispatchSpec,
-      def: dispatchDef,
-      registry,
-      workspaceDir: dir,
-      attempt: 1,
-      worktreeRecord: {
-        path: path.join(dir, "repo"),
-        verify: "printf 'worker verification\\n'",
-      },
-    });
-    expect(out.kind).toBe("completed");
-    expect(out.result.verification.checks).toContain("repo_verify_passed");
-    expect(readFileSync(path.join(dir, ".verify.log"), "utf8")).toContain(
-      "worker verification",
-    );
-  });
+  sandboxTest(
+    "the worker's in-memory record still drives the gate for the same workspace",
+    () => {
+      const dir = forgedWorkspace({
+        repo: "factory",
+        verify: "printf 'forged\\n'",
+      });
+      // Same on-disk marker, but the worker hands over the record it created:
+      // the gate runs the worker's command, not the marker's.
+      const out = verifyResult({
+        spec: dispatchSpec,
+        def: dispatchDef,
+        registry,
+        workspaceDir: dir,
+        attempt: 1,
+        worktreeRecord: {
+          path: path.join(dir, "repo"),
+          verify: "printf 'worker verification\\n'",
+        },
+      });
+      expect(out.kind).toBe("completed");
+      expect(out.result.verification.checks).toContain("repo_verify_passed");
+      expect(readFileSync(path.join(dir, ".verify.log"), "utf8")).toContain(
+        "worker verification",
+      );
+    },
+  );
 });
 
 describe("evidence retention (OPS-206)", () => {
@@ -2869,6 +2923,59 @@ describe("handoff verification helpers (WM-718)", () => {
         nested: false,
       }),
     ).toBe(true);
+  });
+
+  // GH-2267: the seam suites use to self-skip sandbox-requiring cases on a
+  // host that cannot build the boundary (GitHub-hosted cloud runners). It must
+  // answer from the real probe alone — never from an env flag or CI marker a
+  // pull request could set to shed the coverage it is held to.
+  test("handoffSandboxSkipReason answers from the capability probe, not the environment", () => {
+    const capable = { spawn: () => ({ status: 0, error: null }) };
+    const incapable = { spawn: () => ({ status: 1, error: null }) };
+    const base = { cache: false, nested: false, exists: () => true };
+
+    expect(handoffSandboxSkipReason({ ...base, ...capable })).toBeNull();
+
+    const reason = handoffSandboxSkipReason({ ...base, ...incapable });
+    expect(typeof reason).toBe("string");
+    expect(reason).toContain(HANDOFF_SANDBOX_UNAVAILABLE);
+    // The reason is loggable: it names what the host lacks, so a skipped case
+    // reads as an environment fault rather than as missing coverage.
+    expect(reason).toContain("namespace");
+
+    // A missing setup interpreter is equally disqualifying, and is decided
+    // before any spawn.
+    expect(
+      handoffSandboxSkipReason({
+        ...base,
+        ...capable,
+        exists: (p) => p !== HANDOFF_SANDBOX_PYTHON,
+      }),
+    ).toContain(HANDOFF_SANDBOX_UNAVAILABLE);
+
+    // No environment variable can flip the verdict either way.
+    const spoofed = {
+      CI: "true",
+      GITHUB_ACTIONS: "true",
+      FACTORY_SANDBOX_UNAVAILABLE: "1",
+      FACTORY_SKIP_SANDBOX_TESTS: "1",
+    };
+    const restore = {};
+    for (const [k, v] of Object.entries(spoofed)) {
+      restore[k] = process.env[k];
+      process.env[k] = v;
+    }
+    try {
+      expect(handoffSandboxSkipReason({ ...base, ...capable })).toBeNull();
+      expect(handoffSandboxSkipReason({ ...base, ...incapable })).toContain(
+        HANDOFF_SANDBOX_UNAVAILABLE,
+      );
+    } finally {
+      for (const [k, v] of Object.entries(restore)) {
+        if (v === undefined) delete process.env[k];
+        else process.env[k] = v;
+      }
+    }
   });
 
   test("only timeout's own verdict counts as a timeout", () => {

--- a/event-runtime/lib/worker-dispatch-hardening.test.mjs
+++ b/event-runtime/lib/worker-dispatch-hardening.test.mjs
@@ -52,6 +52,7 @@ import {
   registry,
   T0,
 } from "./worker-test-helpers.mjs";
+import { sandboxTest } from "../test-support/sandbox.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -508,251 +509,260 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     db.close();
   });
 
-  test("tier escalation continuation is deferred, not refused, while its projection is pending (#1290)", async () => {
-    const db = openDb(":memory:");
-    const failed = queueRun(
-      db,
-      makeDispatchSpec({
-        runId: "run_pending_projection_light",
-        input: {
-          repo: "wt-worker",
-          ticket: "WM-1290",
+  sandboxTest(
+    "tier escalation continuation is deferred, not refused, while its projection is pending (#1290)",
+    async () => {
+      const db = openDb(":memory:");
+      const failed = queueRun(
+        db,
+        makeDispatchSpec({
+          runId: "run_pending_projection_light",
+          input: {
+            repo: "wt-worker",
+            ticket: "WM-1290",
+            modelTier: "light",
+          },
           modelTier: "light",
+          model: null,
+          maxAttempts: 1,
+        }),
+      );
+      linkEvent(db, failed.runId, {
+        type: "factory.dispatch.requested",
+        correlationId: "pending-projection-tier-root",
+      });
+      let now = T0;
+      let projectionWorks = false;
+      const dispatchOpts = {
+        locksDir: tmpDir("tier-pending-locks-"),
+        leasesDir: tmpDir("tier-pending-leases-"),
+        random: () => 0,
+        fetchTicket: () =>
+          readyDispatchTicket("WM-1290", {
+            labels: {
+              nodes: [{ name: "ai:agent-ready" }, { name: "tier:light" }],
+            },
+          }),
+        fetchViewer: () => ({ id: "factory-owner", name: "Factory" }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        budgetRefusal: () => null,
+        claimTicket: () => ({ ok: true }),
+        unclaimTicket: () => true,
+        projectTierEscalation: () => projectionWorks,
+        onTierEscalationProjectionError: () => {},
+      };
+      const o = opts({
+        now: () => now,
+        onTierEscalationProjectionError: () => {},
+        dispatch: dispatchOpts,
+      });
+      const failure = await runOnce(
+        db,
+        registry,
+        {
+          fake: {
+            async execute() {
+              return { exitCode: 1, timedOut: false };
+            },
+          },
         },
-        modelTier: "light",
-        model: null,
-        maxAttempts: 1,
-      }),
-    );
-    linkEvent(db, failed.runId, {
-      type: "factory.dispatch.requested",
-      correlationId: "pending-projection-tier-root",
-    });
-    let now = T0;
-    let projectionWorks = false;
-    const dispatchOpts = {
-      locksDir: tmpDir("tier-pending-locks-"),
-      leasesDir: tmpDir("tier-pending-leases-"),
-      random: () => 0,
-      fetchTicket: () =>
-        readyDispatchTicket("WM-1290", {
-          labels: {
-            nodes: [{ name: "ai:agent-ready" }, { name: "tier:light" }],
+        o,
+      );
+      expect(failure).toMatchObject({
+        terminalState: "FAILED",
+        reasonCode: "agent_exit_1",
+      });
+      const continuationRunId = failure.escalatedRunId;
+      const projectionState = () =>
+        db
+          .query(
+            `SELECT projection_state AS projectionState
+             FROM tier_escalations WHERE continuation_run_id = ?`,
+          )
+          .get(continuationRunId).projectionState;
+      expect(projectionState()).toBe("pending");
+      expect(runState(db, continuationRunId)).toBe("APPROVED");
+
+      // A continuation admitted to the queue before its projection landed must
+      // not reach the eligibility gate: the planner would refuse it terminally.
+      transition(db, {
+        runId: continuationRunId,
+        to: "QUEUED",
+        expectFrom: "APPROVED",
+        actor: "test",
+        reason: "queued_before_projection",
+        now,
+      });
+      const deferred = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect(deferred).toMatchObject({
+        runId: continuationRunId,
+        terminalState: "QUEUED",
+        reasonCode: "tier_escalation_projection_pending",
+      });
+      expect(deferred.requeueAfterMs).toBeGreaterThan(0);
+      expect(runState(db, continuationRunId)).toBe("QUEUED");
+      expect(projectionState()).toBe("pending");
+      expect(claimNext(db, o)).toBeNull();
+
+      // Once the projection is applied the same continuation proceeds as before.
+      projectionWorks = true;
+      now += deferred.requeueAfterMs;
+      const completed = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect(completed).toMatchObject({
+        runId: continuationRunId,
+        terminalState: "COMPLETED",
+        reasonCode: "ok",
+      });
+      expect(projectionState()).toBe("applied");
+      db.close();
+    },
+  );
+
+  sandboxTest(
+    "only a durable escalation handoff authorises the operator bypass at execute time (GH-845)",
+    async () => {
+      // Regression: an inherited spec field must never be an authorisation.
+      // approvalPolicy — dispatchEvidence included — is copied onto chain runs
+      // by stableChainApprovalPolicyForHash, so a chain descended from one
+      // operator dispatch would otherwise carry a permanent security bypass.
+      const laundered = openDb(":memory:");
+      const chainSpec = queueRun(
+        laundered,
+        makeDispatchSpec({
+          runId: "run_chain_launders_operator",
+          input: { repo: "wt-worker", ticket: "WM-847" },
+          approvalPolicy: {
+            source: "chain",
+            mode: "auto",
+            eventType: "factory.dispatch.requested",
+            escalation: {
+              rootRunId: "run_some_other_root",
+              failedRunId: "run_some_other_root",
+              operatorAuthorized: true,
+            },
+            dispatchEvidence: { checks: { operator_authorized: true } },
           },
         }),
-      fetchViewer: () => ({ id: "factory-owner", name: "Factory" }),
-      fetchInFlight: () => [],
-      countLeases: () => 0,
-      budgetRefusal: () => null,
-      claimTicket: () => ({ ok: true }),
-      unclaimTicket: () => true,
-      projectTierEscalation: () => projectionWorks,
-      onTierEscalationProjectionError: () => {},
-    };
-    const o = opts({
-      now: () => now,
-      onTierEscalationProjectionError: () => {},
-      dispatch: dispatchOpts,
-    });
-    const failure = await runOnce(
-      db,
-      registry,
-      {
-        fake: {
-          async execute() {
-            return { exitCode: 1, timedOut: false };
+      );
+      linkEvent(laundered, chainSpec.runId, {
+        type: "factory.dispatch.requested",
+        source: "chain",
+      });
+      const launderedSummary = await runOnce(
+        laundered,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: tmpDir("evrt-gh845-chain-locks-"),
+            leasesDir: tmpDir("evrt-gh845-chain-leases-"),
+            fetchTicket: () =>
+              readyDispatchTicket("WM-847", {
+                labels: {
+                  nodes: [
+                    { name: "ai:agent-ready" },
+                    { name: "type:security" },
+                  ],
+                },
+              }),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+          },
+        }),
+      );
+      expect(launderedSummary).toMatchObject({
+        terminalState: "REFUSED",
+        reasonCode: "ticket_security",
+      });
+      laundered.close();
+
+      // The same bypass IS granted to a continuation the durable
+      // tier_escalations row authenticates, when the failed run it continues
+      // was operator-sourced.
+      const db = openDb(":memory:");
+      const failed = queueRun(
+        db,
+        makeDispatchSpec({
+          runId: "run_operator_security_light",
+          input: { repo: "wt-worker", ticket: "WM-848", modelTier: "light" },
+          modelTier: "light",
+          model: null,
+          maxAttempts: 1,
+        }),
+      );
+      linkEvent(db, failed.runId, {
+        type: "factory.dispatch.requested",
+        source: "operator",
+      });
+      let ticket = readyDispatchTicket("WM-848", {
+        labels: {
+          nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
+        },
+      });
+      const dispatchOpts = {
+        locksDir: tmpDir("evrt-gh845-escalation-locks-"),
+        leasesDir: tmpDir("evrt-gh845-escalation-leases-"),
+        fetchTicket: () => ticket,
+        fetchViewer: () => ({ id: "factory" }),
+        fetchInFlight: () => [],
+        countLeases: () => 0,
+        budgetRefusal: () => null,
+        claimTicket: () => ({ ok: true }),
+        unclaimTicket: () => true,
+        projectTierEscalation: () => true,
+      };
+      const failure = await runOnce(
+        db,
+        registry,
+        {
+          fake: {
+            async execute() {
+              return { exitCode: 1, timedOut: false };
+            },
           },
         },
-      },
-      o,
-    );
-    expect(failure).toMatchObject({
-      terminalState: "FAILED",
-      reasonCode: "agent_exit_1",
-    });
-    const continuationRunId = failure.escalatedRunId;
-    const projectionState = () =>
-      db
-        .query(
-          `SELECT projection_state AS projectionState
-             FROM tier_escalations WHERE continuation_run_id = ?`,
-        )
-        .get(continuationRunId).projectionState;
-    expect(projectionState()).toBe("pending");
-    expect(runState(db, continuationRunId)).toBe("APPROVED");
+        opts({ dispatch: dispatchOpts }),
+      );
+      expect(failure).toMatchObject({
+        terminalState: "FAILED",
+        reasonCode: "agent_exit_1",
+      });
+      expect(runState(db, failure.escalatedRunId)).toBe("QUEUED");
 
-    // A continuation admitted to the queue before its projection landed must
-    // not reach the eligibility gate: the planner would refuse it terminally.
-    transition(db, {
-      runId: continuationRunId,
-      to: "QUEUED",
-      expectFrom: "APPROVED",
-      actor: "test",
-      reason: "queued_before_projection",
-      now,
-    });
-    const deferred = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(deferred).toMatchObject({
-      runId: continuationRunId,
-      terminalState: "QUEUED",
-      reasonCode: "tier_escalation_projection_pending",
-    });
-    expect(deferred.requeueAfterMs).toBeGreaterThan(0);
-    expect(runState(db, continuationRunId)).toBe("QUEUED");
-    expect(projectionState()).toBe("pending");
-    expect(claimNext(db, o)).toBeNull();
-
-    // Once the projection is applied the same continuation proceeds as before.
-    projectionWorks = true;
-    now += deferred.requeueAfterMs;
-    const completed = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(completed).toMatchObject({
-      runId: continuationRunId,
-      terminalState: "COMPLETED",
-      reasonCode: "ok",
-    });
-    expect(projectionState()).toBe("applied");
-    db.close();
-  });
-
-  test("only a durable escalation handoff authorises the operator bypass at execute time (GH-845)", async () => {
-    // Regression: an inherited spec field must never be an authorisation.
-    // approvalPolicy — dispatchEvidence included — is copied onto chain runs
-    // by stableChainApprovalPolicyForHash, so a chain descended from one
-    // operator dispatch would otherwise carry a permanent security bypass.
-    const laundered = openDb(":memory:");
-    const chainSpec = queueRun(
-      laundered,
-      makeDispatchSpec({
-        runId: "run_chain_launders_operator",
-        input: { repo: "wt-worker", ticket: "WM-847" },
-        approvalPolicy: {
-          source: "chain",
-          mode: "auto",
-          eventType: "factory.dispatch.requested",
-          escalation: {
-            rootRunId: "run_some_other_root",
-            failedRunId: "run_some_other_root",
-            operatorAuthorized: true,
-          },
-          dispatchEvidence: { checks: { operator_authorized: true } },
+      // The continuation resumes the factory's own claim: assigned, In
+      // Progress, and still carrying the security label that only an operator
+      // dispatch may pass.
+      ticket = readyDispatchTicket("WM-848", {
+        state: { name: "In Progress" },
+        assignee: { id: "factory" },
+        labels: {
+          nodes: [{ name: "ai:in-progress" }, { name: "type:security" }],
         },
-      }),
-    );
-    linkEvent(laundered, chainSpec.runId, {
-      type: "factory.dispatch.requested",
-      source: "chain",
-    });
-    const launderedSummary = await runOnce(
-      laundered,
-      registry,
-      { fake: dispatchFakeAdapter },
-      opts({
-        dispatch: {
-          locksDir: tmpDir("evrt-gh845-chain-locks-"),
-          leasesDir: tmpDir("evrt-gh845-chain-leases-"),
-          fetchTicket: () =>
-            readyDispatchTicket("WM-847", {
-              labels: {
-                nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
-              },
-            }),
-          fetchInFlight: () => [],
-          countLeases: () => 0,
-          claimTicket: () => ({ ok: true }),
-        },
-      }),
-    );
-    expect(launderedSummary).toMatchObject({
-      terminalState: "REFUSED",
-      reasonCode: "ticket_security",
-    });
-    laundered.close();
-
-    // The same bypass IS granted to a continuation the durable
-    // tier_escalations row authenticates, when the failed run it continues
-    // was operator-sourced.
-    const db = openDb(":memory:");
-    const failed = queueRun(
-      db,
-      makeDispatchSpec({
-        runId: "run_operator_security_light",
-        input: { repo: "wt-worker", ticket: "WM-848", modelTier: "light" },
-        modelTier: "light",
-        model: null,
-        maxAttempts: 1,
-      }),
-    );
-    linkEvent(db, failed.runId, {
-      type: "factory.dispatch.requested",
-      source: "operator",
-    });
-    let ticket = readyDispatchTicket("WM-848", {
-      labels: {
-        nodes: [{ name: "ai:agent-ready" }, { name: "type:security" }],
-      },
-    });
-    const dispatchOpts = {
-      locksDir: tmpDir("evrt-gh845-escalation-locks-"),
-      leasesDir: tmpDir("evrt-gh845-escalation-leases-"),
-      fetchTicket: () => ticket,
-      fetchViewer: () => ({ id: "factory" }),
-      fetchInFlight: () => [],
-      countLeases: () => 0,
-      budgetRefusal: () => null,
-      claimTicket: () => ({ ok: true }),
-      unclaimTicket: () => true,
-      projectTierEscalation: () => true,
-    };
-    const failure = await runOnce(
-      db,
-      registry,
-      {
-        fake: {
-          async execute() {
-            return { exitCode: 1, timedOut: false };
-          },
-        },
-      },
-      opts({ dispatch: dispatchOpts }),
-    );
-    expect(failure).toMatchObject({
-      terminalState: "FAILED",
-      reasonCode: "agent_exit_1",
-    });
-    expect(runState(db, failure.escalatedRunId)).toBe("QUEUED");
-
-    // The continuation resumes the factory's own claim: assigned, In
-    // Progress, and still carrying the security label that only an operator
-    // dispatch may pass.
-    ticket = readyDispatchTicket("WM-848", {
-      state: { name: "In Progress" },
-      assignee: { id: "factory" },
-      labels: {
-        nodes: [{ name: "ai:in-progress" }, { name: "type:security" }],
-      },
-    });
-    const continued = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      opts({ dispatch: dispatchOpts }),
-    );
-    expect(continued.runId).toBe(failure.escalatedRunId);
-    expect(continued.reasonCode).not.toBe("ticket_security");
-    expect(continued.terminalState).toBe("COMPLETED");
-    db.close();
-  });
+      });
+      const continued = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({ dispatch: dispatchOpts }),
+      );
+      expect(continued.runId).toBe(failure.escalatedRunId);
+      expect(continued.reasonCode).not.toBe("ticket_security");
+      expect(continued.terminalState).toBe("COMPLETED");
+      db.close();
+    },
+  );
 
   test("resolves Linear credentials from env first, then an opt-in env file", () => {
     const dir = tmpDir("evrt-linear-key-");
@@ -863,17 +873,45 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }
   });
 
-  test("FACTORY_DISPATCH_STUB enables the demo stub with a bounded owned-paths fixture", async () => {
-    const previousStub = process.env.FACTORY_DISPATCH_STUB;
-    process.env.FACTORY_DISPATCH_STUB = "1";
-    try {
+  sandboxTest(
+    "FACTORY_DISPATCH_STUB enables the demo stub with a bounded owned-paths fixture",
+    async () => {
+      const previousStub = process.env.FACTORY_DISPATCH_STUB;
+      process.env.FACTORY_DISPATCH_STUB = "1";
+      try {
+        const db = openDb(":memory:");
+        queueRun(db, makeDispatchSpec({ adapter: "pi" }));
+        const summary = await runOnce(
+          db,
+          registry,
+          { pi: dispatchFakeAdapter },
+          opts({
+            resolveLinearKey: () => null,
+          }),
+        );
+        expect(summary).toMatchObject({
+          terminalState: "COMPLETED",
+          reasonCode: "ok",
+        });
+      } finally {
+        if (previousStub === undefined)
+          delete process.env.FACTORY_DISPATCH_STUB;
+        else process.env.FACTORY_DISPATCH_STUB = previousStub;
+      }
+    },
+  );
+
+  sandboxTest(
+    "the fake adapter override explicitly enables the demo dispatch stub",
+    async () => {
       const db = openDb(":memory:");
       queueRun(db, makeDispatchSpec({ adapter: "pi" }));
       const summary = await runOnce(
         db,
         registry,
-        { pi: dispatchFakeAdapter },
+        { fake: dispatchFakeAdapter },
         opts({
+          adapterOverride: "fake",
           resolveLinearKey: () => null,
         }),
       );
@@ -881,29 +919,8 @@ describe("execute-side dispatch hardening (WM-115)", () => {
         terminalState: "COMPLETED",
         reasonCode: "ok",
       });
-    } finally {
-      if (previousStub === undefined) delete process.env.FACTORY_DISPATCH_STUB;
-      else process.env.FACTORY_DISPATCH_STUB = previousStub;
-    }
-  });
-
-  test("the fake adapter override explicitly enables the demo dispatch stub", async () => {
-    const db = openDb(":memory:");
-    queueRun(db, makeDispatchSpec({ adapter: "pi" }));
-    const summary = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      opts({
-        adapterOverride: "fake",
-        resolveLinearKey: () => null,
-      }),
-    );
-    expect(summary).toMatchObject({
-      terminalState: "COMPLETED",
-      reasonCode: "ok",
-    });
-  });
+    },
+  );
 
   // WM-115 / #1252: a partial `dispatch` override used to disable the demo
   // stub wholesale, so the seams the caller left out — notably the WM-718
@@ -911,40 +928,43 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // then spawned `bun tools/ticket.mjs comment` per run: real Linear writes
   // from the test suite, and a wall-clock dependency that timed the burst test
   // out on CI. Use the shared fake tracker CLI and assert nothing reaches it.
-  test("a partial dispatch override still never reaches the tracker CLI under the fake adapter", async () => {
-    const fakeCli = fakeTrackerCli();
-    const previousPath = process.env.PATH;
-    process.env.PATH = `${fakeCli.path}:${previousPath}`;
-    try {
-      const db = openDb(":memory:");
-      const spec = queueRun(
-        db,
-        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-742" } }),
-      );
-      const summary = await runOnce(
-        db,
-        registry,
-        { fake: dispatchFakeAdapter },
-        opts({
-          dispatch: {
-            locksDir: tmpDir("evrt-lock-partial-"),
-            fetchTicket: (ticket) => readyDispatchTicket(ticket),
-            fetchInFlight: () => [],
-            countLeases: () => 0,
-            claimTicket: () => ({ ok: true }),
-          },
-        }),
-      );
-      expect(summary).toMatchObject({
-        terminalState: "COMPLETED",
-        reasonCode: "ok",
-      });
-      expect(runState(db, spec.runId)).toBe("COMPLETED");
-      expect(fakeCli.calls()).toBe("");
-    } finally {
-      process.env.PATH = previousPath;
-    }
-  });
+  sandboxTest(
+    "a partial dispatch override still never reaches the tracker CLI under the fake adapter",
+    async () => {
+      const fakeCli = fakeTrackerCli();
+      const previousPath = process.env.PATH;
+      process.env.PATH = `${fakeCli.path}:${previousPath}`;
+      try {
+        const db = openDb(":memory:");
+        const spec = queueRun(
+          db,
+          makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-742" } }),
+        );
+        const summary = await runOnce(
+          db,
+          registry,
+          { fake: dispatchFakeAdapter },
+          opts({
+            dispatch: {
+              locksDir: tmpDir("evrt-lock-partial-"),
+              fetchTicket: (ticket) => readyDispatchTicket(ticket),
+              fetchInFlight: () => [],
+              countLeases: () => 0,
+              claimTicket: () => ({ ok: true }),
+            },
+          }),
+        );
+        expect(summary).toMatchObject({
+          terminalState: "COMPLETED",
+          reasonCode: "ok",
+        });
+        expect(runState(db, spec.runId)).toBe("COMPLETED");
+        expect(fakeCli.calls()).toBe("");
+      } finally {
+        process.env.PATH = previousPath;
+      }
+    },
+  );
 
   test("acquireClaimLock acquires lock file and prevents concurrent acquire, release unlocks", () => {
     const lockDir = tmpDir("evrt-lock-");
@@ -1048,68 +1068,71 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }
   });
 
-  test("contended claim lock requeues with jittered backoff without consuming an attempt, then runs", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-lock-busy-");
-    const lockFile = dispatchLockPath("wt-worker", lockDir);
-    acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
+  sandboxTest(
+    "contended claim lock requeues with jittered backoff without consuming an attempt, then runs",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-lock-busy-");
+      const lockFile = dispatchLockPath("wt-worker", lockDir);
+      acquireClaimLock(lockFile, { pid: process.pid, now: T0 });
 
-    const spec = queueRun(db, makeDispatchSpec());
-    let now = T0;
-    const o = opts({
-      now: () => now,
-      dispatch: {
-        locksDir: lockDir,
-        random: () => 0,
-        fetchTicket: () => readyDispatchTicket("WM-701"),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-      },
-    });
+      const spec = queueRun(db, makeDispatchSpec());
+      let now = T0;
+      const o = opts({
+        now: () => now,
+        dispatch: {
+          locksDir: lockDir,
+          random: () => 0,
+          fetchTicket: () => readyDispatchTicket("WM-701"),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      });
 
-    const deferred = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(deferred).toMatchObject({
-      terminalState: "QUEUED",
-      reasonCode: "claim_lock_contention",
-    });
-    expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(
-      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-        .attempts,
-    ).toBe(0);
-    expect(
-      db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
-    ).toHaveLength(0);
-    expect(
-      db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId),
-    ).toHaveLength(0);
-    expect(claimNext(db, o)).toBeNull();
+      const deferred = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect(deferred).toMatchObject({
+        terminalState: "QUEUED",
+        reasonCode: "claim_lock_contention",
+      });
+      expect(runState(db, spec.runId)).toBe("QUEUED");
+      expect(
+        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+          .attempts,
+      ).toBe(0);
+      expect(
+        db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
+      ).toHaveLength(0);
+      expect(
+        db.query(`SELECT * FROM results WHERE run_id = ?`).all(spec.runId),
+      ).toHaveLength(0);
+      expect(claimNext(db, o)).toBeNull();
 
-    releaseClaimLock(lockFile);
-    now += deferred.requeueAfterMs;
-    const completed = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(completed).toMatchObject({
-      terminalState: "COMPLETED",
-      reasonCode: "ok",
-      attempt: 1,
-    });
-    expect(runState(db, spec.runId)).toBe("COMPLETED");
-    expect(
-      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-        .attempts,
-    ).toBe(1);
-  });
+      releaseClaimLock(lockFile);
+      now += deferred.requeueAfterMs;
+      const completed = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect(completed).toMatchObject({
+        terminalState: "COMPLETED",
+        reasonCode: "ok",
+        attempt: 1,
+      });
+      expect(runState(db, spec.runId)).toBe("COMPLETED");
+      expect(
+        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+          .attempts,
+      ).toBe(1);
+    },
+  );
 
   test("claim lock starvation refuses with a distinct reason after the requeue ceiling", async () => {
     const db = openDb(":memory:");
@@ -1153,92 +1176,101 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     releaseClaimLock(lockFile);
   });
 
-  test("concurrent disjoint dispatches drain through the claim lock with mutually exclusive claims", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-lock-burst-");
-    const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) =>
-      queueRun(
-        db,
-        makeDispatchSpec({
-          runId: `run_lock_burst_${index + 1}`,
-          input: { repo: "wt-worker", ticket },
-        }),
-      ),
-    );
-    let now = T0;
-    let releaseFirst;
-    let markFirstStarted;
-    const firstStarted = new Promise((resolve) => {
-      markFirstStarted = resolve;
-    });
-    const firstRelease = new Promise((resolve) => {
-      releaseFirst = resolve;
-    });
-    let activeClaims = 0;
-    let maxActiveClaims = 0;
-    const claimedTickets = [];
-    const o = opts({
-      now: () => now,
-      dispatch: {
-        locksDir: lockDir,
-        random: () => 1,
-        fetchTicket: (ticket) => readyDispatchTicket(ticket),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: async ({ ticket }) => {
-          activeClaims += 1;
-          maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
-          claimedTickets.push(ticket);
-          if (ticket === "WM-710") {
-            markFirstStarted();
-            await firstRelease;
-          }
-          activeClaims -= 1;
-          return { ok: true };
+  sandboxTest(
+    "concurrent disjoint dispatches drain through the claim lock with mutually exclusive claims",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-lock-burst-");
+      const specs = ["WM-710", "WM-711", "WM-712"].map((ticket, index) =>
+        queueRun(
+          db,
+          makeDispatchSpec({
+            runId: `run_lock_burst_${index + 1}`,
+            input: { repo: "wt-worker", ticket },
+          }),
+        ),
+      );
+      let now = T0;
+      let releaseFirst;
+      let markFirstStarted;
+      const firstStarted = new Promise((resolve) => {
+        markFirstStarted = resolve;
+      });
+      const firstRelease = new Promise((resolve) => {
+        releaseFirst = resolve;
+      });
+      let activeClaims = 0;
+      let maxActiveClaims = 0;
+      const claimedTickets = [];
+      const o = opts({
+        now: () => now,
+        dispatch: {
+          locksDir: lockDir,
+          random: () => 1,
+          fetchTicket: (ticket) => readyDispatchTicket(ticket),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: async ({ ticket }) => {
+            activeClaims += 1;
+            maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
+            claimedTickets.push(ticket);
+            if (ticket === "WM-710") {
+              markFirstStarted();
+              await firstRelease;
+            }
+            activeClaims -= 1;
+            return { ok: true };
+          },
         },
-      },
-    });
+      });
 
-    const first = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    await firstStarted;
-    const second = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    const third = await runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    expect([second.reasonCode, third.reasonCode]).toEqual([
-      "claim_lock_contention",
-      "claim_lock_contention",
-    ]);
-    releaseFirst();
-    expect((await first).terminalState).toBe("COMPLETED");
+      const first = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+      await firstStarted;
+      const second = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      const third = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect([second.reasonCode, third.reasonCode]).toEqual([
+        "claim_lock_contention",
+        "claim_lock_contention",
+      ]);
+      releaseFirst();
+      expect((await first).terminalState).toBe("COMPLETED");
 
-    now += Math.max(second.requeueAfterMs, third.requeueAfterMs);
-    const drained = [
-      await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
-      await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
-    ];
-    expect(drained.map((summary) => summary.terminalState)).toEqual([
-      "COMPLETED",
-      "COMPLETED",
-    ]);
-    expect(specs.map((spec) => runState(db, spec.runId))).toEqual([
-      "COMPLETED",
-      "COMPLETED",
-      "COMPLETED",
-    ]);
-    expect(
-      specs.map(
-        (spec) =>
-          db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-            .attempts,
-      ),
-    ).toEqual([1, 1, 1]);
-    expect(claimedTickets.sort()).toEqual(["WM-710", "WM-711", "WM-712"]);
-    expect(maxActiveClaims).toBe(1);
-  });
+      now += Math.max(second.requeueAfterMs, third.requeueAfterMs);
+      const drained = [
+        await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
+        await runOnce(db, registry, { fake: dispatchFakeAdapter }, o),
+      ];
+      expect(drained.map((summary) => summary.terminalState)).toEqual([
+        "COMPLETED",
+        "COMPLETED",
+      ]);
+      expect(specs.map((spec) => runState(db, spec.runId))).toEqual([
+        "COMPLETED",
+        "COMPLETED",
+        "COMPLETED",
+      ]);
+      expect(
+        specs.map(
+          (spec) =>
+            db
+              .query(`SELECT attempts FROM runs WHERE run_id = ?`)
+              .get(spec.runId).attempts,
+        ),
+      ).toEqual([1, 1, 1]);
+      expect(claimedTickets.sort()).toEqual(["WM-710", "WM-711", "WM-712"]);
+      expect(maxActiveClaims).toBe(1);
+    },
+  );
 
   // WM-1124: a full-width same-repo dispatch burst must not starve itself. One
   // worker holds the claim lock across a long claim window while the rest of the
@@ -1251,145 +1283,149 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // in-memory SQLite/fake-clock stress case with 570 deliberate contention
   // passes; any wall-clock timeout is the test's genuine load-scaled execution
   // budget, while its liveness assertions remain deterministic.
-  test("a same-repo dispatch burst never claim_lock_starves against a live holder", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-lock-burst20-");
-    const BURST = 20;
-    const tickets = Array.from({ length: BURST }, (_, i) => `WM-${720 + i}`);
-    const specs = tickets.map((ticket, index) =>
-      queueRun(
-        db,
-        makeDispatchSpec({
-          runId: `run_burst_${String(index + 1).padStart(2, "0")}`,
-          input: { repo: "wt-worker", ticket },
-        }),
-      ),
-    );
+  sandboxTest(
+    "a same-repo dispatch burst never claim_lock_starves against a live holder",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-lock-burst20-");
+      const BURST = 20;
+      const tickets = Array.from({ length: BURST }, (_, i) => `WM-${720 + i}`);
+      const specs = tickets.map((ticket, index) =>
+        queueRun(
+          db,
+          makeDispatchSpec({
+            runId: `run_burst_${String(index + 1).padStart(2, "0")}`,
+            input: { repo: "wt-worker", ticket },
+          }),
+        ),
+      );
 
-    let now = T0;
-    let releaseHolder;
-    let markHolderStarted;
-    const holderStarted = new Promise((resolve) => {
-      markHolderStarted = resolve;
-    });
-    const holderRelease = new Promise((resolve) => {
-      releaseHolder = resolve;
-    });
-    let activeClaims = 0;
-    let maxActiveClaims = 0;
-    const claimedTickets = [];
-    const holderTicket = tickets[0];
+      let now = T0;
+      let releaseHolder;
+      let markHolderStarted;
+      const holderStarted = new Promise((resolve) => {
+        markHolderStarted = resolve;
+      });
+      const holderRelease = new Promise((resolve) => {
+        releaseHolder = resolve;
+      });
+      let activeClaims = 0;
+      let maxActiveClaims = 0;
+      const claimedTickets = [];
+      const holderTicket = tickets[0];
 
-    const o = opts({
-      now: () => now,
-      dispatch: {
-        locksDir: lockDir,
-        // Deterministic worst case: full backoff (random -> the cap) every time.
-        random: () => 1,
-        fetchTicket: (ticket) => readyDispatchTicket(ticket),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: async ({ ticket }) => {
-          activeClaims += 1;
-          maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
-          claimedTickets.push(ticket);
-          if (ticket === holderTicket) {
-            // Pin the lock open so the rest of the burst repeatedly contends.
-            markHolderStarted();
-            await holderRelease;
-          }
-          activeClaims -= 1;
-          return { ok: true };
+      const o = opts({
+        now: () => now,
+        dispatch: {
+          locksDir: lockDir,
+          // Deterministic worst case: full backoff (random -> the cap) every time.
+          random: () => 1,
+          fetchTicket: (ticket) => readyDispatchTicket(ticket),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: async ({ ticket }) => {
+            activeClaims += 1;
+            maxActiveClaims = Math.max(maxActiveClaims, activeClaims);
+            claimedTickets.push(ticket);
+            if (ticket === holderTicket) {
+              // Pin the lock open so the rest of the burst repeatedly contends.
+              markHolderStarted();
+              await holderRelease;
+            }
+            activeClaims -= 1;
+            return { ok: true };
+          },
         },
-      },
-    });
+      });
 
-    // One worker wins the lock and holds it across a long claim window.
-    const holder = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
-    await holderStarted;
+      // One worker wins the lock and holds it across a long claim window.
+      const holder = runOnce(db, registry, { fake: dispatchFakeAdapter }, o);
+      await holderStarted;
 
-    // While the live holder keeps the lock, sweep the other 19 through far more
-    // contention cycles than the old fixed ceiling (24) permitted. Every sweep
-    // must defer (QUEUED / claim_lock_contention); none may terminally REFUSE.
-    const CONTENTION_ROUNDS = 30;
-    const contenders = specs.slice(1);
-    for (let round = 0; round < CONTENTION_ROUNDS; round++) {
-      // Advance past every deferred not-before so the whole cohort is eligible.
-      now += CLAIM_LOCK_BACKOFF_MAX_MS;
-      for (let i = 0; i < contenders.length; i++) {
-        const summary = await runOnce(
-          db,
-          registry,
-          { fake: dispatchFakeAdapter },
-          o,
-        );
-        expect(summary).toMatchObject({
-          terminalState: "QUEUED",
-          reasonCode: "claim_lock_contention",
-        });
+      // While the live holder keeps the lock, sweep the other 19 through far more
+      // contention cycles than the old fixed ceiling (24) permitted. Every sweep
+      // must defer (QUEUED / claim_lock_contention); none may terminally REFUSE.
+      const CONTENTION_ROUNDS = 30;
+      const contenders = specs.slice(1);
+      for (let round = 0; round < CONTENTION_ROUNDS; round++) {
+        // Advance past every deferred not-before so the whole cohort is eligible.
+        now += CLAIM_LOCK_BACKOFF_MAX_MS;
+        for (let i = 0; i < contenders.length; i++) {
+          const summary = await runOnce(
+            db,
+            registry,
+            { fake: dispatchFakeAdapter },
+            o,
+          );
+          expect(summary).toMatchObject({
+            terminalState: "QUEUED",
+            reasonCode: "claim_lock_contention",
+          });
+        }
+        // The holder is RUNNING and the rest are deferred to a future not-before,
+        // so nothing else is claimable within this round.
+        expect(claimNext(db, o)).toBeNull();
       }
-      // The holder is RUNNING and the rest are deferred to a future not-before,
-      // so nothing else is claimable within this round.
-      expect(claimNext(db, o)).toBeNull();
-    }
 
-    // Contention must not have spent an execution attempt or left an attempt row.
-    for (const spec of contenders) {
-      expect(
-        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-          .attempts,
-      ).toBe(0);
-      expect(
-        db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
-      ).toHaveLength(0);
-    }
-
-    // Release the holder and drain the whole burst.
-    releaseHolder();
-    expect((await holder).terminalState).toBe("COMPLETED");
-
-    let completed = 1; // the holder
-    let guard = 0;
-    while (completed < BURST && guard++ < BURST * 3) {
-      now += CLAIM_LOCK_BACKOFF_MAX_MS;
-      let summary;
-      while (
-        (summary = await runOnce(
-          db,
-          registry,
-          { fake: dispatchFakeAdapter },
-          o,
-        ))
-      ) {
-        expect(summary.terminalState).toBe("COMPLETED");
-        completed += 1;
-      }
-    }
-
-    // Every burst member ran to completion — none terminally REFUSED.
-    expect(completed).toBe(BURST);
-    expect(specs.map((spec) => runState(db, spec.runId))).toEqual(
-      Array.from({ length: BURST }, () => "COMPLETED"),
-    );
-    expect(
-      db
-        .query(
-          `SELECT COUNT(*) AS n FROM attempts WHERE reason_code = 'claim_lock_starvation'`,
-        )
-        .get().n,
-    ).toBe(0);
-    // Claim atomicity: exactly one claim in flight at a time, each ticket once.
-    expect(maxActiveClaims).toBe(1);
-    expect(claimedTickets.slice().sort()).toEqual(tickets.slice().sort());
-    expect(new Set(claimedTickets).size).toBe(BURST);
-    expect(
-      specs.map(
-        (spec) =>
+      // Contention must not have spent an execution attempt or left an attempt row.
+      for (const spec of contenders) {
+        expect(
           db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
             .attempts,
-      ),
-    ).toEqual(Array.from({ length: BURST }, () => 1));
-  });
+        ).toBe(0);
+        expect(
+          db.query(`SELECT * FROM attempts WHERE run_id = ?`).all(spec.runId),
+        ).toHaveLength(0);
+      }
+
+      // Release the holder and drain the whole burst.
+      releaseHolder();
+      expect((await holder).terminalState).toBe("COMPLETED");
+
+      let completed = 1; // the holder
+      let guard = 0;
+      while (completed < BURST && guard++ < BURST * 3) {
+        now += CLAIM_LOCK_BACKOFF_MAX_MS;
+        let summary;
+        while (
+          (summary = await runOnce(
+            db,
+            registry,
+            { fake: dispatchFakeAdapter },
+            o,
+          ))
+        ) {
+          expect(summary.terminalState).toBe("COMPLETED");
+          completed += 1;
+        }
+      }
+
+      // Every burst member ran to completion — none terminally REFUSED.
+      expect(completed).toBe(BURST);
+      expect(specs.map((spec) => runState(db, spec.runId))).toEqual(
+        Array.from({ length: BURST }, () => "COMPLETED"),
+      );
+      expect(
+        db
+          .query(
+            `SELECT COUNT(*) AS n FROM attempts WHERE reason_code = 'claim_lock_starvation'`,
+          )
+          .get().n,
+      ).toBe(0);
+      // Claim atomicity: exactly one claim in flight at a time, each ticket once.
+      expect(maxActiveClaims).toBe(1);
+      expect(claimedTickets.slice().sort()).toEqual(tickets.slice().sort());
+      expect(new Set(claimedTickets).size).toBe(BURST);
+      expect(
+        specs.map(
+          (spec) =>
+            db
+              .query(`SELECT attempts FROM runs WHERE run_id = ?`)
+              .get(spec.runId).attempts,
+        ),
+      ).toEqual(Array.from({ length: BURST }, () => 1));
+    },
+  );
 
   test("merge-fix gate accepts an assigned In Review ticket without invoking the dispatch claim", async () => {
     const db = openDb(":memory:");
@@ -1477,54 +1513,57 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }
   });
 
-  test("claim-time dispatch gate honors only operator-sourced security runs (GH-1004)", async () => {
-    for (const [source, expectedTerminalState, expectedReasonCode] of [
-      ["operator", "COMPLETED", "ok"],
-      ["chain", "REFUSED", "ticket_security"],
-    ]) {
-      const db = openDb(":memory:");
-      const ticket = source === "operator" ? "WM-701" : "WM-702";
-      const spec = queueRun(
-        db,
-        makeDispatchSpec({
-          runId: `run_security_${source}`,
-          input: { repo: "wt-worker", ticket },
-        }),
-      );
-      linkEvent(db, spec.runId, {
-        type: "factory.dispatch.requested",
-        source,
-      });
+  sandboxTest(
+    "claim-time dispatch gate honors only operator-sourced security runs (GH-1004)",
+    async () => {
+      for (const [source, expectedTerminalState, expectedReasonCode] of [
+        ["operator", "COMPLETED", "ok"],
+        ["chain", "REFUSED", "ticket_security"],
+      ]) {
+        const db = openDb(":memory:");
+        const ticket = source === "operator" ? "WM-701" : "WM-702";
+        const spec = queueRun(
+          db,
+          makeDispatchSpec({
+            runId: `run_security_${source}`,
+            input: { repo: "wt-worker", ticket },
+          }),
+        );
+        linkEvent(db, spec.runId, {
+          type: "factory.dispatch.requested",
+          source,
+        });
 
-      const summary = await runOnce(
-        db,
-        registry,
-        { fake: dispatchFakeAdapter },
-        opts({
-          dispatch: {
-            locksDir: tmpDir(`evrt-security-${source}-locks-`),
-            fetchTicket: () =>
-              readyDispatchTicket(ticket, {
-                labels: {
-                  nodes: [
-                    { name: "ai:agent-ready" },
-                    { name: "type:security" },
-                  ],
-                },
-              }),
-            fetchInFlight: () => [],
-            countLeases: () => 0,
-            claimTicket: () => ({ ok: true }),
-          },
-        }),
-      );
+        const summary = await runOnce(
+          db,
+          registry,
+          { fake: dispatchFakeAdapter },
+          opts({
+            dispatch: {
+              locksDir: tmpDir(`evrt-security-${source}-locks-`),
+              fetchTicket: () =>
+                readyDispatchTicket(ticket, {
+                  labels: {
+                    nodes: [
+                      { name: "ai:agent-ready" },
+                      { name: "type:security" },
+                    ],
+                  },
+                }),
+              fetchInFlight: () => [],
+              countLeases: () => 0,
+              claimTicket: () => ({ ok: true }),
+            },
+          }),
+        );
 
-      expect(summary).toMatchObject({
-        terminalState: expectedTerminalState,
-        reasonCode: expectedReasonCode,
-      });
-    }
-  });
+        expect(summary).toMatchObject({
+          terminalState: expectedTerminalState,
+          reasonCode: expectedReasonCode,
+        });
+      }
+    },
+  );
 
   test("execute-time re-checks refuse on ticket_not_todo, ticket_assigned, capacity_full, owned_paths_overlap, ticket_claim_lost", async () => {
     const db = openDb(":memory:");
@@ -1752,195 +1791,204 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     }
   });
 
-  test("lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-claim-retry-locks-");
-    const leaseDir = tmpDir("evrt-claim-retry-leases-");
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({
-        input: { repo: "wt-worker", ticket: "WM-621" },
-      }),
-    );
-    let now = T0;
-    let ticket = readyDispatchTicket("WM-621");
-    let claimCalls = 0;
-    let unclaimCalls = 0;
-    let adapterCalls = 0;
-    let releaseFirst;
-    let releaseSecond;
-    let markFirstStarted;
-    let markSecondStarted;
-    const firstStarted = new Promise((resolve) => {
-      markFirstStarted = resolve;
-    });
-    const secondStarted = new Promise((resolve) => {
-      markSecondStarted = resolve;
-    });
-    const firstRelease = new Promise((resolve) => {
-      releaseFirst = resolve;
-    });
-    const secondRelease = new Promise((resolve) => {
-      releaseSecond = resolve;
-    });
-    const retryAdapter = {
-      async execute(args) {
-        adapterCalls += 1;
-        if (adapterCalls === 1) {
-          markFirstStarted();
-          await firstRelease;
-          return { exitCode: 1, timedOut: false };
-        }
-        markSecondStarted();
-        await secondRelease;
-        return dispatchFakeAdapter.execute(args);
-      },
-    };
-    const o = opts({
-      now: () => now,
-      workspacesRoot: freshRoot(),
-      dispatch: {
-        locksDir: lockDir,
-        leasesDir: leaseDir,
-        fetchTicket: () => ticket,
-        fetchViewer: () => ({ id: "factory-user", name: "Factory" }),
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => {
-          claimCalls += 1;
-          ticket = readyDispatchTicket("WM-621", {
-            state: { name: "In Progress" },
-            assignee: { id: "factory-user", name: "Factory" },
-            labels: {
-              nodes: [
-                { name: "ai:in-progress" },
-                { name: "agent:claude-code" },
-              ],
-            },
-          });
-          return { ok: true };
+  sandboxTest(
+    "lease-loss attempt 2 resumes its own claim while stale attempt 1 cannot unclaim it (WM-621)",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-claim-retry-locks-");
+      const leaseDir = tmpDir("evrt-claim-retry-leases-");
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({
+          input: { repo: "wt-worker", ticket: "WM-621" },
+        }),
+      );
+      let now = T0;
+      let ticket = readyDispatchTicket("WM-621");
+      let claimCalls = 0;
+      let unclaimCalls = 0;
+      let adapterCalls = 0;
+      let releaseFirst;
+      let releaseSecond;
+      let markFirstStarted;
+      let markSecondStarted;
+      const firstStarted = new Promise((resolve) => {
+        markFirstStarted = resolve;
+      });
+      const secondStarted = new Promise((resolve) => {
+        markSecondStarted = resolve;
+      });
+      const firstRelease = new Promise((resolve) => {
+        releaseFirst = resolve;
+      });
+      const secondRelease = new Promise((resolve) => {
+        releaseSecond = resolve;
+      });
+      const retryAdapter = {
+        async execute(args) {
+          adapterCalls += 1;
+          if (adapterCalls === 1) {
+            markFirstStarted();
+            await firstRelease;
+            return { exitCode: 1, timedOut: false };
+          }
+          markSecondStarted();
+          await secondRelease;
+          return dispatchFakeAdapter.execute(args);
         },
-        unclaimTicket: () => {
-          unclaimCalls += 1;
-          ticket = readyDispatchTicket("WM-621");
-          return true;
+      };
+      const o = opts({
+        now: () => now,
+        workspacesRoot: freshRoot(),
+        dispatch: {
+          locksDir: lockDir,
+          leasesDir: leaseDir,
+          fetchTicket: () => ticket,
+          fetchViewer: () => ({ id: "factory-user", name: "Factory" }),
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => {
+            claimCalls += 1;
+            ticket = readyDispatchTicket("WM-621", {
+              state: { name: "In Progress" },
+              assignee: { id: "factory-user", name: "Factory" },
+              labels: {
+                nodes: [
+                  { name: "ai:in-progress" },
+                  { name: "agent:claude-code" },
+                ],
+              },
+            });
+            return { ok: true };
+          },
+          unclaimTicket: () => {
+            unclaimCalls += 1;
+            ticket = readyDispatchTicket("WM-621");
+            return true;
+          },
         },
-      },
-    });
+      });
 
-    const firstClaim = claimNext(db, o);
-    const firstExecution = executeClaimed(
-      db,
-      registry,
-      { fake: retryAdapter },
-      firstClaim,
-      o,
-    );
-    let retryExecution;
-    try {
-      await firstStarted;
-      expect(claimCalls).toBe(1);
-      expect(ticket.state.name).toBe("In Progress");
+      const firstClaim = claimNext(db, o);
+      const firstExecution = executeClaimed(
+        db,
+        registry,
+        { fake: retryAdapter },
+        firstClaim,
+        o,
+      );
+      let retryExecution;
+      try {
+        await firstStarted;
+        expect(claimCalls).toBe(1);
+        expect(ticket.state.name).toBe("In Progress");
 
-      now = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
-      expect(reapExpiredLeases(db, { now, policyVersion: "test" })).toBe(1);
+        now = T0 + (spec.timeoutSeconds + 120) * 1000 + 1;
+        expect(reapExpiredLeases(db, { now, policyVersion: "test" })).toBe(1);
+        expect(runState(db, spec.runId)).toBe("QUEUED");
+
+        retryExecution = runOnce(db, registry, { fake: retryAdapter }, o);
+        await secondStarted;
+        expect(claimCalls).toBe(1);
+        expect(
+          readFileSync(callsLog, "utf8")
+            .trim()
+            .split("\n")
+            .filter((call) => call === "up WM-621"),
+        ).toHaveLength(2);
+        expect(lifecycleOf(db, spec.runId)).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),
+          ]),
+        );
+
+        releaseFirst();
+        expect(await firstExecution).toEqual({ fenced: true });
+        expect(unclaimCalls).toBe(0);
+        expect(ticket.state.name).toBe("In Progress");
+        expect(
+          liveWorkerLeases("wt-worker", { dir: leaseDir, now }),
+        ).toHaveLength(1);
+
+        releaseSecond();
+        const retried = await retryExecution;
+        expect(retried).toMatchObject({
+          attempt: 2,
+          terminalState: "COMPLETED",
+        });
+      } finally {
+        releaseFirst();
+        releaseSecond();
+        await Promise.allSettled(
+          [firstExecution, retryExecution].filter(Boolean),
+        );
+      }
+    },
+  );
+
+  sandboxTest(
+    "claim-time Linear read failure contradicting plan evidence requeues with backoff",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-transient-linear-");
+      const description = "## Owned Paths\n- src/feature/**\n";
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({
+          input: { repo: "wt-worker", ticket: "WM-707" },
+          approvalPolicy: planTimeDispatchEvidence(description),
+        }),
+      );
+      let now = T0;
+      let reads = 0;
+      const o = opts({
+        now: () => now,
+        dispatch: {
+          locksDir: lockDir,
+          random: () => 0,
+          fetchTicket: () => {
+            reads += 1;
+            if (reads === 1) throw new Error("linear_read_failed: HTTP 503");
+            return readyDispatchTicket("WM-707", { description });
+          },
+          fetchInFlight: () => [],
+          countLeases: () => 0,
+          claimTicket: () => ({ ok: true }),
+        },
+      });
+
+      const deferred = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
+      );
+      expect(deferred).toMatchObject({
+        terminalState: "QUEUED",
+        reasonCode: "linear_read_failed",
+      });
+      expect(deferred.requeueAfterMs).toBeGreaterThan(0);
       expect(runState(db, spec.runId)).toBe("QUEUED");
-
-      retryExecution = runOnce(db, registry, { fake: retryAdapter }, o);
-      await secondStarted;
-      expect(claimCalls).toBe(1);
       expect(
-        readFileSync(callsLog, "utf8")
-          .trim()
-          .split("\n")
-          .filter((call) => call === "up WM-621"),
-      ).toHaveLength(2);
-      expect(lifecycleOf(db, spec.runId)).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ to_state: "RUNNING", attempt: 2 }),
-        ]),
+        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+          .attempts,
+      ).toBe(0);
+      expect(claimNext(db, o)).toBeNull();
+
+      now += deferred.requeueAfterMs;
+      const completed = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        o,
       );
-
-      releaseFirst();
-      expect(await firstExecution).toEqual({ fenced: true });
-      expect(unclaimCalls).toBe(0);
-      expect(ticket.state.name).toBe("In Progress");
-      expect(
-        liveWorkerLeases("wt-worker", { dir: leaseDir, now }),
-      ).toHaveLength(1);
-
-      releaseSecond();
-      const retried = await retryExecution;
-      expect(retried).toMatchObject({ attempt: 2, terminalState: "COMPLETED" });
-    } finally {
-      releaseFirst();
-      releaseSecond();
-      await Promise.allSettled(
-        [firstExecution, retryExecution].filter(Boolean),
-      );
-    }
-  });
-
-  test("claim-time Linear read failure contradicting plan evidence requeues with backoff", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-transient-linear-");
-    const description = "## Owned Paths\n- src/feature/**\n";
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({
-        input: { repo: "wt-worker", ticket: "WM-707" },
-        approvalPolicy: planTimeDispatchEvidence(description),
-      }),
-    );
-    let now = T0;
-    let reads = 0;
-    const o = opts({
-      now: () => now,
-      dispatch: {
-        locksDir: lockDir,
-        random: () => 0,
-        fetchTicket: () => {
-          reads += 1;
-          if (reads === 1) throw new Error("linear_read_failed: HTTP 503");
-          return readyDispatchTicket("WM-707", { description });
-        },
-        fetchInFlight: () => [],
-        countLeases: () => 0,
-        claimTicket: () => ({ ok: true }),
-      },
-    });
-
-    const deferred = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(deferred).toMatchObject({
-      terminalState: "QUEUED",
-      reasonCode: "linear_read_failed",
-    });
-    expect(deferred.requeueAfterMs).toBeGreaterThan(0);
-    expect(runState(db, spec.runId)).toBe("QUEUED");
-    expect(
-      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-        .attempts,
-    ).toBe(0);
-    expect(claimNext(db, o)).toBeNull();
-
-    now += deferred.requeueAfterMs;
-    const completed = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      o,
-    );
-    expect(completed).toMatchObject({
-      terminalState: "COMPLETED",
-      reasonCode: "ok",
-      attempt: 1,
-    });
-  });
+      expect(completed).toMatchObject({
+        terminalState: "COMPLETED",
+        reasonCode: "ok",
+        attempt: 1,
+      });
+    },
+  );
 
   test("empty claim-time description retries only when its hash contradicts plan evidence, then explains recovery", async () => {
     const db = openDb(":memory:");
@@ -2001,84 +2049,90 @@ describe("execute-side dispatch hardening (WM-115)", () => {
     );
   });
 
-  test("worker lease is acquired during execution and released on completion", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-lease-locks-");
-    const leaseDir = tmpDir("evrt-lease-dir-");
+  sandboxTest(
+    "worker lease is acquired during execution and released on completion",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-lease-locks-");
+      const leaseDir = tmpDir("evrt-lease-dir-");
 
-    let sawActiveLease = false;
-    const leaseCheckAdapter = {
-      async execute({ spec, workspaceDir }) {
-        const active = liveWorkerLeases("wt-worker", {
-          dir: leaseDir,
-          now: T0,
-        });
-        sawActiveLease = active.some((l) => l.ticket === spec.input.ticket);
-        return dispatchFakeAdapter.execute({ spec, workspaceDir });
-      },
-    };
-
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-710" } }),
-    );
-    const summary = await runOnce(
-      db,
-      registry,
-      { fake: leaseCheckAdapter },
-      opts({
-        dispatch: {
-          locksDir: lockDir,
-          leasesDir: leaseDir,
-          fetchTicket: () => readyDispatchTicket("WM-710"),
-          fetchInFlight: () => [],
-          countLeases: () => 0,
-          claimTicket: () => ({ ok: true }),
+      let sawActiveLease = false;
+      const leaseCheckAdapter = {
+        async execute({ spec, workspaceDir }) {
+          const active = liveWorkerLeases("wt-worker", {
+            dir: leaseDir,
+            now: T0,
+          });
+          sawActiveLease = active.some((l) => l.ticket === spec.input.ticket);
+          return dispatchFakeAdapter.execute({ spec, workspaceDir });
         },
-      }),
-    );
+      };
 
-    expect(sawActiveLease).toBe(true);
-    expect(summary.terminalState).toBe("COMPLETED");
-    // After execution, the lease must be released
-    expect(
-      liveWorkerLeases("wt-worker", { dir: leaseDir, now: T0 }),
-    ).toHaveLength(0);
-  });
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-710" } }),
+      );
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: leaseCheckAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            leasesDir: leaseDir,
+            fetchTicket: () => readyDispatchTicket("WM-710"),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+          },
+        }),
+      );
 
-  test("mutating worktree is exempt from read-only clean check and runs repo verify command", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-verify-locks-");
-    const leaseDir = tmpDir("evrt-verify-leases-");
+      expect(sawActiveLease).toBe(true);
+      expect(summary.terminalState).toBe("COMPLETED");
+      // After execution, the lease must be released
+      expect(
+        liveWorkerLeases("wt-worker", { dir: leaseDir, now: T0 }),
+      ).toHaveLength(0);
+    },
+  );
 
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-720" } }),
-    );
-    const summary = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      opts({
-        dispatch: {
-          locksDir: lockDir,
-          leasesDir: leaseDir,
-          fetchTicket: () => readyDispatchTicket("WM-720"),
-          fetchInFlight: () => [],
-          countLeases: () => 0,
-          claimTicket: () => ({ ok: true }),
-        },
-      }),
-    );
+  sandboxTest(
+    "mutating worktree is exempt from read-only clean check and runs repo verify command",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-verify-locks-");
+      const leaseDir = tmpDir("evrt-verify-leases-");
 
-    expect(summary.terminalState).toBe("COMPLETED");
-    expect(summary.reasonCode).toBe("ok");
-    const resRow = db
-      .query(`SELECT result_json FROM results WHERE run_id = ?`)
-      .get(spec.runId);
-    const result = JSON.parse(resRow.result_json);
-    expect(result.verification.checks).toContain("repo_verify_passed");
-  });
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({ input: { repo: "wt-worker", ticket: "WM-720" } }),
+      );
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            leasesDir: leaseDir,
+            fetchTicket: () => readyDispatchTicket("WM-720"),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+          },
+        }),
+      );
+
+      expect(summary.terminalState).toBe("COMPLETED");
+      expect(summary.reasonCode).toBe("ok");
+      const resRow = db
+        .query(`SELECT result_json FROM results WHERE run_id = ?`)
+        .get(spec.runId);
+      const result = JSON.parse(resRow.result_json);
+      expect(result.verification.checks).toContain("repo_verify_passed");
+    },
+  );
 
   test("forceFailRun aborts a RUNNING adapter and releases its ticket claim promptly", async () => {
     const db = openDb(":memory:");
@@ -2251,106 +2305,112 @@ describe("execute-side dispatch hardening (WM-115)", () => {
   // WM-718: at handoff (PR_OPEN) a red repo verify is the handoff gate
   // refusing — named `handoff_verification_failed` so the ticket returns to
   // Todo + ai:agent-ready and the PR is held; still FAILED, still no result row.
-  test("failing repo verify command at handoff fails handoff_verification_failed", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-fverify-locks-");
-    const leaseDir = tmpDir("evrt-fverify-leases-");
+  sandboxTest(
+    "failing repo verify command at handoff fails handoff_verification_failed",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-fverify-locks-");
+      const leaseDir = tmpDir("evrt-fverify-leases-");
 
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({
-        input: { repo: "wt-failing-verify", ticket: "WM-730" },
-      }),
-    );
-    const summary = await runOnce(
-      db,
-      registry,
-      { fake: dispatchFakeAdapter },
-      opts({
-        dispatch: {
-          locksDir: lockDir,
-          leasesDir: leaseDir,
-          fetchTicket: () => readyDispatchTicket("WM-730"),
-          fetchInFlight: () => [],
-          countLeases: () => 0,
-          claimTicket: () => ({ ok: true }),
-        },
-      }),
-    );
-
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("handoff_verification_failed");
-    expect(summary.detail).toContain("repo_verify_failed");
-    expect(summary.handoff.repoVerify.exitCode).toBe(42);
-  });
-
-  test("a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red", async () => {
-    const db = openDb(":memory:");
-    const lockDir = tmpDir("evrt-baseline-locks-");
-    const leaseDir = tmpDir("evrt-baseline-leases-");
-    let executionInput = null;
-    const unclaimCalls = [];
-    const blockCalls = [];
-    const observingAdapter = {
-      async execute({ spec, workspaceDir }) {
-        executionInput = JSON.parse(
-          readFileSync(path.join(workspaceDir, "input.json"), "utf8"),
-        );
-        return dispatchFakeAdapter.execute({ spec, workspaceDir });
-      },
-    };
-
-    const spec = queueRun(
-      db,
-      makeDispatchSpec({
-        input: { repo: "wt-baseline-red", ticket: "WM-731" },
-      }),
-    );
-    const summary = await runOnce(
-      db,
-      registry,
-      { fake: observingAdapter },
-      opts({
-        dispatch: {
-          locksDir: lockDir,
-          leasesDir: leaseDir,
-          fetchTicket: () => readyDispatchTicket("WM-731"),
-          fetchInFlight: () => [],
-          countLeases: () => 0,
-          claimTicket: () => ({ ok: true }),
-          unclaimTicket: (payload) => {
-            unclaimCalls.push(payload);
-            return false;
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({
+          input: { repo: "wt-failing-verify", ticket: "WM-730" },
+        }),
+      );
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: dispatchFakeAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            leasesDir: leaseDir,
+            fetchTicket: () => readyDispatchTicket("WM-730"),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
           },
-          blockBaselineTicket: (payload) => {
-            blockCalls.push(payload);
-            return true;
-          },
+        }),
+      );
+
+      expect(summary.terminalState).toBe("FAILED");
+      expect(summary.reasonCode).toBe("handoff_verification_failed");
+      expect(summary.detail).toContain("repo_verify_failed");
+      expect(summary.handoff.repoVerify.exitCode).toBe(42);
+    },
+  );
+
+  sandboxTest(
+    "a deliberately red baseline still reaches the agent with failure context, then terminates baseline_red",
+    async () => {
+      const db = openDb(":memory:");
+      const lockDir = tmpDir("evrt-baseline-locks-");
+      const leaseDir = tmpDir("evrt-baseline-leases-");
+      let executionInput = null;
+      const unclaimCalls = [];
+      const blockCalls = [];
+      const observingAdapter = {
+        async execute({ spec, workspaceDir }) {
+          executionInput = JSON.parse(
+            readFileSync(path.join(workspaceDir, "input.json"), "utf8"),
+          );
+          return dispatchFakeAdapter.execute({ spec, workspaceDir });
         },
-      }),
-    );
+      };
 
-    expect(executionInput).toMatchObject({
-      repo: "wt-baseline-red",
-      ticket: "WM-731",
-      baseline: {
-        status: "red",
-        check: "web_build",
-        output: "entry chunk exceeds budget",
-      },
-    });
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("baseline_red");
-    expect(blockCalls).toHaveLength(1);
-    expect(unclaimCalls).toHaveLength(0);
-    expect(
-      db
-        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
-        .get(spec.runId).reason_code,
-    ).toBe("baseline_red");
-  });
+      const spec = queueRun(
+        db,
+        makeDispatchSpec({
+          input: { repo: "wt-baseline-red", ticket: "WM-731" },
+        }),
+      );
+      const summary = await runOnce(
+        db,
+        registry,
+        { fake: observingAdapter },
+        opts({
+          dispatch: {
+            locksDir: lockDir,
+            leasesDir: leaseDir,
+            fetchTicket: () => readyDispatchTicket("WM-731"),
+            fetchInFlight: () => [],
+            countLeases: () => 0,
+            claimTicket: () => ({ ok: true }),
+            unclaimTicket: (payload) => {
+              unclaimCalls.push(payload);
+              return false;
+            },
+            blockBaselineTicket: (payload) => {
+              blockCalls.push(payload);
+              return true;
+            },
+          },
+        }),
+      );
 
-  test(
+      expect(executionInput).toMatchObject({
+        repo: "wt-baseline-red",
+        ticket: "WM-731",
+        baseline: {
+          status: "red",
+          check: "web_build",
+          output: "entry chunk exceeds budget",
+        },
+      });
+      expect(summary.terminalState).toBe("FAILED");
+      expect(summary.reasonCode).toBe("baseline_red");
+      expect(blockCalls).toHaveLength(1);
+      expect(unclaimCalls).toHaveLength(0);
+      expect(
+        db
+          .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+          .get(spec.runId).reason_code,
+      ).toBe("baseline_red");
+    },
+  );
+
+  sandboxTest(
     "worktree-up handles an actual baseline-red repo verification and deduplicates baseline blocker comments",
     // This test provisions real git worktrees and child processes twice. The
     // 45s ceiling has headroom over the ~9s observed under the 8-run burst

--- a/event-runtime/lib/worker-handoff.test.mjs
+++ b/event-runtime/lib/worker-handoff.test.mjs
@@ -18,6 +18,7 @@ import {
 } from "./worker.mjs";
 import { registerTestProcessCleanup } from "./test-helpers-process.mjs";
 import { opts, queueRun, registry } from "./worker-test-helpers.mjs";
+import { sandboxTest } from "../test-support/sandbox.mjs";
 
 registerTestProcessCleanup(import.meta.url);
 
@@ -316,70 +317,73 @@ describe("handoff verification gate (WM-718)", () => {
     return { db, summary, calls, artifactStore };
   }
 
-  test("a fake agent that leaves a failing test is refused handoff_verification_failed: no result row, ticket back to Todo + agent-ready, PR held, tail in the receipt", async () => {
-    const spec = handoffSpec({ ticket: "WM-7181" });
-    const { db, summary, calls } = await dispatch({
-      spec,
-      description: withCommand("bash run-tests.sh"),
-      adapter: agent({
-        files: {
-          "src/feature/impl.txt": "done\n",
-          "run-tests.sh":
-            'echo "suite start"\necho "(fail) totals > rejects an invalid total"\necho "1 fail" >&2\nexit 1\n',
-        },
-      }),
-    });
+  sandboxTest(
+    "a fake agent that leaves a failing test is refused handoff_verification_failed: no result row, ticket back to Todo + agent-ready, PR held, tail in the receipt",
+    async () => {
+      const spec = handoffSpec({ ticket: "WM-7181" });
+      const { db, summary, calls } = await dispatch({
+        spec,
+        description: withCommand("bash run-tests.sh"),
+        adapter: agent({
+          files: {
+            "src/feature/impl.txt": "done\n",
+            "run-tests.sh":
+              'echo "suite start"\necho "(fail) totals > rejects an invalid total"\necho "1 fail" >&2\nexit 1\n',
+          },
+        }),
+      });
 
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("handoff_verification_failed");
-    expect(summary.detail).toContain("ticket_verify_failed");
-    expect(summary.handoff.verification.command).toBe("bash run-tests.sh");
-    expect(summary.handoff.verification.exitCode).toBe(1);
-    expect(summary.handoff.verification.tail).toContain(
-      "(fail) totals > rejects an invalid total",
-    );
-    // The repo verify passed; the ticket's own command is what caught it.
-    expect(summary.handoff.repoVerify.passed).toBe(true);
+      expect(summary.terminalState).toBe("FAILED");
+      expect(summary.reasonCode).toBe("handoff_verification_failed");
+      expect(summary.detail).toContain("ticket_verify_failed");
+      expect(summary.handoff.verification.command).toBe("bash run-tests.sh");
+      expect(summary.handoff.verification.exitCode).toBe(1);
+      expect(summary.handoff.verification.tail).toContain(
+        "(fail) totals > rejects an invalid total",
+      );
+      // The repo verify passed; the ticket's own command is what caught it.
+      expect(summary.handoff.repoVerify.passed).toBe(true);
 
-    // No PR_OPEN result was published — nothing downstream chains a review.
-    expect(
-      db
-        .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
-        .get(spec.runId).n,
-    ).toBe(0);
-    expect(
-      db
-        .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
-        .get(spec.runId).reason_code,
-    ).toBe("handoff_verification_failed");
-    const journal = lifecycleOf(db, spec.runId)
-      .map((row) => row.reason)
-      .join("\n");
-    expect(journal).toContain("(fail) totals > rejects an invalid total");
-    expect(classifyFailureCause("handoff_verification_failed")).toBe(
-      "agent_error",
-    );
+      // No PR_OPEN result was published — nothing downstream chains a review.
+      expect(
+        db
+          .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
+          .get(spec.runId).n,
+      ).toBe(0);
+      expect(
+        db
+          .query(`SELECT reason_code FROM attempts WHERE run_id = ?`)
+          .get(spec.runId).reason_code,
+      ).toBe("handoff_verification_failed");
+      const journal = lifecycleOf(db, spec.runId)
+        .map((row) => row.reason)
+        .join("\n");
+      expect(journal).toContain("(fail) totals > rejects an invalid total");
+      expect(classifyFailureCause("handoff_verification_failed")).toBe(
+        "agent_error",
+      );
 
-    // Ticket returned (Todo + agent-ready), never Blocked, never the plain unclaim.
-    expect(calls.returned).toHaveLength(1);
-    expect(calls.returned[0].ticket).toBe("WM-7181");
-    expect(calls.returned[0].body).toContain(
-      "## Handoff verification (worker-observed)",
-    );
-    expect(calls.returned[0].body).toContain(
-      "(fail) totals > rejects an invalid total",
-    );
-    expect(calls.returned[0].body).toContain("Todo + ai:agent-ready");
-    expect(calls.unclaim).toHaveLength(0);
-    // The agent's PR is converted to draft with the observed failure quoted.
-    expect(calls.held).toHaveLength(1);
-    expect(calls.held[0]).toMatchObject({
-      prNumber: 77,
-      github: "watt-mind/wt-handoff",
-    });
-    expect(calls.held[0].body).toContain("exit 1 (FAIL)");
-    expect(calls.comments).toHaveLength(0);
-  });
+      // Ticket returned (Todo + agent-ready), never Blocked, never the plain unclaim.
+      expect(calls.returned).toHaveLength(1);
+      expect(calls.returned[0].ticket).toBe("WM-7181");
+      expect(calls.returned[0].body).toContain(
+        "## Handoff verification (worker-observed)",
+      );
+      expect(calls.returned[0].body).toContain(
+        "(fail) totals > rejects an invalid total",
+      );
+      expect(calls.returned[0].body).toContain("Todo + ai:agent-ready");
+      expect(calls.unclaim).toHaveLength(0);
+      // The agent's PR is converted to draft with the observed failure quoted.
+      expect(calls.held).toHaveLength(1);
+      expect(calls.held[0]).toMatchObject({
+        prNumber: 77,
+        github: "watt-mind/wt-handoff",
+      });
+      expect(calls.held[0].body).toContain("exit 1 (FAIL)");
+      expect(calls.comments).toHaveLength(0);
+    },
+  );
 
   test("no Verification Command and no repo verify: refused handoff_verification_unspecified (fail-closed)", async () => {
     const spec = handoffSpec({
@@ -398,323 +402,346 @@ describe("handoff verification gate (WM-718)", () => {
     expect(calls.returned[0].body).toContain("Verification: NONE");
   });
 
-  test("without a Verification Command the repo verify stands in and the run completes with a worker-observed line", async () => {
-    const spec = handoffSpec({ ticket: "WM-7183" });
-    const { db, summary, calls } = await dispatch({
-      spec,
-      description: OWNED,
-      adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
-    });
-    expect(summary.terminalState).toBe("COMPLETED");
-    const result = JSON.parse(
-      db
-        .query(`SELECT result_json FROM results WHERE run_id = ?`)
-        .get(spec.runId).result_json,
-    );
-    expect(result.verification.checks).toContain("repo_verify_passed");
-    expect(result.verification.checks).not.toContain("ticket_verify_passed");
-    expect(calls.comments).toHaveLength(1);
-    expect(calls.comments[0].body).toContain(
-      "- Verification: `echo repo_verified` — exit 0 (pass)",
-    );
-    expect(calls.comments[0].body).toContain("repo `verify:` command stood in");
-  });
+  sandboxTest(
+    "without a Verification Command the repo verify stands in and the run completes with a worker-observed line",
+    async () => {
+      const spec = handoffSpec({ ticket: "WM-7183" });
+      const { db, summary, calls } = await dispatch({
+        spec,
+        description: OWNED,
+        adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
+      });
+      expect(summary.terminalState).toBe("COMPLETED");
+      const result = JSON.parse(
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).result_json,
+      );
+      expect(result.verification.checks).toContain("repo_verify_passed");
+      expect(result.verification.checks).not.toContain("ticket_verify_passed");
+      expect(calls.comments).toHaveLength(1);
+      expect(calls.comments[0].body).toContain(
+        "- Verification: `echo repo_verified` — exit 0 (pass)",
+      );
+      expect(calls.comments[0].body).toContain(
+        "repo `verify:` command stood in",
+      );
+    },
+  );
 
-  test("declared UX screenshots are content-addressed before workspace cleanup and their evidence stays durable", async () => {
-    const screenshot = Buffer.from("fake-png-bytes");
-    const sha256 = sha256Hex(screenshot);
-    let screenshotPath;
-    const spec = handoffSpec({ ticket: "WM-2023" });
-    const { artifactStore, db, summary } = await dispatch({
-      spec,
-      description: withCommand("bash run-tests.sh"),
-      adapter: agent({
-        files: {
-          "run-tests.sh": "echo ux handoff verified\n",
-          "src/feature/impl.txt": "done\n",
+  sandboxTest(
+    "declared UX screenshots are content-addressed before workspace cleanup and their evidence stays durable",
+    async () => {
+      const screenshot = Buffer.from("fake-png-bytes");
+      const sha256 = sha256Hex(screenshot);
+      let screenshotPath;
+      const spec = handoffSpec({ ticket: "WM-2023" });
+      const { artifactStore, db, summary } = await dispatch({
+        spec,
+        description: withCommand("bash run-tests.sh"),
+        adapter: agent({
+          files: {
+            "run-tests.sh": "echo ux handoff verified\n",
+            "src/feature/impl.txt": "done\n",
+          },
+          workspaceFiles: { "ux-artifacts/runs.png": screenshot },
+          artifacts: [{ kind: "ux-screenshot", path: "ux-artifacts/runs.png" }],
+          uxCritique: {
+            status: "required",
+            verdict: "SHIP",
+            evidence: [`sha256:${sha256}`],
+            rounds: 1,
+            prReady: true,
+          },
+          onWorkspace: (workspaceDir) => {
+            screenshotPath = path.join(workspaceDir, "ux-artifacts/runs.png");
+          },
+        }),
+      });
+
+      expect(summary.terminalState).toBe("COMPLETED");
+      const result = JSON.parse(
+        db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(spec.runId).result_json,
+      );
+      const stored = result.artifacts.find(
+        (entry) => entry.kind === "ux-screenshot",
+      );
+      const storedPath = path.join(artifactStore, sha256);
+      expect(stored).toEqual({
+        kind: "ux-screenshot",
+        sha256,
+        uri: `file://${storedPath}`,
+        sizeBytes: screenshot.length,
+      });
+      expect(result.artifact.uxCritique.evidence).toEqual([`sha256:${sha256}`]);
+      expect(existsSync(screenshotPath)).toBe(false);
+      expect(readFileSync(storedPath)).toEqual(screenshot);
+    },
+  );
+
+  sandboxTest(
+    "a PR targeting the wrong base fails handoff verification and is returned",
+    async () => {
+      const spec = handoffSpec({ ticket: "WM-9381" });
+      const { summary, calls } = await dispatch({
+        spec,
+        description: OWNED,
+        adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
+        hooks: {
+          fetchHandoffPullRequest: () => ({ baseRefName: "main" }),
         },
-        workspaceFiles: { "ux-artifacts/runs.png": screenshot },
-        artifacts: [{ kind: "ux-screenshot", path: "ux-artifacts/runs.png" }],
-        uxCritique: {
-          status: "required",
-          verdict: "SHIP",
-          evidence: [`sha256:${sha256}`],
-          rounds: 1,
-          prReady: true,
+      });
+
+      expect(summary.terminalState).toBe("FAILED");
+      expect(summary.reasonCode).toBe("handoff_verification_failed");
+      expect(summary.detail).toContain(
+        "PR #77 targets main, expected configured base develop",
+      );
+      expect(calls.held).toHaveLength(1);
+      expect(calls.returned).toHaveLength(1);
+    },
+  );
+
+  sandboxTest(
+    "a rate-limited handoff PR read defers without drafting the PR, returning the ticket, or spending an attempt",
+    async () => {
+      const spec = handoffSpec({ ticket: "WM-1870" });
+      const { db, summary, calls } = await dispatch({
+        spec,
+        description: OWNED,
+        adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
+        hooks: {
+          fetchHandoffPullRequest: () => {
+            const error = new Error("GitHub secondary rate limit");
+            error.code = "forge_rate_limited";
+            throw error;
+          },
         },
-        onWorkspace: (workspaceDir) => {
-          screenshotPath = path.join(workspaceDir, "ux-artifacts/runs.png");
-        },
-      }),
-    });
+      });
 
-    expect(summary.terminalState).toBe("COMPLETED");
-    const result = JSON.parse(
-      db
-        .query(`SELECT result_json FROM results WHERE run_id = ?`)
-        .get(spec.runId).result_json,
-    );
-    const stored = result.artifacts.find(
-      (entry) => entry.kind === "ux-screenshot",
-    );
-    const storedPath = path.join(artifactStore, sha256);
-    expect(stored).toEqual({
-      kind: "ux-screenshot",
-      sha256,
-      uri: `file://${storedPath}`,
-      sizeBytes: screenshot.length,
-    });
-    expect(result.artifact.uxCritique.evidence).toEqual([`sha256:${sha256}`]);
-    expect(existsSync(screenshotPath)).toBe(false);
-    expect(readFileSync(storedPath)).toEqual(screenshot);
-  });
+      expect(summary).toMatchObject({
+        terminalState: "QUEUED",
+        reasonCode: "handoff_forge_unavailable",
+      });
+      expect(calls.held).toHaveLength(0);
+      expect(calls.returned).toHaveLength(0);
+      expect(
+        db
+          .query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`)
+          .get(spec.runId).n,
+      ).toBe(0);
+      expect(
+        db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
+          .attempts,
+      ).toBe(0);
+    },
+  );
 
-  test("a PR targeting the wrong base fails handoff verification and is returned", async () => {
-    const spec = handoffSpec({ ticket: "WM-9381" });
-    const { summary, calls } = await dispatch({
-      spec,
-      description: OWNED,
-      adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
-      hooks: {
-        fetchHandoffPullRequest: () => ({ baseRefName: "main" }),
-      },
-    });
-
-    expect(summary.terminalState).toBe("FAILED");
-    expect(summary.reasonCode).toBe("handoff_verification_failed");
-    expect(summary.detail).toContain(
-      "PR #77 targets main, expected configured base develop",
-    );
-    expect(calls.held).toHaveLength(1);
-    expect(calls.returned).toHaveLength(1);
-  });
-
-  test("a rate-limited handoff PR read defers without drafting the PR, returning the ticket, or spending an attempt", async () => {
-    const spec = handoffSpec({ ticket: "WM-1870" });
-    const { db, summary, calls } = await dispatch({
-      spec,
-      description: OWNED,
-      adapter: agent({ files: { "src/feature/impl.txt": "done\n" } }),
-      hooks: {
-        fetchHandoffPullRequest: () => {
-          const error = new Error("GitHub secondary rate limit");
-          error.code = "forge_rate_limited";
-          throw error;
-        },
-      },
-    });
-
-    expect(summary).toMatchObject({
-      terminalState: "QUEUED",
-      reasonCode: "handoff_forge_unavailable",
-    });
-    expect(calls.held).toHaveLength(0);
-    expect(calls.returned).toHaveLength(0);
-    expect(
-      db
-        .query(`SELECT COUNT(*) AS n FROM attempts WHERE run_id = ?`)
-        .get(spec.runId).n,
-    ).toBe(0);
-    expect(
-      db.query(`SELECT attempts FROM runs WHERE run_id = ?`).get(spec.runId)
-        .attempts,
-    ).toBe(0);
-  });
-
-  test("a change under event-runtime/web/src/** runs the web build and a red build refuses the handoff", async () => {
-    const description = withCommand("bash run-tests.sh");
-    const files = {
-      "run-tests.sh": "echo ok\n",
-      "event-runtime/web/src/index.ts": "export const x: number = 2;\n",
-    };
-    // Green build: gate runs it (marker written) and records the check.
-    const green = handoffSpec({ ticket: "WM-7184" });
-    const g = await dispatch({
-      spec: green,
-      description,
-      adapter: agent({ files }),
-    });
-    expect(g.summary.terminalState).toBe("COMPLETED");
-    // The chroot maps the worktree at /workspace; when this suite itself runs
-    // inside a handoff sandbox the command is passed through and keeps the
-    // real path. Either way the build ran in the web directory, not the root.
-    expect(g.summary.handoff.webBuild.tail).toContain(
-      `web_built:${insideHandoffSandbox() ? "" : "/workspace"}`,
-    );
-    expect(g.summary.handoff.webBuild.tail).toContain("/event-runtime/web");
-    const result = JSON.parse(
-      g.db
-        .query(`SELECT result_json FROM results WHERE run_id = ?`)
-        .get(green.runId).result_json,
-    );
-    expect(result.verification.checks).toEqual(
-      expect.arrayContaining(["ticket_verify_passed", "web_build_passed"]),
-    );
-    expect(g.calls.comments[0].body).toContain(
-      "- Web build (event-runtime/web/src/** changed): `cd event-runtime/web && bun run build` — exit 0 (pass)",
-    );
-
-    // Red build (tsc-style error) even though the ticket's command is green.
-    const red = handoffSpec({ ticket: "WM-7185" });
-    const r = await dispatch({
-      spec: red,
-      description,
-      adapter: agent({
-        files: {
-          ...files,
-          "event-runtime/web/package.json":
-            '{"name":"web","private":true,"scripts":{"build":"echo \'src/index.ts(1,14): error TS6133: unused local\' >&2; exit 2"}}\n',
-        },
-      }),
-    });
-    expect(r.summary.terminalState).toBe("FAILED");
-    expect(r.summary.reasonCode).toBe("handoff_verification_failed");
-    expect(r.summary.detail).toContain("web_build_failed");
-    expect(r.summary.detail).toContain("error TS6133");
-    expect(r.summary.handoff.webBuild.exitCode).toBe(2);
-    expect(r.calls.held).toHaveLength(1);
-    expect(r.calls.returned).toHaveLength(1);
-
-    // No web/src change: the build is not run at all.
-    const skip = handoffSpec({ ticket: "WM-7186" });
-    const s = await dispatch({
-      spec: skip,
-      description,
-      adapter: agent({
-        files: { "run-tests.sh": "echo ok\n", "src/feature/x.txt": "x\n" },
-      }),
-    });
-    expect(s.summary.terminalState).toBe("COMPLETED");
-    expect(s.summary.handoff.webBuild).toBeNull();
-    expect(s.calls.comments[0].body).toContain("- Web build: skipped");
-  });
-
-  test("the Handoff Verification line is worker-authored: the agent's 'pass' claim cannot override an observed red, and rides below labelled agent-reported", async () => {
-    const description = withCommand("bash run-tests.sh");
-    const failing = handoffSpec({ ticket: "WM-7187" });
-    const f = await dispatch({
-      spec: failing,
-      description,
-      adapter: agent({
-        files: { "run-tests.sh": 'echo "regression in totals"; exit 3\n' },
-        claim: {
-          command: "bash run-tests.sh",
-          passed: true,
-          output: "pass, 2045 tests green",
-        },
-      }),
-    });
-    expect(f.summary.terminalState).toBe("FAILED");
-    const body = f.calls.returned[0].body;
-    const verificationLine = body
-      .split("\n")
-      .find((l) => l.startsWith("- Verification:"));
-    expect(verificationLine).toBe(
-      "- Verification: `bash run-tests.sh` — exit 3 (FAIL)",
-    );
-    expect(body).toContain("regression in totals");
-    expect(body).toContain(
-      "- agent-reported: `bash run-tests.sh` — pass, pass, 2045 tests green",
-    );
-    expect(body).not.toContain("- Verification: `bash run-tests.sh` — pass");
-
-    // Green run: the line still comes from the worker's observation, and a
-    // claim naming a different command is quoted only as agent-reported.
-    const passing = handoffSpec({ ticket: "WM-7188" });
-    const p = await dispatch({
-      spec: passing,
-      description,
-      adapter: agent({
-        files: { "run-tests.sh": 'echo "42 tests, 0 failures"\n' },
-        claim: {
-          command: "bun test --only-my-file",
-          passed: true,
-          output: "green",
-        },
-      }),
-    });
-    expect(p.summary.terminalState).toBe("COMPLETED");
-    const okBody = p.calls.comments[0].body;
-    expect(
-      okBody.split("\n").find((l) => l.startsWith("- Verification:")),
-    ).toBe("- Verification: `bash run-tests.sh` — exit 0 (pass)");
-    expect(okBody).toContain("42 tests, 0 failures");
-    expect(okBody).toContain(
-      "- agent-reported: `bun test --only-my-file` — pass, green",
-    );
-  });
-
-  test("Owned Paths deviations are computed from the diff: listed under advisory (default), refused under strict", async () => {
-    const description = withCommand("bash run-tests.sh");
-    const files = {
-      "run-tests.sh": "echo ok\n",
-      "src/feature/impl.txt": "done\n",
-      "docs/stray.md": "out of scope reflow\n",
-      "orchestrator/tick.mjs": "// out of scope\n",
-    };
-    setPolicy("{}\n"); // key absent → advisory
-    const adv = handoffSpec({ ticket: "WM-7189" });
-    const a = await dispatch({
-      spec: adv,
-      description,
-      adapter: agent({ files }),
-    });
-    expect(a.summary.terminalState).toBe("COMPLETED");
-    expect(a.summary.handoff.ownedPathsDeviations).toEqual([
-      "docs/stray.md",
-      "orchestrator/tick.mjs",
-      "run-tests.sh",
-    ]);
-    const result = JSON.parse(
-      a.db
-        .query(`SELECT result_json FROM results WHERE run_id = ?`)
-        .get(adv.runId).result_json,
-    );
-    expect(result.verification.checks).toContain(
-      "owned_paths_deviations_advisory",
-    );
-    const body = a.calls.comments[0].body;
-    expect(body).toContain("- Files: 4 changed vs origin/develop");
-    expect(body).toContain("- Owned Paths deviations (advisory): 3 file(s)");
-    expect(body).toContain("  - `docs/stray.md`");
-    expect(body).toContain("  - `orchestrator/tick.mjs`");
-    expect(body).toContain("  - `run-tests.sh`");
-    expect(body).not.toContain("  - `src/feature/impl.txt`");
-
-    setPolicy("dispatch:\n  owned_paths_conformance: strict\n");
-    try {
-      const strict = handoffSpec({ ticket: "WM-7190" });
-      const s = await dispatch({
-        spec: strict,
+  sandboxTest(
+    "a change under event-runtime/web/src/** runs the web build and a red build refuses the handoff",
+    async () => {
+      const description = withCommand("bash run-tests.sh");
+      const files = {
+        "run-tests.sh": "echo ok\n",
+        "event-runtime/web/src/index.ts": "export const x: number = 2;\n",
+      };
+      // Green build: gate runs it (marker written) and records the check.
+      const green = handoffSpec({ ticket: "WM-7184" });
+      const g = await dispatch({
+        spec: green,
         description,
         adapter: agent({ files }),
       });
-      expect(s.summary.terminalState).toBe("FAILED");
-      expect(s.summary.reasonCode).toBe("handoff_owned_paths_violation");
-      expect(s.summary.detail).toContain("docs/stray.md");
-      expect(s.calls.returned).toHaveLength(1);
-      expect(s.calls.held).toHaveLength(1);
-      expect(s.calls.returned[0].body).toContain(
-        "Owned Paths deviations (strict): 3 file(s)",
+      expect(g.summary.terminalState).toBe("COMPLETED");
+      // The chroot maps the worktree at /workspace; when this suite itself runs
+      // inside a handoff sandbox the command is passed through and keeps the
+      // real path. Either way the build ran in the web directory, not the root.
+      expect(g.summary.handoff.webBuild.tail).toContain(
+        `web_built:${insideHandoffSandbox() ? "" : "/workspace"}`,
       );
-    } finally {
-      setPolicy("{}\n");
-    }
+      expect(g.summary.handoff.webBuild.tail).toContain("/event-runtime/web");
+      const result = JSON.parse(
+        g.db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(green.runId).result_json,
+      );
+      expect(result.verification.checks).toEqual(
+        expect.arrayContaining(["ticket_verify_passed", "web_build_passed"]),
+      );
+      expect(g.calls.comments[0].body).toContain(
+        "- Web build (event-runtime/web/src/** changed): `cd event-runtime/web && bun run build` — exit 0 (pass)",
+      );
 
-    // Conformant diff: no deviations, the check is recorded.
-    const clean = handoffSpec({ ticket: "WM-7191" });
-    const c = await dispatch({
-      spec: clean,
-      description: `## Owned Paths\n- src/feature/**\n- run-tests.sh\n\n## Verification Command\n\n\`\`\`\nbash run-tests.sh\n\`\`\`\n`,
-      adapter: agent({
-        files: { "run-tests.sh": "echo ok\n", "src/feature/y.txt": "y\n" },
-      }),
-    });
-    expect(c.summary.terminalState).toBe("COMPLETED");
-    expect(c.calls.comments[0].body).toContain(
-      "- Owned Paths deviations: none",
-    );
-  });
+      // Red build (tsc-style error) even though the ticket's command is green.
+      const red = handoffSpec({ ticket: "WM-7185" });
+      const r = await dispatch({
+        spec: red,
+        description,
+        adapter: agent({
+          files: {
+            ...files,
+            "event-runtime/web/package.json":
+              '{"name":"web","private":true,"scripts":{"build":"echo \'src/index.ts(1,14): error TS6133: unused local\' >&2; exit 2"}}\n',
+          },
+        }),
+      });
+      expect(r.summary.terminalState).toBe("FAILED");
+      expect(r.summary.reasonCode).toBe("handoff_verification_failed");
+      expect(r.summary.detail).toContain("web_build_failed");
+      expect(r.summary.detail).toContain("error TS6133");
+      expect(r.summary.handoff.webBuild.exitCode).toBe(2);
+      expect(r.calls.held).toHaveLength(1);
+      expect(r.calls.returned).toHaveLength(1);
+
+      // No web/src change: the build is not run at all.
+      const skip = handoffSpec({ ticket: "WM-7186" });
+      const s = await dispatch({
+        spec: skip,
+        description,
+        adapter: agent({
+          files: { "run-tests.sh": "echo ok\n", "src/feature/x.txt": "x\n" },
+        }),
+      });
+      expect(s.summary.terminalState).toBe("COMPLETED");
+      expect(s.summary.handoff.webBuild).toBeNull();
+      expect(s.calls.comments[0].body).toContain("- Web build: skipped");
+    },
+  );
+
+  sandboxTest(
+    "the Handoff Verification line is worker-authored: the agent's 'pass' claim cannot override an observed red, and rides below labelled agent-reported",
+    async () => {
+      const description = withCommand("bash run-tests.sh");
+      const failing = handoffSpec({ ticket: "WM-7187" });
+      const f = await dispatch({
+        spec: failing,
+        description,
+        adapter: agent({
+          files: { "run-tests.sh": 'echo "regression in totals"; exit 3\n' },
+          claim: {
+            command: "bash run-tests.sh",
+            passed: true,
+            output: "pass, 2045 tests green",
+          },
+        }),
+      });
+      expect(f.summary.terminalState).toBe("FAILED");
+      const body = f.calls.returned[0].body;
+      const verificationLine = body
+        .split("\n")
+        .find((l) => l.startsWith("- Verification:"));
+      expect(verificationLine).toBe(
+        "- Verification: `bash run-tests.sh` — exit 3 (FAIL)",
+      );
+      expect(body).toContain("regression in totals");
+      expect(body).toContain(
+        "- agent-reported: `bash run-tests.sh` — pass, pass, 2045 tests green",
+      );
+      expect(body).not.toContain("- Verification: `bash run-tests.sh` — pass");
+
+      // Green run: the line still comes from the worker's observation, and a
+      // claim naming a different command is quoted only as agent-reported.
+      const passing = handoffSpec({ ticket: "WM-7188" });
+      const p = await dispatch({
+        spec: passing,
+        description,
+        adapter: agent({
+          files: { "run-tests.sh": 'echo "42 tests, 0 failures"\n' },
+          claim: {
+            command: "bun test --only-my-file",
+            passed: true,
+            output: "green",
+          },
+        }),
+      });
+      expect(p.summary.terminalState).toBe("COMPLETED");
+      const okBody = p.calls.comments[0].body;
+      expect(
+        okBody.split("\n").find((l) => l.startsWith("- Verification:")),
+      ).toBe("- Verification: `bash run-tests.sh` — exit 0 (pass)");
+      expect(okBody).toContain("42 tests, 0 failures");
+      expect(okBody).toContain(
+        "- agent-reported: `bun test --only-my-file` — pass, green",
+      );
+    },
+  );
+
+  sandboxTest(
+    "Owned Paths deviations are computed from the diff: listed under advisory (default), refused under strict",
+    async () => {
+      const description = withCommand("bash run-tests.sh");
+      const files = {
+        "run-tests.sh": "echo ok\n",
+        "src/feature/impl.txt": "done\n",
+        "docs/stray.md": "out of scope reflow\n",
+        "orchestrator/tick.mjs": "// out of scope\n",
+      };
+      setPolicy("{}\n"); // key absent → advisory
+      const adv = handoffSpec({ ticket: "WM-7189" });
+      const a = await dispatch({
+        spec: adv,
+        description,
+        adapter: agent({ files }),
+      });
+      expect(a.summary.terminalState).toBe("COMPLETED");
+      expect(a.summary.handoff.ownedPathsDeviations).toEqual([
+        "docs/stray.md",
+        "orchestrator/tick.mjs",
+        "run-tests.sh",
+      ]);
+      const result = JSON.parse(
+        a.db
+          .query(`SELECT result_json FROM results WHERE run_id = ?`)
+          .get(adv.runId).result_json,
+      );
+      expect(result.verification.checks).toContain(
+        "owned_paths_deviations_advisory",
+      );
+      const body = a.calls.comments[0].body;
+      expect(body).toContain("- Files: 4 changed vs origin/develop");
+      expect(body).toContain("- Owned Paths deviations (advisory): 3 file(s)");
+      expect(body).toContain("  - `docs/stray.md`");
+      expect(body).toContain("  - `orchestrator/tick.mjs`");
+      expect(body).toContain("  - `run-tests.sh`");
+      expect(body).not.toContain("  - `src/feature/impl.txt`");
+
+      setPolicy("dispatch:\n  owned_paths_conformance: strict\n");
+      try {
+        const strict = handoffSpec({ ticket: "WM-7190" });
+        const s = await dispatch({
+          spec: strict,
+          description,
+          adapter: agent({ files }),
+        });
+        expect(s.summary.terminalState).toBe("FAILED");
+        expect(s.summary.reasonCode).toBe("handoff_owned_paths_violation");
+        expect(s.summary.detail).toContain("docs/stray.md");
+        expect(s.calls.returned).toHaveLength(1);
+        expect(s.calls.held).toHaveLength(1);
+        expect(s.calls.returned[0].body).toContain(
+          "Owned Paths deviations (strict): 3 file(s)",
+        );
+      } finally {
+        setPolicy("{}\n");
+      }
+
+      // Conformant diff: no deviations, the check is recorded.
+      const clean = handoffSpec({ ticket: "WM-7191" });
+      const c = await dispatch({
+        spec: clean,
+        description: `## Owned Paths\n- src/feature/**\n- run-tests.sh\n\n## Verification Command\n\n\`\`\`\nbash run-tests.sh\n\`\`\`\n`,
+        adapter: agent({
+          files: { "run-tests.sh": "echo ok\n", "src/feature/y.txt": "y\n" },
+        }),
+      });
+      expect(c.summary.terminalState).toBe("COMPLETED");
+      expect(c.calls.comments[0].body).toContain(
+        "- Owned Paths deviations: none",
+      );
+    },
+  );
 });
 
 // The describe block above only exercises the handoff gate through mocked

--- a/event-runtime/test-support/sandbox.mjs
+++ b/event-runtime/test-support/sandbox.mjs
@@ -1,0 +1,36 @@
+import { test } from "bun:test";
+import { handoffSandboxSkipReason } from "../lib/verify.mjs";
+
+/**
+ * Cases that only mean something on a host that can build the handoff sandbox
+ * (GH-2267).
+ *
+ * A large family of worker/verify tests drives a dispatch run all the way
+ * through the verified-PR handoff and asserts a COMPLETED terminal state. That
+ * state is reachable only where the worker can actually enter an unprivileged
+ * user+mount namespace. On a host without one the run legitimately terminates
+ * FAILED / `sandbox_unavailable` — an environment fault, not the branch's red.
+ * GitHub-hosted runners are exactly such a host, and they carry every fork and
+ * Dependabot pull request, so before this seam existed the cloud lane could
+ * only be made green by dropping the whole suite — which took lint, format,
+ * build and every non-sandbox unit test down with it.
+ *
+ * `sandboxTest` skips just those cases, and only where the sandbox is genuinely
+ * absent. The rest of each suite still runs on the cloud lane.
+ *
+ * The verdict comes from `handoffSandboxSkipReason`, i.e. from the same real
+ * `unshare` probe the production handoff gate uses, and from nothing else.
+ * There is deliberately no environment variable or CI marker in this path: a
+ * skip a pull request could switch on for itself would let a fork shed exactly
+ * the coverage it is meant to be held to.
+ */
+export const sandboxSkipReason = handoffSandboxSkipReason();
+
+if (sandboxSkipReason) {
+  // Logged once per test file that imports this, so a skipped case is visible
+  // in the CI log as a named environment limitation rather than as silence.
+  console.warn(`sandbox-dependent cases skipped — ${sandboxSkipReason}`);
+}
+
+/** `test`, but skipped when this host cannot create the handoff sandbox. */
+export const sandboxTest = test.skipIf(Boolean(sandboxSkipReason));


### PR DESCRIPTION
Fixes watt-mind/factory#2267

Cloud-lane CI now skips unavailable sandbox checks while the shadow lane remains fail-closed.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/verify.test.mjs --timeout 20000` | pass | 114 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; lint warnings only |
| UX critique          | factory-ux-critic                | not run | CI-only workflow change |

UX critique: skipped — CI-only workflow change; no user-facing surface

run:run_ad943186-5087-4f0f-828a-7a924b309d85
