### PR TITLE
chore(web): polish follow-ups from PR #2289 review

### DIFF
--- a/event-runtime/web/src/components/FieldValue.tsx
+++ b/event-runtime/web/src/components/FieldValue.tsx
@@ -1,8 +1,8 @@
 /**
  * FieldValue — the shared formatter for generic (viewless) payload rendering.
  *
- * Both generic payload paths render through it — `EventEnvelopeView`'s field
- * list and `ArtifactView`'s `PayloadFields` — so an operator sees the same
+ * Both generic payload paths render through it — `EventPanel`'s field list
+ * and `ArtifactView`'s `PayloadFields` — so an operator sees the same
  * ticket hover cards, PR/commit links and relative timestamps wherever an
  * event's payload is shown. It lives in its own module so neither renderer
  * has to import the other.

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -283,6 +283,22 @@ describe("outboxSummary", () => {
       "legacy outcome",
     );
   });
+
+  test("falls back to the payload heuristic when a view header is empty", () => {
+    expect(
+      outboxSummary("factory.work.requested", { outcome: "PR_OPEN" }, agents),
+    ).toBe("PR_OPEN");
+  });
+
+  test("uses the view summary when its status pointer resolves to nothing", () => {
+    expect(
+      outboxSummary(
+        "factory.work.requested",
+        { summary: "Ready for review" },
+        agents,
+      ),
+    ).toBe("Ready for review");
+  });
 });
 
 describe("groupJournalEntries (WM-100)", () => {

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -23,7 +23,7 @@ import type {
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import { EMPTY, formatBytes, formatRelative } from "../format";
-import { headerFor, inputViewOf } from "../lib/artifactView";
+import { headerFor, inputViewOf, viewApplies } from "../lib/artifactView";
 import type { WorkerHealthFilter } from "./Workers";
 import {
   Button,
@@ -71,21 +71,26 @@ export function outboxSummary(
   payload: Record<string, unknown>,
   agents: readonly AgentDef[],
 ): string | null {
+  // Deliberately duplicate ArtifactView's private routeAgent to avoid loading
+  // EventPanel's lazy chunk just to render this compact outbox cue.
   const requestedAgent = agents.find((agent) =>
     agent.eventTypes.some((route) => route.type === type),
   );
   const view = inputViewOf(requestedAgent?.outputView);
-  if (view) {
-    const header = headerFor(view, payload, requestedAgent?.inputSchema);
-    return header.status?.value ?? header.summary;
-  }
-  return typeof payload.outcome === "string"
-    ? payload.outcome
-    : typeof payload.recommendation === "string"
-      ? payload.recommendation
-      : typeof payload.verdict === "string"
-        ? payload.verdict
-        : null;
+  const header = viewApplies(view, payload)
+    ? headerFor(view, payload, requestedAgent?.inputSchema)
+    : null;
+  return (
+    header?.status?.value ??
+    header?.summary ??
+    (typeof payload.outcome === "string"
+      ? payload.outcome
+      : typeof payload.recommendation === "string"
+        ? payload.recommendation
+        : typeof payload.verdict === "string"
+          ? payload.verdict
+          : null)
+  );
 }
 
 export function SectionTitle({


### PR DESCRIPTION
Fixes #2291

Restores compact outbox cues when mapped view headers are empty.

## Validation

| Check                | Command                                                                                              | Result  | Notes                                      |
| -------------------- | ---------------------------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web --timeout 20000 && bun run check`                                      | pass    | 1464 tests, 0 failures                     |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 618 existing lint warnings          |
| UX critique          | factory-ux-critic                                                                                    | not run | no user-completable flow                   |

UX critique: skipped — compact summary fallback and documentation only; no user-completable flow
run:run_2095d970-ea28-44e5-b5bb-3d27c2e74eaa
