### PR TITLE
fix(chain): restore malformed envelope accessibility (#2301)

### DIFF
--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -38,6 +38,8 @@
  *   Admitted & anomaly events:
  *     - dead-lettered event (lastPlanError present)
  *     - duplicate delivery suppression
+ *     - malformed stored chain envelope (Chain returns envelope: null and
+ *       envelopeMalformed: true, so the degraded envelope UI is inspectable)
  *
  *   RUNNING     repos:["hang"] (approved LAST — single worker holds until 600s timeout)
  *
@@ -845,6 +847,41 @@ try {
   );
   log(
     `${dispatchRunId} → COMPLETED (dispatch@1, simulated working PR workflow with PR_OPEN)`,
+  );
+
+  // A deliberately damaged historic chain envelope makes the Chain view's
+  // degraded state inspectable in every seeded worktree. `chainView` rejects
+  // this stored non-JSON value and safely exposes `envelope: null` with
+  // `envelopeMalformed: true`; it is not a malformed live intake event.
+  const malformedChainEventId = `chain-${dispatchRunId}-malformed-envelope`;
+  db.query(
+    `INSERT INTO events
+       (source, event_id, type, subject, occurred_at, received_at,
+        correlation_id, causation_id, envelope_json, payload_hash, status, admitted_at)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+     ON CONFLICT(source, event_id) DO UPDATE SET
+       correlation_id = excluded.correlation_id,
+       causation_id = excluded.causation_id,
+       envelope_json = excluded.envelope_json,
+       payload_hash = excluded.payload_hash,
+       status = excluded.status,
+       admitted_at = excluded.admitted_at`,
+  ).run(
+    "chain",
+    malformedChainEventId,
+    "factory.dispatch.requested",
+    dispatchTicket,
+    nowStr,
+    nowStr,
+    dispatchEventId,
+    dispatchRunId,
+    "{demo seed intentionally malformed chain envelope",
+    "demo-malformed-chain-envelope",
+    "planned",
+    nowStr,
+  );
+  log(
+    `${malformedChainEventId} inserted (malformed chain envelope; open #/chain/${dispatchEventId})`,
   );
 
   // A hand-authored open item gives web UX review a stable, information-rich

--- a/event-runtime/demo/seed.mjs
+++ b/event-runtime/demo/seed.mjs
@@ -853,6 +853,16 @@ try {
   // degraded state inspectable in every seeded worktree. `chainView` rejects
   // this stored non-JSON value and safely exposes `envelope: null` with
   // `envelopeMalformed: true`; it is not a malformed live intake event.
+  //
+  // This row knowingly violates the invariant every other seeded event upholds:
+  // a `factory.dispatch.requested` event normally carries a parseable envelope
+  // and owns a proposal (and, once approved, a run). This one has neither, so
+  // nothing downstream can plan or execute from it. It stays inert because its
+  // status is 'planned' rather than 'admitted' — planner scans only pick up
+  // admitted events — and because it is written straight to `events` rather
+  // than replayed through intake, no schema validation ever sees it. Read paths
+  // must therefore treat stored envelope JSON as untrusted: `chainView` guards
+  // via `chainEnvelope`, and `eventsView` via `parseObject` (#2301).
   const malformedChainEventId = `chain-${dispatchRunId}-malformed-envelope`;
   db.query(
     `INSERT INTO events

--- a/event-runtime/demo/seed.test.mjs
+++ b/event-runtime/demo/seed.test.mjs
@@ -488,6 +488,47 @@ describe("seed & re-seed deduplication (OPS-464)", () => {
       expect(fixture.body).toContain(
         "```\nbun test event-runtime/demo/seed.test.mjs\n```",
       );
+
+      // The seeded malformed chain envelope (#2301) is what makes the degraded
+      // Chain UI state browser-observable, so assert the API actually degrades
+      // rather than trusting the seed log line alone.
+      const malformedLog = seedRes.stdout.match(
+        /^seed: (\S+) inserted \(malformed chain envelope; open #\/chain\/(\S+)\)$/m,
+      );
+      expect(
+        malformedLog,
+        `seed stdout lacked the malformed-envelope line:\n${seedRes.stdout}`,
+      ).toBeTruthy();
+      const [, malformedEventId, malformedCorrelationId] = malformedLog;
+
+      const chainResponse = await fetch(
+        `http://127.0.0.1:${port}/chain/${encodeURIComponent(malformedCorrelationId)}`,
+        { headers: controlAuthHeaders() },
+      );
+      expect(chainResponse.ok).toBe(true);
+      const chain = await chainResponse.json();
+      const malformedEvents = chain.events.filter(
+        (event) => event.eventId === malformedEventId,
+      );
+      // The hardcoded payload_hash + ON CONFLICT upsert keep re-seeding from
+      // producing a second copy of this row.
+      expect(malformedEvents).toHaveLength(1);
+      expect(malformedEvents[0]).toMatchObject({
+        envelope: null,
+        envelopeMalformed: true,
+        repos: [],
+        status: "planned",
+      });
+
+      // The same row must not take down the flat events list (#2301).
+      const eventsResponse = await fetch(`http://127.0.0.1:${port}/events`, {
+        headers: controlAuthHeaders(),
+      });
+      expect(eventsResponse.status).toBe(200);
+      const { events } = await eventsResponse.json();
+      expect(events.some((event) => event.eventId === malformedEventId)).toBe(
+        true,
+      );
     },
     loadAdjustedTimeout(30_000),
   );

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -201,7 +201,13 @@ function eventsView(
   const hasNextPage = rows.length > page.limit;
   const pageRows = hasNextPage ? rows.slice(0, -1) : rows;
   const events = pageRows.map((row) => {
-    const envelope = JSON.parse(row.envelope_json);
+    // Stored envelopes are not guaranteed to be parseable JSON: rows written by
+    // older writers, hand-repaired databases, and the demo seed's deliberately
+    // damaged chain row all survive in `events`. A bare JSON.parse here threw a
+    // SyntaxError out of GET /events (only ListQueryError is handled), taking
+    // the whole list down for one bad row, so degrade to an empty envelope and
+    // keep listing the row instead.
+    const envelope = parseObject(row.envelope_json);
     return {
       source: row.source,
       eventId: row.event_id,

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -984,6 +984,39 @@ describe("list views carry repos[] (OPS-356)", () => {
     }
   });
 
+  test("GET /events survives a malformed stored envelope (#2301)", async () => {
+    const s = await makeServer();
+    try {
+      await s.client.replay(
+        envelope({ eventId: "envelope-ok", payload: { repos: ["ok"] } }),
+      );
+      await s.client.replay(
+        envelope({ eventId: "envelope-broken", payload: { repos: ["bad"] } }),
+      );
+      // Matches the demo seed's deliberately damaged chain envelope.
+      s.db
+        .query(`UPDATE events SET envelope_json = ? WHERE event_id = ?`)
+        .run(
+          "{demo seed intentionally malformed chain envelope",
+          "envelope-broken",
+        );
+
+      const res = await fetch(s.url("/events"));
+      expect(res.status).toBe(200);
+      const { events } = await res.json();
+      const broken = events.find((e) => e.eventId === "envelope-broken");
+      expect(broken).toBeDefined();
+      expect(broken.envelope).toEqual({});
+      expect(broken.repos).toEqual([]);
+      // The healthy row is still rendered normally.
+      expect(events.find((e) => e.eventId === "envelope-ok").repos).toEqual([
+        "ok",
+      ]);
+    } finally {
+      s.close();
+    }
+  });
+
   test("GET /events defaults to a cursor page and walks tied timestamps", async () => {
     const s = await makeServer({ now: () => 1_700_000_000_000 });
     try {

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -660,8 +660,10 @@ describe("Chain navigation shortcuts (WM-875)", () => {
     );
     await waitFor(() => {
       expect(
-        view.getByText("Complete envelope unavailable in this chain response."),
-      ).toBeTruthy();
+        view
+          .getByText("Complete envelope unavailable in this chain response.")
+          .getAttribute("role"),
+      ).toBe("status");
     });
   });
 });

--- a/event-runtime/web/src/views/Chain.test.tsx
+++ b/event-runtime/web/src/views/Chain.test.tsx
@@ -666,4 +666,39 @@ describe("Chain navigation shortcuts (WM-875)", () => {
       ).toBe("status");
     });
   });
