### PR TITLE
chore(runtime): guard malformed stored JSON

### DIFF
--- a/event-runtime/cli/approve.mjs
+++ b/event-runtime/cli/approve.mjs
@@ -15,6 +15,7 @@ export async function approveProposal(client, id) {
     if (err?.body?.reason !== MALFORMED_STORED_ROW) throw err;
     throw new Error(
       `proposal ${id} cannot be approved — its stored row is corrupt (${err.body.kind ?? MALFORMED_STORED_ROW}); repair or reject the proposal, approving again will not clear it`,
+      { cause: err },
     );
   }
   if (outcome.approved) console.log(`approved — run ${outcome.runId} queued`);

--- a/event-runtime/cli/approve.mjs
+++ b/event-runtime/cli/approve.mjs
@@ -1,13 +1,31 @@
 import { fail, withClient } from "./shared.mjs";
 
+/**
+ * The control API's refusal code for a proposal whose stored envelope or spec
+ * JSON no longer parses (lib/proposals.mjs MalformedStoredRowError). Re-running
+ * approve cannot clear it, so the CLI says so instead of reporting a re-plan.
+ */
+const MALFORMED_STORED_ROW = "malformed_stored_row";
+
+export async function approveProposal(client, id) {
+  let outcome;
+  try {
+    outcome = await client.approve(id);
+  } catch (err) {
+    if (err?.body?.reason !== MALFORMED_STORED_ROW) throw err;
+    throw new Error(
+      `proposal ${id} cannot be approved — its stored row is corrupt (${err.body.kind ?? MALFORMED_STORED_ROW}); repair or reject the proposal, approving again will not clear it`,
+    );
+  }
+  if (outcome.approved) console.log(`approved — run ${outcome.runId} queued`);
+  else
+    console.log(
+      `proposal expired and re-planned — review and approve the new proposal ${outcome.proposal.id}`,
+    );
+  return outcome;
+}
+
 export default function approve(args) {
   if (!args[0]) fail("usage: approve <proposal-id>");
-  return withClient(async (client) => {
-    const outcome = await client.approve(args[0]);
-    if (outcome.approved) console.log(`approved — run ${outcome.runId} queued`);
-    else
-      console.log(
-        `proposal expired and re-planned — review and approve the new proposal ${outcome.proposal.id}`,
-      );
-  });
+  return withClient((client) => approveProposal(client, args[0]));
 }

