### PR TITLE
fix(chain): make malformed envelopes unavailable

### DIFF
--- a/event-runtime/lib/api-chain.mjs
+++ b/event-runtime/lib/api-chain.mjs
@@ -39,8 +39,7 @@ function chainEnvelope(envelopeJson) {
   } catch {
     // Do not return unparsed database bytes to the control surface.
   }
-  // Keep the safe envelope shape separate from the unambiguous row signal.
-  return { envelope: {}, malformed: true };
+  return { envelope: null, malformed: true };
 }
 
 export function chainView(db, correlationId) {

--- a/event-runtime/lib/api-chain.test.mjs
+++ b/event-runtime/lib/api-chain.test.mjs
@@ -186,7 +186,7 @@ describe("GET /chain/:correlationId (WM-527)", () => {
       const event = chainView(s.db, "corr-1").events.find(
         (item) => item.eventId === "chain-run-1-B",
       );
-      expect(event.envelope).toEqual({});
+      expect(event.envelope).toBeNull();
       expect(event.envelopeMalformed).toBe(true);
       expect(event.repos).toEqual([]);
     } finally {

--- a/event-runtime/web/src/types.ts
+++ b/event-runtime/web/src/types.ts
@@ -138,8 +138,8 @@ export interface ChainEvent {
   proposalStatus: string | null;
   proposalDecision: string | null;
   runId: string | null;
-  /** Complete persisted envelope. Empty when a damaged historic row is omitted. */
-  envelope?: Record<string, unknown>;
+  /** Complete persisted envelope, or null when a historic row is damaged. */
+  envelope?: Record<string, unknown> | null;
   /** True when the stored historic envelope could not be parsed. */
   envelopeMalformed?: boolean;
   repos: string[];

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -107,7 +107,7 @@ function malformedChainEvent(eventId: string): ChainEvent {
   return chainEvent(eventId, {
     source: "chain",
     correlationId: CORR,
-    envelope: {},
+    envelope: null,
     envelopeMalformed: true,
   });
 }
@@ -636,7 +636,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     });
   });
 
-  test("names the safe malformed envelope fallback from the row flag", async () => {
+  test("uses the complete-envelope fallback for a malformed stored envelope", async () => {
     const evtNodeId = `event:chain:${FIX_EVENT}`;
     const view = renderWithClient(
       <Chain
@@ -660,9 +660,7 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     );
     await waitFor(() => {
       expect(
-        view.getByText(
-          "Stored envelope is malformed; its raw form cannot be shown.",
-        ),
+        view.getByText("Complete envelope unavailable in this chain response."),
       ).toBeTruthy();
     });
   });

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -525,7 +525,8 @@ export function Chain({
   );
   const selectedEnvelope = useMemo(() => {
     if (selected?.kind !== "chainEvent") return null;
-    return selected.event.envelope ?? null;
+    if (selected.event.envelopeMalformed) return null;
+    return selected.event.envelope;
   }, [selected]);
 
   const timelineListRef = useRef<HTMLOListElement | null>(null);
@@ -1061,15 +1062,7 @@ export function Chain({
                 )}
               </Section>
               <Section id="chain-envelope" title="Envelope">
-                {selected.event.envelopeMalformed === true ? (
-                  /* No inline escape hatch here: the header "Open in Events" button already covers navigating to the raw event. */
-                  <div
-                    role="status"
-                    className="text-[12px] text-(--text-faint)"
-                  >
-                    Stored envelope is malformed; its raw form cannot be shown.
-                  </div>
-                ) : selectedEnvelope ? (
+                {selectedEnvelope ? (
                   <Suspense
                     fallback={
                       <div className="text-(--text-faint)">


### PR DESCRIPTION
Fixes watt-mind/factory#2299

Malformed chain envelopes now present the safe unavailable fallback.

## Validation

| Check                | Command                                                            | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------ | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib/api-chain.test.mjs event-runtime/web --timeout 20000` | pass    | 1472 tests, 0 failures                     |
| Repo verify          | `bun run check`                                                | pass    | emit, TypeScript, and Prettier clean       |
| UX critique          | factory-ux-critic                                                  | pass    | required — SHIP; live fixture observed     |

UX critique: required — SHIP; evidence: sha256:f164801787116610e18c5829c8946f07d35e59ea9a1dc03a8ace0136380f9764; ephemeral-url:http://127.0.0.1:7623/#/chain/clock%3Atriage-factory%3A2026-09-02T16%3A00%3A00.000Z/event%3Aschedule%3Aclock%3Atriage-factory%3A2026-09-02T16%3A00%3A00.000Z

run:run_e1a2b324-405b-4271-acfc-d090e02f91c5
