### PR TITLE
feat(api): include admitted event envelopes in chain detail responses

### DIFF
--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -27,6 +27,22 @@ export function chainKeyOf(event) {
   );
 }
 
+/**
+ * Chain rows must retain a safe, inspectable envelope even for historic rows
+ * whose stored JSON was damaged outside normal admission.
+ */
+function chainEnvelope(envelopeJson) {
+  try {
+    const envelope = JSON.parse(envelopeJson);
+    if (envelope && typeof envelope === "object" && !Array.isArray(envelope))
+      return envelope;
+  } catch {
+    // A named fallback makes the degraded record explicit without returning
+    // unparsed database bytes to the control surface.
+  }
+  return { malformed: true };
+}
+
 export function chainView(db, correlationId) {
   const eventRows = db
     .query(
@@ -50,12 +66,8 @@ export function chainView(db, correlationId) {
   if (eventRows.length === 0) return null;
 
   const events = eventRows.map((row) => {
-    let payload = null;
-    try {
-      payload = JSON.parse(row.envelope_json)?.payload ?? null;
-    } catch {
-      /* malformed envelope: payload stays null from the initializer */
-    }
+    const envelope = chainEnvelope(row.envelope_json);
+    const payload = envelope.malformed ? null : (envelope.payload ?? null);
     return {
       source: row.source,
       eventId: row.event_id,
@@ -71,6 +83,7 @@ export function chainView(db, correlationId) {
       proposalStatus: row.proposal_status ?? null,
       proposalDecision: row.proposal_decision ?? null,
       runId: row.run_id ?? null,
+      envelope,
       repos: repoNamesFromInput(payload),
     };
   });

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -148,6 +148,16 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     expect(byId["chain-run-1-B"].status).toBe("dead_lettered");
     expect(byId["chain-run-2"].causationId).toBe("run-2");
     expect(byId["chain-run-2"].runId).toBe("run-3");
+    expect(byId["origin-1"].envelope).toMatchObject({
+      schemaVersion: "factory.event/v1",
+      eventId: "origin-1",
+      payload: { repos: ["ok"] },
+    });
+    expect(byId["chain-run-1-A"].envelope).toMatchObject({
+      schemaVersion: "factory.event/v1",
+      eventId: "chain-run-1-A",
+      type: "factory.work.requested",
+    });
 
     expect(body.runs.map((r) => r.runId)).toEqual(["run-1", "run-2", "run-3"]);
     const run2 = body.runs.find((r) => r.runId === "run-2");
@@ -163,6 +173,59 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     const run3 = body.runs.find((r) => r.runId === "run-3");
     expect(run3.state).toBe("RUNNING");
     expect(run3.finishedAt).toBeNull();
+  });
+
+  test("names a safe fallback when a historic envelope is malformed", () => {
+    const original = s.db
+      .query("SELECT envelope_json FROM events WHERE event_id = ?")
+      .get("chain-run-1-B").envelope_json;
+    s.db
+      .query("UPDATE events SET envelope_json = ? WHERE event_id = ?")
+      .run("{historic malformed JSON", "chain-run-1-B");
+    try {
+      const event = chainView(s.db, "corr-1").events.find(
+        (item) => item.eventId === "chain-run-1-B",
+      );
+      expect(event.envelope).toEqual({ malformed: true });
+      expect(event.repos).toEqual([]);
+    } finally {
+      s.db
+        .query("UPDATE events SET envelope_json = ? WHERE event_id = ?")
+        .run(original, "chain-run-1-B");
+    }
+  });
+
+  test("returns a completed event's full envelope", () => {
+    const original = s.db
+      .query("SELECT type, envelope_json FROM events WHERE event_id = ?")
+      .get("chain-run-1-B");
+    const completed = envelope({
+      eventId: "chain-run-1-B",
+      source: "chain",
+      type: "factory.work.completed",
+      correlationId: "corr-1",
+      causationId: "run-1",
+      payload: { repo: "factory", outcome: "completed" },
+    });
+    s.db
+      .query("UPDATE events SET type = ?, envelope_json = ? WHERE event_id = ?")
+      .run(completed.type, JSON.stringify(completed), "chain-run-1-B");
+    try {
+      const event = chainView(s.db, "corr-1").events.find(
+        (item) => item.eventId === "chain-run-1-B",
+      );
+      expect(event.type).toBe("factory.work.completed");
+      expect(event.envelope).toMatchObject({
+        type: "factory.work.completed",
+        payload: { repo: "factory", outcome: "completed" },
+      });
+    } finally {
+      s.db
+        .query(
+          "UPDATE events SET type = ?, envelope_json = ? WHERE event_id = ?",
+        )
+        .run(original.type, original.envelope_json, "chain-run-1-B");
+    }
   });
 
   test("falls back to the origin's own eventId when it carried no correlation id", async () => {

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -138,6 +138,8 @@ export interface ChainEvent {
   proposalStatus: string | null;
   proposalDecision: string | null;
   runId: string | null;
+  /** Complete persisted envelope, or `{ malformed: true }` for damaged history. */
+  envelope?: Record<string, unknown>;
   repos: string[];
 }
 

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -85,6 +85,17 @@ function chainEvent(
     proposalStatus: null,
     proposalDecision: null,
     runId: null,
+    envelope: {
+      schemaVersion: "factory.event/v1",
+      eventId,
+      type: "factory.dispatch.requested",
+      source: "factory",
+      subject: "WM-273",
+      occurredAt: NOW,
+      correlationId: "operator:dispatch:WM-518",
+      causationId: null,
+      payload: {},
+    },
     repos: [],
     ...overrides,
   };
@@ -128,6 +139,17 @@ function chainView(): ChainView {
         proposalStatus: "approved",
         proposalDecision: "run",
         runId: FIX_RUN,
+        envelope: {
+          schemaVersion: "factory.event/v1",
+          eventId: FIX_EVENT,
+          type: "factory.merge-fix.requested",
+          source: "chain",
+          subject: "factory",
+          occurredAt: "2026-08-17T19:05:58.000Z",
+          correlationId: CORR,
+          causationId: null,
+          payload: { repo: "factory" },
+        },
         repos: ["factory"],
       },
     ],
@@ -585,12 +607,58 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     expect(view.jumpedEvents).toContain(`chain:${FIX_EVENT}`);
   });
 
-  test("when event node is selected, renders Envelope section with id chain-envelope (WM-192)", async () => {
+  test("when an old event node is selected, renders its chain envelope without a recent-events lookup", async () => {
+    localStorage.clear();
     const evtNodeId = `event:chain:${FIX_EVENT}`;
-    const view = renderChain({ focusNodeId: evtNodeId });
+    const events = mock(async () => {
+      throw new Error("recent event window must not be queried");
+    });
+    await withApi({ events }, async () => {
+      const view = renderChain({ focusNodeId: evtNodeId });
+      await waitFor(() => {
+        expect(view.getByText("Envelope")).toBeTruthy();
+        expect(
+          view.getAllByText("factory.merge-fix.requested").length,
+        ).toBeGreaterThan(0);
+      });
+      expect(events).not.toHaveBeenCalled();
+    });
+  });
 
+  test("names the safe malformed envelope fallback", async () => {
+    const evtNodeId = `event:chain:${FIX_EVENT}`;
+    const view = renderWithClient(
+      <Chain
+        correlationId={CORR}
+        focusNodeId={evtNodeId}
+        onSelectNode={noop}
+        onJumpEvent={noop}
+        onJumpRun={noop}
+        onOpenRunFull={noop}
+        onJumpProposal={noop}
+        onJumpAgent={noop}
+      />,
+      {
+        apiMocks: {
+          chain: async () => ({
+            ...chainView(),
+            events: [
+              chainEvent(FIX_EVENT, {
+                source: "chain",
+                correlationId: CORR,
+                envelope: { malformed: true },
+              }),
+            ],
+          }),
+        },
+      },
+    );
     await waitFor(() => {
-      expect(view.getByText("Envelope")).toBeTruthy();
+      expect(
+        view.getByText(
+          "Stored envelope is malformed; its raw envelope is unavailable.",
+        ),
+      ).toBeTruthy();
     });
   });
 });

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -275,18 +275,6 @@ export function Chain({
     retry: (count, err) =>
       !(err instanceof ApiError && err.status === 404) && count < 2,
   });
-  // Chain rows intentionally remain compact server projections. Reuse the
-  // admitted-event envelope when it is in the bounded recent-event window;
-  // older envelopes retain an explicit Events escape hatch until #2285 adds
-  // them to the chain response itself.
-  const eventEnvelopesQ = useQuery({
-    queryKey: ["events", "chain-envelopes", focusNodeId ?? ""],
-    queryFn: () => api.events(undefined, { limit: 100 }),
-    enabled: Boolean(focusNodeId),
-    // A one-shot lookup for the selected node: envelopes are immutable, so
-    // polling this list would only add load to the shared events endpoint.
-    staleTime: 60_000,
-  });
   const agentsQ = useQuery({
     queryKey: ["agents"],
     queryFn: api.agents,
@@ -537,14 +525,8 @@ export function Chain({
   );
   const selectedEnvelope = useMemo(() => {
     if (selected?.kind !== "chainEvent") return null;
-    return (
-      eventEnvelopesQ.data?.events.find(
-        (event) =>
-          event.source === selected.event.source &&
-          event.eventId === selected.event.eventId,
-      ) ?? null
-    );
-  }, [eventEnvelopesQ.data, selected]);
+    return selected.event.envelope ?? null;
+  }, [selected]);
 
   const timelineListRef = useRef<HTMLOListElement | null>(null);
   const revealSelected = () => {
@@ -1079,7 +1061,15 @@ export function Chain({
                 )}
               </Section>
               <Section id="chain-envelope" title="Envelope">
-                {selectedEnvelope ? (
+                {selectedEnvelope?.malformed === true ? (
+                  <div
+                    role="status"
+                    className="text-[12px] text-(--text-faint)"
+                  >
+                    Stored envelope is malformed; its raw envelope is
+                    unavailable.
+                  </div>
+                ) : selectedEnvelope ? (
                   <Suspense
                     fallback={
                       <div className="text-(--text-faint)">
@@ -1088,9 +1078,9 @@ export function Chain({
                     }
                   >
                     <EventPanel
-                      envelope={selectedEnvelope.envelope}
+                      envelope={selectedEnvelope}
                       agents={agentsQ.data?.agents}
-                      runId={selectedEnvelope.runId}
+                      runId={selected.event.runId}
                       now={now}
                       onJumpRun={onJumpRun}
                       onJumpChain={(id) => {
@@ -1103,8 +1093,7 @@ export function Chain({
                   </Suspense>
                 ) : (
                   <div className="text-[12px] text-(--text-faint)">
-                    Complete envelope unavailable in this chain response. Open
-                    the event in Events to inspect its View or Raw form.
+                    Complete envelope unavailable in this chain response.
                   </div>
                 )}
               </Section>


### PR DESCRIPTION
Fixes watt-mind/factory#2285

Chain detail now provides each event's stored envelope directly, including historical events outside the recent-events window.

## Validation

| Check                | Command                                                                          | Result | Notes                    |
| -------------------- | -------------------------------------------------------------------------------- | ------ | ------------------------ |
| Verification Command | `bun test event-runtime/lib/api-chain.test.mjs event-runtime/web --timeout 20000 && bun run check` | pass   | 1475 tests, 0 failures  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass   | lint warnings only       |
| UX critique          | factory-ux-critic                                                                | pass   | required — SHIP, 2 shots |

UX critique: required — SHIP
run:run_738b1ef3-0363-4fd9-81e6-4d17398db17c
