### PR TITLE
fix(worker): retain integrity evidence safely

### DIFF
--- a/event-runtime/lib/janitor.mjs
+++ b/event-runtime/lib/janitor.mjs
@@ -5,6 +5,7 @@ import {
   artifactsRoot,
   DEFAULT_PROPOSAL_TTL_SECONDS,
   runtimeHome,
+  workspacesRoot,
 } from "./config.mjs";
 import { openDb, txImmediate } from "./db.mjs";
 import { ALL_TERMINAL_STATES, transition } from "./lifecycle.mjs";
@@ -17,6 +18,7 @@ export const JANITOR_MAX_BUFFER = 1_000_000;
 export const DEFAULT_TRACE_RETENTION_DAYS = 14;
 export const DEFAULT_ARTIFACT_RETENTION_DAYS = 30;
 export const DEFAULT_ROW_RETENTION_DAYS = 30;
+export const DEFAULT_WORKSPACE_RETENTION_DAYS = 30;
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const SHA256 = /^[a-f0-9]{64}$/;
@@ -185,6 +187,30 @@ function resultArtifactHashes(result, fallbackHash) {
   return hashes;
 }
 
+/** Remove only expired retained workspace-integrity evidence directories. */
+function sweepRetainedIntegrityWorkspaces(
+  root,
+  { cutoffMs, apply = false } = {},
+) {
+  let deleted = 0;
+  let retained = 0;
+  if (!root || !existsSync(root)) return { deleted, retained, dryRun: !apply };
+
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const workspace = path.join(root, entry.name);
+    if (!existsSync(path.join(workspace, "workspace-integrity-status.txt")))
+      continue;
+    if (statSync(workspace).mtimeMs >= cutoffMs) {
+      retained += 1;
+      continue;
+    }
+    deleted += 1;
+    if (apply) rmSync(workspace, { recursive: true, force: true });
+  }
+  return { deleted, retained, dryRun: !apply };
+}
+
 /**
  * Retain recent trace audit rows and artifacts referenced by recently-created
  * runs. This is deliberately a standalone maintenance operation: dry-run is
@@ -197,6 +223,8 @@ export function sweepRuntimeRetention(
     traceRetentionDays = DEFAULT_TRACE_RETENTION_DAYS,
     artifactRetentionDays = DEFAULT_ARTIFACT_RETENTION_DAYS,
     rowRetentionDays = DEFAULT_ROW_RETENTION_DAYS,
+    workspaceRetentionDays = DEFAULT_WORKSPACE_RETENTION_DAYS,
+    workspaceRoot = null,
     now = Date.now(),
     apply = false,
     log = () => {},
@@ -210,6 +238,8 @@ export function sweepRuntimeRetention(
   const rowCutoff = new Date(
     now - retentionMs(rowRetentionDays, "rowRetentionDays"),
   ).toISOString();
+  const workspaceCutoffMs =
+    now - retentionMs(workspaceRetentionDays, "workspaceRetentionDays");
   const nowIso = new Date(now).toISOString();
   const proposed = terminalizeExpiredProposedRuns(db, { now, apply });
   const trace = db
@@ -264,6 +294,10 @@ export function sweepRuntimeRetention(
     }
   }
   const rows = sweepTerminalRows(db, { rowCutoff, nowIso, apply });
+  const workspaces = sweepRetainedIntegrityWorkspaces(workspaceRoot, {
+    cutoffMs: workspaceCutoffMs,
+    apply,
+  });
 
   // VACUUM reclaims the file space freed by the row deletions (#1065). It must
   // run outside any transaction, so it follows the sweep's own commit.
@@ -276,12 +310,13 @@ export function sweepRuntimeRetention(
     runs: rows.runs,
     proposals: rows.proposals,
     events: rows.events,
+    workspaces,
     vacuum: { ran: apply },
   };
   log(
     `retention: ${trace} trace rows and ${deleted} artifacts (${freedBytes} bytes)` +
       `, ${proposed.cancelled} proposed runs ${apply ? "cancelled" : "would be cancelled"}` +
-      `, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events ` +
+      `, ${rows.runs.deleted} runs, ${rows.proposals.deleted} proposals, ${rows.events.deleted} events, ${workspaces.deleted} retained integrity workspaces ` +
       `${apply ? "deleted (VACUUMed)" : "would be deleted"}`,
   );
   return result;
@@ -293,15 +328,18 @@ export function runtimeRetentionCommand(args = [], options = {}) {
   let traceRetentionDays = DEFAULT_TRACE_RETENTION_DAYS;
   let artifactRetentionDays = DEFAULT_ARTIFACT_RETENTION_DAYS;
   let rowRetentionDays = DEFAULT_ROW_RETENTION_DAYS;
+  let workspaceRetentionDays = DEFAULT_WORKSPACE_RETENTION_DAYS;
   for (let i = 0; i < args.length; i++) {
     if (args[i] === "--apply") apply = true;
     else if (args[i] === "--trace-days") traceRetentionDays = Number(args[++i]);
     else if (args[i] === "--artifact-days")
       artifactRetentionDays = Number(args[++i]);
     else if (args[i] === "--row-days") rowRetentionDays = Number(args[++i]);
+    else if (args[i] === "--workspace-days")
+      workspaceRetentionDays = Number(args[++i]);
     else
       throw new Error(
-        "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N] [--row-days N]",
+        "usage: janitor.mjs retention [--apply] [--trace-days N] [--artifact-days N] [--row-days N] [--workspace-days N]",
       );
   }
   const db = options.db ?? openDb();
@@ -313,6 +351,8 @@ export function runtimeRetentionCommand(args = [], options = {}) {
         traceRetentionDays,
         artifactRetentionDays,
         rowRetentionDays,
+        workspaceRetentionDays,
+        workspaceRoot: options.workspaceRoot ?? workspacesRoot(runtimeHome()),
         apply,
         now: options.now,
         log: options.log ?? console.log,

--- a/event-runtime/lib/janitor.test.mjs
+++ b/event-runtime/lib/janitor.test.mjs
@@ -1,5 +1,5 @@
 import { describe, expect, test } from "bun:test";
-import { mkdirSync, utimesSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, utimesSync, writeFileSync } from "node:fs";
 import path from "node:path";
 import { tmpDir } from "../test-support/tmp.mjs?file=event-runtime-lib-janitor-test-mjs";
 import { DEFAULT_PROPOSAL_TTL_SECONDS } from "./config.mjs";
@@ -7,6 +7,7 @@ import { openDb } from "./db.mjs";
 import {
   DEFAULT_ARTIFACT_RETENTION_DAYS,
   DEFAULT_ROW_RETENTION_DAYS,
+  DEFAULT_WORKSPACE_RETENTION_DAYS,
   janitorArgv,
   JANITOR_MAX_BUFFER,
   JANITOR_TIMEOUT_MS,
@@ -118,6 +119,66 @@ describe("runtime retention", () => {
 
   test("retention defaults preserve the documented 30-day artifact window", () => {
     expect(DEFAULT_ARTIFACT_RETENTION_DAYS).toBe(30);
+  });
+
+  test("retains recent integrity evidence workspaces and removes old ones", () => {
+    const root = tmpDir("evrt-integrity-workspace-retention-");
+    const store = path.join(root, "artifacts");
+    const workspaces = path.join(root, "workspaces");
+    const db = openDb(path.join(root, "runtime.db"));
+    const now = Date.parse("2026-08-20T12:00:00.000Z");
+    const old = new Date(now - 31 * 24 * 60 * 60 * 1000);
+    const recent = new Date(now - 24 * 60 * 60 * 1000);
+    const stale = path.join(workspaces, "run-stale-a1");
+    const kept = path.join(workspaces, "run-kept-a1");
+    const unrelated = path.join(workspaces, "run-unrelated-a1");
+    try {
+      mkdirSync(store);
+      for (const [dir, mtime, evidence] of [
+        [stale, old, true],
+        [kept, recent, true],
+        [unrelated, old, false],
+      ]) {
+        mkdirSync(dir, { recursive: true });
+        if (evidence)
+          writeFileSync(
+            path.join(dir, "workspace-integrity-status.txt"),
+            "checkoutBaselineSha256: sha256:test\n",
+          );
+        utimesSync(dir, mtime, mtime);
+      }
+
+      const dry = sweepRuntimeRetention(db, store, {
+        now,
+        workspaceRoot: workspaces,
+      });
+      expect(dry.workspaces).toEqual({
+        deleted: 1,
+        retained: 1,
+        dryRun: true,
+      });
+      expect(existsSync(stale)).toBe(true);
+
+      const applied = sweepRuntimeRetention(db, store, {
+        now,
+        workspaceRoot: workspaces,
+        apply: true,
+      });
+      expect(applied.workspaces).toEqual({
+        deleted: 1,
+        retained: 1,
+        dryRun: false,
+      });
+      expect(existsSync(stale)).toBe(false);
+      expect(existsSync(kept)).toBe(true);
+      expect(existsSync(unrelated)).toBe(true);
+    } finally {
+      db.close();
+    }
+  });
+
+  test("workspace retention default follows the 30-day retention convention", () => {
+    expect(DEFAULT_WORKSPACE_RETENTION_DAYS).toBe(30);
   });
 });
 
@@ -381,7 +442,7 @@ describe("terminal row retention (#1065)", () => {
       });
       expect(dry.proposed).toEqual({ cancelled: 7, dryRun: true });
       expect(dryLog).toEqual([
-        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs would be cancelled, 0 runs, 0 proposals, 0 events would be deleted",
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs would be cancelled, 0 runs, 0 proposals, 0 events, 0 retained integrity workspaces would be deleted",
       ]);
       expect(
         db.query(`SELECT COUNT(*) AS count FROM lifecycle_events`).get().count,
@@ -395,7 +456,7 @@ describe("terminal row retention (#1065)", () => {
       });
       expect(applied.proposed).toEqual({ cancelled: 7, dryRun: false });
       expect(applyLog).toEqual([
-        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs cancelled, 0 runs, 0 proposals, 0 events deleted (VACUUMed)",
+        "retention: 0 trace rows and 0 artifacts (0 bytes), 7 proposed runs cancelled, 0 runs, 0 proposals, 0 events, 0 retained integrity workspaces deleted (VACUUMed)",
       ]);
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-expired'`).get()

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -1663,7 +1663,7 @@ export function repositoryStatus(
 const WORKSPACE_INTEGRITY_STATUS_MAX_BYTES = 12 * 1024;
 
 /** Keep checkout dirt evidence useful without letting one run grow trace storage unbounded. */
