### PR TITLE
fix(chain): disambiguate malformed envelopes

### DIFF
--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -40,7 +40,7 @@ function chainEnvelope(envelopeJson) {
     // A named fallback makes the degraded record explicit without returning
     // unparsed database bytes to the control surface.
   }
-  return { malformed: true };
+  return { __malformed: true };
 }
 
 export function chainView(db, correlationId) {
@@ -67,7 +67,7 @@ export function chainView(db, correlationId) {
 
   const events = eventRows.map((row) => {
     const envelope = chainEnvelope(row.envelope_json);
-    const payload = envelope.malformed ? null : (envelope.payload ?? null);
+    const payload = envelope.__malformed ? null : (envelope.payload ?? null);
     return {
       source: row.source,
       eventId: row.event_id,
@@ -83,6 +83,9 @@ export function chainView(db, correlationId) {
       proposalStatus: row.proposal_status ?? null,
       proposalDecision: row.proposal_decision ?? null,
       runId: row.run_id ?? null,
+      // Long chains re-transfer these complete envelopes on every primary poll.
+      // If they become common, consider an on-demand GET /event/:source/:id/envelope
+      // endpoint or including an envelope only for the selected row.
       envelope,
       repos: repoNamesFromInput(payload),
     };

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -186,7 +186,7 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       const event = chainView(s.db, "corr-1").events.find(
         (item) => item.eventId === "chain-run-1-B",
       );
-      expect(event.envelope).toEqual({ malformed: true });
+      expect(event.envelope).toEqual({ __malformed: true });
       expect(event.repos).toEqual([]);
     } finally {
       s.db
@@ -206,6 +206,7 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       correlationId: "corr-1",
       causationId: "run-1",
       payload: { repo: "factory", outcome: "completed" },
+      malformed: true,
     });
     s.db
       .query("UPDATE events SET type = ?, envelope_json = ? WHERE event_id = ?")
@@ -218,7 +219,9 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       expect(event.envelope).toMatchObject({
         type: "factory.work.completed",
         payload: { repo: "factory", outcome: "completed" },
+        malformed: true,
       });
+      expect(event.envelope.__malformed).toBeUndefined();
     } finally {
       s.db
         .query(

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -138,7 +138,7 @@ export interface ChainEvent {
   proposalStatus: string | null;
   proposalDecision: string | null;
   runId: string | null;
-  /** Complete persisted envelope, or `{ malformed: true }` for damaged history. */
+  /** Complete persisted envelope, or `{ __malformed: true }` for damaged history. */
   envelope?: Record<string, unknown>;
   repos: string[];
 }

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -646,7 +646,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
               chainEvent(FIX_EVENT, {
                 source: "chain",
                 correlationId: CORR,
-                envelope: { malformed: true },
+                envelope: { __malformed: true },
               }),
             ],
           }),
@@ -656,7 +656,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     await waitFor(() => {
       expect(
         view.getByText(
-          "Stored envelope is malformed; its raw envelope is unavailable.",
+          "Stored envelope is malformed; its raw form cannot be shown.",
         ),
       ).toBeTruthy();
     });

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -1062,6 +1062,7 @@ export function Chain({
               </Section>
               <Section id="chain-envelope" title="Envelope">
                 {selectedEnvelope?.__malformed === true ? (
+                  /* No inline escape hatch here: the header "Open in Events" button already covers navigating to the raw event. */
                   <div
                     role="status"
                     className="text-[12px] text-(--text-faint)"

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -1061,13 +1061,12 @@ export function Chain({
                 )}
               </Section>
               <Section id="chain-envelope" title="Envelope">
-                {selectedEnvelope?.malformed === true ? (
+                {selectedEnvelope?.__malformed === true ? (
                   <div
                     role="status"
                     className="text-[12px] text-(--text-faint)"
                   >
-                    Stored envelope is malformed; its raw envelope is
-                    unavailable.
+                    Stored envelope is malformed; its raw form cannot be shown.
                   </div>
                 ) : selectedEnvelope ? (
                   <Suspense


### PR DESCRIPTION
Fixes watt-mind/factory#2292

Review the unambiguous chain-envelope fallback and its targeted coverage.

## Validation
| Check                | Command                                                                        | Result       | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------ | ------------ | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/api-chain.test.mjs event-runtime/web --timeout 20000 && bun run check` | pass | 1470 tests, 0 failures; check passed |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 3178 tests, 0 failures; lint warnings only |
| UX critique          | `factory-ux-critic`                                                           | not assessed | fixture rendered Events error; screenshot captured |
UX critique: required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); malformed historic envelope unavailable and the live Events fallback rendered an error.

run:run_15d43fd9-774d-477e-b5df-a090b6154d10
