### PR TITLE
test(runtime): reset merge review warning state

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -276,15 +276,20 @@ function normalizeListedPr(raw, baseSha, github) {
 
 function positiveIntegerMinutes(env, name, defaultMinutes) {
   const raw = env[name];
+  if (raw === undefined || raw === "") return defaultMinutes;
   const value = Number(raw);
   if (Number.isInteger(value) && value > 0) return value;
-  if (raw !== undefined && !invalidMinuteConfigWarnings.has(name)) {
+  if (!invalidMinuteConfigWarnings.has(name)) {
     invalidMinuteConfigWarnings.add(name);
     console.warn(
       `invalid ${name}=${JSON.stringify(raw)}; using default ${defaultMinutes} minutes`,
     );
   }
   return defaultMinutes;
+}
+
+export function resetInvalidMinuteConfigWarnings() {
+  invalidMinuteConfigWarnings.clear();
 }
 
 export function rebaseSkipFreshCiMinutes(env = process.env) {

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -1,4 +1,4 @@
-import { describe, expect, test } from "bun:test";
+import { beforeEach, describe, expect, test } from "bun:test";
 import path from "node:path";
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { Database } from "bun:sqlite";
@@ -16,6 +16,7 @@ import {
   mergeFixRefusalCooldownMs,
   persistMergeReviewFromResult,
   rebaseSkipFreshCiMinutes,
+  resetInvalidMinuteConfigWarnings,
   runScanCli,
   upsertMergeReview,
 } from "./merge-reviews.mjs";
@@ -39,6 +40,10 @@ const repos = new Map([
     },
   ],
 ]);
+
+beforeEach(() => {
+  resetInvalidMinuteConfigWarnings();
+});
 
 describe("merge-fix refusal cooldown configuration", () => {
   test.each([
@@ -106,13 +111,14 @@ describe("merge-fix refusal cooldown configuration", () => {
       42 * 60_000,
     ],
   ])(
-    "is silent when the %s value is unset or valid",
+    "is silent when the %s value is unset, empty, or valid",
     (_name, accessor, key, defaultValue, validValue) => {
       const warnings = [];
       const warn = console.warn;
       console.warn = (message) => warnings.push(message);
       try {
         expect(accessor({})).toBe(defaultValue);
+        expect(accessor({ [key]: "" })).toBe(defaultValue);
         expect(accessor({ [key]: "42" })).toBe(validValue);
       } finally {
         console.warn = warn;


### PR DESCRIPTION
Fixes watt-mind/factory#2268

Reset merge-review warning state between test executions and treat empty minute configuration as unset.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass | 56 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2507 pass, formatting and lint clean |
| UX critique | `factory-ux-critic` | not run | no user-facing surface |

UX critique: skipped — internal runtime module and tests; no user-facing surface
run:run_973e3021-8678-46c5-9aff-3968a51539f7