-function boundedWorkspaceIntegrityStatus(status) {
+export function boundedWorkspaceIntegrityStatus(status) {
   if (status === null) {
     return { value: null, bytes: null, truncated: false };
   }
@@ -1672,13 +1672,47 @@ function boundedWorkspaceIntegrityStatus(status) {
     return { value: status, bytes, truncated: false };
   }
   const suffix = `\n… truncated; ${bytes} bytes total\n`;
-  const previewBytes =
+  let previewBytes =
     WORKSPACE_INTEGRITY_STATUS_MAX_BYTES - Buffer.byteLength(suffix);
+  const encoded = Buffer.from(status, "utf8");
+  // `Buffer#toString` replaces a partial UTF-8 sequence with U+FFFD. Walk
+  // back from the byte boundary to preserve only complete characters.
+  while (previewBytes > 0 && (encoded[previewBytes] & 0xc0) === 0x80)
+    previewBytes -= 1;
   return {
-    value: `${Buffer.from(status).subarray(0, previewBytes).toString("utf8")}${suffix}`,
+    value: `${encoded.subarray(0, previewBytes).toString("utf8")}${suffix}`,
     bytes,
     truncated: true,
   };
+}
+
+export function writeWorkspaceIntegrityStatus(
+  workspaceDir,
+  { checkoutStatus, checkoutBaseline },
+) {
+  const status = boundedWorkspaceIntegrityStatus(checkoutStatus);
+  const baseline = boundedWorkspaceIntegrityStatus(checkoutBaseline);
+  const hash = (value) => (value === null ? null : hashBytes(value));
+  const text = [
+    "workspace integrity violation",
+    `checkoutStatusBytes: ${status.bytes ?? "null"}`,
+    `checkoutStatusTruncated: ${status.truncated}`,
+    `checkoutStatusSha256: ${hash(checkoutStatus) ?? "null"}`,
+    "checkoutStatus:",
+    status.value ?? "null",
+    `checkoutBaselineBytes: ${baseline.bytes ?? "null"}`,
+    `checkoutBaselineTruncated: ${baseline.truncated}`,
+    `checkoutBaselineSha256: ${hash(checkoutBaseline) ?? "null"}`,
+    "checkoutBaseline:",
+    baseline.value ?? "null",
+    "",
+  ].join("\n");
+  writeFileSync(
+    path.join(workspaceDir, "workspace-integrity-status.txt"),
+    text,
+    "utf8",
+  );
+  return { status, baseline };
 }
 
 /** Fail closed: a read-only repository workspace is acceptable only if clean. */
@@ -3848,10 +3882,7 @@ export async function executeClaimed(
   let worktreePath = null;
   let checkoutBaseline;
   let worktreeRecord;
-  const cleanupWorkspace = ({
-    retainWorkspace = false,
-    retainCheckout = false,
-  } = {}) => {
+  const cleanupWorkspace = ({ retainWorkspace = false } = {}) => {
     if (!workspaceDir) return;
     const fenced = !assertCurrentToken(db, runId, fencingToken);
     if (fenced && spec.workspace?.type === "worktree") {
@@ -3866,10 +3897,9 @@ export async function executeClaimed(
     }
     destroyWorkspace(workspaceDir, {
       retain: retainWorkspace,
-      // A retained integrity failure needs its dirty checkout for diagnosis.
-      // Releasing a repository checkout removes it before the retained wrapper
-      // can be inspected, which makes this guard's failure opaque.
-      checkout: fenced || retainCheckout ? null : checkoutPath,
+      // Integrity evidence is persisted in the retained wrapper, so its
+      // repository checkout can always be released and deregistered.
+      checkout: fenced ? null : checkoutPath,
       repoName,
     });
   };
@@ -5470,19 +5500,20 @@ export async function executeClaimed(
       (checkoutBaseline === null || checkoutStatus !== checkoutBaseline)
     ) {
       const reasonCode = "workspace_integrity_violation";
-      const evidence = boundedWorkspaceIntegrityStatus(checkoutStatus);
+      const evidence = writeWorkspaceIntegrityStatus(workspaceDir, {
+        checkoutStatus,
+        checkoutBaseline,
+      });
       recorder("lifecycle", {
         note: reasonCode,
-        checkoutStatus: evidence.value,
-        checkoutStatusBytes: evidence.bytes,
-        checkoutStatusTruncated: evidence.truncated,
+        checkoutStatus: evidence.status.value,
+        checkoutStatusBytes: evidence.status.bytes,
+        checkoutStatusTruncated: evidence.status.truncated,
         checkoutBaselineSha256:
-          checkoutBaseline === null
-            ? null
-            : `sha256:${hashBytes(checkoutBaseline)}`,
+          checkoutBaseline === null ? null : hashBytes(checkoutBaseline),
       });
       const res = failTerminal("FAILED", reasonCode, reasonCode);
-      cleanupWorkspace({ retainWorkspace: true, retainCheckout: true });
+      cleanupWorkspace({ retainWorkspace: true });
       if (res?.fenced) return { fenced: true };
       return { runId, attempt, terminalState: "FAILED", reasonCode };
     }

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -84,6 +84,7 @@ import {
   acquireClaimLock,
   adapterExecuteTimeoutMs,
   assertHandoffPullRequestBase,
+  boundedWorkspaceIntegrityStatus,
   cancelRun,
   CLAIM_LOCK_BACKOFF_MAX_MS,
   claimNext,
@@ -140,6 +141,7 @@ import {
   runLinearCli,
   runOnce,
   ticketHandoffContext,
+  writeWorkspaceIntegrityStatus,
 } from "./worker.mjs";
 import {
   liveWorkerLeases,
@@ -1184,9 +1186,15 @@ sh -c 'sleep 5 & wait'
       reasonCode: "workspace_integrity_violation",
     });
     const workspace = path.join(o.workspacesRoot, `${spec.runId}-a1`);
-    expect(existsSync(path.join(workspace, "repo", "agent-write.log"))).toBe(
-      true,
+    const evidenceFile = path.join(workspace, "workspace-integrity-status.txt");
+    expect(existsSync(evidenceFile)).toBe(true);
+    expect(readFileSync(evidenceFile, "utf8")).toContain("agent-write.log");
+    expect(readFileSync(evidenceFile, "utf8")).toContain(
+      "checkoutBaselineSha256: sha256:",
     );
+    // The retained wrapper preserves the evidence file, not a live checkout
+    // registration in its mirror.
+    expect(existsSync(path.join(workspace, "repo"))).toBe(false);
     const evidence = db
       .query(
         `SELECT payload_json FROM attempt_trace
@@ -1201,6 +1209,52 @@ sh -c 'sleep 5 & wait'
       }),
     );
     db.close();
+  });
+
+  test("bounds workspace integrity status without splitting UTF-8 characters", () => {
+    const status = `${"x".repeat(12 * 1024 - 1)}é`;
+    const evidence = boundedWorkspaceIntegrityStatus(status);
+
+    expect(evidence.truncated).toBe(true);
+    expect(evidence.value).not.toContain("\uFFFD");
+    expect(Buffer.byteLength(evidence.value, "utf8")).toBeLessThanOrEqual(
+      12 * 1024,
+    );
+  });
+
+  test("preserves null workspace integrity status", () => {
+    expect(boundedWorkspaceIntegrityStatus(null)).toEqual({
+      value: null,
+      bytes: null,
+      truncated: false,
+    });
+  });
+
+  test("writes bounded status, baseline, and hashes to retained evidence", () => {
+    const workspace = tmpDir("evrt-integrity-evidence-");
+    writeWorkspaceIntegrityStatus(workspace, {
+      checkoutStatus: "?? agent-write.log\n",
+      checkoutBaseline: "!! generated/setup.log\n",
+    });
+
+    expect(
+      readFileSync(
+        path.join(workspace, "workspace-integrity-status.txt"),
+        "utf8",
+      ),
+    ).toContain("?? agent-write.log");
+    expect(
+      readFileSync(
+        path.join(workspace, "workspace-integrity-status.txt"),
+        "utf8",
+      ),
+    ).toContain("!! generated/setup.log");
+    expect(
+      readFileSync(
+        path.join(workspace, "workspace-integrity-status.txt"),
+        "utf8",
+      ),
+    ).toMatch(/checkout(?:Status|Baseline)Sha256: sha256:[a-f0-9]{64}/);
   });
 
   test("repository status returns null when git exceeds its timeout", () => {


### PR DESCRIPTION
Fixes watt-mind/factory#2307

Persist bounded integrity evidence while releasing checkout registrations and reclaiming expired retained wrappers.

## Validation

| Check                | Command                                                                                             | Result  | Notes                                  |
| -------------------- | --------------------------------------------------------------------------------------------------- | ------- | -------------------------------------- |
| Verification Command | `bun test event-runtime/lib --timeout 20000`                                                       | pass    | 2528 pass, 10 skipped                  |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | emit, format, lint clean               |
| UX critique          | `factory-ux-critic`                                                                                | not run | backend-only worker and janitor change |

UX critique: skipped — backend-only worker and janitor change; no user-facing surface
run:run_9928c646-8a24-4f7c-a8de-e54b59f3ff2a
