### PR TITLE
feat(workers): terminate live worker leases

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -25,7 +25,7 @@ import {
   cancelRun,
   extendRunDeadline,
   policyMaxRunMinutes,
-  terminateWorkerLease,
+  releaseStalledWorkerLease,
   retryRun,
 } from "./worker.mjs";
 import { agentFamily, proposalSubject } from "./proposal-subject.mjs";
@@ -2485,7 +2485,7 @@ export async function handleRunApiRoute({
     try {
       return send(
         200,
-        terminateWorkerLease(
+        releaseStalledWorkerLease(
           db,
           { workerId, runId: body.runId },
           { actor, now: nowMs, policyVersion },

--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -25,7 +25,7 @@ import {
   cancelRun,
   extendRunDeadline,
   policyMaxRunMinutes,
-  releaseStalledWorkerLease,
+  terminateWorkerLease,
   retryRun,
 } from "./worker.mjs";
 import { agentFamily, proposalSubject } from "./proposal-subject.mjs";
@@ -2485,7 +2485,7 @@ export async function handleRunApiRoute({
     try {
       return send(
         200,
-        releaseStalledWorkerLease(
+        terminateWorkerLease(
           db,
           { workerId, runId: body.runId },
           { actor, now: nowMs, policyVersion },

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -2856,7 +2856,7 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
     }
   });
 
-  test("releasing a live worker terminates its workspace instead of requiring a stale heartbeat", async () => {
+  test("releasing a live worker is refused; termination is a separate opt-in (GH-2311)", async () => {
     const nowMs = 300_000;
     const { db, server, port } = await makeServer({ now: () => nowMs });
     const client = apiClient({ port, token: CONTROL_TOKEN });
@@ -2880,24 +2880,25 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
         now: nowMs,
       });
 
-      expect(await client.releaseWorker("worker-live", "run-live")).toEqual({
-        released: true,
-        runId: "run-live",
-      });
+      const refused = await rejection(
+        client.releaseWorker("worker-live", "run-live"),
+      );
+      expect(refused.status).toBe(409);
+      expect(String(refused.message)).toContain("not stalled");
       expect(
         db.query(`SELECT state FROM runs WHERE run_id = 'run-live'`).get(),
       ).toEqual({
-        state: "CANCELLED",
+        state: "RUNNING",
       });
       expect(
         db
           .query(
-            `SELECT terminal_state, reason_code FROM attempts WHERE run_id = 'run-live'`,
+            `SELECT terminal_state, lease_owner FROM attempts WHERE run_id = 'run-live'`,
           )
           .get(),
       ).toEqual({
-        terminal_state: "CANCELLED",
-        reason_code: "operator_terminated",
+        terminal_state: null,
+        lease_owner: "worker-live",
       });
     } finally {
       server.close();

--- a/event-runtime/lib/api-runs.test.mjs
+++ b/event-runtime/lib/api-runs.test.mjs
@@ -2856,6 +2856,54 @@ describe("webui surface: proposal linkage, history, journal, outbox, requeue (OP
     }
   });
 
+  test("releasing a live worker terminates its workspace instead of requiring a stale heartbeat", async () => {
+    const nowMs = 300_000;
+    const { db, server, port } = await makeServer({ now: () => nowMs });
+    const client = apiClient({ port, token: CONTROL_TOKEN });
+    try {
+      db.query(
+        `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+         VALUES ('run-live', 'live-key', ?, 'sha256:live', 'RUNNING', 1, ?, ?)`,
+      ).run(
+        JSON.stringify({ timeoutSeconds: 60, maxAttempts: 2 }),
+        new Date(nowMs).toISOString(),
+        new Date(nowMs).toISOString(),
+      );
+      db.query(
+        `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner, lease_expires_at)
+         VALUES ('run-live', 1, 1, 'worker-live', ?)`,
+      ).run(new Date(nowMs + 60_000).toISOString());
+      registerWorker(db, { workerId: "worker-live", now: nowMs });
+      heartbeat(db, "worker-live", {
+        state: "busy",
+        runId: "run-live",
+        now: nowMs,
+      });
+
+      expect(await client.releaseWorker("worker-live", "run-live")).toEqual({
+        released: true,
+        runId: "run-live",
+      });
+      expect(
+        db.query(`SELECT state FROM runs WHERE run_id = 'run-live'`).get(),
+      ).toEqual({
+        state: "CANCELLED",
+      });
+      expect(
+        db
+          .query(
+            `SELECT terminal_state, reason_code FROM attempts WHERE run_id = 'run-live'`,
+          )
+          .get(),
+      ).toEqual({
+        terminal_state: "CANCELLED",
+        reason_code: "operator_terminated",
+      });
+    } finally {
+      server.close();
+    }
+  });
+
   test("requeueing a human_needed event supersedes its open proposal", async () => {
     const { db, server, port } = await makeServer();
     const client = apiClient({ port, token: CONTROL_TOKEN });

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -68,7 +68,7 @@ import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos, reposRoot } from "./repos.mjs";
 import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
-import { cancelRun } from "./worker.mjs";
+import { terminateLiveWorkerLease } from "./worker.mjs";
 import { IllegalTransition } from "./lifecycle.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
 import { loadLinearBudget } from "../../tools/ticket.mjs";
@@ -413,24 +413,29 @@ export function createApi({
           });
         }
         try {
-          cancelRun(db, body.runId, {
-            actor,
-            reason: "operator_workspace_terminate",
-            now: nowMs,
-            policyVersion,
-          });
+          const outcome = terminateLiveWorkerLease(
+            db,
+            { workerId, runId: body.runId },
+            { actor, now: nowMs, policyVersion },
+          );
+          if (!outcome.released) {
+            // A run that finished between the operator's click and this
+            // request has nothing left to terminate. Answer in operator
+            // terms — what state the run reached — rather than leaking the
+            // state machine's own wording.
+            return send(409, {
+              error: `run ${body.runId} already finished (${outcome.state ?? "unknown state"}); nothing to terminate`,
+            });
+          }
           return send(200, {
             released: true,
-            runId: body.runId,
+            runId: outcome.runId,
             terminated: true,
           });
         } catch (err) {
           if (String(err.message).startsWith("unknown run"))
             return send(404, { error: err.message });
-          // A run that finished between the operator's click and this request
-          // refuses the transition. Answer in operator terms — what state the
-          // run reached and that there is nothing left to terminate — rather
-          // than leaking the state machine's own wording.
+          // A concurrent settlement can still race the delegated cancel.
           if (err instanceof IllegalTransition) {
             return send(409, {
               error: `run ${body.runId} already finished (${err.from ?? "unknown state"}); nothing to terminate`,

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -100,6 +100,24 @@ describe("workspace termination API (GH-2310)", () => {
           .query(`SELECT state FROM runs WHERE run_id = 'run-workspace'`)
           .get().state,
       ).toBe("CANCELLED");
+      expect(
+        s.db
+          .query(
+            `SELECT terminal_state, reason_code, lease_owner FROM attempts WHERE run_id = 'run-workspace'`,
+          )
+          .get(),
+      ).toEqual({
+        terminal_state: "CANCELLED",
+        reason_code: "operator_terminated",
+        lease_owner: null,
+      });
+      expect(
+        s.db
+          .query(
+            `SELECT state, current_run FROM workers WHERE worker_id = 'worker-workspace'`,
+          )
+          .get(),
+      ).toEqual({ state: "stopped", current_run: null });
 
       const raced = await s.request(
         "/workers/worker-workspace/release?terminate=true",

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -6543,10 +6543,12 @@ export function releaseStalledWorkerLease(
 /**
  * Terminate a live worker's current workspace at the operator's request.
  *
- * This is deliberately not a retry: a live workspace is cancelled/failed
- * according to the closed lifecycle, its attempt is finalized, and its
- * fencing token is advanced before the state transition commits. A late
- * completion from the worker therefore observes a stale token and cannot
+ * This is deliberately not a retry: the current attempt is fenced (its
+ * fencing token is advanced and the lease released) and the worker row is
+ * stopped in one transaction, then settlement and cleanup — the lifecycle
+ * transition, attempt finalization, open-proposal close, tier-escalation
+ * refusal/unclaim, and workspace destruction — are delegated to `cancelRun`.
+ * A late completion from the worker observes a stale token and cannot
  * publish a result after the operator has settled the attempt.
  */
 export function terminateLiveWorkerLease(
@@ -6559,11 +6561,20 @@ export function terminateLiveWorkerLease(
   } = {},
 ) {
   const currentNow = resolveNow(now);
-  const outcome = txImmediate(db, () => {
+  const fenced = txImmediate(db, () => {
     const worker = db
-      .query(`SELECT current_run FROM workers WHERE worker_id = ?`)
+      .query(`SELECT state, current_run FROM workers WHERE worker_id = ?`)
       .get(workerId);
     if (!worker) throw new Error(`unknown worker ${workerId}`);
+    if (worker.state === "stopped") {
+      // A stopped worker has nothing left to terminate, even when its row
+      // still points at a run: never settle that run on its behalf here.
+      return {
+        released: false,
+        runId: worker.current_run ?? runId ?? null,
+        reason: "already_terminal",
+      };
+    }
     if (!worker.current_run)
       throw new Error(`worker ${workerId} has no active run`);
     if (runId && worker.current_run !== runId) {
@@ -6578,13 +6589,13 @@ export function terminateLiveWorkerLease(
       .get(heldRunId);
     if (!run)
       throw new Error(`worker ${workerId} references unknown run ${heldRunId}`);
-    if (
-      ["COMPLETED", "REFUSED", "TIMED_OUT", "CANCELLED"].includes(run.state)
-    ) {
-      return { released: false, runId: heldRunId, reason: "already_terminal" };
-    }
     if (!["LEASED", "RUNNING", "VERIFYING"].includes(run.state)) {
-      throw new Error(`run ${heldRunId} is ${run.state}, not actively leased`);
+      return {
+        released: false,
+        runId: heldRunId,
+        reason: "already_terminal",
+        state: run.state,
+      };
     }
 
     const attempt = db
@@ -6608,87 +6619,21 @@ export function terminateLiveWorkerLease(
           SET fencing_token = ?, lease_owner = NULL, lease_expires_at = ?
         WHERE run_id = ? AND attempt = ?`,
     ).run(fencingToken, iso(currentNow), heldRunId, run.attempts);
-
-    if (run.state === "VERIFYING") {
-      transition(db, {
-        runId: heldRunId,
-        to: "FAILED",
-        actor,
-        reason: "operator_termination",
-        attempt: run.attempts,
-        policyVersion,
-        now: currentNow,
-      });
-      finishAttempt(
-        db,
-        heldRunId,
-        run.attempts,
-        "FAILED",
-        "operator_terminated",
-        currentNow,
-      );
-    } else {
-      transition(db, {
-        runId: heldRunId,
-        to: "CANCELLED",
-        actor,
-        reason: "operator_termination",
-        attempt: run.attempts,
-        policyVersion,
-        now: currentNow,
-      });
-      finishAttempt(
-        db,
-        heldRunId,
-        run.attempts,
-        "CANCELLED",
-        "operator_terminated",
-        currentNow,
-      );
-    }
     db.query(
       `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,
     ).run(iso(currentNow), workerId);
     return { released: true, runId: heldRunId };
   });
+  if (!fenced.released) return fenced;
 
-  if (outcome.released)
-    ACTIVE_EXECUTIONS.get(outcome.runId)?.abort("operator_termination");
-  return outcome;
-}
-
-/**
- * Release a worker workspace while preserving the stale-worker recovery
- * policy. Stalled workers retain lease-expiry retry semantics; live workers
- * are explicitly terminated instead.
- */
-export function terminateWorkerLease(db, { workerId, runId }, options = {}) {
-  const currentNow = resolveNow(options.now);
-  const worker = db
-    .query(`SELECT state, last_seen FROM workers WHERE worker_id = ?`)
-    .get(workerId);
-  if (!worker) throw new Error(`unknown worker ${workerId}`);
-  const stale =
-    worker.state !== "stopped" &&
-    currentNow - Date.parse(worker.last_seen) > HEARTBEAT_STALE_MS;
-  if (stale) {
-    return releaseStalledWorkerLease(
-      db,
-      { workerId, runId },
-      {
-        ...options,
-        now: currentNow,
-      },
-    );
-  }
-  return terminateLiveWorkerLease(
-    db,
-    { workerId, runId },
-    {
-      ...options,
-      now: currentNow,
-    },
-  );
+  cancelRun(db, fenced.runId, {
+    actor,
+    reason: "operator_terminated",
+    attemptReasonCode: "operator_terminated",
+    now: currentNow,
+    policyVersion,
+  });
+  return { released: true, runId: fenced.runId };
 }
 
 /**
@@ -6835,6 +6780,7 @@ export function cancelRun(
   {
     actor,
     reason = "operator_cancel",
+    attemptReasonCode = "cancelled",
     now = () => Date.now(),
     policyVersion,
     unclaimTierEscalation = defaultUnclaimTicket,
@@ -6863,7 +6809,14 @@ export function cancelRun(
         policyVersion,
         now: currentNow,
       });
-      finishAttempt(db, runId, run.attempts, "FAILED", "cancelled", currentNow);
+      finishAttempt(
+        db,
+        runId,
+        run.attempts,
+        "FAILED",
+        attemptReasonCode,
+        currentNow,
+      );
     } else {
       result = transition(db, {
         runId,
@@ -6879,7 +6832,7 @@ export function cancelRun(
           runId,
           run.attempts,
           "CANCELLED",
-          "cancelled",
+          attemptReasonCode,
           currentNow,
         );
       }

--- a/event-runtime/lib/worker.mjs
+++ b/event-runtime/lib/worker.mjs
@@ -6541,6 +6541,157 @@ export function releaseStalledWorkerLease(
 }
 
 /**
+ * Terminate a live worker's current workspace at the operator's request.
+ *
+ * This is deliberately not a retry: a live workspace is cancelled/failed
+ * according to the closed lifecycle, its attempt is finalized, and its
+ * fencing token is advanced before the state transition commits. A late
+ * completion from the worker therefore observes a stale token and cannot
+ * publish a result after the operator has settled the attempt.
+ */
+export function terminateLiveWorkerLease(
+  db,
+  { workerId, runId },
+  {
+    now = () => Date.now(),
+    policyVersion = "unknown",
+    actor = "operator",
+  } = {},
+) {
+  const currentNow = resolveNow(now);
+  const outcome = txImmediate(db, () => {
+    const worker = db
+      .query(`SELECT current_run FROM workers WHERE worker_id = ?`)
+      .get(workerId);
+    if (!worker) throw new Error(`unknown worker ${workerId}`);
+    if (!worker.current_run)
+      throw new Error(`worker ${workerId} has no active run`);
+    if (runId && worker.current_run !== runId) {
+      throw new Error(
+        `worker ${workerId} holds ${worker.current_run}, not ${runId}`,
+      );
+    }
+
+    const heldRunId = worker.current_run;
+    const run = db
+      .query(`SELECT state, attempts FROM runs WHERE run_id = ?`)
+      .get(heldRunId);
+    if (!run)
+      throw new Error(`worker ${workerId} references unknown run ${heldRunId}`);
+    if (
+      ["COMPLETED", "REFUSED", "TIMED_OUT", "CANCELLED"].includes(run.state)
+    ) {
+      return { released: false, runId: heldRunId, reason: "already_terminal" };
+    }
+    if (!["LEASED", "RUNNING", "VERIFYING"].includes(run.state)) {
+      throw new Error(`run ${heldRunId} is ${run.state}, not actively leased`);
+    }
+
+    const attempt = db
+      .query(
+        `SELECT lease_owner FROM attempts WHERE run_id = ? AND attempt = ?`,
+      )
+      .get(heldRunId, run.attempts);
+    if (!attempt) throw new Error(`run ${heldRunId} has no current attempt`);
+    if (attempt.lease_owner && attempt.lease_owner !== workerId) {
+      throw new Error(
+        `run ${heldRunId} is leased by ${attempt.lease_owner}, not ${workerId}`,
+      );
+    }
+
+    // Revoking the current token fences a concurrent executor before it can
+    // write a result. Keep the same attempt number: this operation settles it
+    // rather than creating a retryable attempt.
+    const fencingToken = nextCounter(db, "fencing");
+    db.query(
+      `UPDATE attempts
+          SET fencing_token = ?, lease_owner = NULL, lease_expires_at = ?
+        WHERE run_id = ? AND attempt = ?`,
+    ).run(fencingToken, iso(currentNow), heldRunId, run.attempts);
+
+    if (run.state === "VERIFYING") {
+      transition(db, {
+        runId: heldRunId,
+        to: "FAILED",
+        actor,
+        reason: "operator_termination",
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
+      });
+      finishAttempt(
+        db,
+        heldRunId,
+        run.attempts,
+        "FAILED",
+        "operator_terminated",
+        currentNow,
+      );
+    } else {
+      transition(db, {
+        runId: heldRunId,
+        to: "CANCELLED",
+        actor,
+        reason: "operator_termination",
+        attempt: run.attempts,
+        policyVersion,
+        now: currentNow,
+      });
+      finishAttempt(
+        db,
+        heldRunId,
+        run.attempts,
+        "CANCELLED",
+        "operator_terminated",
+        currentNow,
+      );
+    }
+    db.query(
+      `UPDATE workers SET state = 'stopped', current_run = NULL, stopped_at = ? WHERE worker_id = ?`,
+    ).run(iso(currentNow), workerId);
+    return { released: true, runId: heldRunId };
+  });
+
+  if (outcome.released)
+    ACTIVE_EXECUTIONS.get(outcome.runId)?.abort("operator_termination");
+  return outcome;
+}
+
+/**
+ * Release a worker workspace while preserving the stale-worker recovery
+ * policy. Stalled workers retain lease-expiry retry semantics; live workers
+ * are explicitly terminated instead.
+ */
+export function terminateWorkerLease(db, { workerId, runId }, options = {}) {
+  const currentNow = resolveNow(options.now);
+  const worker = db
+    .query(`SELECT state, last_seen FROM workers WHERE worker_id = ?`)
+    .get(workerId);
+  if (!worker) throw new Error(`unknown worker ${workerId}`);
+  const stale =
+    worker.state !== "stopped" &&
+    currentNow - Date.parse(worker.last_seen) > HEARTBEAT_STALE_MS;
+  if (stale) {
+    return releaseStalledWorkerLease(
+      db,
+      { workerId, runId },
+      {
+        ...options,
+        now: currentNow,
+      },
+    );
+  }
+  return terminateLiveWorkerLease(
+    db,
+    { workerId, runId },
+    {
+      ...options,
+      now: currentNow,
+    },
+  );
+}
+
+/**
  * Re-queue LEASED/RUNNING/VERIFYING runs whose current attempt's lease expired.
  * The stale attempt keeps its (now lower) fencing token, so a late publish from
  * it is fenced out. Lease loss spends only the dedicated environment budget.

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -125,7 +125,6 @@ import {
   reapExpiredLeases,
   releaseStalledWorkerLease,
   terminateLiveWorkerLease,
-  terminateWorkerLease,
   releaseClaimLock,
   repositoryIsClean,
   repositoryStatus,
@@ -6367,7 +6366,7 @@ sh -c 'sleep 5 & wait'
     });
 
     expect(
-      terminateWorkerLease(
+      terminateLiveWorkerLease(
         db,
         { workerId: "w-terminal", runId: spec.runId },
         { now: T0, policyVersion: "test" },
@@ -6376,8 +6375,47 @@ sh -c 'sleep 5 & wait'
       released: false,
       runId: spec.runId,
       reason: "already_terminal",
+      state: "CANCELLED",
     });
     expect(runState(db, spec.runId)).toBe("CANCELLED");
+  });
+
+  test("operator termination refuses a stopped worker still pointing at a run", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const claim = claimNext(db, opts({ owner: "w-stopped" }));
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      actor: "w-stopped",
+      reason: "started",
+      attempt: claim.attempt,
+      now: T0,
+    });
+    registerWorker(db, { workerId: "w-stopped", now: T0 });
+    heartbeat(db, "w-stopped", { state: "busy", runId: spec.runId, now: T0 });
+    db.query(
+      `UPDATE workers SET state = 'stopped' WHERE worker_id = 'w-stopped'`,
+    ).run();
+
+    expect(
+      terminateLiveWorkerLease(
+        db,
+        { workerId: "w-stopped", runId: spec.runId },
+        { now: T0, policyVersion: "test" },
+      ),
+    ).toEqual({
+      released: false,
+      runId: spec.runId,
+      reason: "already_terminal",
+    });
+    // Nothing was settled on the stopped worker's behalf.
+    expect(runState(db, spec.runId)).toBe("RUNNING");
+    expect(
+      db
+        .query(`SELECT lease_owner FROM attempts WHERE run_id = ?`)
+        .get(spec.runId).lease_owner,
+    ).toBe("w-stopped");
   });
 
   test("operator termination fences a completing workspace despite a concurrent heartbeat", async () => {

--- a/event-runtime/lib/worker.test.mjs
+++ b/event-runtime/lib/worker.test.mjs
@@ -124,6 +124,8 @@ import {
   materializeRunHarness,
   reapExpiredLeases,
   releaseStalledWorkerLease,
+  terminateLiveWorkerLease,
+  terminateWorkerLease,
   releaseClaimLock,
   repositoryIsClean,
   repositoryStatus,
@@ -143,6 +145,7 @@ import {
   ticketHandoffContext,
   writeWorkspaceIntegrityStatus,
 } from "./worker.mjs";
+import { heartbeat, registerWorker } from "./workers.mjs";
 import {
   liveWorkerLeases,
   writeWorkerLease,
@@ -6265,6 +6268,175 @@ sh -c 'sleep 5 & wait'
     expect(lifecycleOf(reapedDb, reapedSpec.runId).at(-1).reason).toBe(
       "retry:environment",
     );
+  });
+
+  test.each([
+    ["LEASED", "CANCELLED", "CANCELLED"],
+    ["RUNNING", "CANCELLED", "CANCELLED"],
+    ["VERIFYING", "FAILED", "FAILED"],
+  ])(
+    "operator termination settles a live %s workspace without retrying",
+    (initialState, finalState, attemptState) => {
+      const db = openDb(":memory:");
+      const spec = queueRun(db, makeSpec());
+      const claim = claimNext(db, opts({ owner: "w-live" }));
+      registerWorker(db, { workerId: "w-live", now: T0 });
+      heartbeat(db, "w-live", {
+        state: "busy",
+        runId: spec.runId,
+        now: T0,
+      });
+      if (initialState !== "LEASED") {
+        transition(db, {
+          runId: spec.runId,
+          to: "RUNNING",
+          actor: "w-live",
+          reason: "started",
+          attempt: claim.attempt,
+          now: T0,
+        });
+      }
+      if (initialState === "VERIFYING") {
+        transition(db, {
+          runId: spec.runId,
+          to: "VERIFYING",
+          actor: "w-live",
+          reason: "verifying",
+          attempt: claim.attempt,
+          now: T0,
+        });
+      }
+
+      expect(
+        terminateLiveWorkerLease(
+          db,
+          { workerId: "w-live", runId: spec.runId },
+          { now: T0, policyVersion: "test" },
+        ),
+      ).toEqual({ released: true, runId: spec.runId });
+      expect(runState(db, spec.runId)).toBe(finalState);
+      const terminatedAttempt = db
+        .query(
+          `SELECT terminal_state, reason_code, fencing_token, lease_owner
+           FROM attempts WHERE run_id = ? AND attempt = ?`,
+        )
+        .get(spec.runId, claim.attempt);
+      expect(terminatedAttempt).toEqual({
+        terminal_state: attemptState,
+        reason_code: "operator_terminated",
+        fencing_token: expect.any(Number),
+        lease_owner: null,
+      });
+      expect(terminatedAttempt.fencing_token).toBeGreaterThan(
+        claim.fencingToken,
+      );
+      expect(
+        db
+          .query(`SELECT state, current_run FROM workers WHERE worker_id = ?`)
+          .get("w-live"),
+      ).toEqual({ state: "stopped", current_run: null });
+      expect(claimedRetryFor(db, spec.runId, claim.attempt + 1)).toBeNull();
+    },
+  );
+
+  test("operator termination is a no-op for a worker still pointing at a terminal run", () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec());
+    const claim = claimNext(db, opts({ owner: "w-terminal" }));
+    transition(db, {
+      runId: spec.runId,
+      to: "RUNNING",
+      actor: "w-terminal",
+      reason: "started",
+      attempt: claim.attempt,
+      now: T0,
+    });
+    transition(db, {
+      runId: spec.runId,
+      to: "CANCELLED",
+      actor: "operator",
+      reason: "operator_cancel",
+      attempt: claim.attempt,
+      now: T0,
+    });
+    registerWorker(db, { workerId: "w-terminal", now: T0 });
+    heartbeat(db, "w-terminal", {
+      state: "busy",
+      runId: spec.runId,
+      now: T0,
+    });
+
+    expect(
+      terminateWorkerLease(
+        db,
+        { workerId: "w-terminal", runId: spec.runId },
+        { now: T0, policyVersion: "test" },
+      ),
+    ).toEqual({
+      released: false,
+      runId: spec.runId,
+      reason: "already_terminal",
+    });
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+  });
+
+  test("operator termination fences a completing workspace despite a concurrent heartbeat", async () => {
+    const db = openDb(":memory:");
+    const spec = queueRun(db, makeSpec({ adapter: "late" }));
+    const claim = claimNext(db, opts({ owner: "w-race" }));
+    registerWorker(db, { workerId: "w-race", now: T0 });
+    heartbeat(db, "w-race", { state: "busy", runId: spec.runId, now: T0 });
+    let started;
+    const executing = new Promise((resolve) => {
+      started = resolve;
+    });
+    let complete;
+    const completion = new Promise((resolve) => {
+      complete = resolve;
+    });
+    const execution = executeClaimed(
+      db,
+      registry,
+      {
+        late: {
+          async execute() {
+            started();
+            return completion;
+          },
+        },
+      },
+      claim,
+      opts({ owner: "w-race" }),
+    );
+    await executing;
+
+    expect(
+      terminateLiveWorkerLease(
+        db,
+        { workerId: "w-race", runId: spec.runId },
+        { now: T0, policyVersion: "test" },
+      ),
+    ).toEqual({ released: true, runId: spec.runId });
+    heartbeat(db, "w-race", { state: "busy", runId: spec.runId, now: T0 + 1 });
+    complete({ exitCode: 0, timedOut: false });
+
+    expect(await execution).toEqual(expect.objectContaining({ fenced: true }));
+    expect(runState(db, spec.runId)).toBe("CANCELLED");
+    expect(
+      db
+        .query(`SELECT COUNT(*) AS n FROM results WHERE run_id = ?`)
+        .get(spec.runId).n,
+    ).toBe(0);
+    expect(
+      db
+        .query(
+          `SELECT terminal_state, reason_code FROM attempts WHERE run_id = ?`,
+        )
+        .get(spec.runId),
+    ).toEqual({
+      terminal_state: "CANCELLED",
+      reason_code: "operator_terminated",
+    });
   });
 
   test("cancelRun on a RUNNING attempt aborts adapter immediately and records attempt (OPS-417)", async () => {

--- a/event-runtime/web/src/api.ts
+++ b/event-runtime/web/src/api.ts
@@ -536,7 +536,8 @@ export const api = {
       { runId },
     ),
   // Deliberately cancel a live workspace. This is distinct from stale-lease
-  // recovery above: using that recovery route on a live worker would retry it.
+  // recovery above, which refuses a live (still heartbeating) worker with a
+  // 409 and only requeues/fails the run held by a stale one.
   terminateWorkspace: (workerId: string, runId: string) =>
     call<{ released: boolean; runId: string; terminated: true }>(
       "POST",


### PR DESCRIPTION
Fixes watt-mind/factory#2311

Operators can terminate live worker workspaces without waiting for a stale heartbeat; late completion is fenced.

## Validation

| Check                | Command                                                                    | Result  | Notes                              |
| -------------------- | -------------------------------------------------------------------------- | ------- | ---------------------------------- |
| Verification Command | `bun test event-runtime/lib/worker.test.mjs event-runtime/lib/api-runs.test.mjs --timeout 20000` | pass | 246 tests, 0 failures |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass | clean; baseline lint warnings only |
| UX critique          | `factory-ux-critic`                                                       | not run | backend lifecycle/API; no user-facing surface |

UX critique: skipped — backend lifecycle/API only; no user-facing surface

run:run_5b6053f2-4bd2-4714-b420-26a94299322e
