### PR TITLE
fix(merge-reviews): reject fabricated branch tickets

### DIFF
--- a/event-runtime/lib/merge-reviews.mjs
+++ b/event-runtime/lib/merge-reviews.mjs
@@ -31,7 +31,7 @@ export const MERGE_SCAN_AGENT = "merge-scan@2";
 export const MERGE_REVIEW_AGENT = "merge-review@1";
 
 const SHA40 = /^[0-9a-f]{40}$/;
-const TICKET = /[A-Z]+-[0-9]+/;
+const REF_TICKET = /(?:^|[^A-Za-z0-9_])([A-Z]+-[0-9]+)(?=$|[^A-Za-z0-9_])/;
 const GITHUB_REF_TICKET = /(?:^|\/)gh-([0-9]+)$/i;
 const BARE_GITHUB_REF_TICKET = /^([0-9]+)$/;
 const GITHUB_BODY_TICKET =
@@ -82,7 +82,14 @@ function asPr(value) {
   return Number.isInteger(n) && n >= 1 ? n : null;
 }
 
-function ticketFromRef(headRef, title, body, github) {
+function githubTicketFromText(text, prNumber) {
+  const match =
+    typeof text === "string" ? text.match(GITHUB_BODY_TICKET) : null;
+  if (!match || Number(match[1].split("#")[1]) === prNumber) return null;
+  return match[1];
+}
+
+function ticketFromRef(headRef, title, body, github, prNumber) {
   const githubRef =
     typeof headRef === "string"
       ? (headRef.match(GITHUB_REF_TICKET) ??
@@ -92,14 +99,14 @@ function ticketFromRef(headRef, title, body, github) {
     return `${github}#${githubRef[1] ?? githubRef[2]}`;
   }
   const fromRef =
-    typeof headRef === "string" ? headRef.toUpperCase().match(TICKET) : null;
-  if (fromRef) return fromRef[0];
-  const fromBody =
-    typeof body === "string" ? body.match(GITHUB_BODY_TICKET) : null;
-  if (fromBody) return fromBody[1];
-  const fromTitle =
-    typeof title === "string" ? title.toUpperCase().match(TICKET) : null;
-  return fromTitle ? fromTitle[0] : null;
+    typeof headRef === "string" ? headRef.match(REF_TICKET) : null;
+  if (fromRef) return fromRef[1];
+  const fromBody = githubTicketFromText(body, prNumber);
+  if (fromBody) return fromBody;
+  const fromTitleGithub = githubTicketFromText(title, prNumber);
+  if (fromTitleGithub) return fromTitleGithub;
+  const fromTitle = typeof title === "string" ? title.match(REF_TICKET) : null;
+  return fromTitle ? fromTitle[1] : null;
 }
 
 function parseJsonColumn(raw, fallback) {
@@ -263,7 +270,7 @@ function normalizeListedPr(raw, baseSha, github) {
     baseSha: base,
     headRef: typeof raw.headRefName === "string" ? raw.headRefName : null,
     baseRefName: typeof raw.baseRefName === "string" ? raw.baseRefName : null,
-    ticket: ticketFromRef(raw.headRefName, raw.title, raw.body, github),
+    ticket: ticketFromRef(raw.headRefName, raw.title, raw.body, github, number),
     mergeable:
       typeof raw.mergeable === "string" ? raw.mergeable.toUpperCase() : "",
     mergeStateStatus:
@@ -798,6 +805,10 @@ function assemble({
           headSha: pr.headSha,
         })
       ) {
+        continue;
+      }
+      if (!pr.ticket) {
+        rebaseSkipped.push({ pr: pr.number, reason: "ticket_missing" });
         continue;
       }
       const item = rebaseFixItem(pr, hit, { forge, github });

--- a/event-runtime/lib/merge-reviews.test.mjs
+++ b/event-runtime/lib/merge-reviews.test.mjs
@@ -524,7 +524,7 @@ describe("merge_reviews ledger keying (WM-907 / WM-936)", () => {
 });
 
 describe("merge-scan enumerator (WM-907)", () => {
-  test("canonicalizes GitHub ref slugs and falls back to a Fixes body reference", () => {
+  test("canonicalizes GitHub ref slugs and derives only uppercase ref tickets", () => {
     const result = enumerateMergeScan({
       input: { repo: "factory" },
       db: openDb(":memory:"),
@@ -535,9 +535,20 @@ describe("merge-scan enumerator (WM-907)", () => {
         pr({
           number: 880,
           headRefName: "feat/no-ticket",
-          body: "Fixes watt-mind/factory#880",
+          body: "Fixes watt-mind/factory#881",
         }),
         pr({ number: 123, headRefName: "feat/WM-123" }),
+        pr({
+          number: 7,
+          headRefName: "dependabot/github_actions/develop/actions/setup-node-7",
+          title: "Bump actions/setup-node-7",
+        }),
+        pr({
+          number: 2261,
+          headRefName: "feat/no-ticket",
+          title: "No ticket",
+          body: "Fixes watt-mind/factory#2261",
+        }),
       ]),
       repos,
     });
@@ -546,8 +557,10 @@ describe("merge-scan enumerator (WM-907)", () => {
       "watt-mind/factory#877",
       "watt-mind/factory#878",
       "watt-mind/factory#879",
-      "watt-mind/factory#880",
+      "watt-mind/factory#881",
       "WM-123",
+      undefined,
+      undefined,
     ]);
   });
 
@@ -1100,6 +1113,37 @@ describe("merge-scan enumerator (WM-936)", () => {
       repos,
     });
     expect(result.artifact.fix).toHaveLength(1);
+  });
+
+  test("ticketless dependabot rebase records the skipped mechanical fix", () => {
+    const db = openDb(":memory:");
+    upsertMergeReview(db, {
+      github: GITHUB,
+      pr: 9,
+      headSha: HEAD,
+      baseSha: BASE,
+      verdict: "FIX",
+      fix: rebaseItem(9),
+    });
+    const result = enumerateMergeScan({
+      input: { repo: "factory" },
+      db,
+      forge: forgeWith([
+        pr({
+          number: 9,
+          headRefName: "dependabot/github_actions/develop/actions/checkout-7",
+          title: "Bump actions/checkout from 6 to 7",
+          mergeable: "CONFLICTING",
+          mergeStateStatus: "DIRTY",
+        }),
+      ]),
+      repos,
+    });
+
+    expect(result.artifact.fix).toEqual([]);
+    expect(result.artifact.summary).toContain(
+      "rebase_skipped:ticket_missing #9",
+    );
   });
 
   test("ai:landing PR never emits a rebase item", () => {


### PR DESCRIPTION
Fixes #2283

Avoid merge-fix loops caused by fabricated Dependabot tickets.

## Validation

| Check                | Command                                                                                                                       | Result  | Notes                                      |
| -------------------- | ----------------------------------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `env -u FACTORY_ROOT -u FACTORY_REPOS_ROOT -u FACTORY_CONTROL_API_TOKEN FACTORY_EVENT_HOME=$(mktemp -d) FACTORY_LINEAR_OFFLINE=1 bun test event-runtime/lib/merge-reviews.test.mjs --timeout 20000` | pass    | 57 tests, 0 failures                       |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint`         | pass    | unit, emit, format, and lint exited 0      |
| UX critique          | factory-ux-critic                                                                                                             | not run | internal merge-scan logic; no user surface |

UX critique: skipped — internal merge-scan logic; no user-facing surface
run:run_aefa512b-7a93-4e34-a469-31ad1ea215e2
