### PR TITLE
chore(api): terminate-path follow-ups from #2312 review (#2313)

### DIFF
--- a/event-runtime/lib/api-runs.mjs
+++ b/event-runtime/lib/api-runs.mjs
@@ -27,6 +27,7 @@ import {
   policyMaxRunMinutes,
   releaseStalledWorkerLease,
   retryRun,
+  terminateLiveWorkerLease,
 } from "./worker.mjs";
 import { agentFamily, proposalSubject } from "./proposal-subject.mjs";
 import {
@@ -2480,7 +2481,76 @@ export async function handleRunApiRoute({
   const workerRelease = url.pathname.match(/^\/workers\/([^/]+)\/release$/);
   if (req.method === "POST" && workerRelease) {
     const workerId = decodeURIComponent(workerRelease[1]);
-    const body = parseJson(await readBody(req)).value ?? {};
+    const parsed = parseJson(await readBody(req));
+    // Workspace termination opts in with `terminate=true` and must win over
+    // stale-lease recovery for the same path: it cancels the active run so
+    // the executor aborts and normal cleanup removes the worktree.
+    if (url.searchParams.get("terminate") === "true") {
+      if (parsed.error) return send(400, { error: "invalid_json" });
+      const body = parsed.value ?? {};
+      if (typeof body.runId !== "string" || body.runId === "")
+        return send(422, { error: "runId required" });
+      const worker = db
+        .query(`SELECT state, current_run FROM workers WHERE worker_id = ?`)
+        .get(workerId);
+      if (!worker) return send(404, { error: `unknown worker ${workerId}` });
+      if (worker.state === "stopped" || worker.current_run !== body.runId) {
+        return send(409, {
+          error: `worker ${workerId} does not hold ${body.runId}`,
+        });
+      }
+      if (
+        !db.query(`SELECT run_id FROM runs WHERE run_id = ?`).get(body.runId)
+      ) {
+        return send(404, { error: `unknown run ${body.runId}` });
+      }
+      try {
+        const outcome = terminateLiveWorkerLease(
+          db,
+          { workerId, runId: body.runId },
+          { actor, now: nowMs, policyVersion },
+        );
+        if (!outcome.released) {
+          // A run that finished between the operator's click and this
+          // request has nothing left to terminate. Answer in operator
+          // terms — what state the run reached — rather than leaking the
+          // state machine's own wording.
+          return send(409, {
+            error: `run ${body.runId} already finished (${outcome.state ?? "unknown state"}); nothing to terminate`,
+          });
+        }
+        const payload = {
+          released: true,
+          runId: outcome.runId,
+          terminated: true,
+        };
+        // cancelRun already closed (or left) open proposals; 2+ remaining
+        // open rows is the same `proposalClose.ambiguous` signal cancel
+        // surfaces as `ambiguousOpenProposals`.
+        const openCount = db
+          .query(
+            `SELECT COUNT(*) AS n FROM proposals WHERE run_id = ? AND status = 'open'`,
+          )
+          .get(outcome.runId).n;
+        if (openCount > 1) {
+          payload.ambiguousOpenProposals = [
+            { runId: outcome.runId, count: openCount },
+          ];
+        }
+        return send(200, payload);
+      } catch (err) {
+        if (String(err.message).includes("unknown run"))
+          return send(404, { error: `unknown run ${body.runId}` });
+        if (err instanceof IllegalTransition) {
+          return send(409, {
+            error: `run ${body.runId} already finished (${err.from ?? "unknown state"}); nothing to terminate`,
+          });
+        }
+        return send(409, { error: err.message });
+      }
+    }
+
+    const body = parsed.value ?? {};
     if (!body.runId) return send(422, { error: "runId required" });
     try {
       return send(

--- a/event-runtime/lib/api.mjs
+++ b/event-runtime/lib/api.mjs
@@ -68,8 +68,6 @@ import { notifyCommand, sendNotification } from "./notify.mjs";
 import { loadRepos, reposRoot } from "./repos.mjs";
 import { scheduleView } from "./schedules.mjs";
 import { handleStatusApiRoute, workerCapacityView } from "./status-view.mjs";
-import { terminateLiveWorkerLease } from "./worker.mjs";
-import { IllegalTransition } from "./lifecycle.mjs";
 import { loadWorkerPolicy } from "./workers.mjs";
 import { loadLinearBudget } from "../../tools/ticket.mjs";
 
@@ -384,65 +382,6 @@ export function createApi({
       }
       if (route === "GET /status" || route === "GET /workers") {
         return handleStatusApiRoute({ ...common, getStoreStats });
-      }
-      // Keep the established stale-lease recovery request below in api-runs.
-      // A deliberate workspace termination opts in with `terminate: true`: it
-      // cancels the active run, which aborts its executor and lets normal run
-      // cleanup remove the worktree rather than merely expiring its lease.
-      const workspaceRelease = url.pathname.match(
-        /^\/workers\/([^/]+)\/release$/,
-      );
-      if (
-        req.method === "POST" &&
-        workspaceRelease &&
-        url.searchParams.get("terminate") === "true"
-      ) {
-        const parsed = parseJson(await readBody(req));
-        if (parsed.error) return send(400, { error: "invalid_json" });
-        const body = parsed.value ?? {};
-        if (typeof body.runId !== "string" || body.runId === "")
-          return send(422, { error: "runId required" });
-        const workerId = decodeURIComponent(workspaceRelease[1]);
-        const worker = db
-          .query(`SELECT state, current_run FROM workers WHERE worker_id = ?`)
-          .get(workerId);
-        if (!worker) return send(404, { error: `unknown worker ${workerId}` });
-        if (worker.state === "stopped" || worker.current_run !== body.runId) {
-          return send(409, {
-            error: `worker ${workerId} does not hold ${body.runId}`,
-          });
-        }
-        try {
-          const outcome = terminateLiveWorkerLease(
-            db,
-            { workerId, runId: body.runId },
-            { actor, now: nowMs, policyVersion },
-          );
-          if (!outcome.released) {
-            // A run that finished between the operator's click and this
-            // request has nothing left to terminate. Answer in operator
-            // terms — what state the run reached — rather than leaking the
-            // state machine's own wording.
-            return send(409, {
-              error: `run ${body.runId} already finished (${outcome.state ?? "unknown state"}); nothing to terminate`,
-            });
-          }
-          return send(200, {
-            released: true,
-            runId: outcome.runId,
-            terminated: true,
-          });
-        } catch (err) {
-          if (String(err.message).startsWith("unknown run"))
-            return send(404, { error: err.message });
-          // A concurrent settlement can still race the delegated cancel.
-          if (err instanceof IllegalTransition) {
-            return send(409, {
-              error: `run ${body.runId} already finished (${err.from ?? "unknown state"}); nothing to terminate`,
-            });
-          }
-          return send(409, { error: err.message });
-        }
       }
       if (route === "GET /config") {
         return handleConfigApiRoute({

--- a/event-runtime/lib/api.test.mjs
+++ b/event-runtime/lib/api.test.mjs
@@ -58,37 +58,45 @@ const makeServer = async (...args) => {
 };
 
 describe("workspace termination API (GH-2310)", () => {
+  const nowMs = Date.parse("2026-09-05T19:00:00.000Z");
+  const at = new Date(nowMs).toISOString();
+
+  function insertLiveWorkspace(
+    db,
+    {
+      workerId = "worker-workspace",
+      runId = "run-workspace",
+      state = "RUNNING",
+    } = {},
+  ) {
+    db.query(
+      `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
+       VALUES (?, ?, '{}', ?, ?, 1, ?, ?)`,
+    ).run(runId, `${runId}-key`, `sha256:${runId}`, state, at, at);
+    db.query(
+      `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner)
+       VALUES (?, 1, 1, ?)`,
+    ).run(runId, workerId);
+    registerWorker(db, { workerId, now: nowMs });
+    heartbeat(db, workerId, { state: "busy", runId, now: nowMs });
+  }
+
+  async function terminate(s, workerId, body, { raw = false } = {}) {
+    return s.request(`/workers/${workerId}/release?terminate=true`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: raw ? body : JSON.stringify(body),
+    });
+  }
+
   test("cancels only the active run held by the selected worker", async () => {
-    const nowMs = Date.parse("2026-09-05T19:00:00.000Z");
     const s = await makeServer({ now: () => nowMs });
     try {
-      s.db
-        .query(
-          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-           VALUES ('run-workspace', 'workspace-key', '{}', 'sha256:workspace', 'RUNNING', 1, ?, ?)`,
-        )
-        .run(new Date(nowMs).toISOString(), new Date(nowMs).toISOString());
-      s.db
-        .query(
-          `INSERT INTO attempts (run_id, attempt, fencing_token, lease_owner)
-           VALUES ('run-workspace', 1, 1, 'worker-workspace')`,
-        )
-        .run();
-      registerWorker(s.db, { workerId: "worker-workspace", now: nowMs });
-      heartbeat(s.db, "worker-workspace", {
-        state: "busy",
-        runId: "run-workspace",
-        now: nowMs,
-      });
+      insertLiveWorkspace(s.db);
 
-      const terminated = await s.request(
-        "/workers/worker-workspace/release?terminate=true",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ runId: "run-workspace" }),
-        },
-      );
+      const terminated = await terminate(s, "worker-workspace", {
+        runId: "run-workspace",
+      });
       expect(terminated.status).toBe(200);
       expect(await terminated.json()).toEqual({
         released: true,
@@ -119,14 +127,9 @@ describe("workspace termination API (GH-2310)", () => {
           .get(),
       ).toEqual({ state: "stopped", current_run: null });
 
-      const raced = await s.request(
-        "/workers/worker-workspace/release?terminate=true",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ runId: "other-run" }),
-        },
-      );
+      const raced = await terminate(s, "worker-workspace", {
+        runId: "other-run",
+      });
       expect(raced.status).toBe(409);
       expect((await raced.json()).error).toBe(
         "worker worker-workspace does not hold other-run",
@@ -137,34 +140,136 @@ describe("workspace termination API (GH-2310)", () => {
   });
 
   test("answers an already-terminal run with an operator-legible 409", async () => {
-    const nowMs = Date.parse("2026-09-05T19:00:00.000Z");
     const s = await makeServer({ now: () => nowMs });
     try {
-      s.db
-        .query(
-          `INSERT INTO runs (run_id, idempotency_key, spec_json, spec_hash, state, attempts, created_at, updated_at)
-           VALUES ('run-finished', 'finished-key', '{}', 'sha256:finished', 'COMPLETED', 1, ?, ?)`,
-        )
-        .run(new Date(nowMs).toISOString(), new Date(nowMs).toISOString());
-      registerWorker(s.db, { workerId: "worker-finished", now: nowMs });
-      heartbeat(s.db, "worker-finished", {
-        state: "busy",
+      insertLiveWorkspace(s.db, {
+        workerId: "worker-finished",
         runId: "run-finished",
-        now: nowMs,
+        state: "COMPLETED",
       });
 
-      const refused = await s.request(
-        "/workers/worker-finished/release?terminate=true",
-        {
-          method: "POST",
-          headers: { "content-type": "application/json" },
-          body: JSON.stringify({ runId: "run-finished" }),
-        },
-      );
+      const refused = await terminate(s, "worker-finished", {
+        runId: "run-finished",
+      });
       expect(refused.status).toBe(409);
       expect((await refused.json()).error).toBe(
         "run run-finished already finished (COMPLETED); nothing to terminate",
       );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("surfaces ambiguousOpenProposals when two open proposals target the run", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      insertLiveWorkspace(s.db);
+      s.db
+        .query(
+          `INSERT INTO proposals (id, event_source, event_id, run_id, decision, created_at, ttl_seconds)
+           VALUES ('prop-a', 'test', 'e1', 'run-workspace', 'run', ?, 1800),
+                  ('prop-b', 'test', 'e2', 'run-workspace', 'run', ?, 1800)`,
+        )
+        .run(at, at);
+
+      const terminated = await terminate(s, "worker-workspace", {
+        runId: "run-workspace",
+      });
+      expect(terminated.status).toBe(200);
+      expect(await terminated.json()).toEqual({
+        released: true,
+        runId: "run-workspace",
+        terminated: true,
+        ambiguousOpenProposals: [{ runId: "run-workspace", count: 2 }],
+      });
+      expect(
+        s.db
+          .query(`SELECT status FROM proposals WHERE run_id = 'run-workspace'`)
+          .all()
+          .map((row) => row.status),
+      ).toEqual(["open", "open"]);
+    } finally {
+      s.close();
+    }
+  });
+
+  test("refuses an unknown worker with 404", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const refused = await terminate(s, "ghost-worker", {
+        runId: "run-workspace",
+      });
+      expect(refused.status).toBe(404);
+      expect((await refused.json()).error).toBe("unknown worker ghost-worker");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("refuses an unknown run the worker still holds with 404", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      registerWorker(s.db, { workerId: "worker-ghost-run", now: nowMs });
+      heartbeat(s.db, "worker-ghost-run", {
+        state: "busy",
+        runId: "ghost-run",
+        now: nowMs,
+      });
+
+      const refused = await terminate(s, "worker-ghost-run", {
+        runId: "ghost-run",
+      });
+      expect(refused.status).toBe(404);
+      expect((await refused.json()).error).toBe("unknown run ghost-run");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("refuses a stopped worker with 409", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      insertLiveWorkspace(s.db, {
+        workerId: "worker-stopped",
+        runId: "run-stopped",
+      });
+      s.db
+        .query(
+          `UPDATE workers SET state = 'stopped' WHERE worker_id = 'worker-stopped'`,
+        )
+        .run();
+
+      const refused = await terminate(s, "worker-stopped", {
+        runId: "run-stopped",
+      });
+      expect(refused.status).toBe(409);
+      expect((await refused.json()).error).toBe(
+        "worker worker-stopped does not hold run-stopped",
+      );
+    } finally {
+      s.close();
+    }
+  });
+
+  test("refuses invalid JSON with 400", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const refused = await terminate(s, "worker-workspace", "{", {
+        raw: true,
+      });
+      expect(refused.status).toBe(400);
+      expect((await refused.json()).error).toBe("invalid_json");
+    } finally {
+      s.close();
+    }
+  });
+
+  test("refuses a missing runId with 422", async () => {
+    const s = await makeServer({ now: () => nowMs });
+    try {
+      const refused = await terminate(s, "worker-workspace", {});
+      expect(refused.status).toBe(422);
+      expect((await refused.json()).error).toBe("runId required");
     } finally {
       s.close();
     }

--- a/event-runtime/web/src/views/Workers.tsx
+++ b/event-runtime/web/src/views/Workers.tsx
@@ -632,9 +632,7 @@ export function Workers({
 
   // GET /workers gained capacity without changing the legacy client method's
   // minimum response contract; older servers simply exercise the fallback.
-  const response = query.data as
-    { workers: Worker[]; capacity?: WorkerCapacity } | undefined;
-  const rawRows = response?.workers ?? [];
+  const rawRows = query.data?.workers ?? [];
   const missingRunIds = useMemo(
     () =>
       [...new Set(rawRows.flatMap((w) => w.currentRun ?? []))].filter(
@@ -687,7 +685,7 @@ export function Workers({
     () => rawRows.map((w) => enrichWorker(w, allRuns, loadingRunIds)),
     [rawRows, allRuns, loadingRunIds],
   );
-  const capacity = response?.capacity ?? capacityFromWorkers(rawRows);
+  const capacity = query.data?.capacity ?? capacityFromWorkers(rawRows);
 
   const parts = useMemo(() => partitionWorkers(rows), [rows]);
   const banner = useMemo(() => fleetBanner(rows), [rows]);


### PR DESCRIPTION
Fixes watt-mind/factory#2313

Co-locate both /workers/:id/release handlers, surface ambiguousOpenProposals on terminate, cover refusal branches, and drop the redundant Workers.tsx cast.

## Validation

| Check                | Command                          | Result  | Notes                  |
| -------------------- | -------------------------------- | ------- | ---------------------- |
| Verification Command | `bun test event-runtime/lib/api.test.mjs event-runtime/lib/api-runs.test.mjs --timeout 20000 && (cd event-runtime/web && bun run typecheck)` | pass    | 89 tests, 0 failures, tsc clean |
| Repo verify          | `bun test event-runtime/lib --timeout 20000 && bun build/emit.mjs --check && bun run format:check && bun run lint` | pass    | 2542 pass, 0 fail, emit ok, lint 0 errors |
| UX critique          | factory-ux-critic                | not run | no user-facing surface |

UX critique: skipped — API hygiene and a type-only Workers.tsx cast; no user-completable flow changed

run:run_93c70419-75d3-414c-b83f-d256282e41ad
