### PR TITLE
fix(ci): stabilize stray result recovery probe

### DIFF
--- a/event-runtime/lib/verify.mjs
+++ b/event-runtime/lib/verify.mjs
@@ -1745,6 +1745,7 @@ export function verifyResult({
   worktreeRecord = null,
   checkoutPath = null,
   onTrace = null,
+  checkoutResultIsTrackedFn = checkoutResultIsTracked,
   verifyTimeoutMs = repoVerifyTimeoutMs(),
   runHandoffCommandFn = runHandoffCommand,
   dependencyInstaller = defaultDependencyInstaller,
@@ -1756,6 +1757,7 @@ export function verifyResult({
     checkout: checkoutPath ?? worktreeRecord?.path ?? null,
     attemptStartedAt,
     onTrace,
+    checkoutResultIsTrackedFn,
   });
 
   let candidate;
@@ -1794,7 +1796,13 @@ export function verifyResult({
  * their mtime proves they belong to this attempt; an old sibling ticket's
  * envelope is never a valid substitute for this run's result.
  */
-function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
+function readResultFile({
+  workspaceDir,
+  checkout,
+  attemptStartedAt,
+  onTrace,
+  checkoutResultIsTrackedFn,
+}) {
   const resultPath = path.join(workspaceDir, "result.json");
   try {
     return readFileSync(resultPath, "utf8");
@@ -1829,7 +1837,7 @@ function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
     if (
       checkout &&
       candidatePath === path.join(checkout, "result.json") &&
-      checkoutResultIsTracked(checkout)
+      checkoutResultIsTrackedSafely(checkout, checkoutResultIsTrackedFn)
     ) {
       stalePaths.push({ path: candidatePath, skipped: "tracked_in_checkout" });
       continue;
@@ -1866,6 +1874,17 @@ function readResultFile({ workspaceDir, checkout, attemptStartedAt, onTrace }) {
   if (stalePaths.length > 0) err.missingResultPaths = stalePaths;
   if (candidates.length > 0) err.missingResultFallbacks = candidates;
   throw err;
+}
+
+// A failed subprocess probe is indistinguishable from a tracked file at this
+// deletion boundary. Keep that fail-closed decision outside the subprocess
+// helper so recovery tests can exercise it without relying on host git timing.
+function checkoutResultIsTrackedSafely(checkout, checkoutResultIsTrackedFn) {
+  try {
+    return checkoutResultIsTrackedFn(checkout);
+  } catch {
+    return true;
+  }
 }
 
 function checkoutResultIsTracked(checkout) {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -627,7 +627,6 @@ describe("verifyResult", () => {
   test("probes the checkout handed over separately from the worktree record", () => {
     const workspaceDir = tmpDir("evrt-verify-workspace-");
     const checkout = tmpDir("evrt-verify-checkout-");
-    execFileSync("git", ["init", "--quiet", checkout]);
     const strayPath = path.join(checkout, "result.json");
     writeFileSync(
       strayPath,
@@ -650,10 +649,45 @@ describe("verifyResult", () => {
       checkoutPath: checkout,
       attempt: 1,
       attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      // This recovery test needs a known-untracked checkout result. Injecting
+      // that fact avoids making its assertion depend on a contended CI host
+      // scheduling an unrelated git subprocess.
+      checkoutResultIsTrackedFn: () => false,
     });
 
     expect(out.kind).toBe("completed");
     expect(existsSync(strayPath)).toBe(false);
+  });
+
+  test("fails closed when an injected tracked-file probe errors", () => {
+    const workspaceDir = tmpDir("evrt-verify-workspace-");
+    const checkout = tmpDir("evrt-verify-checkout-");
+    const candidatePath = path.join(checkout, "result.json");
+    writeFileSync(
+      candidatePath,
+      JSON.stringify({
+        schemaVersion: "factory.agent-result/v1",
+        terminalState: "completed",
+        artifact: VALID_ARTIFACT,
+      }),
+      "utf8",
+    );
+
+    expect(() =>
+      verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        checkoutPath: checkout,
+        attempt: 1,
+        attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+        checkoutResultIsTrackedFn: () => {
+          throw new Error("git probe timed out");
+        },
+      }),
+    ).toThrow(ContractViolation);
+    expect(existsSync(candidatePath)).toBe(true);
   });
 
   test("rejects a stale stray result from before this attempt", () => {

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -716,6 +716,10 @@ describe("verifyResult", () => {
         worktreeRecord: { path: checkout },
         attempt: 1,
         attemptStartedAt: attemptStartedAt.toISOString(),
+        // This staleness test needs a known-untracked checkout result. Injecting
+        // that fact avoids making its assertion depend on a contended CI host
+        // scheduling an unrelated git subprocess.
+        checkoutResultIsTrackedFn: () => false,
       });
       throw new Error("expected ContractViolation");
     } catch (err) {


### PR DESCRIPTION
Fixes watt-mind/factory#2271

The fixture now injects its known-untracked state, so contended host git probes cannot turn a recovery assertion into missing_result.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/verify.test.mjs --timeout 20000` | pass    | 116 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | all gates passed       |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — no user-facing surface
run:run_71e5eb3b-f40a-4c7f-8c41-db9ecb94b255