### PR TITLE
fix(chain): flag malformed envelopes

### DIFF
--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -35,12 +35,12 @@ function chainEnvelope(envelopeJson) {
   try {
     const envelope = JSON.parse(envelopeJson);
     if (envelope && typeof envelope === "object" && !Array.isArray(envelope))
-      return envelope;
+      return { envelope, malformed: false };
   } catch {
-    // A named fallback makes the degraded record explicit without returning
-    // unparsed database bytes to the control surface.
+    // Do not return unparsed database bytes to the control surface.
   }
-  return { __malformed: true };
+  // Keep the safe envelope shape separate from the unambiguous row signal.
+  return { envelope: {}, malformed: true };
 }
 
 export function chainView(db, correlationId) {
@@ -66,8 +66,10 @@ export function chainView(db, correlationId) {
   if (eventRows.length === 0) return null;
 
   const events = eventRows.map((row) => {
-    const envelope = chainEnvelope(row.envelope_json);
-    const payload = envelope.__malformed ? null : (envelope.payload ?? null);
+    const { envelope, malformed: envelopeMalformed } = chainEnvelope(
+      row.envelope_json,
+    );
+    const payload = envelopeMalformed ? null : (envelope.payload ?? null);
     return {
       source: row.source,
       eventId: row.event_id,
@@ -87,6 +89,7 @@ export function chainView(db, correlationId) {
       // If they become common, consider an on-demand GET /event/:source/:id/envelope
       // endpoint or including an envelope only for the selected row.
       envelope,
+      envelopeMalformed,
       repos: repoNamesFromInput(payload),
     };
   });

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -175,7 +175,7 @@ describe("GET /chain/:correlationId (WM-527)", () => {
     expect(run3.finishedAt).toBeNull();
   });
 
-  test("names a safe fallback when a historic envelope is malformed", () => {
+  test("marks a historic malformed envelope without overloading its payload", () => {
     const original = s.db
       .query("SELECT envelope_json FROM events WHERE event_id = ?")
       .get("chain-run-1-B").envelope_json;
@@ -186,7 +186,8 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       const event = chainView(s.db, "corr-1").events.find(
         (item) => item.eventId === "chain-run-1-B",
       );
-      expect(event.envelope).toEqual({ __malformed: true });
+      expect(event.envelope).toEqual({});
+      expect(event.envelopeMalformed).toBe(true);
       expect(event.repos).toEqual([]);
     } finally {
       s.db
@@ -221,7 +222,7 @@ describe("GET /chain/:correlationId (WM-527)", () => {
         payload: { repo: "factory", outcome: "completed" },
         malformed: true,
       });
-      expect(event.envelope.__malformed).toBeUndefined();
+      expect(event.envelopeMalformed).toBe(false);
     } finally {
       s.db
         .query(

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -138,8 +138,10 @@ export interface ChainEvent {
   proposalStatus: string | null;
   proposalDecision: string | null;
   runId: string | null;
-  /** Complete persisted envelope, or `{ __malformed: true }` for damaged history. */
+  /** Complete persisted envelope. Empty when a damaged historic row is omitted. */
   envelope?: Record<string, unknown>;
+  /** True when the stored historic envelope could not be parsed. */
+  envelopeMalformed?: boolean;
   repos: string[];
 }
 

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -96,9 +96,20 @@ function chainEvent(
       causationId: null,
       payload: {},
     },
+    envelopeMalformed: false,
     repos: [],
     ...overrides,
   };
+}
+
+/** Reproducible damaged-history fixture for the selected-chain envelope UI. */
+function malformedChainEvent(eventId: string): ChainEvent {
+  return chainEvent(eventId, {
+    source: "chain",
+    correlationId: CORR,
+    envelope: {},
+    envelopeMalformed: true,
+  });
 }
 
 function renderChainGraph() {
@@ -625,7 +636,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     });
   });
 
-  test("names the safe malformed envelope fallback", async () => {
+  test("names the safe malformed envelope fallback from the row flag", async () => {
     const evtNodeId = `event:chain:${FIX_EVENT}`;
     const view = renderWithClient(
       <Chain
@@ -642,13 +653,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
         apiMocks: {
           chain: async () => ({
             ...chainView(),
-            events: [
-              chainEvent(FIX_EVENT, {
-                source: "chain",
-                correlationId: CORR,
-                envelope: { __malformed: true },
-              }),
-            ],
+            events: [malformedChainEvent(FIX_EVENT)],
           }),
         },
       },

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -1061,7 +1061,7 @@ export function Chain({
                 )}
               </Section>
               <Section id="chain-envelope" title="Envelope">
-                {selectedEnvelope?.__malformed === true ? (
+                {selected.event.envelopeMalformed === true ? (
                   /* No inline escape hatch here: the header "Open in Events" button already covers navigating to the raw event. */
                   <div
                     role="status"


### PR DESCRIPTION
Fixes watt-mind/factory#2296

Chain rows now expose an explicit malformed-envelope signal for reliable degraded-state rendering.

## Validation

| Check                | Command                                                            | Result  | Notes                         |
| -------------------- | ------------------------------------------------------------------ | ------- | ----------------------------- |
| Verification Command | `bun test event-runtime/lib/api-chain.test.mjs event-runtime/web --timeout 20000` | pass    | 1472 tests, 0 failures        |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | 2514 pass, 0 failures |
| UX critique          | `factory-ux-critic`                                               | not run | required; NOT-ASSESSED        |

UX critique: required — NOT-ASSESSED, authenticated fixture succeeded (GET /api/runs HTTP 200); malformed envelope fixture is not browser-observable; evidence: http://127.0.0.1:7495/#/runs

run:run_0d2623d2-e124-43b7-8847-2edd17a5e067