### PR TITLE
fix(web): add lint script

### DIFF
--- a/event-runtime/web/package.json
+++ b/event-runtime/web/package.json
@@ -7,6 +7,7 @@
     "typecheck": "tsc --noEmit",
     "build": "tsc --noEmit && vite build",
     "build:fast": "vite build",
+    "lint": "eslint src",
     "test": "bun test",
     "test:e2e": "bun add --no-save --exact \"@playwright/test@$(bun e2e/playwright-version.mjs)\" && bun playwright test --config playwright.config.ts"
   },


### PR DESCRIPTION
Fixes watt-mind/factory#2062

Add a web-local lint script so factory#1915's verification command can run end-to-end.

## Validation

| Check                | Command                                                                                                                        | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/web/src/views/Agents.test.tsx --timeout 20000` | pass | 20 tests, 0 failures                       |
| Web lint             | `cd event-runtime/web && bun run lint`                                                                                        | pass    | 149 warnings, 0 errors                     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`           | pass    | 2509 pass; 613 lint warnings, 0 errors     |
| UX critique          | `factory-ux-critic`                                                                                                           | not run | no user-facing surface; build tooling only |

UX critique: skipped — no user-facing surface (build tooling only)

run:run_a2411a16-b2e7-4d57-b3b4-27e073afdeae