--- a/event-runtime/cli/approve.test.mjs
+++ b/event-runtime/cli/approve.test.mjs
@@ -1,0 +1,92 @@
+import { describe, expect, test } from "bun:test";
+import { approveProposal } from "./approve.mjs";
+
+function capture(run) {
+  const lines = [];
+  const original = console.log;
+  console.log = (...args) => lines.push(args.join(" "));
+  return run()
+    .then((value) => ({ value, lines }))
+    .finally(() => {
+      console.log = original;
+    });
+}
+
+function apiError(status, body) {
+  const err = new Error(body.error);
+  err.status = status;
+  err.body = body;
+  return err;
+}
+
+describe("approve command", () => {
+  test("reports the queued run on approval", async () => {
+    const { lines } = await capture(() =>
+      approveProposal(
+        { approve: async () => ({ approved: true, runId: "run-1" }) },
+        "p-1",
+      ),
+    );
+
+    expect(lines).toEqual(["approved — run run-1 queued"]);
+  });
+
+  test("names the fresh proposal after a re-plan", async () => {
+    const { lines } = await capture(() =>
+      approveProposal(
+        {
+          approve: async () => ({
+            approved: false,
+            replanned: true,
+            proposal: { id: "p-2" },
+          }),
+        },
+        "p-1",
+      ),
+    );
+
+    expect(lines[0]).toContain("re-planned");
+    expect(lines[0]).toContain("p-2");
+  });
+
+  // A corrupt stored row is not a re-plan: the CLI must not tell the operator
+  // to go approve a fresh proposal that does not exist.
+  test("fails with a corruption message naming the proposal id", async () => {
+    const client = {
+      approve: async () => {
+        throw apiError(409, {
+          error: "proposal p-1: malformed_event_envelope",
+          reason: "malformed_stored_row",
+          kind: "malformed_event_envelope",
+        });
+      },
+    };
+
+    const err = await approveProposal(client, "p-1").then(
+      () => null,
+      (e) => e,
+    );
+
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toContain("p-1");
+    expect(err.message).toContain("corrupt");
+    expect(err.message).toContain("malformed_event_envelope");
+  });
+
+  test("propagates unrelated API errors unchanged", async () => {
+    const original = apiError(404, { error: "unknown proposal p-9" });
+    const err = await approveProposal(
+      {
+        approve: async () => {
+          throw original;
+        },
+      },
+      "p-9",
+    ).then(
+      () => null,
+      (e) => e,
+    );
+
+    expect(err).toBe(original);
+  });
+});

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -2537,6 +2537,14 @@ export async function handleRunApiRoute({
     } catch (err) {
       if (isBusyError(err))
         return send(503, { error: "db_busy", retryable: true });
+      // A corrupt stored row is a refusal, not a re-plan: the response must
+      // never look like the 200 `{ approved: false, replanned: true }` body.
+      if (err?.code === "malformed_stored_row")
+        return send(409, {
+          error: err.message,
+          reason: err.code,
+          kind: err.kind,
+        });
       const status = String(err.message).startsWith("unknown proposal")
         ? 404
         : 409;

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -2329,6 +2329,28 @@ describe("watched flow and operator verbs (§12, §13, §15)", () => {
     expect(again.message).toContain("not open");
   });
 
+  // A corrupt stored row is a refusal, not the 200 `replanned: true` body:
+  // an operator client that reads `approved === false` as "re-planned" would
+  // otherwise chase a fresh proposal that was never created.
+  test("approve a proposal whose stored envelope is corrupt → 409, not a re-plan", async () => {
+    const prop = await planned("malformed-envelope-1");
+    s.db
+      .query(`UPDATE events SET envelope_json = ? WHERE event_id = ?`)
+      .run("{damaged stored envelope", "malformed-envelope-1");
+
+    const err = await rejection(s.client.approve(prop.id));
+
+    expect(err.status).toBe(409);
+    expect(err.body).toMatchObject({
+      reason: "malformed_stored_row",
+      kind: "malformed_event_envelope",
+    });
+    expect(err.message).toContain(prop.id);
+    expect((await s.client.run(prop.runId)).run.state).toBe("PROPOSED");
+    const { proposals } = await s.client.proposals();
+    expect(proposals.find((p) => p.id === prop.id)?.status).toBe("open");
+  });
+
   test("reject an open proposal → run CANCELLED", async () => {
     const prop = await planned("rej-1");
     const rejected = await s.client.reject(prop.id, "not today");

--- a/event-runtime/lib/auto-approval.test.mjs
+++ b/event-runtime/lib/auto-approval.test.mjs
@@ -792,6 +792,34 @@ describe("chain auto approval (WM-357)", () => {
     ]);
   });
 
+  // approveProposal throws MalformedStoredRowError on a corrupt stored row, so
+  // this pass can never mistake corruption for a completed re-plan. Chain
+  // eligibility catches both corruption kinds first, with a typed reason, and
+  // the row is held open rather than approved or dropped.
+  test("a malformed stored row is held open, never approved or reported as re-planned", async () => {
+    for (const [id, table, column, reason] of [
+      ["malformed-envelope", "events", "envelope_json", "event_unparseable"],
+      ["malformed-spec", "proposals", "spec_json", "proposal_unparseable"],
+    ]) {
+      const db = openDb(":memory:");
+      const candidate = seed(db, { id });
+      const idColumn = table === "events" ? "event_id" : "id";
+      const rowId = table === "events" ? `event-${id}` : candidate.id;
+      db.query(`UPDATE ${table} SET ${column} = ? WHERE ${idColumn} = ?`).run(
+        "{damaged stored row",
+        rowId,
+      );
+
+      const result = await auto(db, { runtimeGuard: () => null });
+
+      expect(result.approved).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(result.open).toEqual([{ proposalId: candidate.id, reason }]);
+      expect(runState(db, candidate.runId)).toBe("PROPOSED");
+      expect(reasonOf(db, candidate.id)).toContain(reason);
+    }
+  });
+
   test("dispatch.paused skips open chain proposals and resumes them after it clears", async () => {
     const db = openDb(":memory:");
     const candidate = seed(db, { id: "paused" });

--- a/event-runtime/lib/decision-effects.test.mjs
+++ b/event-runtime/lib/decision-effects.test.mjs
@@ -8,6 +8,7 @@ import {
   decideInboxItem,
   retryInboxDecision,
 } from "./inbox.mjs";
+import { MalformedStoredRowError } from "./proposals.mjs";
 
 const NOW = Date.parse("2026-08-18T12:00:00.000Z");
 
@@ -172,6 +173,33 @@ describe("runtime decision effects", () => {
       outcome: "applied",
       detail: "replanned_awaiting_approval",
       newProposalId: "prop_fresh",
+    });
+  });
+
+  // A corrupt stored row throws out of approveProposal: the effect must record
+  // a failed transport, not resolve the inbox item as approved.
+  test("a malformed stored proposal row fails the effect instead of resolving it", async () => {
+    const result = await applyDecisionEffect(
+      null,
+      item("approve_proposal"),
+      response(),
+      {
+        linear: {},
+        planner: {
+          approveProposal: () => {
+            throw new MalformedStoredRowError(
+              "prop_313",
+              "malformed_proposal_spec",
+            );
+          },
+        },
+        now: NOW,
+      },
+    );
+    expect(result).toEqual({
+      kind: "approve_proposal",
+      outcome: "failed",
+      error: "proposal prop_313: malformed_proposal_spec",
     });
   });
 

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2528,6 +2528,18 @@ function existingOutcome(db, event) {
   };
 }
 
+/** Historic event rows may have bypassed intake validation. */
+function parseStoredEnvelope(json) {
+  try {
+    const value = JSON.parse(json);
+    if (value && typeof value === "object" && !Array.isArray(value))
+      return value;
+  } catch {
+    // The planner records a typed refusal below instead of poisoning its pass.
+  }
+  return null;
+}
+
 /**
  * Plan one admitted event: NOOP | HUMAN_NEEDED | RUN (§4). All writes for one
  * plan happen in one transaction; re-planning is idempotent.
@@ -2563,56 +2575,60 @@ export function planEvent(
       )
       .get(source, eventId);
     if (row?.status === "admitted") {
-      const preEnvelope = JSON.parse(row.envelope_json);
-      const preMapping = getEventType(registry, preEnvelope.type);
-      const preDef =
-        preMapping && preMapping.observe !== true
-          ? registry.agents.get(preMapping.agent)
-          : null;
-      // An event already outside the definition's repo scope (WM-64) skips
-      // the gate's Linear/lease reads entirely — the transaction below parks
-      // it repo_not_allowed before anything else happens.
-      if (
-        worktreeGateFor(preDef) === "dispatch" &&
-        typeof preEnvelope.payload?.repo === "string" &&
-        typeof preEnvelope.payload?.ticket === "string" &&
-        !(
-          preEnvelope.type === "factory.dispatch.requested" &&
-          preEnvelope.source !== "operator" &&
-          policyDispatchPaused(undefined, configSnapshot)
-        ) &&
-        !repoNotAllowed(preDef, preEnvelope.payload)
-      ) {
-        if (preEnvelope.type === "factory.dispatch.requested") {
-          toolchainEligibility = dispatchToolchainEligibility(
-            preEnvelope.payload,
-            { configSnapshot, toolchain },
-          );
-        }
-        if (toolchainEligibility?.ready !== false) {
-          try {
-            worktreeEligibility = worktreeDispatchAutoEligibility(
+      const preEnvelope = parseStoredEnvelope(row.envelope_json);
+      if (!preEnvelope) {
+        // The transaction below records the malformed row as human-needed.
+      } else {
+        const preMapping = getEventType(registry, preEnvelope.type);
+        const preDef =
+          preMapping && preMapping.observe !== true
+            ? registry.agents.get(preMapping.agent)
+            : null;
+        // An event already outside the definition's repo scope (WM-64) skips
+        // the gate's Linear/lease reads entirely — the transaction below parks
+        // it repo_not_allowed before anything else happens.
+        if (
+          worktreeGateFor(preDef) === "dispatch" &&
+          typeof preEnvelope.payload?.repo === "string" &&
+          typeof preEnvelope.payload?.ticket === "string" &&
+          !(
+            preEnvelope.type === "factory.dispatch.requested" &&
+            preEnvelope.source !== "operator" &&
+            policyDispatchPaused(undefined, configSnapshot)
+          ) &&
+          !repoNotAllowed(preDef, preEnvelope.payload)
+        ) {
+          if (preEnvelope.type === "factory.dispatch.requested") {
+            toolchainEligibility = dispatchToolchainEligibility(
               preEnvelope.payload,
-              {
-                ...dispatch,
-                operatorAuthorized: preEnvelope.source === "operator",
-                configSnapshot,
-              },
+              { configSnapshot, toolchain },
             );
-          } catch (err) {
-            if (!isLinearReadDeferred(err)) throw err;
-            const reason = linearReadDeferredReason(err);
-            worktreeEligibility = {
-              ok: false,
-              linearReadDeferred: true,
-              reason,
-              resetAt: err.resetAt ?? null,
-              refusal: {
-                decision: "retry_later",
+          }
+          if (toolchainEligibility?.ready !== false) {
+            try {
+              worktreeEligibility = worktreeDispatchAutoEligibility(
+                preEnvelope.payload,
+                {
+                  ...dispatch,
+                  operatorAuthorized: preEnvelope.source === "operator",
+                  configSnapshot,
+                },
+              );
+            } catch (err) {
+              if (!isLinearReadDeferred(err)) throw err;
+              const reason = linearReadDeferredReason(err);
+              worktreeEligibility = {
+                ok: false,
+                linearReadDeferred: true,
                 reason,
-                detail: err.message,
-              },
-            };
+                resetAt: err.resetAt ?? null,
+                refusal: {
+                  decision: "retry_later",
+                  reason,
+                  detail: err.message,
+                },
+              };
+            }
           }
         }
       }
@@ -2642,8 +2658,16 @@ export function planEvent(
     if (!event) throw new Error(`no admitted event (${source}, ${eventId})`);
     if (event.status !== "admitted") return existingOutcome(db, event);
 
-    const envelope = JSON.parse(event.envelope_json);
     const at = new Date(now).toISOString();
+    const envelope = parseStoredEnvelope(event.envelope_json);
+    if (!envelope)
+      return humanNeeded(
+        db,
+        event,
+        "malformed_event_envelope",
+        at,
+        DEFAULT_PROPOSAL_TTL_SECONDS,
+      );
 
     const gitMapping = getEventType(registry, envelope.type);
     if (!gitMapping)

--- a/event-runtime/lib/planner.mjs
+++ b/event-runtime/lib/planner.mjs
@@ -2528,7 +2528,12 @@ function existingOutcome(db, event) {
   };
 }
 
-/** Historic event rows may have bypassed intake validation. */
+/**
+ * Historic event rows may have bypassed intake validation. A non-object
+ * (array or scalar) is rejected deliberately alongside unparsable JSON:
+ * planning reads `type`/`payload`/`source` off the envelope, so a valid-JSON
+ * `[]` or `"x"` is exactly as unplannable as a truncated row.
+ */
 function parseStoredEnvelope(json) {
   try {
     const value = JSON.parse(json);

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -169,6 +169,40 @@ describe("merge concurrency policy", () => {
 });
 
 describe("planEvent", () => {
+  test("parks a malformed stored envelope while planning an unrelated event", () => {
+    const db = openDb(":memory:");
+    const malformed = admit(db, {
+      eventId: "malformed-stored-envelope",
+      correlationId: "malformed-stored-envelope",
+    });
+    const healthy = admit(db, {
+      eventId: "healthy-after-malformed-envelope",
+      correlationId: "healthy-after-malformed-envelope",
+    });
+    db.query(
+      `UPDATE events SET envelope_json = ? WHERE source = ? AND event_id = ?`,
+    ).run("{damaged stored envelope", malformed.source, malformed.eventId);
+
+    expect(
+      planAdmittedEvents(db, registry, { now: NOW, policyVersion: "git:test" }),
+    ).toEqual({ planned: 2, failed: 0, deadLettered: 0 });
+    expect(
+      db
+        .query(`SELECT status, plan_failures FROM events WHERE event_id = ?`)
+        .get(malformed.eventId),
+    ).toEqual({ status: "human_needed", plan_failures: 0 });
+    expect(
+      db
+        .query(`SELECT reason FROM proposals WHERE event_id = ?`)
+        .get(malformed.eventId).reason,
+    ).toBe("malformed_event_envelope");
+    expect(
+      db
+        .query(`SELECT status FROM events WHERE event_id = ?`)
+        .get(healthy.eventId).status,
+    ).toBe("planned");
+  });
+
   test("pins workspace-only intent into the RunSpec for the execute-time admission backstop (#962)", () => {
     const db = openDb(":memory:");
     const ref = admit(db, {

--- a/event-runtime/lib/planner.test.mjs
+++ b/event-runtime/lib/planner.test.mjs
@@ -203,6 +203,43 @@ describe("planEvent", () => {
     ).toBe("planned");
   });
 
+  // The dispatch-eligibility pre-pass parses the stored envelope outside the
+  // transaction to decide whether to make Linear/worktree reads. A corrupt row
+  // must fall through to the in-transaction refusal instead of throwing there.
+  test("parks a malformed dispatch envelope from the pre-transaction eligibility pass", () => {
+    const db = openDb(":memory:");
+    const ref = admit(db, {
+      eventId: "dispatch-malformed-stored-envelope",
+      type: "factory.dispatch.requested",
+      source: "operator",
+      correlationId: "dispatch-malformed-stored-envelope",
+      payload: { repo: "factory", ticket: "WM-480" },
+    });
+    db.query(
+      `UPDATE events SET envelope_json = ? WHERE source = ? AND event_id = ?`,
+    ).run("{damaged dispatch envelope", ref.source, ref.eventId);
+
+    expect(
+      planEvent(db, registry, ref, {
+        now: NOW,
+        policyVersion: "git:test",
+        dispatch: {
+          // Reaching this would mean the guard failed to short-circuit.
+          fetchTicket: () => {
+            throw new Error("eligibility must not run on a malformed row");
+          },
+        },
+      }),
+    ).toMatchObject({
+      decision: "human_needed",
+      reason: "malformed_event_envelope",
+    });
+    expect(
+      db.query(`SELECT status FROM events WHERE event_id = ?`).get(ref.eventId)
+        .status,
+    ).toBe("human_needed");
+  });
+
   test("pins workspace-only intent into the RunSpec for the execute-time admission backstop (#962)", () => {
     const db = openDb(":memory:");
     const ref = admit(db, {

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -59,22 +59,56 @@ function recordedSpecPinsVersion(spec) {
   );
 }
 
-/** Stored proposal JSON can outlive the writer that validated it. */
-function parseStoredObject(json) {
-  try {
-    const value = JSON.parse(json);
-    if (value && typeof value === "object" && !Array.isArray(value))
-      return value;
-  } catch {
-    // A hand-repaired or legacy row must not take down the approval surface.
+/**
+ * A stored row whose JSON no longer parses as an object. Approval refuses
+ * such a row loudly: callers funnel a thrown error into their existing
+ * failure paths, whereas a success-shaped `{ approved: false }` return reads
+ * as a completed re-plan at every call site.
+ */
+export class MalformedStoredRowError extends Error {
+  constructor(proposalId, kind) {
+    super(`proposal ${proposalId}: ${kind}`);
+    this.name = "MalformedStoredRowError";
+    this.code = "malformed_stored_row";
+    this.proposalId = proposalId;
+    /** `malformed_event_envelope` | `malformed_proposal_spec` */
+    this.kind = kind;
   }
+}
+
+/**
+ * Stored proposal JSON can outlive the writer that validated it. A non-object
+ * (array or scalar) is rejected deliberately: every caller reads named fields
+ * off the result, so a valid-JSON `[]` or `7` is as unusable as a parse error.
+ */
+function parseStoredObject(json, { field, id } = {}) {
+  let value;
+  try {
+    value = JSON.parse(json);
+  } catch (err) {
+    // A hand-repaired or legacy row must not take down the approval surface.
+    console.error(
+      `proposals_stored_json_unparsable: ${field ?? "json"} ${id ?? "?"}: ${String(err?.message ?? err)}`,
+    );
+    return null;
+  }
+  if (value && typeof value === "object" && !Array.isArray(value)) return value;
+  console.error(
+    `proposals_stored_json_not_object: ${field ?? "json"} ${id ?? "?"}: parsed as ${Array.isArray(value) ? "array" : typeof value}`,
+  );
   return null;
 }
 
 function withSpec(row) {
+  const spec = row.spec_json
+    ? parseStoredObject(row.spec_json, { field: "spec_json", id: row.id })
+    : null;
   return {
     ...row,
-    spec: row.spec_json ? parseStoredObject(row.spec_json) : null,
+    spec,
+    // Read paths degrade to `spec: null`; the flag tells an inbox or CLI view
+    // apart from a proposal that legitimately records no spec.
+    ...(row.spec_json && !spec ? { specMalformed: true } : {}),
   };
 }
 
@@ -166,7 +200,10 @@ function loadEnvelope(db, proposal) {
     throw new Error(
       `proposal ${proposal.id} references missing event (${proposal.event_source}, ${proposal.event_id})`,
     );
-  return parseStoredObject(event.envelope_json);
+  return parseStoredObject(event.envelope_json, {
+    field: "envelope_json",
+    id: `${proposal.event_source}/${proposal.event_id}`,
+  });
 }
 
 /**
@@ -262,9 +299,13 @@ function approveRun(
  * superseded, the still-PROPOSED run gets the fresh spec, and a new open
  * proposal is returned instead (§12).
  *
+ * A row whose stored envelope or spec JSON no longer parses as an object
+ * throws {@link MalformedStoredRowError} rather than returning: corruption is
+ * an operator-visible failure, never a silent success-shaped outcome.
+ *
  * @returns {{ approved: true, runId: string }
- *         | { approved: false, replanned: true, proposal: object }
- *         | { approved: false, malformed: true, reason: string, proposal: object }}
+ *         | { approved: false, replanned: true, proposal: object }}
+ * @throws {MalformedStoredRowError} when spec_json or envelope_json is corrupt
  */
 export function approveProposal(
   db,
@@ -294,12 +335,7 @@ export function approveProposal(
 
     const envelope = loadEnvelope(db, proposal);
     if (!envelope)
-      return {
-        approved: false,
-        malformed: true,
-        reason: "malformed_event_envelope",
-        proposal: withSpec(proposal),
-      };
+      throw new MalformedStoredRowError(id, "malformed_event_envelope");
     // Structural no-auto-approval (docs/event-runtime-dispatch.md §7, WM-111):
     // a humanApprovalOnly event type rejects every non-operator actor —
     // schedule auto-approval included — fail-closed, before any state moves.
@@ -315,15 +351,10 @@ export function approveProposal(
       throw err;
     }
     const recordedSpec = proposal.spec_json
-      ? parseStoredObject(proposal.spec_json)
+      ? parseStoredObject(proposal.spec_json, { field: "spec_json", id })
       : null;
     if (proposal.spec_json && !recordedSpec)
-      return {
-        approved: false,
-        malformed: true,
-        reason: "malformed_proposal_spec",
-        proposal: withSpec(proposal),
-      };
+      throw new MalformedStoredRowError(id, "malformed_proposal_spec");
     // Fail-closed: an unknown/omitted caller version is *not equal* to a
     // recorded pin. Skipping the comparison here used to approve the
     // recorded spec as-is whenever a caller forwarded the default.
@@ -382,8 +413,7 @@ export function approveProposal(
       throw new Error(
         `proposal ${id} requires re-planning but event type ${envelope.type} is no longer registered`,
       );
-    const storedSpec = recordedSpec;
-    const replanOptions = ttlReplanOptions(storedSpec, mapping.adapter);
+    const replanOptions = ttlReplanOptions(recordedSpec, mapping.adapter);
     const built = {
       ...buildRunSpec(registry, envelope, mapping, {
         runId: proposal.run_id,
@@ -394,18 +424,18 @@ export function approveProposal(
       // configSnapshot can affect planning and is itself part of specs that
       // explicitly pin it. Keep the pin in the rebuilt spec as well as
       // supplying it to buildRunSpec above.
-      ...(Object.hasOwn(storedSpec, "configSnapshot")
-        ? { configSnapshot: storedSpec.configSnapshot }
+      ...(Object.hasOwn(recordedSpec, "configSnapshot")
+        ? { configSnapshot: recordedSpec.configSnapshot }
         : {}),
       // A run is its existing idempotency generation, not a new family
       // member. Reapply the stored key after buildRunSpec derives its normal
       // declaration key.
-      idempotencyKey: storedSpec.idempotencyKey,
+      idempotencyKey: recordedSpec.idempotencyKey,
     };
     // Preserve the definition-attestation generation of the recorded spec.
     // Older rows without defHash remain byte-compatible; pinned rows always
     // receive a fresh pin rather than losing the guard during re-planning.
-    const fresh = storedSpec?.defHash
+    const fresh = recordedSpec?.defHash
       ? {
           ...built,
           defHash: computeDefHash(getAgent(registry, built.agent)),
@@ -425,7 +455,7 @@ export function approveProposal(
       registryVersionMismatch &&
       isKnownPolicyVersion(policyVersion) &&
       !registryReloadMismatch &&
-      matchesAfterRegistryVersionRefresh(storedSpec, fresh);
+      matchesAfterRegistryVersionRefresh(recordedSpec, fresh);
     if (
       !registryReloadMismatch &&
       (freshHash === proposal.spec_hash || versionRefreshMatches)

--- a/event-runtime/lib/proposals.mjs
+++ b/event-runtime/lib/proposals.mjs
@@ -59,8 +59,23 @@ function recordedSpecPinsVersion(spec) {
   );
 }
 
+/** Stored proposal JSON can outlive the writer that validated it. */
+function parseStoredObject(json) {
+  try {
+    const value = JSON.parse(json);
+    if (value && typeof value === "object" && !Array.isArray(value))
+      return value;
+  } catch {
+    // A hand-repaired or legacy row must not take down the approval surface.
+  }
+  return null;
+}
+
 function withSpec(row) {
-  return { ...row, spec: row.spec_json ? JSON.parse(row.spec_json) : null };
+  return {
+    ...row,
+    spec: row.spec_json ? parseStoredObject(row.spec_json) : null,
+  };
 }
 
 /** Open proposals, oldest first, annotated with `expired` and parsed `spec`. */
@@ -151,7 +166,7 @@ function loadEnvelope(db, proposal) {
     throw new Error(
       `proposal ${proposal.id} references missing event (${proposal.event_source}, ${proposal.event_id})`,
     );
-  return JSON.parse(event.envelope_json);
+  return parseStoredObject(event.envelope_json);
 }
 
 /**
@@ -248,7 +263,8 @@ function approveRun(
  * proposal is returned instead (§12).
  *
  * @returns {{ approved: true, runId: string }
- *         | { approved: false, replanned: true, proposal: object }}
+ *         | { approved: false, replanned: true, proposal: object }
+ *         | { approved: false, malformed: true, reason: string, proposal: object }}
  */
 export function approveProposal(
   db,
@@ -277,6 +293,13 @@ export function approveProposal(
       );
 
     const envelope = loadEnvelope(db, proposal);
+    if (!envelope)
+      return {
+        approved: false,
+        malformed: true,
+        reason: "malformed_event_envelope",
+        proposal: withSpec(proposal),
+      };
     // Structural no-auto-approval (docs/event-runtime-dispatch.md §7, WM-111):
     // a humanApprovalOnly event type rejects every non-operator actor —
     // schedule auto-approval included — fail-closed, before any state moves.
@@ -292,8 +315,15 @@ export function approveProposal(
       throw err;
     }
     const recordedSpec = proposal.spec_json
-      ? JSON.parse(proposal.spec_json)
+      ? parseStoredObject(proposal.spec_json)
       : null;
+    if (proposal.spec_json && !recordedSpec)
+      return {
+        approved: false,
+        malformed: true,
+        reason: "malformed_proposal_spec",
+        proposal: withSpec(proposal),
+      };
     // Fail-closed: an unknown/omitted caller version is *not equal* to a
     // recorded pin. Skipping the comparison here used to approve the
     // recorded spec as-is whenever a caller forwarded the default.
@@ -352,7 +382,7 @@ export function approveProposal(
       throw new Error(
         `proposal ${id} requires re-planning but event type ${envelope.type} is no longer registered`,
       );
-    const storedSpec = recordedSpec ?? JSON.parse(proposal.spec_json);
+    const storedSpec = recordedSpec;
     const replanOptions = ttlReplanOptions(storedSpec, mapping.adapter);
     const built = {
       ...buildRunSpec(registry, envelope, mapping, {

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -169,6 +169,17 @@ describe("openProposals / getProposal", () => {
     expect(getProposal(db, "prop_nope")).toBeNull();
   });
 
+  test("keeps malformed stored proposal specs inspectable without throwing", () => {
+    const { db, proposal } = planned();
+    db.query(`UPDATE proposals SET spec_json = ? WHERE id = ?`).run(
+      "{damaged proposal spec",
+      proposal.id,
+    );
+
+    expect(getProposal(db, proposal.id).spec).toBeNull();
+    expect(openProposals(db)).toMatchObject([{ id: proposal.id, spec: null }]);
+  });
+
   test("does not expire a parked non-run proposal by TTL", () => {
     const db = openDb(":memory:");
     const admitted = admitEvent(
@@ -282,6 +293,32 @@ describe("approveProposal within TTL", () => {
     expect(journal[1].actor).toBe("operator");
     expect(journal[1].correlation_id).toBe("workflow-01");
     expect(journal.at(-1).reason).toBe("approved");
+  });
+
+  test("refuses malformed stored envelope or spec without changing the proposed run", () => {
+    for (const [column, value, reason] of [
+      ["envelope_json", "{damaged event envelope", "malformed_event_envelope"],
+      ["spec_json", "{damaged proposal spec", "malformed_proposal_spec"],
+    ]) {
+      const { db, proposal, runId } = planned();
+      const table = column === "envelope_json" ? "events" : "proposals";
+      const idColumn = column === "envelope_json" ? "event_id" : "id";
+      const id = column === "envelope_json" ? proposal.event_id : proposal.id;
+      db.query(`UPDATE ${table} SET ${column} = ? WHERE ${idColumn} = ?`).run(
+        value,
+        id,
+      );
+
+      expect(
+        approveProposal(db, registry, proposal.id, {
+          actor: "operator",
+          now: NOW + 60_000,
+          policyVersion: "git:test",
+        }),
+      ).toMatchObject({ approved: false, malformed: true, reason });
+      expect(runState(db, runId)).toBe("PROPOSED");
+      expect(getProposal(db, proposal.id).status).toBe("open");
+    }
   });
 
   test("re-plans a stale registry version, then queues the refreshed spec when only its versions changed", () => {

--- a/event-runtime/lib/proposals.test.mjs
+++ b/event-runtime/lib/proposals.test.mjs
@@ -13,6 +13,7 @@ import {
   approveProposal,
   closeOpenProposalForRun,
   getProposal,
+  MalformedStoredRowError,
   openProposals,
   rejectProposal,
   sweepOrphanedNonRunProposals,
@@ -176,8 +177,13 @@ describe("openProposals / getProposal", () => {
       proposal.id,
     );
 
-    expect(getProposal(db, proposal.id).spec).toBeNull();
-    expect(openProposals(db)).toMatchObject([{ id: proposal.id, spec: null }]);
+    expect(getProposal(db, proposal.id)).toMatchObject({
+      spec: null,
+      specMalformed: true,
+    });
+    expect(openProposals(db)).toMatchObject([
+      { id: proposal.id, spec: null, specMalformed: true },
+    ]);
   });
 
   test("does not expire a parked non-run proposal by TTL", () => {
@@ -309,13 +315,25 @@ describe("approveProposal within TTL", () => {
         id,
       );
 
-      expect(
+      // A success-shaped `{ approved: false }` return reads as a completed
+      // re-plan at every call site, so corruption throws instead.
+      let thrown = null;
+      try {
         approveProposal(db, registry, proposal.id, {
           actor: "operator",
           now: NOW + 60_000,
           policyVersion: "git:test",
-        }),
-      ).toMatchObject({ approved: false, malformed: true, reason });
+        });
+      } catch (err) {
+        thrown = err;
+      }
+      expect(thrown).toBeInstanceOf(MalformedStoredRowError);
+      expect(thrown).toMatchObject({
+        code: "malformed_stored_row",
+        kind: reason,
+        proposalId: proposal.id,
+      });
+      expect(thrown.message).toContain(proposal.id);
       expect(runState(db, runId)).toBe("PROPOSED");
       expect(getProposal(db, proposal.id).status).toBe("open");
     }


### PR DESCRIPTION
Fixes watt-mind/factory#2303

Guards persisted event envelopes and proposal specs so damaged rows remain contained.

## Validation

| Check                | Command                                                                         | Result  | Notes                                      |
| -------------------- | ------------------------------------------------------------------------------- | ------- | ------------------------------------------ |
| Verification Command | `bun test event-runtime/lib --timeout 20000`                                    | pass    | 2518 passed, 10 skipped                    |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | clean; 618 pre-existing lint warnings      |
| UX critique          | factory-ux-critic                                                               | not run | no user-facing surface                     |

UX critique: skipped — backend runtime data-read hardening only
run:run_e25a4b69-2f2b-4fd9-873c-a9f9d69c5ee9
