### PR TITLE
chore(web): polish notes from PR #2294 review

### DIFF
--- a/event-runtime/web/src/components/FieldValue.tsx
+++ b/event-runtime/web/src/components/FieldValue.tsx
@@ -1,11 +1,10 @@
 /**
  * FieldValue — the shared formatter for generic (viewless) payload rendering.
  *
- * Both generic payload paths render through it — `EventPanel`'s field list
- * and `ArtifactView`'s `PayloadFields` — so an operator sees the same
- * ticket hover cards, PR/commit links and relative timestamps wherever an
- * event's payload is shown. It lives in its own module so neither renderer
- * has to import the other.
+ * `ArtifactView`'s `PayloadFields` is its sole call site, so an operator sees
+ * consistent ticket hover cards, PR/commit links, and relative timestamps
+ * wherever that event payload is shown. It lives in its own module so the
+ * renderer can stay focused on layout.
  */
 import type { ReactNode } from "react";
 import { TicketHoverCard } from "./TicketHoverCard";

--- a/event-runtime/web/src/views/Overview.test.tsx
+++ b/event-runtime/web/src/views/Overview.test.tsx
@@ -284,7 +284,7 @@ describe("outboxSummary", () => {
     );
   });
 
-  test("falls back to the payload heuristic when a view header is empty", () => {
+  test("falls back to the payload heuristic when no view applies", () => {
     expect(
       outboxSummary("factory.work.requested", { outcome: "PR_OPEN" }, agents),
     ).toBe("PR_OPEN");

--- a/event-runtime/web/src/views/Overview.tsx
+++ b/event-runtime/web/src/views/Overview.tsx
@@ -23,7 +23,7 @@ import type {
 import type { OperatorContext } from "../context";
 import { scopedCount, scopedTally } from "../context";
 import { EMPTY, formatBytes, formatRelative } from "../format";
-import { headerFor, inputViewOf, viewApplies } from "../lib/artifactView";
+import { headerFor, inputViewOf } from "../lib/artifactView";
 import type { WorkerHealthFilter } from "./Workers";
 import {
   Button,
@@ -77,7 +77,7 @@ export function outboxSummary(
     agent.eventTypes.some((route) => route.type === type),
   );
   const view = inputViewOf(requestedAgent?.outputView);
-  const header = viewApplies(view, payload)
+  const header = view
     ? headerFor(view, payload, requestedAgent?.inputSchema)
     : null;
   return (


### PR DESCRIPTION
Fixes watt-mind/factory#2295

Simplifies redundant outbox header resolution without changing fallback behavior.

## Validation

| Check                | Command                                                                                                      | Result  | Notes                          |
| -------------------- | ------------------------------------------------------------------------------------------------------------ | ------- | ------------------------------ |
| Verification Command | `bun test event-runtime/web --timeout 20000`                                                              | pass    | 1464 tests, 0 failures         |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 618 existing warnings   |
| UX critique          | `factory-ux-critic`                                                                                       | not run | no user-facing behavior change |

UX critique: skipped — internal performance, documentation, and test-name cleanup only

run:run_bdf38b0d-a9c9-48d1-9b33-58f4326c97c8
