### PR TITLE
feat(web): add active workspace dropdown

### DIFF
--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -68,6 +68,7 @@ import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos, reposRoot } from "./repos.mjs";
 import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
+import { cancelRun } from "./worker.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
 import { loadLinearBudget } from "../../tools/ticket.mjs";
 
@@ -382,6 +383,52 @@ export function createApi({
       }
       if (route === "GET /status" || route === "GET /workers") {
         return handleStatusApiRoute({ ...common, getStoreStats });
+      }
+      // Keep the established stale-lease recovery request below in api-runs.
+      // A deliberate workspace termination opts in with `terminate: true`: it
+      // cancels the active run, which aborts its executor and lets normal run
+      // cleanup remove the worktree rather than merely expiring its lease.
+      const workspaceRelease = url.pathname.match(
+        /^\/workers\/([^/]+)\/release$/,
+      );
+      if (
+        req.method === "POST" &&
+        workspaceRelease &&
+        url.searchParams.get("terminate") === "true"
+      ) {
+        const parsed = parseJson(await readBody(req));
+        if (parsed.error) return send(400, { error: "invalid_json" });
+        const body = parsed.value ?? {};
+        if (typeof body.runId !== "string" || body.runId === "")
+          return send(422, { error: "runId required" });
+        const workerId = decodeURIComponent(workspaceRelease[1]);
+        const worker = db
+          .query(`SELECT state, current_run FROM workers WHERE worker_id = ?`)
+          .get(workerId);
+        if (!worker) return send(404, { error: `unknown worker ${workerId}` });
+        if (worker.state === "stopped" || worker.current_run !== body.runId) {
+          return send(409, {
+            error: `worker ${workerId} does not hold ${body.runId}`,
+          });
+        }
+        try {
+          cancelRun(db, body.runId, {
+            actor,
+            reason: "operator_workspace_terminate",
+            now: nowMs,
+            policyVersion,
+          });
+          return send(200, {
+            released: true,
+            runId: body.runId,
+            terminated: true,
+          });
+        } catch (err) {
+          const status = String(err.message).startsWith("unknown run")
+            ? 404
+            : 409;
+          return send(status, { error: err.message });
+        }
       }
       if (route === "GET /config") {
         return handleConfigApiRoute({

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -69,6 +69,7 @@ import { loadRepos, reposRoot } from "./repos.mjs";
 import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
 import { cancelRun } from "./worker.mjs";
+import { IllegalTransition } from "./lifecycle.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
 import { loadLinearBudget } from "../../tools/ticket.mjs";
 
@@ -424,10 +425,18 @@ export function createApi({
             terminated: true,
           });
         } catch (err) {
-          const status = String(err.message).startsWith("unknown run")
-            ? 404
-            : 409;
-          return send(status, { error: err.message });
+          if (String(err.message).startsWith("unknown run"))
+            return send(404, { error: err.message });
+          // A run that finished between the operator's click and this request
+          // refuses the transition. Answer in operator terms — what state the
+          // run reached and that there is nothing left to terminate — rather
+          // than leaking the state machine's own wording.
+          if (err instanceof IllegalTransition) {
+            return send(409, {
+              error: `run ${body.runId} already finished (${err.from ?? "unknown state"}); nothing to terminate`,
+            });
+          }
+          return send(409, { error: err.message });
         }
       }
       if (route === "GET /config") {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -117,6 +117,40 @@ describe("workspace termination API (GH-2310)", () => {
       s.close();
     }
   });
+
+  test("answers an already-terminal run with an operator-legible 409", async () => {
+    const nowMs = Date.parse("2026-09-05T19:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+           VALUES ('run-finished', 'finished-key', '{}', 'sha256:finished', 'COMPLETED', 1, ?, ?)`,
+        )
+        .run(new Date(nowMs).toISOString(), new Date(nowMs).toISOString());
+      registerWorker(s.db, { workerId: "worker-finished", now: nowMs });
+      heartbeat(s.db, "worker-finished", {
+        state: "busy",
+        runId: "run-finished",
+        now: nowMs,
+      });
+
+      const refused = await s.request(
+        "/workers/worker-finished/release?terminate=true",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ runId: "run-finished" }),
+        },
+      );
+      expect(refused.status).toBe(409);
+      expect((await refused.json()).error).toBe(
+        "run run-finished already finished (COMPLETED); nothing to terminate",
+      );
+    } finally {
+      s.close();
+    }
+  });
 });
 
 describe("inbox decision API (WM-390)", () => {

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -57,6 +57,68 @@ const makeServer = async (...args) => {
   return result;
 };
 
+describe("workspace termination API (GH-2310)", () => {
+  test("cancels only the active run held by the selected worker", async () => {
+    const nowMs = Date.parse("2026-09-05T19:00:00.000Z");
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      s.db
+        .query(
+          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+           VALUES ('run-workspace', 'workspace-key', '{}', 'sha256:workspace', 'RUNNING', 1, ?, ?)`,
+        )
+        .run(new Date(nowMs).toISOString(), new Date(nowMs).toISOString());
+      s.db
+        .query(
+          `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner)
+           VALUES ('run-workspace', 1, 1, 'worker-workspace')`,
+        )
+        .run();
+      registerWorker(s.db, { workerId: "worker-workspace", now: nowMs });
+      heartbeat(s.db, "worker-workspace", {
+        state: "busy",
+        runId: "run-workspace",
+        now: nowMs,
+      });
+
+      const terminated = await s.request(
+        "/workers/worker-workspace/release?terminate=true",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ runId: "run-workspace" }),
+        },
+      );
+      expect(terminated.status).toBe(200);
+      expect(await terminated.json()).toEqual({
+        released: true,
+        runId: "run-workspace",
+        terminated: true,
+      });
+      expect(
+        s.db
+          .query(`SELECT state FROM runs WHERE run_id = 'run-workspace'`)
+          .get().state,
+      ).toBe("CANCELLED");
+
+      const raced = await s.request(
+        "/workers/worker-workspace/release?terminate=true",
+        {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ runId: "other-run" }),
+        },
+      );
+      expect(raced.status).toBe(409);
+      expect((await raced.json()).error).toBe(
+        "worker worker-workspace does not hold other-run",
+      );
+    } finally {
+      s.close();
+    }
+  });
+});
+
 describe("inbox decision API (WM-390)", () => {
   const request = {
     schemaVersion: "factory.decision-request/v1",

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -50,6 +50,7 @@ import {
   copyLink,
   copyText,
 } from "./components/ui";
+import { WorkspaceDropdown } from "./components/WorkspaceDropdown";
 import {
   NAV,
   navIsCurrent,
@@ -726,6 +727,7 @@ export function App() {
             </div>
           </div>
           <div className="flex-1 px-2">
+            <WorkspaceDropdown />
             {NAV.map((n, index) => {
               const prev = index > 0 ? NAV[index - 1] : null;
               const isGroupBoundary = prev && prev.group !== n.group;

--- a/event-runtime/web/src/App.tsx
+++ b/event-runtime/web/src/App.tsx
@@ -50,7 +50,13 @@ import {
   copyLink,
   copyText,
 } from "./components/ui";
-import { WorkspaceDropdown } from "./components/WorkspaceDropdown";
+// Lazy: the dropdown is chrome, not first paint — keeping it (and its
+// run-detail plumbing) out of the entry chunk protects the budget below.
+const WorkspaceDropdown = lazy(() =>
+  import("./components/WorkspaceDropdown").then((module) => ({
+    default: module.WorkspaceDropdown,
+  })),
+);
 import {
   NAV,
   navIsCurrent,
@@ -727,7 +733,9 @@ export function App() {
             </div>
           </div>
           <div className="flex-1 px-2">
-            <WorkspaceDropdown />
+            <Suspense fallback={null}>
+              <WorkspaceDropdown />
+            </Suspense>
             {NAV.map((n, index) => {
               const prev = index > 0 ? NAV[index - 1] : null;
               const isGroupBoundary = prev && prev.group !== n.group;

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -530,7 +530,15 @@ export const api = {
     call<{ archived: boolean }>("POST", "/events/archive", { source, eventId }),
   // Requeue/fail the run held by a stale worker and retire its registry row.
   releaseWorker: (workerId: string, runId: string) =>
-    call<{ released: boolean; runId: string; terminated?: boolean }>(
+    call<{ released: boolean; runId: string }>(
+      "POST",
+      `/workers/${encodeURIComponent(workerId)}/release`,
+      { runId },
+    ),
+  // Deliberately cancel a live workspace. This is distinct from stale-lease
+  // recovery above: using that recovery route on a live worker would retry it.
+  terminateWorkspace: (workerId: string, runId: string) =>
+    call<{ released: boolean; runId: string; terminated: true }>(
       "POST",
       `/workers/${encodeURIComponent(workerId)}/release?terminate=true`,
       { runId },

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -30,6 +30,7 @@ import type {
   TicketSummary,
   TraceView,
   Worker,
+  WorkerCapacity,
 } from "./types";
 
 // Same contract as lib/client.mjs: one function per endpoint, an Error with
@@ -529,9 +530,9 @@ export const api = {
     call<{ archived: boolean }>("POST", "/events/archive", { source, eventId }),
   // Requeue/fail the run held by a stale worker and retire its registry row.
   releaseWorker: (workerId: string, runId: string) =>
-    call<{ released: boolean; runId: string }>(
+    call<{ released: boolean; runId: string; terminated?: boolean }>(
       "POST",
-      `/workers/${encodeURIComponent(workerId)}/release`,
+      `/workers/${encodeURIComponent(workerId)}/release?terminate=true`,
       { runId },
     ),
   // The agent registry, fully readable: definitions, prompts, schemas, pins.
@@ -597,7 +598,8 @@ export const api = {
       apply,
     }),
   // The worker registry: which processes are alive, where, and what they run.
-  workers: () => call<{ workers: Worker[] }>("GET", "/workers"),
+  workers: () =>
+    call<{ workers: Worker[]; capacity?: WorkerCapacity }>("GET", "/workers"),
   // Human inbox ledger (WM-285): everything waiting on the operator, by status.
   inbox: (
     status: InboxStatus = "open",

--- a/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
@@ -3,8 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
 import { api, type RepoItem } from "../api";
-import { createRunListItemFixture } from "../test-render";
-import type { Worker } from "../types";
+import type { RunDetail, Worker } from "../types";
 import {
   WorkspaceDropdown,
   activeWorkspaces,
@@ -25,11 +24,13 @@ const worker: Worker = {
   startedAt: NOW,
   stoppedAt: null,
 };
-const run = createRunListItemFixture({
-  runId: "run_workspace_1",
-  repos: ["bj29"],
-  eventId: "CLNT-123",
-});
+const run = {
+  run: {
+    runId: "run_workspace_1",
+    spec: { input: { repo: "bj29", ticket: "CLNT-123" } },
+  },
+  subject: "CLNT-123",
+} as RunDetail;
 
 function renderDropdown() {
   const client = new QueryClient({
@@ -64,21 +65,21 @@ describe("active workspace dropdown", () => {
   test("renders mocked workers, shows the limit, and releases a confirmed workspace", async () => {
     const original = {
       workers: api.workers,
-      runs: api.runs,
       repos: api.repos,
-      releaseWorker: api.releaseWorker,
+      run: api.run,
+      terminateWorkspace: api.terminateWorkspace,
     };
     let releases = 0;
     api.workers = async () => ({ workers: [worker] });
-    api.runs = async () => ({ runs: [run] });
+    api.run = async () => run;
     api.repos = async () => ({
       repos: [{ name: "bj29", effective: { maxInFlight: 4 } } as RepoItem],
     });
-    api.releaseWorker = async (workerId, runId) => {
+    api.terminateWorkspace = async (workerId, runId) => {
       releases += 1;
       expect(workerId).toBe("worker_workspace_1");
       expect(runId).toBe("run_workspace_1");
-      return { released: true, runId };
+      return { released: true, runId, terminated: true as const };
     };
 
     try {
@@ -94,9 +95,9 @@ describe("active workspace dropdown", () => {
       await waitFor(() => expect(releases).toBe(1));
     } finally {
       api.workers = original.workers;
-      api.runs = original.runs;
       api.repos = original.repos;
-      api.releaseWorker = original.releaseWorker;
+      api.run = original.run;
+      api.terminateWorkspace = original.terminateWorkspace;
     }
   });
 });

--- a/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
@@ -1,0 +1,102 @@
+import "../test-dom";
+import { afterEach, describe, expect, test } from "bun:test";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { cleanup, fireEvent, render, waitFor } from "@testing-library/react";
+import { api, type RepoItem } from "../api";
+import { createRunListItemFixture } from "../test-render";
+import type { Worker } from "../types";
+import {
+  WorkspaceDropdown,
+  activeWorkspaces,
+  groupActiveWorkspaces,
+} from "./WorkspaceDropdown";
+
+const NOW = new Date().toISOString();
+const worker: Worker = {
+  workerId: "worker_workspace_1",
+  host: "lab",
+  pid: 1,
+  labels: {},
+  adapters: ["pi"],
+  state: "busy",
+  currentRun: "run_workspace_1",
+  lastSeen: NOW,
+  stale: true,
+  startedAt: NOW,
+  stoppedAt: null,
+};
+const run = createRunListItemFixture({
+  runId: "run_workspace_1",
+  repos: ["bj29"],
+  eventId: "CLNT-123",
+});
+
+function renderDropdown() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <WorkspaceDropdown />
+    </QueryClientProvider>,
+  );
+}
+
+afterEach(() => cleanup());
+
+describe("active workspace dropdown", () => {
+  test("projects active worker runs into tenant groups with their configured limit", () => {
+    const workspaces = activeWorkspaces([worker], [run]);
+    expect(workspaces).toMatchObject([
+      {
+        repo: "bj29",
+        subject: "CLNT-123",
+        worker: { workerId: worker.workerId },
+      },
+    ]);
+    expect(
+      groupActiveWorkspaces(workspaces, [
+        { name: "bj29", effective: { maxInFlight: 4 } } as RepoItem,
+      ]),
+    ).toMatchObject([{ repo: "bj29", limit: 4, workspaces: [{}] }]);
+  });
+
+  test("renders mocked workers, shows the limit, and releases a confirmed workspace", async () => {
+    const original = {
+      workers: api.workers,
+      runs: api.runs,
+      repos: api.repos,
+      releaseWorker: api.releaseWorker,
+    };
+    let releases = 0;
+    api.workers = async () => ({ workers: [worker] });
+    api.runs = async () => ({ runs: [run] });
+    api.repos = async () => ({
+      repos: [{ name: "bj29", effective: { maxInFlight: 4 } } as RepoItem],
+    });
+    api.releaseWorker = async (workerId, runId) => {
+      releases += 1;
+      expect(workerId).toBe("worker_workspace_1");
+      expect(runId).toBe("run_workspace_1");
+      return { released: true, runId };
+    };
+
+    try {
+      const view = renderDropdown();
+      fireEvent.click(view.getByRole("button", { name: /Munkaterületek/ }));
+      expect(await view.findByText("CLNT-123")).toBeTruthy();
+      expect(view.getByText("1 / 4")).toBeTruthy();
+
+      fireEvent.click(
+        view.getByRole("button", { name: "Terminate workspace CLNT-123" }),
+      );
+      fireEvent.click(view.getByRole("button", { name: "Confirm terminate" }));
+      await waitFor(() => expect(releases).toBe(1));
+    } finally {
+      api.workers = original.workers;
+      api.runs = original.runs;
+      api.repos = original.repos;
+      api.releaseWorker = original.releaseWorker;
+    }
+  });
+});

--- a/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.test.tsx
@@ -66,11 +66,18 @@ describe("active workspace dropdown", () => {
     const original = {
       workers: api.workers,
       repos: api.repos,
+      runs: api.runs,
       run: api.run,
       terminateWorkspace: api.terminateWorkspace,
     };
     let releases = 0;
     api.workers = async () => ({ workers: [worker] });
+    // The bounded GET /runs summary carries no spec (WM-976): the component
+    // must fall back to the per-run detail for ids the list cannot label.
+    api.runs = (async () => ({
+      runs: [],
+      nextBefore: null,
+    })) as typeof api.runs;
     api.run = async () => run;
     api.repos = async () => ({
       repos: [{ name: "bj29", effective: { maxInFlight: 4 } } as RepoItem],
@@ -93,11 +100,54 @@ describe("active workspace dropdown", () => {
       );
       fireEvent.click(view.getByRole("button", { name: "Confirm terminate" }));
       await waitFor(() => expect(releases).toBe(1));
+      // The worker list has not caught up yet; the terminated row's button
+      // stays inert instead of offering a second cancel.
+      await waitFor(() =>
+        expect(
+          (
+            view.getByRole("button", {
+              name: "Terminate workspace CLNT-123",
+            }) as HTMLButtonElement
+          ).disabled,
+        ).toBe(true),
+      );
     } finally {
       api.workers = original.workers;
       api.repos = original.repos;
+      api.runs = original.runs;
       api.run = original.run;
       api.terminateWorkspace = original.terminateWorkspace;
+    }
+  });
+
+  test("shows an error line and a bare run-id row when details cannot load", async () => {
+    const original = {
+      workers: api.workers,
+      repos: api.repos,
+      runs: api.runs,
+      run: api.run,
+    };
+    api.workers = async () => ({ workers: [worker] });
+    api.repos = async () => ({ repos: [] });
+    api.runs = (async () => {
+      throw new Error("list unavailable");
+    }) as typeof api.runs;
+    api.run = async () => {
+      throw new Error("detail unavailable");
+    };
+
+    try {
+      const view = renderDropdown();
+      fireEvent.click(view.getByRole("button", { name: /Munkaterületek/ }));
+      expect(await view.findByRole("alert")).toBeTruthy();
+      // The unresolved worker renders as a bare row keyed by its run id
+      // rather than an indefinite loading message.
+      expect(await view.findByTitle("run_workspace_1")).toBeTruthy();
+    } finally {
+      api.workers = original.workers;
+      api.repos = original.repos;
+      api.runs = original.runs;
+      api.run = original.run;
     }
   });
 });

--- a/event-runtime/web/src/components/WorkspaceDropdown.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.tsx
@@ -1,0 +1,227 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useMemo, useState } from "react";
+import { api, type RepoItem } from "../api";
+import { refetchIntervals } from "../hooks";
+import type { RunListItem, Worker } from "../types";
+import { Button, notify, shortId } from "./ui";
+
+export type ActiveWorkspace = {
+  worker: Worker;
+  run: RunListItem;
+  repo: string;
+  subject: string;
+};
+
+/**
+ * A workspace occupies a tenant slot while its worker has a current run. The
+ * worker endpoint is the authority for that relationship; the run list only
+ * supplies the operator-facing repository and subject labels.
+ */
+export function activeWorkspaces(
+  workers: Worker[],
+  runs: RunListItem[],
+): ActiveWorkspace[] {
+  const byId = new Map(runs.map((run) => [run.runId, run]));
+  return workers.flatMap((worker) => {
+    if (worker.state === "stopped" || !worker.currentRun) return [];
+    const run = byId.get(worker.currentRun);
+    if (!run) return [];
+    return [
+      {
+        worker,
+        run,
+        repo: run.repos[0] ?? "Unassigned",
+        subject: run.eventId ?? run.runId,
+      },
+    ];
+  });
+}
+
+type WorkspaceGroup = {
+  repo: string;
+  limit: number | null;
+  workspaces: ActiveWorkspace[];
+};
+
+export function groupActiveWorkspaces(
+  workspaces: ActiveWorkspace[],
+  repos: RepoItem[],
+): WorkspaceGroup[] {
+  const limits = new Map(
+    repos.map((repo) => [repo.name, repo.effective?.maxInFlight ?? null]),
+  );
+  const groups = new Map<string, ActiveWorkspace[]>();
+  for (const workspace of workspaces) {
+    const group = groups.get(workspace.repo) ?? [];
+    group.push(workspace);
+    groups.set(workspace.repo, group);
+  }
+  return [...groups.entries()]
+    .map(([repo, entries]) => ({
+      repo,
+      limit: limits.get(repo) ?? null,
+      workspaces: entries,
+    }))
+    .sort((left, right) => left.repo.localeCompare(right.repo));
+}
+
+/** A compact, always-available view of tenant workspaces in the app chrome. */
+export function WorkspaceDropdown() {
+  const [open, setOpen] = useState(false);
+  const [confirming, setConfirming] = useState<ActiveWorkspace | null>(null);
+  const queryClient = useQueryClient();
+  const workersQuery = useQuery({
+    queryKey: ["workers"],
+    queryFn: api.workers,
+    ...refetchIntervals.primary,
+  });
+  const runsQuery = useQuery({
+    queryKey: ["runs"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.secondary,
+  });
+  const reposQuery = useQuery({
+    queryKey: ["repos"],
+    queryFn: api.repos,
+    ...refetchIntervals.secondary,
+  });
+  const workspaces = useMemo(
+    () =>
+      activeWorkspaces(
+        workersQuery.data?.workers ?? [],
+        runsQuery.data?.runs ?? [],
+      ),
+    [workersQuery.data, runsQuery.data],
+  );
+  const groups = useMemo(
+    () => groupActiveWorkspaces(workspaces, reposQuery.data?.repos ?? []),
+    [workspaces, reposQuery.data],
+  );
+
+  const release = useMutation({
+    mutationFn: (workspace: ActiveWorkspace) =>
+      api.releaseWorker(workspace.worker.workerId, workspace.run.runId),
+    onSuccess: (_, workspace) => {
+      void queryClient.invalidateQueries({ queryKey: ["workers"] });
+      void queryClient.invalidateQueries({ queryKey: ["runs"] });
+      void queryClient.invalidateQueries({ queryKey: ["status"] });
+      setConfirming(null);
+      notify(`Terminated workspace ${workspace.subject}`, "ok");
+    },
+    onError: (error: Error, workspace) => {
+      notify(
+        `Could not terminate ${workspace.subject}: ${error.message}`,
+        "err",
+      );
+    },
+  });
+
+  const total = workspaces.length;
+  return (
+    <section className="relative mb-2" aria-label="Active workspaces">
+      <Button
+        type="button"
+        size="sm"
+        aria-expanded={open}
+        aria-controls="active-workspaces-menu"
+        onClick={() => setOpen((value) => !value)}
+        className="w-full justify-between"
+      >
+        <span>Munkaterületek</span>
+        <span className="mono text-(--text-faint)">{total}</span>
+      </Button>
+      {open && (
+        <div
+          id="active-workspaces-menu"
+          role="region"
+          aria-label="Running workspaces"
+          className="mt-1 max-h-80 overflow-y-auto rounded-md border border-(--border) bg-(--surface-1) p-2 shadow-lg"
+        >
+          {groups.length === 0 ? (
+            <p className="px-1 py-2 text-[12px] text-(--text-faint)">
+              No running workspaces.
+            </p>
+          ) : (
+            groups.map((group) => (
+              <div
+                key={group.repo}
+                className="py-1 not-last:border-b not-last:border-(--border)"
+              >
+                <div className="flex items-center justify-between gap-2 px-1 py-1 text-[11px] font-semibold text-(--text-dim)">
+                  <span className="truncate">{group.repo}</span>
+                  <span
+                    className="mono shrink-0"
+                    aria-label={`${group.workspaces.length}${group.limit === null ? " active workspaces" : ` of ${group.limit} workspace limit`}`}
+                  >
+                    {group.workspaces.length}
+                    {group.limit === null ? "" : ` / ${group.limit}`}
+                  </span>
+                </div>
+                {group.workspaces.map((workspace) => {
+                  const isConfirming =
+                    confirming?.run.runId === workspace.run.runId;
+                  return (
+                    <div
+                      key={workspace.worker.workerId}
+                      className="rounded px-1 py-1.5 hover:bg-(--surface-2)"
+                    >
+                      <div className="flex items-start justify-between gap-2">
+                        <div className="min-w-0 text-[12px]">
+                          <div
+                            className="truncate text-(--text)"
+                            title={workspace.subject}
+                          >
+                            {workspace.subject}
+                          </div>
+                          <div className="mono truncate text-[11px] text-(--text-faint)">
+                            {shortId(workspace.run.runId)} ·{" "}
+                            {workspace.worker.stale
+                              ? "stale"
+                              : workspace.worker.state}
+                          </div>
+                        </div>
+                        {!isConfirming && (
+                          <Button
+                            type="button"
+                            size="sm"
+                            disabled={release.isPending}
+                            aria-label={`Terminate workspace ${workspace.subject}`}
+                            onClick={() => setConfirming(workspace)}
+                          >
+                            Terminate
+                          </Button>
+                        )}
+                      </div>
+                      {isConfirming && (
+                        <div className="mt-2 flex items-center justify-between gap-2 rounded bg-(--surface-3) p-2 text-[11px] text-(--text-dim)">
+                          <span>Stop this workspace?</span>
+                          <span className="flex gap-1">
+                            <Button
+                              type="button"
+                              size="sm"
+                              onClick={() => setConfirming(null)}
+                            >
+                              Keep
+                            </Button>
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={release.isPending}
+                              onClick={() => release.mutate(workspace)}
+                            >
+                              Confirm terminate
+                            </Button>
+                          </span>
+                        </div>
+                      )}
+                    </div>
+                  );
+                })}
+              </div>
+            ))
+          )}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/event-runtime/web/src/components/WorkspaceDropdown.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.tsx
@@ -7,7 +7,7 @@ import {
 import { useMemo, useState } from "react";
 import { api, type RepoItem } from "../api";
 import { refetchIntervals } from "../hooks";
-import type { RunDetail, Worker } from "../types";
+import type { RunDetail, RunListItem, Worker } from "../types";
 import { Button, notify, shortId } from "./ui";
 
 export type ActiveWorkspace = {
@@ -111,37 +111,79 @@ export function WorkspaceDropdown() {
     () => activeWorkers.map((worker) => worker.currentRun!),
     [activeWorkers],
   );
-  // GET /runs is a bounded summary and intentionally omits repository and
-  // subject data. Resolve each direct worker reference through GET /runs/:id.
+  // Resolve run labels from the shared run list first (one request on the
+  // relaxed cadence, same cache key other views poll — Workers.tsx precedent).
+  // GET /runs is a bounded summary that has omitted `spec` since WM-976, so
+  // any id the list cannot label falls back to GET /runs/:id — and those
+  // detail requests only run while the menu is open.
+  const runsQuery = useQuery({
+    queryKey: ["runs"],
+    queryFn: () => api.runs(),
+    ...refetchIntervals.secondary,
+  });
+  const listDetails = useMemo(() => {
+    const rows = new Map<string, RunListItem>(
+      (runsQuery.data?.runs ?? []).map((row) => [row.runId, row]),
+    );
+    return new Map<string, RunDetail>(
+      runIds.flatMap((runId) => {
+        const row = rows.get(runId);
+        if (!row?.spec) return [];
+        return [[runId, { run: { runId, spec: row.spec } } as RunDetail]];
+      }),
+    );
+  }, [runsQuery.data, runIds]);
+  const missingRunIds = useMemo(
+    () => runIds.filter((runId) => !listDetails.has(runId)),
+    [runIds, listDetails],
+  );
   const runQueries = useQueries({
-    queries: runIds.map((runId) => ({
+    queries: missingRunIds.map((runId) => ({
       queryKey: ["run", runId],
       queryFn: () => api.run(runId),
       ...refetchIntervals.primary,
       retry: 1,
+      enabled: open,
     })),
   });
   const runDetailKey = runQueries.map((query) => query.dataUpdatedAt).join(",");
   const workspaces = useMemo(
     () =>
-      activeWorkspaces(
-        activeWorkers,
-        runQueries.flatMap((query) => (query.data ? [query.data] : [])),
-      ),
+      activeWorkspaces(activeWorkers, [
+        ...listDetails.values(),
+        ...runQueries.flatMap((query) => (query.data ? [query.data] : [])),
+      ]),
     // useQueries returns a new array every render; timestamps are its stable
     // data dependency.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activeWorkers, runDetailKey],
+    [activeWorkers, listDetails, runDetailKey],
   );
+  const resolvedRunIds = useMemo(
+    () => new Set(workspaces.map((workspace) => workspace.runId)),
+    [workspaces],
+  );
+  const unresolvedWorkers = useMemo(
+    () =>
+      activeWorkers.filter((worker) => !resolvedRunIds.has(worker.currentRun!)),
+    [activeWorkers, resolvedRunIds],
+  );
+  const runQueryError =
+    runsQuery.isError || runQueries.some((query) => query.isError);
   const groups = useMemo(
     () => groupActiveWorkspaces(workspaces, reposQuery.data?.repos ?? []),
     [workspaces, reposQuery.data],
   );
 
+  const [terminatedRunIds, setTerminatedRunIds] = useState<Set<string>>(
+    () => new Set(),
+  );
   const release = useMutation({
     mutationFn: (workspace: ActiveWorkspace) =>
       api.terminateWorkspace(workspace.worker.workerId, workspace.runId),
     onSuccess: (_, workspace) => {
+      // The worker list catches up on its next poll; until then keep this
+      // row's Terminate inert so a double-click cannot race the cancel.
+      setTerminatedRunIds((prev) => new Set(prev).add(workspace.runId));
       void queryClient.invalidateQueries({ queryKey: ["workers"] });
       void queryClient.invalidateQueries({ queryKey: ["run"] });
       void queryClient.invalidateQueries({ queryKey: ["status"] });
@@ -181,87 +223,117 @@ export function WorkspaceDropdown() {
             <p className="px-1 py-2 text-[12px] text-(--text-faint)">
               No running workspaces.
             </p>
-          ) : groups.length === 0 ? (
-            <p className="px-1 py-2 text-[12px] text-(--text-faint)">
-              Loading running workspaces…
-            </p>
           ) : (
-            groups.map((group) => (
-              <div
-                key={group.repo}
-                className="py-1 not-last:border-b not-last:border-(--border)"
-              >
-                <div className="flex items-center justify-between gap-2 px-1 py-1 text-[11px] font-semibold text-(--text-dim)">
-                  <span className="truncate">{group.repo}</span>
-                  <span
-                    className="mono shrink-0"
-                    aria-label={`${group.workspaces.length}${group.limit === null ? " active workspaces" : ` of ${group.limit} workspace limit`}`}
-                  >
-                    {group.workspaces.length}
-                    {group.limit === null ? "" : ` / ${group.limit}`}
-                  </span>
-                </div>
-                {group.workspaces.map((workspace) => {
-                  const isConfirming = confirming?.runId === workspace.runId;
-                  return (
-                    <div
-                      key={workspace.worker.workerId}
-                      className="rounded px-1 py-1.5 hover:bg-(--surface-2)"
+            <>
+              {runQueryError && (
+                <p
+                  role="alert"
+                  className="px-1 py-1 text-[12px] text-(--hue-err)"
+                >
+                  Some workspace details failed to load.
+                </p>
+              )}
+              {groups.map((group) => (
+                <div
+                  key={group.repo}
+                  className="py-1 not-last:border-b not-last:border-(--border)"
+                >
+                  <div className="flex items-center justify-between gap-2 px-1 py-1 text-[11px] font-semibold text-(--text-dim)">
+                    <span className="truncate">{group.repo}</span>
+                    <span
+                      className="mono shrink-0"
+                      aria-label={`${group.workspaces.length}${group.limit === null ? " active workspaces" : ` of ${group.limit} workspace limit`}`}
                     >
-                      <div className="flex items-start justify-between gap-2">
-                        <div className="min-w-0 text-[12px]">
-                          <div
-                            className="truncate text-(--text)"
-                            title={workspace.subject}
-                          >
-                            {workspace.subject}
+                      {group.workspaces.length}
+                      {group.limit === null ? "" : ` / ${group.limit}`}
+                    </span>
+                  </div>
+                  {group.workspaces.map((workspace) => {
+                    const isConfirming = confirming?.runId === workspace.runId;
+                    return (
+                      <div
+                        key={workspace.worker.workerId}
+                        className="rounded px-1 py-1.5 hover:bg-(--surface-2)"
+                      >
+                        <div className="flex items-start justify-between gap-2">
+                          <div className="min-w-0 text-[12px]">
+                            <div
+                              className="truncate text-(--text)"
+                              title={workspace.subject}
+                            >
+                              {workspace.subject}
+                            </div>
+                            <div className="mono truncate text-[11px] text-(--text-faint)">
+                              {shortId(workspace.runId)} ·{" "}
+                              {workspace.worker.stale
+                                ? "stale"
+                                : workspace.worker.state}
+                            </div>
                           </div>
-                          <div className="mono truncate text-[11px] text-(--text-faint)">
-                            {shortId(workspace.runId)} ·{" "}
-                            {workspace.worker.stale
-                              ? "stale"
-                              : workspace.worker.state}
-                          </div>
+                          {!isConfirming && (
+                            <Button
+                              type="button"
+                              size="sm"
+                              disabled={
+                                release.isPending ||
+                                terminatedRunIds.has(workspace.runId)
+                              }
+                              aria-label={`Terminate workspace ${workspace.subject}`}
+                              onClick={() => setConfirming(workspace)}
+                            >
+                              Terminate
+                            </Button>
+                          )}
                         </div>
-                        {!isConfirming && (
-                          <Button
-                            type="button"
-                            size="sm"
-                            disabled={release.isPending}
-                            aria-label={`Terminate workspace ${workspace.subject}`}
-                            onClick={() => setConfirming(workspace)}
-                          >
-                            Terminate
-                          </Button>
+                        {isConfirming && (
+                          <div className="mt-2 flex items-center justify-between gap-2 rounded bg-(--surface-3) p-2 text-[11px] text-(--text-dim)">
+                            <span>Stop this workspace?</span>
+                            <span className="flex gap-1">
+                              <Button
+                                type="button"
+                                size="sm"
+                                onClick={() => setConfirming(null)}
+                              >
+                                Keep
+                              </Button>
+                              <Button
+                                type="button"
+                                size="sm"
+                                disabled={
+                                  release.isPending ||
+                                  terminatedRunIds.has(workspace.runId)
+                                }
+                                onClick={() => release.mutate(workspace)}
+                              >
+                                Confirm terminate
+                              </Button>
+                            </span>
+                          </div>
                         )}
                       </div>
-                      {isConfirming && (
-                        <div className="mt-2 flex items-center justify-between gap-2 rounded bg-(--surface-3) p-2 text-[11px] text-(--text-dim)">
-                          <span>Stop this workspace?</span>
-                          <span className="flex gap-1">
-                            <Button
-                              type="button"
-                              size="sm"
-                              onClick={() => setConfirming(null)}
-                            >
-                              Keep
-                            </Button>
-                            <Button
-                              type="button"
-                              size="sm"
-                              disabled={release.isPending}
-                              onClick={() => release.mutate(workspace)}
-                            >
-                              Confirm terminate
-                            </Button>
-                          </span>
-                        </div>
-                      )}
+                    );
+                  })}
+                </div>
+              ))}
+              {unresolvedWorkers.map((worker) => (
+                <div
+                  key={worker.currentRun!}
+                  className="rounded px-1 py-1.5 hover:bg-(--surface-2)"
+                >
+                  <div className="min-w-0 text-[12px]">
+                    <div
+                      className="mono truncate text-(--text)"
+                      title={worker.currentRun!}
+                    >
+                      {shortId(worker.currentRun!)}
                     </div>
-                  );
-                })}
-              </div>
-            ))
+                    <div className="mono truncate text-[11px] text-(--text-faint)">
+                      {worker.stale ? "stale" : worker.state}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </>
           )}
         </div>
       )}

--- a/event-runtime/web/src/components/WorkspaceDropdown.tsx
+++ b/event-runtime/web/src/components/WorkspaceDropdown.tsx
@@ -1,13 +1,18 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 import { useMemo, useState } from "react";
 import { api, type RepoItem } from "../api";
 import { refetchIntervals } from "../hooks";
-import type { RunListItem, Worker } from "../types";
+import type { RunDetail, Worker } from "../types";
 import { Button, notify, shortId } from "./ui";
 
 export type ActiveWorkspace = {
   worker: Worker;
-  run: RunListItem;
+  runId: string;
   repo: string;
   subject: string;
 };
@@ -19,19 +24,34 @@ export type ActiveWorkspace = {
  */
 export function activeWorkspaces(
   workers: Worker[],
-  runs: RunListItem[],
+  runDetails: RunDetail[],
 ): ActiveWorkspace[] {
-  const byId = new Map(runs.map((run) => [run.runId, run]));
+  const byId = new Map(runDetails.map((detail) => [detail.run.runId, detail]));
   return workers.flatMap((worker) => {
     if (worker.state === "stopped" || !worker.currentRun) return [];
-    const run = byId.get(worker.currentRun);
-    if (!run) return [];
+    const detail = byId.get(worker.currentRun);
+    if (!detail) return [];
+    const input = detail.run.spec.input as Record<string, unknown>;
+    const repo =
+      (typeof input.repo === "string" && input.repo) ||
+      (Array.isArray(input.repos) &&
+        input.repos.find(
+          (value): value is string => typeof value === "string",
+        )) ||
+      "Unassigned";
+    const subject =
+      (typeof input.ticket === "string" && input.ticket) ||
+      (typeof input.ticketId === "string" && input.ticketId) ||
+      (typeof input.issue === "string" && input.issue) ||
+      (typeof input.issueId === "string" && input.issueId) ||
+      detail.subject ||
+      worker.currentRun;
     return [
       {
         worker,
-        run,
-        repo: run.repos[0] ?? "Unassigned",
-        subject: run.eventId ?? run.runId,
+        runId: worker.currentRun,
+        repo,
+        subject,
       },
     ];
   });
@@ -75,23 +95,43 @@ export function WorkspaceDropdown() {
     queryFn: api.workers,
     ...refetchIntervals.primary,
   });
-  const runsQuery = useQuery({
-    queryKey: ["runs"],
-    queryFn: () => api.runs(),
-    ...refetchIntervals.secondary,
-  });
   const reposQuery = useQuery({
     queryKey: ["repos"],
     queryFn: api.repos,
     ...refetchIntervals.secondary,
   });
+  const activeWorkers = useMemo(
+    () =>
+      (workersQuery.data?.workers ?? []).filter(
+        (worker) => worker.state !== "stopped" && worker.currentRun,
+      ),
+    [workersQuery.data],
+  );
+  const runIds = useMemo(
+    () => activeWorkers.map((worker) => worker.currentRun!),
+    [activeWorkers],
+  );
+  // GET /runs is a bounded summary and intentionally omits repository and
+  // subject data. Resolve each direct worker reference through GET /runs/:id.
+  const runQueries = useQueries({
+    queries: runIds.map((runId) => ({
+      queryKey: ["run", runId],
+      queryFn: () => api.run(runId),
+      ...refetchIntervals.primary,
+      retry: 1,
+    })),
+  });
+  const runDetailKey = runQueries.map((query) => query.dataUpdatedAt).join(",");
   const workspaces = useMemo(
     () =>
       activeWorkspaces(
-        workersQuery.data?.workers ?? [],
-        runsQuery.data?.runs ?? [],
+        activeWorkers,
+        runQueries.flatMap((query) => (query.data ? [query.data] : [])),
       ),
-    [workersQuery.data, runsQuery.data],
+    // useQueries returns a new array every render; timestamps are its stable
+    // data dependency.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeWorkers, runDetailKey],
   );
   const groups = useMemo(
     () => groupActiveWorkspaces(workspaces, reposQuery.data?.repos ?? []),
@@ -100,10 +140,10 @@ export function WorkspaceDropdown() {
 
   const release = useMutation({
     mutationFn: (workspace: ActiveWorkspace) =>
-      api.releaseWorker(workspace.worker.workerId, workspace.run.runId),
+      api.terminateWorkspace(workspace.worker.workerId, workspace.runId),
     onSuccess: (_, workspace) => {
       void queryClient.invalidateQueries({ queryKey: ["workers"] });
-      void queryClient.invalidateQueries({ queryKey: ["runs"] });
+      void queryClient.invalidateQueries({ queryKey: ["run"] });
       void queryClient.invalidateQueries({ queryKey: ["status"] });
       setConfirming(null);
       notify(`Terminated workspace ${workspace.subject}`, "ok");
@@ -116,7 +156,7 @@ export function WorkspaceDropdown() {
     },
   });
 
-  const total = workspaces.length;
+  const total = activeWorkers.length;
   return (
     <section className="relative mb-2" aria-label="Active workspaces">
       <Button
@@ -137,9 +177,13 @@ export function WorkspaceDropdown() {
           aria-label="Running workspaces"
           className="mt-1 max-h-80 overflow-y-auto rounded-md border border-(--border) bg-(--surface-1) p-2 shadow-lg"
         >
-          {groups.length === 0 ? (
+          {total === 0 ? (
             <p className="px-1 py-2 text-[12px] text-(--text-faint)">
               No running workspaces.
+            </p>
+          ) : groups.length === 0 ? (
+            <p className="px-1 py-2 text-[12px] text-(--text-faint)">
+              Loading running workspaces…
             </p>
           ) : (
             groups.map((group) => (
@@ -158,8 +202,7 @@ export function WorkspaceDropdown() {
                   </span>
                 </div>
                 {group.workspaces.map((workspace) => {
-                  const isConfirming =
-                    confirming?.run.runId === workspace.run.runId;
+                  const isConfirming = confirming?.runId === workspace.runId;
                   return (
                     <div
                       key={workspace.worker.workerId}
@@ -174,7 +217,7 @@ export function WorkspaceDropdown() {
                             {workspace.subject}
                           </div>
                           <div className="mono truncate text-[11px] text-(--text-faint)">
-                            {shortId(workspace.run.runId)} ·{" "}
+                            {shortId(workspace.runId)} ·{" "}
                             {workspace.worker.stale
                               ? "stale"
                               : workspace.worker.state}

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -570,6 +570,17 @@ describe("ToastContainer", () => {
       r.queryByRole("button", { name: /Operation succeeded/i }),
     ).toBeNull();
   });
+
+  test("deduplicates repeated identical error messages", () => {
+    const r = render(<ToastContainer />);
+    act(() => {
+      notify("Workspace release failed", "err");
+      notify("Workspace release failed", "err");
+    });
+    expect(
+      r.getAllByRole("button", { name: "Workspace release failed" }),
+    ).toHaveLength(1);
+  });
 });
 
 describe("Countdown", () => {

--- a/event-runtime/web/src/components/ui.test.tsx
+++ b/event-runtime/web/src/components/ui.test.tsx
@@ -581,6 +581,41 @@ describe("ToastContainer", () => {
       r.getAllByRole("button", { name: "Workspace release failed" }),
     ).toHaveLength(1);
   });
+
+  test("does not deduplicate repeated ok toasts", () => {
+    const r = render(<ToastContainer />);
+    act(() => {
+      notify("Saved", "ok");
+      notify("Saved", "ok");
+    });
+    expect(r.getAllByRole("button", { name: "Saved" })).toHaveLength(2);
+  });
+
+  test("re-arms the dismissal timer when an error repeats", () => {
+    const r = render(<ToastContainer />);
+    act(() => {
+      notify("Workspace release keeps failing", "err");
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    act(() => {
+      notify("Workspace release keeps failing", "err");
+    });
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    // 4s after the first notify: without the re-arm the toast is gone.
+    expect(
+      r.getByRole("button", { name: "Workspace release keeps failing" }),
+    ).toBeTruthy();
+    act(() => {
+      jest.advanceTimersByTime(1500);
+    });
+    expect(
+      r.queryByRole("button", { name: "Workspace release keeps failing" }),
+    ).toBeNull();
+  });
 });
 
 describe("Countdown", () => {

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1721,23 +1721,43 @@ export interface ToastMessage {
 
 const toastListeners = new Set<(toasts: ToastMessage[]) => void>();
 let activeToasts: ToastMessage[] = [];
+const toastTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+function armDismiss(id: string) {
+  const pending = toastTimers.get(id);
+  if (pending !== undefined) clearTimeout(pending);
+  toastTimers.set(
+    id,
+    setTimeout(() => dismissToast(id), 3000),
+  );
+}
 
 export function notify(message: string, type: "ok" | "err" | "info" = "ok") {
   // A retrying mutation can report the same failure faster than an operator can
-  // act on it. Keep one visible, announced error rather than growing a stack.
-  if (
-    activeToasts.some(
+  // act on it. Keep one visible, announced error rather than growing a stack —
+  // but re-arm its dismissal timer, so a still-recurring failure stays on
+  // screen instead of vanishing 3s after its first occurrence. Only errors
+  // dedupe: repeated ok/info toasts are distinct confirmations of distinct
+  // actions and each deserves its own announcement.
+  if (type === "err") {
+    const existing = activeToasts.find(
       (toast) => toast.message === message && toast.type === type,
-    )
-  )
-    return;
+    );
+    if (existing) {
+      armDismiss(existing.id);
+      return;
+    }
+  }
   const id = Math.random().toString(36).slice(2);
   activeToasts = [...activeToasts, { id, type, message }].slice(-5);
   toastListeners.forEach((l) => l(activeToasts));
-  setTimeout(() => dismissToast(id), 3000);
+  armDismiss(id);
 }
 
 function dismissToast(id: string) {
+  const pending = toastTimers.get(id);
+  if (pending !== undefined) clearTimeout(pending);
+  toastTimers.delete(id);
   const next = activeToasts.filter((t) => t.id !== id);
   if (next.length === activeToasts.length) return;
   activeToasts = next;
@@ -1745,6 +1765,8 @@ function dismissToast(id: string) {
 }
 
 export function clearToasts() {
+  toastTimers.forEach((timer) => clearTimeout(timer));
+  toastTimers.clear();
   activeToasts = [];
   toastListeners.forEach((l) => l(activeToasts));
 }

--- a/event-runtime/web/src/components/ui.tsx
+++ b/event-runtime/web/src/components/ui.tsx
@@ -1723,6 +1723,14 @@ const toastListeners = new Set<(toasts: ToastMessage[]) => void>();
 let activeToasts: ToastMessage[] = [];
 
 export function notify(message: string, type: "ok" | "err" | "info" = "ok") {
+  // A retrying mutation can report the same failure faster than an operator can
+  // act on it. Keep one visible, announced error rather than growing a stack.
+  if (
+    activeToasts.some(
+      (toast) => toast.message === message && toast.type === type,
+    )
+  )
+    return;
   const id = Math.random().toString(36).slice(2);
   activeToasts = [...activeToasts, { id, type, message }].slice(-5);
   toastListeners.forEach((l) => l(activeToasts));

--- a/event-runtime/web/src/test-render.tsx
+++ b/event-runtime/web/src/test-render.tsx
@@ -363,6 +363,11 @@ export function createDefaultApiMocks(): Record<ApiKey, any> {
       released: true,
       runId,
     })),
+    terminateWorkspace: mock(async (_workerId: string, runId: string) => ({
+      released: true,
+      runId,
+      terminated: true as const,
+    })),
     agents: mock(async () => createAgentsFixture()),
     putEventTypeOverride: mock(
       async (_type: string, body: { adapter: string }) => ({


### PR DESCRIPTION
## Summary
- add an always-available active-workspaces dropdown with tenant counts and concurrency limits
- add confirmed workspace termination through the worker release endpoint while retaining stale-lease recovery semantics
- deduplicate repeated toast messages and cover dropdown, termination API, and dedupe behavior

## Verification
- `bun test src --timeout 20000` (from `event-runtime/web`): 1453 pass
- `bun test event-runtime/lib/api.test.mjs --timeout 20000`: 24 pass
- `bun x tsc --noEmit` (from `event-runtime/web`): pass
- `bun run format:check`: pass

## UX
The required UX-critic invocation timed out in this harness before it could return browser findings. The flow has focused component coverage for loading, visible tenant limit, confirmation, successful termination, and failure toast behavior.



Fixes #2310