+
+  test("announces the malformed-envelope fallback as a live status region", async () => {
+    const evtNodeId = `event:chain:${FIX_EVENT}`;
+    const view = renderWithClient(
+      <Chain
+        correlationId={CORR}
+        focusNodeId={evtNodeId}
+        onSelectNode={noop}
+        onJumpEvent={noop}
+        onJumpRun={noop}
+        onOpenRunFull={noop}
+        onJumpProposal={noop}
+        onJumpAgent={noop}
+      />,
+      {
+        apiMocks: {
+          chain: async () => ({
+            ...chainView(),
+            events: [malformedChainEvent(FIX_EVENT)],
+          }),
+        },
+      },
+    );
+    await waitFor(() => {
+      expect(
+        view.getByText("Complete envelope unavailable in this chain response."),
+      ).toBeTruthy();
+    });
+    // Assistive tech reaches this text through the status role, so assert the
+    // role lookup itself resolves to the node carrying the fallback copy.
+    const status = view.getByRole("status");
+    expect(status.textContent).toBe(
+      "Complete envelope unavailable in this chain response.",
+    );
+  });
 });

--- a/event-runtime/web/src/views/Chain.tsx
+++ b/event-runtime/web/src/views/Chain.tsx
@@ -526,7 +526,7 @@ export function Chain({
   const selectedEnvelope = useMemo(() => {
     if (selected?.kind !== "chainEvent") return null;
     if (selected.event.envelopeMalformed) return null;
-    return selected.event.envelope;
+    return selected.event.envelope ?? null;
   }, [selected]);
 
   const timelineListRef = useRef<HTMLOListElement | null>(null);
@@ -1085,7 +1085,10 @@ export function Chain({
                     />
                   </Suspense>
                 ) : (
-                  <div className="text-[12px] text-(--text-faint)">
+                  <div
+                    className="text-[12px] text-(--text-faint)"
+                    role="status"
+                  >
                     Complete envelope unavailable in this chain response.
                   </div>
                 )}


### PR DESCRIPTION
Fixes watt-mind/factory#2301

Review the malformed Chain envelope fallback and its seeded browser fixture.

## Validation

| Check                | Command                          | Result  | Notes                                      |
| -------------------- | -------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/web --timeout 20000` | pass    | 1464 pass, 0 fail                          |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | completed; 618 existing lint warnings      |
| UX critique          | factory-ux-critic                | pass    | required — SHIP                            |

UX critique: required — SHIP

run:run_367de5aa-05ae-4e26-87cf-de494dc15e09
