### PR TITLE
test(runtime): stabilize hosted CI fixtures (GH-2276)

### DIFF
--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -752,7 +752,9 @@ describe("bearer-token auth on the control API (WM-1152)", () => {
           );
         });
         req.on("error", reject);
-        req.end();
+        // Send the declared bytes too: Bun 1.3's node:http client rewrites an
+        // empty request's Content-Length, which otherwise bypasses this guard.
+        req.end(Buffer.alloc(1024 * 1024 + 1));
       });
       expect(res.status).toBe(413);
       expect(res.body).toEqual({

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -38,11 +38,7 @@ import {
   writeFileSync,
 } from "./api-test-helpers.mjs";
 import { cpSync } from "node:fs";
-import {
-  MAX_BODY_BYTES,
-  PayloadTooLargeError,
-  readBody,
-} from "./api-http.mjs";
+import { MAX_BODY_BYTES, PayloadTooLargeError, readBody } from "./api-http.mjs";
 import { emitDueTicks } from "./schedules.mjs";
 import { createInboxItem } from "./inbox.mjs";
 import { decisionRequestHash } from "./decision.mjs";

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -577,16 +577,26 @@ describe("verifyResult", () => {
       "utf8",
     );
 
-    const out = verifyResult({
-      spec: makeSpec(),
-      def,
-      registry,
-      workspaceDir,
-      worktreeRecord: { path: checkout },
-      attempt: 1,
-      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-      onTrace: (kind, payload) => events.push({ kind, payload }),
-    });
+    let out;
+    try {
+      out = verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        worktreeRecord: { path: checkout },
+        attempt: 1,
+        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+        onTrace: (kind, payload) => events.push({ kind, payload }),
+      });
+    } catch (err) {
+      throw new Error(
+        `recovery diagnostics: ${JSON.stringify({
+          missingResultPaths: err.missingResultPaths,
+          missingResultFallbacks: err.missingResultFallbacks,
+        })}`,
+      );
+    }
 
     expect(out.kind).toBe("completed");
     expect(readFileSync(trackedPath, "utf8")).toBe(trackedResult);

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -505,7 +505,9 @@ describe("verifyResult", () => {
     execFileSync("git", ["init", "--quiet", checkout]);
     const truncatedPath = path.join(checkout, "result.json");
     writeFileSync(truncatedPath, '{"schemaVersion": "factory.age', "utf8");
-    const strayPath = path.join(physicalParent, "result.json");
+    // Match the physical sibling path that readResultFile() probes. TMPDIR may
+    // itself be symlinked on hosted runners, so physicalParent is not reliable.
+    const strayPath = path.join(realpathSync(checkout), "..", "result.json");
     writeFileSync(
       strayPath,
       JSON.stringify({

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -571,7 +571,9 @@ describe("verifyResult", () => {
       workspaceDir,
       worktreeRecord: { path: checkout },
       attempt: 1,
-      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      // Keep the fixture's recovery window independent of hosted runner
+      // filesystem timestamp precision; stale-rejection is tested separately.
+      attemptStartedAt: new Date(Date.now() - 60_000).toISOString(),
       onTrace: (kind, payload) => events.push({ kind, payload }),
     });
 
@@ -653,7 +655,9 @@ describe("verifyResult", () => {
       worktreeRecord: {},
       checkoutPath: checkout,
       attempt: 1,
-      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      // Keep the fixture's recovery window independent of hosted runner
+      // filesystem timestamp precision; stale-rejection is tested separately.
+      attemptStartedAt: new Date(Date.now() - 60_000).toISOString(),
     });
 
     expect(out.kind).toBe("completed");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -473,16 +473,26 @@ describe("verifyResult", () => {
       "utf8",
     );
 
-    const out = verifyResult({
-      spec: makeSpec(),
-      def,
-      registry,
-      workspaceDir,
-      worktreeRecord: { path: checkout },
-      attempt: 1,
-      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-      onTrace: (kind, payload) => events.push({ kind, payload }),
-    });
+    let out;
+    try {
+      out = verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        worktreeRecord: { path: checkout },
+        attempt: 1,
+        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+        onTrace: (kind, payload) => events.push({ kind, payload }),
+      });
+    } catch (err) {
+      throw new Error(
+        `recovery diagnostics: ${JSON.stringify({
+          missingResultPaths: err.missingResultPaths,
+          missingResultFallbacks: err.missingResultFallbacks,
+        })}`,
+      );
+    }
 
     expect(out.kind).toBe("completed");
     expect(existsSync(strayPath)).toBe(false);
@@ -648,16 +658,26 @@ describe("verifyResult", () => {
 
     // The timed-out preflight suppresses worktree command verification with an
     // empty record while still naming the checkout for the stray probe.
-    const out = verifyResult({
-      spec: makeSpec(),
-      def,
-      registry,
-      workspaceDir,
-      worktreeRecord: {},
-      checkoutPath: checkout,
-      attempt: 1,
-      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-    });
+    let out;
+    try {
+      out = verifyResult({
+        spec: makeSpec(),
+        def,
+        registry,
+        workspaceDir,
+        worktreeRecord: {},
+        checkoutPath: checkout,
+        attempt: 1,
+        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+      });
+    } catch (err) {
+      throw new Error(
+        `recovery diagnostics: ${JSON.stringify({
+          missingResultPaths: err.missingResultPaths,
+          missingResultFallbacks: err.missingResultFallbacks,
+        })}`,
+      );
+    }
 
     expect(out.kind).toBe("completed");
     expect(existsSync(strayPath)).toBe(false);

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -62,6 +62,9 @@ const registry = loadRegistry();
 const def = getAgent(registry, "factory-status-report@1");
 const dispatchDef = getAgent(registry, "dispatch@1");
 const workScanDef = getAgent(registry, "work-scan@1");
+// Path-selection fixtures do not test age; the stale-result test below does.
+// A broad window keeps their candidate selection independent of host clocks.
+const RECOVERY_ATTEMPT_STARTED_AT = "1970-01-01T00:00:00.000Z";
 
 function makeSpec(input = { repos: ["bj29"] }) {
   return {
@@ -477,7 +480,7 @@ describe("verifyResult", () => {
       workspaceDir,
       worktreeRecord: { path: checkout },
       attempt: 1,
-      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
       onTrace: (kind, payload) => events.push({ kind, payload }),
     });
 
@@ -525,7 +528,7 @@ describe("verifyResult", () => {
       workspaceDir,
       worktreeRecord: { path: checkout },
       attempt: 1,
-      attemptStartedAt: new Date(Date.now() - 5_000).toISOString(),
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
     });
 
     expect(out.kind).toBe("completed");
@@ -571,9 +574,7 @@ describe("verifyResult", () => {
       workspaceDir,
       worktreeRecord: { path: checkout },
       attempt: 1,
-      // Keep the fixture's recovery window independent of hosted runner
-      // filesystem timestamp precision; stale-rejection is tested separately.
-      attemptStartedAt: new Date(Date.now() - 60_000).toISOString(),
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
       onTrace: (kind, payload) => events.push({ kind, payload }),
     });
 
@@ -655,9 +656,7 @@ describe("verifyResult", () => {
       worktreeRecord: {},
       checkoutPath: checkout,
       attempt: 1,
-      // Keep the fixture's recovery window independent of hosted runner
-      // filesystem timestamp precision; stale-rejection is tested separately.
-      attemptStartedAt: new Date(Date.now() - 60_000).toISOString(),
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
     });
 
     expect(out.kind).toBe("completed");

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -63,8 +63,17 @@ const def = getAgent(registry, "factory-status-report@1");
 const dispatchDef = getAgent(registry, "dispatch@1");
 const workScanDef = getAgent(registry, "work-scan@1");
 // Path-selection fixtures do not test age; the stale-result test below does.
-// A broad window keeps their candidate selection independent of host clocks.
+// This fixed timestamp is valid on both the host and CI clock domains.
 const RECOVERY_ATTEMPT_STARTED_AT = "1970-01-01T00:00:00.000Z";
+const RECOVERY_CANDIDATE_TIMESTAMP = new Date("2000-01-01T00:00:00.000Z");
+
+function markRecoveryCandidate(filePath) {
+  utimesSync(
+    filePath,
+    RECOVERY_CANDIDATE_TIMESTAMP,
+    RECOVERY_CANDIDATE_TIMESTAMP,
+  );
+}
 
 function makeSpec(input = { repos: ["bj29"] }) {
   return {
@@ -472,27 +481,18 @@ describe("verifyResult", () => {
       }),
       "utf8",
     );
+    markRecoveryCandidate(strayPath);
 
-    let out;
-    try {
-      out = verifyResult({
-        spec: makeSpec(),
-        def,
-        registry,
-        workspaceDir,
-        worktreeRecord: { path: checkout },
-        attempt: 1,
-        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-        onTrace: (kind, payload) => events.push({ kind, payload }),
-      });
-    } catch (err) {
-      throw new Error(
-        `recovery diagnostics: ${JSON.stringify({
-          missingResultPaths: err.missingResultPaths,
-          missingResultFallbacks: err.missingResultFallbacks,
-        })}`,
-      );
-    }
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: { path: checkout },
+      attempt: 1,
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+      onTrace: (kind, payload) => events.push({ kind, payload }),
+    });
 
     expect(out.kind).toBe("completed");
     expect(existsSync(strayPath)).toBe(false);
@@ -518,8 +518,7 @@ describe("verifyResult", () => {
     execFileSync("git", ["init", "--quiet", checkout]);
     const truncatedPath = path.join(checkout, "result.json");
     writeFileSync(truncatedPath, '{"schemaVersion": "factory.age', "utf8");
-    // Match the physical sibling path that readResultFile() probes. TMPDIR may
-    // itself be symlinked on hosted runners, so physicalParent is not reliable.
+    // Use the same physical sibling path that readResultFile() probes.
     const strayPath = path.join(realpathSync(checkout), "..", "result.json");
     writeFileSync(
       strayPath,
@@ -530,6 +529,7 @@ describe("verifyResult", () => {
       }),
       "utf8",
     );
+    markRecoveryCandidate(strayPath);
 
     const out = verifyResult({
       spec: makeSpec(),
@@ -563,8 +563,7 @@ describe("verifyResult", () => {
     writeFileSync(trackedPath, trackedResult, "utf8");
     execFileSync("git", ["init", "--quiet", checkout]);
     execFileSync("git", ["-C", checkout, "add", "result.json"]);
-    // Match the physical sibling path that readResultFile() probes. TMPDIR may
-    // itself be symlinked on hosted runners, so physicalParent is not reliable.
+    // Use the same physical sibling path that readResultFile() probes.
     const strayPath = path.join(realpathSync(checkout), "..", "result.json");
     const events = [];
     writeFileSync(
@@ -576,27 +575,18 @@ describe("verifyResult", () => {
       }),
       "utf8",
     );
+    markRecoveryCandidate(strayPath);
 
-    let out;
-    try {
-      out = verifyResult({
-        spec: makeSpec(),
-        def,
-        registry,
-        workspaceDir,
-        worktreeRecord: { path: checkout },
-        attempt: 1,
-        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-        onTrace: (kind, payload) => events.push({ kind, payload }),
-      });
-    } catch (err) {
-      throw new Error(
-        `recovery diagnostics: ${JSON.stringify({
-          missingResultPaths: err.missingResultPaths,
-          missingResultFallbacks: err.missingResultFallbacks,
-        })}`,
-      );
-    }
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: { path: checkout },
+      attempt: 1,
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+      onTrace: (kind, payload) => events.push({ kind, payload }),
+    });
 
     expect(out.kind).toBe("completed");
     expect(readFileSync(trackedPath, "utf8")).toBe(trackedResult);
@@ -665,29 +655,20 @@ describe("verifyResult", () => {
       }),
       "utf8",
     );
+    markRecoveryCandidate(strayPath);
 
     // The timed-out preflight suppresses worktree command verification with an
     // empty record while still naming the checkout for the stray probe.
-    let out;
-    try {
-      out = verifyResult({
-        spec: makeSpec(),
-        def,
-        registry,
-        workspaceDir,
-        worktreeRecord: {},
-        checkoutPath: checkout,
-        attempt: 1,
-        attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
-      });
-    } catch (err) {
-      throw new Error(
-        `recovery diagnostics: ${JSON.stringify({
-          missingResultPaths: err.missingResultPaths,
-          missingResultFallbacks: err.missingResultFallbacks,
-        })}`,
-      );
-    }
+    const out = verifyResult({
+      spec: makeSpec(),
+      def,
+      registry,
+      workspaceDir,
+      worktreeRecord: {},
+      checkoutPath: checkout,
+      attempt: 1,
+      attemptStartedAt: RECOVERY_ATTEMPT_STARTED_AT,
+    });
 
     expect(out.kind).toBe("completed");
     expect(existsSync(strayPath)).toBe(false);

--- a/event-runtime/lib/verify.test.mjs
+++ b/event-runtime/lib/verify.test.mjs
@@ -548,7 +548,9 @@ describe("verifyResult", () => {
     writeFileSync(trackedPath, trackedResult, "utf8");
     execFileSync("git", ["init", "--quiet", checkout]);
     execFileSync("git", ["-C", checkout, "add", "result.json"]);
-    const strayPath = path.join(physicalParent, "result.json");
+    // Match the physical sibling path that readResultFile() probes. TMPDIR may
+    // itself be symlinked on hosted runners, so physicalParent is not reliable.
+    const strayPath = path.join(realpathSync(checkout), "..", "result.json");
     const events = [];
     writeFileSync(
       strayPath,


### PR DESCRIPTION
Fixes watt-mind/factory#2276

Hosted-runner fixture fixes are ready for review.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/verify.test.mjs event-runtime/lib/api.test.mjs --timeout 20000` | pass | 137 tests, 0 failures |
| Repo verify | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean (613 baseline warnings) |
| UX critique | `factory-ux-critic` | not run | test-only change; no user-facing surface |

UX critique: skipped — test-only change; no user-facing surface

run:run_b8c563c1-b05b-43bc-ba41-671d7e7bffe9